### PR TITLE
MULE-7088: Improve the way Mime types are registered for outbound http attachments

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleMessage.java
+++ b/core/src/main/java/org/mule/DefaultMuleMessage.java
@@ -24,6 +24,8 @@ import org.mule.api.transport.OutputHandler;
 import org.mule.api.transport.PropertyScope;
 import org.mule.config.MuleManifest;
 import org.mule.config.i18n.CoreMessages;
+import org.mule.message.ds.ByteArrayDataSource;
+import org.mule.message.ds.StringDataSource;
 import org.mule.transformer.TransformerUtils;
 import org.mule.transformer.types.DataTypeFactory;
 import org.mule.transformer.types.MimeTypes;
@@ -1105,6 +1107,21 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
             {
                 dh = new DataHandler((URL) object);
             }
+        }
+        else if (object instanceof String)
+        {
+            if (contentType != null)
+            {
+                dh = new DataHandler(new StringDataSource((String) object, name, contentType));
+            }
+            else
+            {
+                dh = new DataHandler(new StringDataSource((String) object, name));
+            }
+        }
+        else if (object instanceof byte[] && contentType != null)
+        {
+            dh = new DataHandler(new ByteArrayDataSource((byte[]) object, contentType, name));
         }
         else
         {

--- a/core/src/main/java/org/mule/message/ds/ByteArrayDataSource.java
+++ b/core/src/main/java/org/mule/message/ds/ByteArrayDataSource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.message.ds;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import javax.activation.DataSource;
+
+public class ByteArrayDataSource implements DataSource
+{
+
+    private final byte[] data;
+    private final String contentType;
+    private final String name;
+
+    public ByteArrayDataSource(byte[] data, String contentType, String name)
+    {
+        this.data = data;
+        this.contentType = contentType;
+        this.name = name;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException
+    {
+        return new ByteArrayInputStream(data);
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException
+    {
+        throw new IOException("Cannot write into a ByteArrayDataSource");
+    }
+
+    @Override
+    public String getContentType()
+    {
+        return contentType;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/transports/http/pom.xml
+++ b/transports/http/pom.xml
@@ -99,12 +99,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <!-- This dependency is needed for MIME types but should be removed. See MULE-7088 -->
-            <groupId>org.mule.transports</groupId>
-            <artifactId>mule-transport-email</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>

--- a/transports/http/src/test/java/org/mule/transport/http/functional/HttpOutboundAttachmentFunctionalTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/functional/HttpOutboundAttachmentFunctionalTestCase.java
@@ -19,8 +19,6 @@ import org.junit.Test;
 public class HttpOutboundAttachmentFunctionalTestCase extends FunctionalTestCase
 {
 
-    private static final String TEST_ENDPOINT = "vm://in";
-
     @Rule
     public DynamicPort httpPort = new DynamicPort("port");
 
@@ -31,10 +29,22 @@ public class HttpOutboundAttachmentFunctionalTestCase extends FunctionalTestCase
     }
 
     @Test
-    public void sendsAttachmentCorrectlyInHttpOutboundEndpoint() throws Exception
+    public void sendsStringAttachmentCorrectly() throws Exception
+    {
+        sendMessageAndAssertResponse("vm://inString");
+    }
+
+    @Test
+    public void sendsByteArrayAttachmentCorrectly() throws Exception
+    {
+        sendMessageAndAssertResponse("vm://inByteArray");
+    }
+
+
+    private void sendMessageAndAssertResponse(String endpoint) throws Exception
     {
         MuleClient client = muleContext.getClient();
-        MuleMessage answer = client.send(TEST_ENDPOINT, TEST_MESSAGE, null);
+        MuleMessage answer = client.send(endpoint, TEST_MESSAGE, null);
         assertEquals(TEST_MESSAGE, answer.getPayloadAsString());
     }
 }

--- a/transports/http/src/test/resources/http-outbound-attachments-config.xml
+++ b/transports/http/src/test/resources/http-outbound-attachments-config.xml
@@ -8,9 +8,16 @@
           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
-    <flow name="client">
-        <vm:inbound-endpoint path="in" exchange-pattern="request-response"/>
+    <flow name="stringAttachment">
+        <vm:inbound-endpoint path="inString" exchange-pattern="request-response"/>
         <set-attachment attachmentName="file" value="#[payload]" contentType="text/plain"/>
+        <http:outbound-endpoint host="localhost" port="${port}" path="upload" method="POST"/>
+    </flow>
+
+    <flow name="byteArrayAttachment">
+        <vm:inbound-endpoint path="inByteArray" exchange-pattern="request-response"/>
+        <string-to-byte-array-transformer />
+        <set-attachment attachmentName="file" value="#[payload]" contentType="application/zip"/>
         <http:outbound-endpoint host="localhost" port="${port}" path="upload" method="POST"/>
     </flow>
 


### PR DESCRIPTION
Removed dependency between http and email transport by using custom data sources that don't require Mime types to be previously registered.
