### PR TITLE
MULE-7028 MuleMessageToHttpResponse not evaluating outbound scope to set

### DIFF
--- a/transports/http/src/main/java/org/mule/transport/http/transformers/MuleMessageToHttpResponse.java
+++ b/transports/http/src/main/java/org/mule/transport/http/transformers/MuleMessageToHttpResponse.java
@@ -267,10 +267,10 @@ public class MuleMessageToHttpResponse extends AbstractMessageTransformer
             }
             else
             {
-                Object value = msg.getInvocationProperty(headerName);
+                Object value = msg.getOutboundProperty(headerName);
                 if (value == null)
                 {
-                    value = msg.getOutboundProperty(headerName);
+                    value = msg.getInvocationProperty(headerName);
                 }
                 if (value != null)
                 {

--- a/transports/http/src/test/java/org/mule/transport/http/transformers/MuleMessageToHttpResponseTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/transformers/MuleMessageToHttpResponseTestCase.java
@@ -9,7 +9,10 @@ package org.mule.transport.http.transformers;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.mule.DefaultMuleMessage;
+import org.mule.api.MuleContext;
 import org.mule.api.MuleMessage;
+import org.mule.api.transport.PropertyScope;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 import org.mule.transport.http.HttpConstants;
@@ -17,8 +20,10 @@ import org.mule.transport.http.HttpResponse;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.httpclient.Cookie;
@@ -93,5 +98,36 @@ public class MuleMessageToHttpResponseTestCase extends AbstractMuleTestCase
             }
         }
         Assert.assertTrue("Missing 'Date' header", hasDateHeader);
+    }
+    
+    @Test
+    public void testContentTypeOnOutbound() throws Exception
+    {
+        MuleMessageToHttpResponse transformer = new MuleMessageToHttpResponse();
+        final String contentType = "text/xml";
+        final String wrongContentType = "text/json";
+        Map<String, Object> outboundProperties =  new HashMap<String, Object>();
+        outboundProperties.put(HttpConstants.HEADER_CONTENT_TYPE, wrongContentType);
+        MuleContext muleContext = mock(MuleContext.class);
+        MuleMessage msg = new DefaultMuleMessage(null,outboundProperties, muleContext);
+        //Making sure that the outbound property overrides both invocation and inbound
+        msg.setInvocationProperty(HttpConstants.HEADER_CONTENT_TYPE, wrongContentType);
+        msg.setProperty(HttpConstants.HEADER_CONTENT_TYPE, wrongContentType, PropertyScope.INBOUND);
+        
+        msg.setOutboundProperty(HttpConstants.HEADER_CONTENT_TYPE, contentType);
+
+        HttpResponse response = transformer.createResponse(null, "UTF-8", msg);
+        Header[] headers = response.getHeaders();
+
+        boolean hasContentTypeHeader = false;
+        for (Header header : headers)
+        {
+            if (HttpConstants.HEADER_CONTENT_TYPE.equals(header.getName()))
+            {
+                hasContentTypeHeader = true;
+                Assert.assertEquals(contentType, header.getValue());
+            }
+        }
+        Assert.assertTrue("Missing "+HttpConstants.HEADER_CONTENT_TYPE+" header", hasContentTypeHeader);
     }
 }


### PR DESCRIPTION
the content type header
