### PR TITLE
ftp inbound connector accepts zero size files

### DIFF
--- a/transports/ftp/src/main/java/org/mule/transport/ftp/FtpMuleMessageFactory.java
+++ b/transports/ftp/src/main/java/org/mule/transport/ftp/FtpMuleMessageFactory.java
@@ -57,14 +57,7 @@ public class FtpMuleMessageFactory extends AbstractMuleMessageFactory
                     file.getName(), ftpClient.getReplyCode()));
             }
             byte[] bytes = baos.toByteArray();
-            if (bytes.length > 0)
-            {
-                return bytes;
-            }
-            else
-            {
-                throw new IOException("File " + file.getName() + " is empty (zero bytes)");
-            }
+            return bytes;
         }
     }
 


### PR DESCRIPTION
Related to:
MULE-4400 Zero-size file handling
MULE-6367 FTP Inbound endpoint fails when reading empty file
