### PR TITLE
MULE-7148: Differentiate HTTP connection timeout from responseTimeout

### DIFF
--- a/transports/http/pom.xml
+++ b/transports/http/pom.xml
@@ -194,5 +194,11 @@
             <artifactId>jetty-servlet</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.modules</groupId>
+            <artifactId>mule-module-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/transports/http/src/main/java/org/mule/transport/http/HttpClientMessageDispatcher.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpClientMessageDispatcher.java
@@ -196,7 +196,6 @@ public class HttpClientMessageDispatcher extends AbstractMessageDispatcher
         // precedence and is not available before send/dispatch.
         // Given that dispatchers are borrowed from a thread pool mutating client
         // here is ok even though it is not ideal.
-        client.getHttpConnectionManager().getParams().setConnectionTimeout(endpoint.getResponseTimeout());
         client.getHttpConnectionManager().getParams().setSoTimeout(endpoint.getResponseTimeout());
 
         MuleMessage msg = event.getMessage();

--- a/transports/http/src/main/java/org/mule/transport/http/HttpConnector.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpConnector.java
@@ -171,6 +171,7 @@ public class HttpConnector extends TcpConnector
     public static final String COOKIE_SPEC_NETSCAPE = "netscape";
     public static final String COOKIE_SPEC_RFC2109 = "rfc2109";
     public static final String ROOT_PATH = "/";
+    public static final int DEFAULT_CONNECTION_TIMEOUT = 2000;
 
     private String proxyHostname = null;
 
@@ -237,6 +238,16 @@ public class HttpConnector extends TcpConnector
             params.setTcpNoDelay(isSendTcpNoDelay());
             params.setMaxTotalConnections(dispatchers.getMaxTotal());
             params.setDefaultMaxConnectionsPerHost(dispatchers.getMaxTotal());
+
+            if (getConnectionTimeout() != INT_VALUE_NOT_SET)
+            {
+                params.setConnectionTimeout(getConnectionTimeout());
+            }
+            else
+            {
+                params.setConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT);
+            }
+
             clientConnectionManager.setParams(params);
         }
         //connection manager must be created during initialization due that devkit requires the connection manager before start phase.

--- a/transports/http/src/main/resources/META-INF/mule-http.xsd
+++ b/transports/http/src/main/resources/META-INF/mule-http.xsd
@@ -384,6 +384,13 @@
                 <xsd:documentation>Controls if the connection is kept alive.</xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="connectionTimeout" type="mule:substitutableInt">
+            <xsd:annotation>
+                <xsd:documentation>
+                    Number of milliseconds to wait until a connection to a remote server is successfully created. When no value is specified a default timeout of 2000ms is used
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
     </xsd:attributeGroup>
 
     <xsd:simpleType name="httpMethodTypes">

--- a/transports/http/src/test/java/org/mule/transport/http/AbstractNamespaceHandlerTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/AbstractNamespaceHandlerTestCase.java
@@ -41,6 +41,7 @@ public abstract class AbstractNamespaceHandlerTestCase extends FunctionalTestCas
         assertEquals(5678, connector.getSendBufferSize());
         assertEquals(6789, connector.getSocketSoLinger());
         assertEquals(7890, connector.getServerSoTimeout());
+        assertEquals(4000, connector.getConnectionTimeout());
         assertEquals(true, connector.isEnableCookies());
         assertEquals(true, connector.isKeepAlive());
         assertEquals(true, connector.isKeepSendSocketOpen());

--- a/transports/http/src/test/java/org/mule/transport/http/HttpConnectionTimeoutTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/HttpConnectionTimeoutTestCase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import org.mule.api.FutureMessageResult;
+import org.mule.api.MuleMessage;
+import org.mule.module.client.MuleClient;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.transport.NullPayload;
+
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+public class HttpConnectionTimeoutTestCase extends FunctionalTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-connection-timeout-config.xml";
+    }
+
+    @Test
+    public void usesConnectionTimeout() throws Exception
+    {
+
+        final MuleClient client = new MuleClient(muleContext);
+        FutureMessageResult result = client.sendAsync("vm://testInput", TEST_MESSAGE, null);
+
+        MuleMessage message = null;
+        try
+        {
+            message = result.getMessage(1000);
+        }
+        catch (TimeoutException e)
+        {
+            fail("Connection timeout not honored.");
+        }
+
+        assertEquals(NullPayload.getInstance(), message.getPayload());
+        assertNotNull(message.getExceptionPayload());
+    }
+}

--- a/transports/http/src/test/java/org/mule/transport/http/HttpsConnectionTimeoutTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/HttpsConnectionTimeoutTestCase.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.http;
+
+public class HttpsConnectionTimeoutTestCase extends HttpConnectionTimeoutTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "https-connection-timeout-config.xml";
+    }
+}

--- a/transports/http/src/test/resources/http-connection-timeout-config.xml
+++ b/transports/http/src/test/resources/http-connection-timeout-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+            http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <http:connector name="httpConnector" connectionTimeout="1"/>
+
+    <flow name="testConnectionTimeout">
+        <vm:inbound-endpoint path="testInput" exchange-pattern="request-response"/>
+
+        <!-- Uses a big responseTimeout so it' clear that the connection timeout is caused by the connectionTimeout attribute -->
+        <http:outbound-endpoint address="http://1.2.3.4:9003" exchange-pattern="request-response" responseTimeout="50000"/>
+    </flow>
+</mule>

--- a/transports/http/src/test/resources/http-namespace-config.xml
+++ b/transports/http/src/test/resources/http-namespace-config.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:spring="http://www.springframework.org/schema/beans"
        xmlns:http="http://www.mulesoft.org/schema/mule/http"
     xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
 
@@ -24,7 +22,8 @@
                     keepAlive="true"
                     keepSendSocketOpen="true"
                     sendTcpNoDelay="true"
-                    validateConnections="false"/>
+                    validateConnections="false"
+                    connectionTimeout="4000"/>
 
     <http:polling-connector name="polling" checkEtag="false" pollingFrequency="3456" discardEmptyContent="false"/>
     

--- a/transports/http/src/test/resources/http-placeholder-test.xml
+++ b/transports/http/src/test/resources/http-placeholder-test.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:spring="http://www.springframework.org/schema/beans"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:http="http://www.mulesoft.org/schema/mule/http"
     xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd
        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
@@ -29,6 +27,7 @@
                     keepSendSocketOpen="true"
                     sendTcpNoDelay="true"
                     validateConnections="false"
+                    connectionTimeout="4000"
     />
     
 </mule>

--- a/transports/http/src/test/resources/https-connection-timeout-config.xml
+++ b/transports/http/src/test/resources/https-connection-timeout-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:https="http://www.mulesoft.org/schema/mule/https"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/https http://www.mulesoft.org/schema/mule/https/current/mule-https.xsd
+            http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <https:connector name="httpConnector" connectionTimeout="1"/>
+
+    <flow name="testConnectionTimeout">
+        <vm:inbound-endpoint path="testInput" exchange-pattern="request-response"/>
+
+        <!-- Uses a big responseTimeout so it' clear that the connection timeout is caused by the connectionTimeout attribute -->
+        <https:outbound-endpoint address="https://1.2.3.4:9003" exchange-pattern="request-response" responseTimeout="50000"/>
+    </flow>
+</mule>

--- a/transports/http/src/test/resources/https-namespace-config.xml
+++ b/transports/http/src/test/resources/https-namespace-config.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:spring="http://www.springframework.org/schema/beans"
        xmlns:https="http://www.mulesoft.org/schema/mule/https"
     xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/https http://www.mulesoft.org/schema/mule/https/current/mule-https.xsd">
 
@@ -12,7 +10,7 @@
                      proxyPassword="cde" proxyPort="2345" proxyUsername="def" receiveBacklog="34"
                      receiveBufferSize="4567" sendBufferSize="5678" socketSoLinger="6789" serverSoTimeout="7890"
                      enableCookies="true" keepAlive="true" keepSendSocketOpen="true" sendTcpNoDelay="true"
-                     validateConnections="false">
+                     validateConnections="false" connectionTimeout="4000">
         <https:tls-client path="clientKeystore" storePassword="mulepassword"/>
         <https:tls-key-store keyAlias="muleserver" keyPassword="mulepassword" path="serverKeystore" storePassword="mulepassword"/>
         <https:tls-server path="trustStore" storePassword="mulepassword" explicitOnly="true"

--- a/transports/http/src/test/resources/typed-placeholder-mule-1887-test.xml
+++ b/transports/http/src/test/resources/typed-placeholder-mule-1887-test.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:spring="http://www.springframework.org/schema/beans"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:http="http://www.mulesoft.org/schema/mule/http"
     xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd
        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
@@ -29,6 +27,7 @@
                     keepSendSocketOpen="true"
                     sendTcpNoDelay="true"
                     validateConnections="false"
+                    connectionTimeout="4000"
     />
     
 </mule>


### PR DESCRIPTION
_Adding connectionTimeout property with default value of 2000ms
_ Using connectionTimeout property instead of endpoint's response timeout
