### PR TITLE
Fix flaky test: HttpRequestDispatcherTestCase

### DIFF
--- a/transports/http/src/test/java/org/mule/transport/http/HttpRequestDispatcherTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/HttpRequestDispatcherTestCase.java
@@ -8,6 +8,7 @@ package org.mule.transport.http;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -120,7 +121,7 @@ public class HttpRequestDispatcherTestCase extends AbstractMuleTestCase
             {
                 fail("retry template should be executed");
             }
-            verify(mockExceptionListener, Mockito.atLeast(1)).handleException(Mockito.isA(Exception.class));
+            verify(mockExceptionListener, timeout(WAIT_TIME)).handleException(Mockito.isA(Exception.class));
         }
         finally
         {


### PR DESCRIPTION
_ There was a race condition where  acceptCalledLath.await returned true before the exception was thrown and manage.
