### PR TITLE
MULE-7040:Request-reply throwing ResponseTimeoutException on Mule shutdo...

### DIFF
--- a/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
+++ b/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
@@ -82,7 +82,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
         }
         else
         {
-            locks.put(getAsyncReplyCorrelationId(event), new Latch());
+            locks.put(getAsyncReplyCorrelationId(event), createEventLock());
 
             sendAsyncRequest(event);
 
@@ -101,6 +101,15 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
             }
             return resultEvent;
         }
+    }
+
+    /**
+     * Creates the lock used to synchronize a given event
+     * @return a new Latch instance
+     */
+    protected Latch createEventLock()
+    {
+        return new Latch();
     }
 
     public void setTimeout(long timeout)
@@ -243,12 +252,8 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
             if (interruptedWhileWaiting)
             {
                 Thread.currentThread().interrupt();
+                return null;
             }
-        }
-
-        if (interruptedWhileWaiting)
-        {
-            Thread.currentThread().interrupt();
         }
 
         if (resultAvailable)

--- a/core/src/test/java/org/mule/routing/requestreply/AsyncRequestReplyRequesterTestCase.java
+++ b/core/src/test/java/org/mule/routing/requestreply/AsyncRequestReplyRequesterTestCase.java
@@ -6,6 +6,12 @@
  */
 package org.mule.routing.requestreply;
 
+import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import org.mule.MessageExchangePattern;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -14,24 +20,24 @@ import org.mule.api.config.MuleProperties;
 import org.mule.api.context.WorkManager;
 import org.mule.api.context.WorkManagerSource;
 import org.mule.api.endpoint.InboundEndpoint;
-import org.mule.api.lifecycle.InitialisationException;
-import org.mule.api.processor.RequestReplyRequesterMessageProcessor;
+import org.mule.api.processor.MessageProcessor;
 import org.mule.api.routing.ResponseTimeoutException;
 import org.mule.api.service.Service;
+import org.mule.api.source.MessageSource;
 import org.mule.processor.LaxAsyncInterceptingMessageProcessor;
 import org.mule.tck.SensingNullMessageProcessor;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.util.concurrent.Latch;
+import org.mule.util.store.MuleObjectStoreManager;
 
 import java.beans.ExceptionListener;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.resource.spi.work.Work;
 
 import org.junit.Test;
-import org.mule.util.store.MuleObjectStoreManager;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class AsyncRequestReplyRequesterTestCase extends AbstractMuleContextTestCase
     implements ExceptionListener
@@ -139,6 +145,66 @@ public class AsyncRequestReplyRequesterTestCase extends AbstractMuleContextTestC
         {
             assertEquals(ResponseTimeoutException.class, e.getClass());
         }
+    }
+
+    @Test
+    public void returnsNullWhenInterruptedWhileWaitingForReply() throws Exception
+    {
+        final Latch fakeLatch = new Latch()
+        {
+            @Override
+            public void await() throws InterruptedException
+            {
+                throw new InterruptedException();
+            }
+        };
+
+        asyncReplyMP = new TestAsyncRequestReplyRequester(muleContext)
+        {
+            @Override
+            protected Latch createEventLock()
+            {
+                return fakeLatch;
+            }
+        };
+
+        final MuleEvent event = getTestEvent(TEST_MESSAGE, getTestService(),
+                                             getTestInboundEndpoint(MessageExchangePattern.ONE_WAY));
+
+        final CountDownLatch processingLatch = new CountDownLatch(1);
+
+        MessageProcessor target = mock(MessageProcessor.class);
+        asyncReplyMP.setListener(target);
+
+        MessageSource messageSource = mock(MessageSource.class);
+        asyncReplyMP.setReplySource(messageSource);
+
+        final boolean[] exceptionThrown = new boolean[1];
+        final Object[] responseEvent = new Object[1];
+
+        Thread thread = new Thread(new Runnable()
+        {
+            public void run()
+            {
+                try
+                {
+                    responseEvent[0] = asyncReplyMP.process(event);
+                }
+                catch (MuleException e)
+                {
+                    exceptionThrown[0] = true;
+                }
+                finally
+                {
+                    processingLatch.countDown();
+                }
+            }
+        });
+
+        thread.start();
+        assertTrue(processingLatch.await(RECEIVE_TIMEOUT, TimeUnit.MILLISECONDS));
+        assertFalse(exceptionThrown[0]);
+        assertNull(responseEvent[0]);
     }
 
     @Test


### PR DESCRIPTION
...wn

_ Adding AbstractAsyncRequestReplyRequester#createEventLock factory method to be able to use fake Latchs on tests.
