### PR TITLE
MULE-7050: MuleApplicationClassLoader loadClass() method not synchronize...

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/FineGrainedControlClassLoader.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/FineGrainedControlClassLoader.java
@@ -71,7 +71,7 @@ public class FineGrainedControlClassLoader extends GoodCitizenClassLoader
     }
 
     @Override
-    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException
+    protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException
     {
         Class<?> result = findLoadedClass(name);
 

--- a/modules/launcher/src/main/java/org/mule/module/launcher/MuleApplicationClassLoader.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/MuleApplicationClassLoader.java
@@ -141,12 +141,6 @@ public class MuleApplicationClassLoader extends FineGrainedControlClassLoader im
     }
 
     @Override
-    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException
-    {
-        return super.loadClass(name, resolve);
-    }
-
-    @Override
     public URL getResource(String name)
     {
         return super.getResource(name);

--- a/modules/launcher/src/test/java/org/mule/module/launcher/FineGrainedControlClassLoaderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/FineGrainedControlClassLoaderTestCase.java
@@ -6,7 +6,10 @@
  */
 package org.mule.module.launcher;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.junit4.FlakinessDetectorTestRunner;
 import org.mule.tck.size.SmallTest;
 
 import java.net.URL;
@@ -14,12 +17,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.runner.RunWith;
 
 @SmallTest
-public class FineGrainedControlClassLoaderTest extends AbstractMuleTestCase
+@RunWith(FlakinessDetectorTestRunner.class)
+public class FineGrainedControlClassLoaderTestCase extends AbstractMuleTestCase
 {
     @Test
     public void isBlockedFQClassName() throws Exception

--- a/modules/launcher/src/test/java/org/mule/module/launcher/SynchronizedClassLoaderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/SynchronizedClassLoaderTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher;
+
+import static org.junit.Assert.assertFalse;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.MediumTest;
+
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+@MediumTest
+public class SynchronizedClassLoaderTestCase extends AbstractMuleTestCase
+{
+
+    private final CountDownLatch onExclusionZone = new CountDownLatch(2);
+    private final CountDownLatch onTestComplete = new CountDownLatch(1);
+
+    @Test
+    public void synchronizesLoadClassInFineGrainedControlClassLoader() throws Exception
+    {
+        doLoadClassSynchronizationTest(new FineGrainedControlClassLoader(new URL[] {}, new TestClassLoader()));
+    }
+
+    @Test
+    public void synchronizesLoadClassInMuleApplicationClassLoader() throws Exception
+    {
+        doLoadClassSynchronizationTest(new MuleApplicationClassLoader("test", new TestClassLoader()));
+    }
+
+    private void doLoadClassSynchronizationTest(ClassLoader classLoader) throws InterruptedException
+    {
+
+        LoadClass loadClass1 = new LoadClass(classLoader);
+        Thread thread1 = new Thread(loadClass1);
+
+        LoadClass loadClass2 = new LoadClass(classLoader);
+        Thread thread2 = new Thread(loadClass2);
+
+        try
+        {
+            thread1.start();
+            thread2.start();
+
+            assertFalse("There are multiple threads loading classes", onExclusionZone.await(250, TimeUnit.MILLISECONDS));
+            assertFalse(loadClass1.error);
+            assertFalse(loadClass2.error);
+        }
+        finally
+        {
+            onTestComplete.countDown();
+        }
+    }
+
+    private static class LoadClass implements Runnable
+    {
+
+        private final ClassLoader classLoader;
+        private boolean error;
+
+        public LoadClass(ClassLoader classLoader)
+        {
+            this.classLoader = classLoader;
+        }
+
+        public void run()
+        {
+            try
+            {
+                classLoader.loadClass("org.mule.Foo");
+            }
+            catch (Exception e)
+            {
+                error = true;
+            }
+        }
+    }
+
+    private class TestClassLoader extends ClassLoader
+    {
+
+        @Override
+        public Class<?> loadClass(String s) throws ClassNotFoundException
+        {
+            onExclusionZone.countDown();
+
+            try
+            {
+                onTestComplete.await();
+            }
+            catch (InterruptedException e)
+            {
+                throw new IllegalStateException(e);
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
...d

_Adding synchronizing FineGrainedControlClassLoader#loadClass(String,boolean)
_Removing  MuleApplicationClassLoader#loadClass(String, boolean) override
_Adding test to verify the fix
_Renaming FineGrainedControlClassLoaderTest to FineGrainedControlClassLoaderTestCase
