### PR TITLE
MULE-7023: Rename keep-alive attribute in HTTP/HTTPS endpoints

### DIFF
--- a/transports/http/src/main/resources/META-INF/mule-http.xsd
+++ b/transports/http/src/main/resources/META-INF/mule-http.xsd
@@ -376,9 +376,12 @@
         </xsd:attribute>
         <xsd:attribute name="keep-alive" type="mule:substitutableBoolean">
             <xsd:annotation>
-                <xsd:documentation>Controls if the socket connection is kept alive. If set to true,
-                a keep-alive header with the connection timeout specified in the connector will be
-                returned. If set to false, a "Connection: close" header will be returned.</xsd:documentation>
+                <xsd:documentation>DEPRECATED: Use keepAlive attribute instead.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="keepAlive" type="mule:substitutableBoolean">
+            <xsd:annotation>
+                <xsd:documentation>Controls if the connection is kept alive.</xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
     </xsd:attributeGroup>

--- a/transports/http/src/test/resources/http-keep-alive-config-flow.xml
+++ b/transports/http/src/test/resources/http-keep-alive-config-flow.xml
@@ -22,14 +22,14 @@
     </flow>
     
     <flow name="ConnectorKeepAliveEpNoKeepAlive">
-        <http:inbound-endpoint address="http://localhost:${port2}/http-in" exchange-pattern="request-response" keep-alive="false"
+        <http:inbound-endpoint address="http://localhost:${port2}/http-in" exchange-pattern="request-response" keepAlive="false"
                                connector-ref="HttpConnectorKeepAlive"
                                name="inConnectorKeepAliveEpNoKeepAlive"/>
         <echo-component/>
     </flow>
     
     <flow name="ConnectorKeepAliveEpKeepAlive">
-        <http:inbound-endpoint address="http://localhost:${port3}/http-in" exchange-pattern="request-response" keep-alive="true"
+        <http:inbound-endpoint address="http://localhost:${port3}/http-in" exchange-pattern="request-response" keepAlive="true"
                                connector-ref="HttpConnectorKeepAlive"
                                name="inConnectorKeepAliveEpKeepAlive"/>
         <echo-component/>
@@ -43,14 +43,14 @@
     </flow>
     
     <flow name="ConnectorNoKeepAliveEpNoKeepAlive">
-        <http:inbound-endpoint address="http://localhost:${port5}/http-in" exchange-pattern="request-response" keep-alive="false"
+        <http:inbound-endpoint address="http://localhost:${port5}/http-in" exchange-pattern="request-response" keepAlive="false"
                                connector-ref="HttpConnectorNoKeepAlive"
                                name="inConnectorNoKeepAliveEpNoKeepAlive"/>
         <echo-component/>
     </flow>
     
     <flow name="ConnectorNoKeepAliveEpKeepAlive">
-        <http:inbound-endpoint address="http://localhost:${port6}/http-in" exchange-pattern="request-response" keep-alive="true"
+        <http:inbound-endpoint address="http://localhost:${port6}/http-in" exchange-pattern="request-response" keepAlive="true"
                                connector-ref="HttpConnectorNoKeepAlive"
                                name="inConnectorNoKeepAliveEpKeepAlive"/>
         <echo-component/>

--- a/transports/http/src/test/resources/http-outbound-keep-alive.xml
+++ b/transports/http/src/test/resources/http-outbound-keep-alive.xml
@@ -11,25 +11,25 @@
 
     <flow name="keepAliveOneWay">
         <vm:inbound-endpoint path="keepAliveOneWay"/>
-        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keep-alive="true" exchange-pattern="one-way"/>
+        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keepAlive="true" exchange-pattern="one-way"/>
         <echo-component/>
     </flow>
 
     <flow name="keepAliveRequestResponse">
         <vm:inbound-endpoint path="keepAliveRequestResponse"/>
-        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keep-alive="true" exchange-pattern="request-response"/>
+        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keepAlive="true" exchange-pattern="request-response"/>
         <echo-component/>
     </flow>
 
     <flow name="noKeepAliveOneWay">
         <vm:inbound-endpoint path="noKeepAliveOneWay"/>
-        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keep-alive="false" exchange-pattern="one-way"/>
+        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keepAlive="false" exchange-pattern="one-way"/>
         <echo-component/>
     </flow>
 
     <flow name="noKeepAliveRequestResponse">
         <vm:inbound-endpoint path="noKeepAliveRequestResponse"/>
-        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keep-alive="false" exchange-pattern="request-response"/>
+        <http:outbound-endpoint address="http://localhost:${httpPort}/" method="GET" keepAlive="false" exchange-pattern="request-response"/>
         <echo-component/>
     </flow>
 


### PR DESCRIPTION
A new keepAlive attribute was created in the schema. Tests for HTTP inbound/outbound endpoints were changed to use this property. Inbound endpoint tests which use services still use the old keep-alive property (in order to check that it still works).
