### PR TITLE
MFPC-372 : Fix memory leak on spring registry. The factory bean feed a

### DIFF
--- a/core/src/main/java/org/mule/api/registry/MuleRegistry.java
+++ b/core/src/main/java/org/mule/api/registry/MuleRegistry.java
@@ -62,6 +62,8 @@ public interface MuleRegistry extends Registry
     // /////////////////////////////////////////////////////////////////////////
 
     Connector lookupConnector(String name);
+    
+    boolean existConnector(String name);
 
     /**
      * Looks-up endpoint builders which can be used to repeatably create endpoints with the same configuration.

--- a/core/src/main/java/org/mule/api/registry/Registry.java
+++ b/core/src/main/java/org/mule/api/registry/Registry.java
@@ -34,6 +34,18 @@ public interface Registry extends Initialisable, Disposable
      */
     <T> T lookupObject(String key);
 
+    /** 
+     * Check if single object exist by name. 
+     * @return true if exist or false if not found
+     */
+    boolean existObject(String key);
+    
+    /** 
+     * Check if single object exist by name and type. 
+     * @return true if exist or false if not found
+     */
+    <T> boolean existObject(String key, Class<T> type);
+    
     /**
      * Look up all objects of a given type.
      *

--- a/core/src/main/java/org/mule/registry/AbstractRegistryBroker.java
+++ b/core/src/main/java/org/mule/registry/AbstractRegistryBroker.java
@@ -126,6 +126,29 @@ public abstract class AbstractRegistryBroker implements RegistryBroker
         return (T) obj;
     }
 
+    public boolean existObject(String key)
+    {
+        Iterator<Registry> it = getRegistries().iterator();
+        while (it.hasNext())
+        {
+            if (((Registry) it.next()).existObject(key))
+            	return true;
+        }
+        return false;
+    }
+    
+    public <T> boolean existObject(String key, Class<T> type)
+    {
+        Iterator<Registry> it = getRegistries().iterator();
+        while (it.hasNext())
+        {
+            if (((Registry) it.next()).existObject(key, type))
+            	return true;
+        }
+        return false;
+    }
+
+    
     public <T> T lookupObject(Class<T> type) throws RegistrationException
     {
         Object object;

--- a/core/src/main/java/org/mule/registry/MuleRegistryHelper.java
+++ b/core/src/main/java/org/mule/registry/MuleRegistryHelper.java
@@ -128,7 +128,15 @@ public class MuleRegistryHelper implements MuleRegistry
     {
         return (Connector) registry.lookupObject(name);
     }
-
+    
+    /**
+     * {@inheritDoc}
+     */
+    public boolean existConnector(String name)
+    {
+        return registry.existObject(name, Connector.class);
+    }
+    
     /**
      * Removed this method from {@link Registry} API as it should only be used
      * internally and may confuse users. The {@link EndpointFactory} should be used
@@ -677,6 +685,24 @@ public class MuleRegistryHelper implements MuleRegistry
         return (T) registry.lookupObject(key);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean existObject(String key)
+    {
+        return registry.existObject(key);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> boolean existObject(String key, Class<T> type)
+    {
+        return registry.existObject(key, type);
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/org/mule/registry/TransientRegistry.java
+++ b/core/src/main/java/org/mule/registry/TransientRegistry.java
@@ -161,6 +161,18 @@ public class TransientRegistry extends AbstractRegistry
         return registryMap.<T>get(key);
     }
 
+    public boolean existObject(String key)
+    {
+        return registryMap.contains(key);
+    }
+
+    public <T> boolean existObject(String key, Class<T> type)
+    {
+    	Object obj = registryMap.get(key);
+        return  obj != null && type.isAssignableFrom(obj.getClass());
+    }
+
+    
     @SuppressWarnings("unchecked")
     public <T> Collection<T> lookupObjects(Class<T> returntype)
     {
@@ -420,6 +432,20 @@ public class TransientRegistry extends AbstractRegistry
             {
                 readLock.lock();
                 return (T) registry.get(key);
+            }
+            finally
+            {
+                readLock.unlock();
+            }
+        }
+        
+        public boolean contains(String key)
+        {
+            Lock readLock = registryLock.readLock();
+            try
+            {
+                readLock.lock();
+                return registry.containsKey(key);
             }
             finally
             {

--- a/core/src/main/java/org/mule/util/ObjectNameHelper.java
+++ b/core/src/main/java/org/mule/util/ObjectNameHelper.java
@@ -64,7 +64,7 @@ public final class ObjectNameHelper
         // We can't check local edpoints right now but the chances of conflict are
         // very small and will be
         // reported during JMX object registration
-        while (muleContext.getRegistry().lookupObject(tempName) != null)
+        while (muleContext.getRegistry().existObject(tempName))
         {
             i++;
             tempName = name + SEPARATOR + i;
@@ -83,7 +83,7 @@ public final class ObjectNameHelper
         // reported during JMX object registration
         try
         {
-            while (muleContext.getRegistry().lookupConnector(tempName) != null)
+            while (muleContext.getRegistry().existConnector(tempName))
             {
                 i++;
                 tempName = name + SEPARATOR + i;

--- a/modules/guice/src/main/java/org/mule/module/guice/GuiceRegistry.java
+++ b/modules/guice/src/main/java/org/mule/module/guice/GuiceRegistry.java
@@ -95,6 +95,42 @@ public class GuiceRegistry extends AbstractRegistry
         return null;
     }
 
+    public boolean existObject(String key)
+    {
+        //Guice isn't really supposed to work this way but in Mule we need to look up objects by name only sometimes
+        for (Map.Entry<Key<?>, Binding<?>> entry : injector.getBindings().entrySet())
+        {
+            if (entry.getKey().getAnnotation() instanceof Named)
+            {
+                String name = ((Named) entry.getKey().getAnnotation()).value();
+                if (name.equals(key))
+                {
+                    return entry.getValue().getProvider().get() != null;
+                }
+            }
+        }
+        return false;
+    }
+
+    public <T> boolean existObject(String key, Class<T> type)
+    {
+        //Guice isn't really supposed to work this way but in Mule we need to look up objects by name only sometimes
+        for (Map.Entry<Key<?>, Binding<?>> entry : injector.getBindings().entrySet())
+        {
+            if (entry.getKey().getAnnotation() instanceof Named)
+            {
+                String name = ((Named) entry.getKey().getAnnotation()).value();
+                if (name.equals(key))
+                {
+                	Object o = entry.getValue().getProvider().get();
+                    return o != null && type.isAssignableFrom(o.getClass());
+                }
+            }
+        }
+        return false;
+    }
+
+    
     @Override
     public <T> T lookupObject(Class<T> type) throws RegistrationException
     {


### PR DESCRIPTION
alreadyCreated Set but never clean it. And mule ensure unique name by
getting bean on factory. So we create à large number of false already
created bean in Spring.