### PR TITLE
Fix for MULE-7147 Deprecated or undocumented code in WilcardFilter

### DIFF
--- a/core/src/main/java/org/mule/routing/filters/WildcardFilter.java
+++ b/core/src/main/java/org/mule/routing/filters/WildcardFilter.java
@@ -9,7 +9,6 @@ package org.mule.routing.filters;
 import org.mule.api.MuleMessage;
 import org.mule.api.routing.filter.Filter;
 import org.mule.api.routing.filter.ObjectFilter;
-import org.mule.util.ClassUtils;
 import org.mule.util.StringUtils;
 
 import org.apache.commons.logging.Log;
@@ -115,28 +114,6 @@ public class WildcardFilter implements Filter, ObjectFilter
                 if (foundMatch)
                 {
                     return true;
-                }
-                else if (pattern.endsWith("+") && pattern.length() > 1)
-                {
-                    String className = pattern.substring(0, pattern.length() - 1);
-                    try
-                    {
-                        Class<?> theClass = ClassUtils.loadClass(className, this.getClass());
-                        if (!(object instanceof String))
-                        {
-                            if (theClass.isInstance(object))
-                            {
-                                return true;
-                            }
-                        }
-                        else if (theClass.isAssignableFrom(ClassUtils.loadClass(object.toString(),this.getClass())))
-                        {
-                            return true;
-                        }
-                    }
-                    catch (ClassNotFoundException e)
-                    {
-                    }
                 }
             }
         }

--- a/core/src/test/java/org/mule/routing/filters/WildcardFilterTestCase.java
+++ b/core/src/test/java/org/mule/routing/filters/WildcardFilterTestCase.java
@@ -125,36 +125,4 @@ public class WildcardFilterTestCase extends AbstractMuleTestCase
         assertTrue(filter.accept("The quick Brown fox"));
     }
 
-    @Test
-    public void testClassAndSubclass()
-    {
-        WildcardFilter filter = new WildcardFilter();
-
-        filter.setPattern("java.lang.Throwable+");
-        assertTrue(filter.accept(new Exception()));
-        assertTrue(filter.accept(new Throwable()));
-        assertFalse(filter.accept(new Object()));
-
-        filter.setPattern("java.lang.Throwable");
-        assertFalse(filter.accept(new Exception()));
-        assertTrue(filter.accept(new Throwable()));
-        assertFalse(filter.accept(new Object()));
-    }
-
-    @Test
-    public void testClassAndSubclassUsingString()
-    {
-        WildcardFilter filter = new WildcardFilter();
-
-        filter.setPattern("java.lang.Throwable+");
-        assertTrue(filter.accept(new Exception().getClass().getName()));
-        assertTrue(filter.accept(new Throwable().getClass().getName()));
-        assertFalse(filter.accept(new Object().getClass().getName()));
-
-        filter.setPattern("java.lang.Throwable");
-        assertFalse(filter.accept(new Exception().getClass().getName()));
-        assertTrue(filter.accept(new Throwable().getClass().getName()));
-        assertFalse(filter.accept(new Object().getClass().getName()));
-    }
-
 }


### PR DESCRIPTION
There is a undocumented feature (probably a vestige from Mule2) that if the wilcard expression finishes with a plus sign + it will try to check the type of the payload to the class passed before the plus sign.
