### PR TITLE
MULE-7042: Event correlation timeout incorrectly detected on cluster

### DIFF
--- a/core/src/main/java/org/mule/routing/EventGroup.java
+++ b/core/src/main/java/org/mule/routing/EventGroup.java
@@ -75,7 +75,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
                       String storePrefix)
     {
         super();
-        this.created = System.nanoTime();
+        this.created = System.currentTimeMillis();
         this.muleContext = muleContext;
         this.storePrefix = storePrefix;
 
@@ -293,7 +293,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
     }
 
     /**
-     * Return the creation timestamp of the current group in nanoseconds.
+     * Return the creation timestamp of the current group in milliseconds.
      *
      * @return the timestamp when this group was instantiated.
      */

--- a/core/src/main/java/org/mule/routing/correlation/EventCorrelator.java
+++ b/core/src/main/java/org/mule/routing/correlation/EventCorrelator.java
@@ -59,8 +59,6 @@ public class EventCorrelator implements Startable, Stoppable, Disposable
 
     public static final int MAX_PROCESSED_GROUPS = 50000;
 
-    protected static final long MILLI_TO_NANO_MULTIPLIER = 1000000L;
-
     private static final long ONE_DAY_IN_MILLI = 1000 * 60 * 60 * 24;
 
     protected long groupTimeToLive = ONE_DAY_IN_MILLI;
@@ -335,7 +333,7 @@ public class EventCorrelator implements Startable, Stoppable, Disposable
     {
         synchronized (groupsLock)
         {
-            processedGroups.store((Serializable) id, System.nanoTime());
+            processedGroups.store((Serializable) id, System.currentTimeMillis());
         }
     }
 
@@ -540,7 +538,7 @@ public class EventCorrelator implements Startable, Stoppable, Disposable
                 for (Serializable o : eventGroups.allKeys())
                 {
                     EventGroup group = getEventGroup(o) ;
-                    if ((group.getCreated() + getTimeout() * MILLI_TO_NANO_MULTIPLIER) < System.nanoTime())
+                    if (group.getCreated() + getTimeout() < System.currentTimeMillis())
                     {
                         expired.add(group);
                     }


### PR DESCRIPTION
Fixing the problem replacing  System.nanoTime with System.currentTimeMillis that is consistent across different machines provided that their clocks are synchronized
