### PR TITLE
Fix for MULE-5512 org.mule.endpoint.URIBuilder prevent the use of expres...

### DIFF
--- a/core/src/main/java/org/mule/endpoint/URIBuilder.java
+++ b/core/src/main/java/org/mule/endpoint/URIBuilder.java
@@ -186,24 +186,17 @@ public class URIBuilder implements AnnotatedObject
     public void setPath(String path)
     {
         assertNotUsed();
-        if (null != path)
+        if (null != path && path.contains(BACKSLASH))
         {
-            if (path.indexOf(DOTS_SLASHES) > -1)
+            // Windows syntax.  convert it to URI syntax
+            try
             {
-                throw new IllegalArgumentException("Unusual syntax in path: '" + path + "' contains " + DOTS_SLASHES);
+                URI pathUri = new File(path).toURI();
+                path = pathUri.getPath();
             }
-            else if (path.contains(BACKSLASH))
+            catch (Exception ex)
             {
-                // Windows syntax.  convert it to URI syntax
-                try
-                {
-                    URI pathUri = new File(path).toURI();
-                    path = pathUri.getPath();
-                }
-                catch (Exception ex)
-                {
-                    throw new IllegalArgumentException("Illegal syntax in path: " + path, ex);
-                }
+                throw new IllegalArgumentException("Illegal syntax in path: " + path, ex);
             }
         }
         this.path = path;

--- a/core/src/test/java/org/mule/endpoint/URIBuilderTestCase.java
+++ b/core/src/test/java/org/mule/endpoint/URIBuilderTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.endpoint;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import org.mule.api.MuleContext;
 import org.mule.api.endpoint.EndpointURI;
 import org.mule.tck.junit4.AbstractMuleTestCase;
@@ -123,6 +124,14 @@ public class URIBuilderTestCase extends AbstractMuleTestCase
         assertEquals("http://localhost:8080/test", result);
     }
 
+    @Test
+    public void testConstructAddressWithXPath()
+    {
+        URIBuilder uri = createURIBuilder("localhost", 8080, "http", "#[xpath(//whatever)]");
+        String result = uri.getEncodedConstructor();
+        assertNotNull(result);
+    }
+    
     @Test
     public void testConstructAddressWithRootTrailingSlashInPath()
     {


### PR DESCRIPTION
There is a IMHO excessively defensive implementation of the "path" parser. In URIBuilder.java we can find :
public void setPath(String path)
...
if (path.indexOf(DOTS_SLASHES) > -1)
{ throw new IllegalArgumentException("Unusual syntax in path: '" + path + "' contains " + DOTS_SLASHES); }
This should not be done of done after exploding expressions. With this check something as simple as :
<http:outbound-endpoint host="localhost" port="8080" path="#[xpath://whatever]" />
Won't work because of the "//".
