### PR TITLE
Fixing flaky test: MuleServerTestCase

### DIFF
--- a/tests/functional/src/test/java/org/mule/MuleServerTestCase.java
+++ b/tests/functional/src/test/java/org/mule/MuleServerTestCase.java
@@ -6,21 +6,29 @@
  */
 package org.mule;
 
-import java.security.Permission;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.util.ClassUtils;
 import org.mule.util.FilenameUtils;
 import org.mule.util.JdkVersionUtils;
 
-import org.junit.Test;
+import java.security.Permission;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.After;
+import org.junit.Test;
 
 public class MuleServerTestCase extends AbstractMuleTestCase
 {
+
+    private static String originalConfigBuilderClassName = MuleServer.getConfigBuilderClassName();
+
+    @After
+    public void restoreOriginalConfigBuilderClassName() throws Exception
+    {
+        MuleServer.setConfigBuilderClassName(originalConfigBuilderClassName);
+    }
 
     @Test
     public void testMuleServer() throws Exception
@@ -82,7 +90,7 @@ public class MuleServerTestCase extends AbstractMuleTestCase
         assertEquals("org.mule.config.spring.SpringXmlConfigurationBuilder", MuleServer.getConfigBuilderClassName());
         muleServer.initialize();
     }
-    
+
     @Test
     public void testMuleServerAppConfig() throws Exception
     {
@@ -95,7 +103,7 @@ public class MuleServerTestCase extends AbstractMuleTestCase
         final String workingDirectory = MuleServer.muleContext.getConfiguration().getWorkingDirectory();
         assertTrue(FilenameUtils.separatorsToUnix(workingDirectory).endsWith("/target/.appT"));
     }
-    
+
     @Test(expected=ExitException.class)
     public void testMuleServerJdkVersion()
     {
@@ -121,7 +129,7 @@ public class MuleServerTestCase extends AbstractMuleTestCase
 	    	finally
 	    	{
 		        System.setSecurityManager(manager);
-	    	}   
+	    	}
     	}
     	finally
     	{


### PR DESCRIPTION
_Test is flaky because it depends on the other on which test methods are executed. Sometimes the execution order is not the usual "from top to bottom" and some tests broke because a static property in MuleServer has a different value.
