### PR TITLE
Fixed invalid characters in pom.xml <name> attribute

### DIFF
--- a/examples/loanbroker-legacy/common-tests/pom.xml
+++ b/examples/loanbroker-legacy/common-tests/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>mule-example-loanbroker-common-tests</artifactId>
     <packaging>jar</packaging>
-    <name>Loan Broker Example: Shared classes for unit tests</name>
+    <name>Loan Broker Example - Shared classes for unit tests</name>
 
     <properties>
         <licensePath>../../../LICENSE_HEADER.txt</licensePath>

--- a/examples/loanbroker-legacy/common/pom.xml
+++ b/examples/loanbroker-legacy/common/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>mule-example-loanbroker-common</artifactId>
     <packaging>jar</packaging>
-    <name>Loan Broker Example: Shared classes</name>
+    <name>Loan Broker Example - Shared classes</name>
 
     <properties>
         <licensePath>../../../LICENSE_HEADER.txt</licensePath>

--- a/examples/loanbroker-legacy/credit-agency/pom.xml
+++ b/examples/loanbroker-legacy/credit-agency/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>mule-example-loanbroker-credit-agency</artifactId>
     <packaging>ejb</packaging>
-    <name>Loan Broker Example: Credit Agency EJB</name>
+    <name>Loan Broker Example - Credit Agency EJB</name>
 
     <properties>
         <licensePath>../../../LICENSE_HEADER.txt</licensePath>

--- a/modules/drools/pom.xml
+++ b/modules/drools/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>mule-module-drools</artifactId>
     <packaging>jar</packaging>
-    <name>BPM Support: JBoss Rules (Drools)</name>
+    <name>BPM Support - JBoss Rules (Drools)</name>
     <description>Classes which allow Mule to integrate with Drools via the BPM Module.</description>
 
     <properties>

--- a/modules/jbpm/pom.xml
+++ b/modules/jbpm/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>mule-module-jbpm</artifactId>
     <packaging>jar</packaging>
-    <name>BPM Support: JBoss jBPM</name>
+    <name>BPM Support - JBoss jBPM</name>
     <description>Classes which allow Mule to integrate with JBoss jBPM via the BPM Module.</description>
 
     <properties>

--- a/transports/axis/pom.xml
+++ b/transports/axis/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>mule-transport-axis</artifactId>
     <packaging>jar</packaging>
-    <name>SOAP Transport: Axis</name>
+    <name>SOAP Transport - Axis</name>
     <description>A Mule transport for Soap Connectivity using Axis.</description>
 
     <properties>

--- a/transports/stdio/pom.xml
+++ b/transports/stdio/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>mule-transport-stdio</artifactId>
     <packaging>jar</packaging>
-    <name>System I/O Transport</name>
+    <name>System IO Transport</name>
     <description>A Mule transport used as the interface to Java's System.out and System.in objects, typically for testing purposes.</description>
 
     <properties>


### PR DESCRIPTION
Some names contained a colon or forward slash.  While this was allowed,
it prevented importing project into eclipse workspace.  Changed the
colon to a dash and removed the forward slash.  Now everything imports
properly.
