### PR TITLE
MULE-6920: fix by synchronizing getManifest()

### DIFF
--- a/core/src/main/java/org/mule/config/MuleManifest.java
+++ b/core/src/main/java/org/mule/config/MuleManifest.java
@@ -109,7 +109,8 @@ public class MuleManifest
 		return getManifestProperty("Recommended-Jdks");
 	}
 
-    public static Manifest getManifest()
+    // synchronize this method as manifest initialized here.
+    public static synchronized Manifest getManifest()
     {
         if (manifest == null)
         {


### PR DESCRIPTION
See https://www.mulesoft.org/jira/browse/MULE-6920

This problem only occurs, if more than one Mule Contexts are started in parallel in different threads.
