### PR TITLE
MULE-6943 adding warning and ignoring null values for watermark

### DIFF
--- a/core/src/main/java/org/mule/config/i18n/CoreMessages.java
+++ b/core/src/main/java/org/mule/config/i18n/CoreMessages.java
@@ -1424,4 +1424,13 @@ public class CoreMessages extends MessageFactory
         return factory.createMessage(BUNDLE_PATH, 348, endpoint);
     }
 
+    public static Message notSerializableWatermark()
+    {
+        return factory.createMessage(BUNDLE_PATH, 349);
+    }
+
+    public static Message nullWatermark()
+    {
+        return factory.createMessage(BUNDLE_PATH, 350);
+    }
 }

--- a/core/src/main/java/org/mule/transport/polling/schedule/FixedFrequencyScheduler.java
+++ b/core/src/main/java/org/mule/transport/polling/schedule/FixedFrequencyScheduler.java
@@ -186,7 +186,7 @@ public class FixedFrequencyScheduler<T extends Runnable> extends PollScheduler<T
                     {
                         try
                         {
-                            executor.awaitTermination(5000, TimeUnit.MILLISECONDS);
+                            executor.awaitTermination(1000, TimeUnit.MILLISECONDS);
                         }
                         catch (InterruptedException e)
                         {

--- a/core/src/main/resources/META-INF/services/org/mule/i18n/core-messages.properties
+++ b/core/src/main/resources/META-INF/services/org/mule/i18n/core-messages.properties
@@ -338,3 +338,5 @@
 346=Could not register the scheduler {0} in the registry
 347=Polling of {0} returned null, the flow will not be invoked.
 348=The endpoint {0} does not return responses and therefore can't be used for polling.
+349=Value retrieved from event is not serializable and hence can't be saved to the object store
+350=Watermark value is null and will be ignored

--- a/tests/integration/src/test/resources/org/mule/test/integration/watermark/watermark-polling-config.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/watermark/watermark-polling-config.xml
@@ -14,6 +14,10 @@
 
     <vm:endpoint path="foo" exchange-pattern="request-response" name="foo"/>
 
+    <spring:beans>
+        <spring:bean class="org.mule.test.integration.watermark.WatermarkPollingTestCase$PollStopper"/>
+    </spring:beans>
+
 
     <flow name="echo">
         <inbound-endpoint ref="foo"/>
@@ -58,6 +62,34 @@
         </poll>
         <set-payload value="#[test3]"/>
         <set-variable variableName="test3" value="keyPresent"/>
+        <component class="org.mule.test.integration.watermark.WatermarkPollingTestCase$FooComponent"/>
+    </flow>
+
+
+    <flow name="usingWatermarkFlowWithNullValue" processingStrategy="synchronous">
+        <poll frequency="1000">
+            <watermark variable="testNull" default-expression="#[null]" update-expression="#[string:noWatermark]"/>
+            <outbound-endpoint ref="foo"/>
+        </poll>
+        <choice>
+            <when expression="#[testNull != null]">
+                <set-payload value="#[testNull]"/>
+                <component class="org.mule.test.integration.watermark.WatermarkPollingTestCase$FooComponent"/>
+            </when>
+            <otherwise>
+                <logger level="ERROR" message="Watermark value is null as expected"/>
+            </otherwise>
+        </choice>
+
+    </flow>
+
+    <flow name="usingWatermarkFlowWithNullUpdateValue" processingStrategy="synchronous">
+        <poll frequency="1000">
+            <watermark variable="testUpdateAsNull" default-expression="#[string:defaultValue]" update-expression="#[null]"/>
+            <outbound-endpoint ref="foo"/>
+        </poll>
+
+        <set-payload value="#[testUpdateAsNull]"/>
         <component class="org.mule.test.integration.watermark.WatermarkPollingTestCase$FooComponent"/>
     </flow>
 
@@ -135,7 +167,6 @@
 
     </flow>
 
-    <spring:bean name="pollStopper" class="org.mule.test.integration.watermark.WatermarkPollingTestCase$PollStopper"/>
 
 
 </mule>


### PR DESCRIPTION
I added the null validation for watermark, watermark ignores null values, logs a warning in those cases. Also modified watermark test to use prober and to include this new scenario.
