### PR TITLE
MULE-6998 Incorrect maven dependency for drools

### DIFF
--- a/modules/drools/pom.xml
+++ b/modules/drools/pom.xml
@@ -71,6 +71,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- required for the java dialect in drools rules -->
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>jasper-jdt</artifactId>
+            <version>6.0.29</version>
+        </dependency>
 
         <!-- Unit tests only -->
         <dependency>


### PR DESCRIPTION
In the end, the fix for this issue is the same on 3.x as on 3.4.x. Please apply.
