### PR TITLE
Scripting pack libraries should also go to inside lib directory. MULE-7059

### DIFF
--- a/distributions/studio/assembly.xml
+++ b/distributions/studio/assembly.xml
@@ -39,7 +39,7 @@
     <dependencySets>
         <!-- Scripting pack libraries -->
         <dependencySet>
-            <outputDirectory>user</outputDirectory>
+            <outputDirectory>lib/user</outputDirectory>
             <scope>runtime</scope>
             <fileMode>0644</fileMode>
         </dependencySet>


### PR DESCRIPTION
Adding missing libraries.
