### PR TITLE
Fix flaky tests that use SftpServer (like SftpFileNameFilterTestCase) wh...

### DIFF
--- a/tests/functional/src/main/java/org/mule/tck/util/sftp/SftpServer.java
+++ b/tests/functional/src/main/java/org/mule/tck/util/sftp/SftpServer.java
@@ -89,7 +89,7 @@ public class SftpServer
     {
         try
         {
-            sshdServer.stop();
+            sshdServer.stop(true);
         }
         catch (InterruptedException e)
         {


### PR DESCRIPTION
...ich fail randomly when stopping the server
