### PR TITLE
MULE-7125: requireClientAuthentication="true" not working on jetty SSL connector

### DIFF
--- a/transports/jetty/src/test/java/org/mule/transport/servlet/jetty/functional/JettyHttpsClientAuthenticationTestCase.java
+++ b/transports/jetty/src/test/java/org/mule/transport/servlet/jetty/functional/JettyHttpsClientAuthenticationTestCase.java
@@ -15,7 +15,7 @@ import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.transport.NullPayload;
 
-import java.net.SocketException;
+import java.io.IOException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,7 +46,7 @@ public class JettyHttpsClientAuthenticationTestCase extends FunctionalTestCase
         MuleClient client = muleContext.getClient();
         MuleMessage response = client.send("vm://notAuthenticatedClientEndpoint", TEST_MESSAGE, null);
         assertEquals(NullPayload.getInstance(), response.getPayload());
-        assertTrue(response.getExceptionPayload().getException().getCause() instanceof SocketException);
+        assertTrue(response.getExceptionPayload().getException().getCause() instanceof IOException);
     }
 
 }


### PR DESCRIPTION
Fixing flaky test "rejectsClientWithoutAuthentication". The exception thrown in the client when the server rejects the connection depends on the JVM.
