### PR TITLE
MULE-7144: Differentiate TCP connection timeout from responseTimeout

### DIFF
--- a/transports/tcp/src/main/java/org/mule/transport/tcp/TcpConnector.java
+++ b/transports/tcp/src/main/java/org/mule/transport/tcp/TcpConnector.java
@@ -57,6 +57,7 @@ public class TcpConnector extends AbstractConnector
 
     private int clientSoTimeout = DEFAULT_SOCKET_TIMEOUT;
     private int serverSoTimeout = DEFAULT_SOCKET_TIMEOUT;
+    private int connectionTimeout = DEFAULT_SOCKET_TIMEOUT;
     private int socketMaxWait = DEFAULT_WAIT_TIMEOUT;
     private int sendBufferSize = DEFAULT_BUFFER_SIZE;
     private int receiveBufferSize = DEFAULT_BUFFER_SIZE;
@@ -92,7 +93,6 @@ public class TcpConnector extends AbstractConnector
     public TcpConnector(MuleContext context)
     {
         super(context);
-        setSocketFactory(new TcpSocketFactory());
         setServerSocketFactory(new TcpServerSocketFactory());
         setTcpProtocol(new SafeProtocol());
     }
@@ -147,6 +147,9 @@ public class TcpConnector extends AbstractConnector
     @Override
     protected void doInitialise() throws InitialisationException
     {
+        TcpSocketFactory tcpSocketFactory = new TcpSocketFactory(getConnectionTimeout());
+        setSocketFactory(tcpSocketFactory);
+
         socketsPool.setFactory(getSocketFactory());
         socketsPool.setTestOnBorrow(true);
         socketsPool.setTestOnReturn(true);
@@ -313,6 +316,16 @@ public class TcpConnector extends AbstractConnector
     public void setClientSoTimeout(int timeout)
     {
         this.clientSoTimeout = valueOrDefault(timeout, 0, DEFAULT_SOCKET_TIMEOUT);
+    }
+
+    public int getConnectionTimeout()
+    {
+        return this.connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int timeout)
+    {
+        this.connectionTimeout= valueOrDefault(timeout, 0, DEFAULT_SOCKET_TIMEOUT);
     }
 
     public int getServerSoTimeout()

--- a/transports/tcp/src/main/java/org/mule/transport/tcp/TcpSocketFactory.java
+++ b/transports/tcp/src/main/java/org/mule/transport/tcp/TcpSocketFactory.java
@@ -6,6 +6,8 @@
  */
 package org.mule.transport.tcp;
 
+import org.mule.api.transport.Connector;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -13,10 +15,20 @@ import java.net.Socket;
 public class TcpSocketFactory extends AbstractTcpSocketFactory
 {
 
+    private final int connectionTimeout;
+
+    public TcpSocketFactory(int connectionTimeout)
+    {
+        this.connectionTimeout = connectionTimeout;
+    }
+
     protected Socket createSocket(TcpSocketKey key) throws IOException
     {
         Socket socket = new Socket();
-        socket.connect(new InetSocketAddress(key.getInetAddress(), key.getPort()), key.getEndpoint().getResponseTimeout());
+
+        int timeout = connectionTimeout != Connector.INT_VALUE_NOT_SET ? connectionTimeout : key.getEndpoint().getResponseTimeout();
+
+        socket.connect(new InetSocketAddress(key.getInetAddress(), key.getPort()), timeout);
         return socket;
     }
 

--- a/transports/tcp/src/main/resources/META-INF/mule-tcp.xsd
+++ b/transports/tcp/src/main/resources/META-INF/mule-tcp.xsd
@@ -103,6 +103,13 @@
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="connectionTimeout" type="mule:substitutableInt">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Number of milliseconds to wait until an outbound connection to a remote server is successfully created. No timeout is configured by default.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
                 <xsd:attribute name="clientSoTimeout" type="mule:substitutableInt">
                     <xsd:annotation>
                         <xsd:documentation>

--- a/transports/tcp/src/test/java/org/mule/transport/tcp/TcpConnectorTestCase.java
+++ b/transports/tcp/src/test/java/org/mule/transport/tcp/TcpConnectorTestCase.java
@@ -6,12 +6,11 @@
  */
 package org.mule.transport.tcp;
 
+import static org.junit.Assert.assertEquals;
 import org.mule.api.transport.Connector;
 import org.mule.transport.AbstractConnectorTestCase;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class TcpConnectorTestCase extends AbstractConnectorTestCase
 {
@@ -47,9 +46,13 @@ public class TcpConnectorTestCase extends AbstractConnectorTestCase
         assertEquals(TcpConnector.DEFAULT_SOCKET_TIMEOUT, c.getServerSoTimeout());
         c.setClientSoTimeout(-1);
         assertEquals(TcpConnector.DEFAULT_SOCKET_TIMEOUT, c.getClientSoTimeout());
+        c.setConnectionTimeout(-1);
+        assertEquals(TcpConnector.DEFAULT_SOCKET_TIMEOUT, c.getConnectionTimeout());
         c.setClientSoTimeout(1000);
         c.setServerSoTimeout(1000);
+        c.setConnectionTimeout(1000);
         assertEquals(1000, c.getServerSoTimeout());
         assertEquals(1000, c.getClientSoTimeout());
+        assertEquals(1000, c.getConnectionTimeout());
     }
 }

--- a/transports/tcp/src/test/java/org/mule/transport/tcp/TcpNamespaceHandlerTestCase.java
+++ b/transports/tcp/src/test/java/org/mule/transport/tcp/TcpNamespaceHandlerTestCase.java
@@ -43,6 +43,7 @@ public class TcpNamespaceHandlerTestCase extends FunctionalTestCase
         // this is what we want - i was worried that the client was used as default if the server
         // wasn't set, but that's not the case
         assertEquals(-1, c.getServerSoTimeout());
+        assertEquals(-1, c.getConnectionTimeout());
         assertEquals(3000, c.getClientSoTimeout());
         assertEquals(3000, c.getSocketMaxWait());
         assertTrue(c.isKeepAlive());
@@ -60,6 +61,7 @@ public class TcpNamespaceHandlerTestCase extends FunctionalTestCase
         assertNotNull(c);
         assertEquals(4000, c.getServerSoTimeout());
         assertEquals(3000, c.getClientSoTimeout());
+        assertEquals(2000, c.getConnectionTimeout());
         assertEquals(-1, c.getSocketMaxWait());
         assertTrue(c.isConnected());
         assertTrue(c.isStarted());

--- a/transports/tcp/src/test/java/org/mule/transport/tcp/integration/TcpConnectionTimeoutTestCase.java
+++ b/transports/tcp/src/test/java/org/mule/transport/tcp/integration/TcpConnectionTimeoutTestCase.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.tcp.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import org.mule.api.FutureMessageResult;
+import org.mule.api.MuleMessage;
+import org.mule.module.client.MuleClient;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.transport.NullPayload;
+
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+public class TcpConnectionTimeoutTestCase extends FunctionalTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "tcp-connection-timeout-config.xml";
+    }
+
+    @Test
+    public void usesConnectionTimeout() throws Exception
+    {
+        final MuleClient client = new MuleClient(muleContext);
+        FutureMessageResult result = client.sendAsync("vm://testInput", TEST_MESSAGE, null);
+
+        MuleMessage message = null;
+        try
+        {
+            message = result.getMessage(1000);
+        }
+        catch (TimeoutException e)
+        {
+            fail("Connection timeout not honored.");
+        }
+
+        assertEquals(NullPayload.getInstance(), message.getPayload());
+        assertNotNull(message.getExceptionPayload());
+    }
+}

--- a/transports/tcp/src/test/resources/tcp-connection-timeout-config.xml
+++ b/transports/tcp/src/test/resources/tcp-connection-timeout-config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:tcp="http://www.mulesoft.org/schema/mule/tcp"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/tcp http://www.mulesoft.org/schema/mule/tcp/current/mule-tcp.xsd
+            http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <tcp:connector name="tcpConnector" connectionTimeout="1"/>
+
+    <flow name="testConnectionTimeout">
+        <vm:inbound-endpoint path="testInput" exchange-pattern="request-response"/>
+
+        <!-- Uses a big responseTimeout so it' clear that the connection timeout is caused by the connectionTimeout attribute -->
+        <tcp:outbound-endpoint address="tcp://1.2.3.4:9003" exchange-pattern="request-response" responseTimeout="500000"/>
+    </flow>
+
+</mule>

--- a/transports/tcp/src/test/resources/tcp-namespace-config.xml
+++ b/transports/tcp/src/test/resources/tcp-namespace-config.xml
@@ -21,6 +21,7 @@
     </tcp:connector>
 
     <tcp:connector name="separateTimeouts"
+                   connectionTimeout="2000"
                    clientSoTimeout="3000"
                    serverSoTimeout="4000"/>
                    


### PR DESCRIPTION
_TcpSocketFactory: passing connectionTimeout in constructor. When no connectionTimeout is configured defaults to key.getEndpoint().getResponseTimeout() as before.
_TcpConnector: adding connectionTimeout property
_TcpConnector: moved TcpSocketFactory instantiation to doInitialise in order to apply the correct connection timeout
