### PR TITLE
MULE-7027: ExpiringGroupMonitoringThread must process event groups only ...

### DIFF
--- a/core/src/main/java/org/mule/routing/correlation/EventCorrelator.java
+++ b/core/src/main/java/org/mule/routing/correlation/EventCorrelator.java
@@ -525,6 +525,15 @@ public class EventCorrelator implements Startable, Stoppable, Disposable
         @Override
         public void doRun()
         {
+
+            ////TODO(pablo.kraan): is not good to have threads doing nothing in all the nodes but the primary. Need to
+            ////start the thread on the primary node only, and then use a notification schema to start a new thread
+            ////in a different node when the primary goes down.
+            if (!muleContext.isPrimaryPollingInstance())
+            {
+                return;
+            }
+
             List<EventGroup> expired = new ArrayList<EventGroup>(1);
             try
             {

--- a/core/src/test/java/org/mule/routing/correlation/EventCorrelatorTestCase.java
+++ b/core/src/test/java/org/mule/routing/correlation/EventCorrelatorTestCase.java
@@ -6,14 +6,15 @@
  */
 package org.mule.routing.correlation;
 
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import org.mule.DefaultMessageCollection;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -26,7 +27,10 @@ import org.mule.api.store.ListableObjectStore;
 import org.mule.api.store.ObjectAlreadyExistsException;
 import org.mule.api.store.ObjectStoreManager;
 import org.mule.routing.EventGroup;
+import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
+
+import java.util.Collections;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +40,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
-public class EventCorrelatorTestCase
+public class EventCorrelatorTestCase extends AbstractMuleTestCase
 {
 
 
@@ -112,6 +116,47 @@ public class EventCorrelatorTestCase
         eventCorrelator.dispose();
         verify((Disposable)mockExpireGroupsObjectStore,times(1)).dispose();
         verify((Disposable)mockProcessedGroups,times(1)).dispose();
+    }
+
+    @Test
+    public void processesExpiredGroupInPrimaryNode() throws Exception
+    {
+        doExpiredGroupMonitoringTest(true);
+    }
+
+    @Test
+    public void doesNotProcessExpiredGroupInSecondaryNode() throws Exception
+    {
+        try
+        {
+            doExpiredGroupMonitoringTest(false);
+
+            fail("Expiring group monitoring thread is not supposed to do any work on a secondary node");
+        }
+        catch (AssertionError e)
+        {
+            // Expected
+        }
+    }
+
+    private void doExpiredGroupMonitoringTest(boolean primaryNode) throws Exception
+    {
+        when(mockMuleContext.isPrimaryPollingInstance()).thenReturn(primaryNode);
+
+        EventCorrelator eventCorrelator = createEventCorrelator();
+        when(mockObjectStore.allKeys()).thenReturn(Collections.singletonList(TEST_GROUP_ID));
+        when(mockEventCorrelatorCallback.createEventGroup(mockMuleEvent, TEST_GROUP_ID)).thenReturn(mockEventGroup);
+
+        eventCorrelator.start();
+
+        try
+        {
+            verify(mockObjectStore, timeout(100)).remove(TEST_GROUP_ID);
+        }
+        finally
+        {
+            eventCorrelator.stop();
+        }
     }
 
     private EventCorrelator createEventCorrelator() throws Exception


### PR DESCRIPTION
...when the node is primary
