### PR TITLE
MULE-7148: Differentiate HTTP connection timeout from responseTimeout

### DIFF
--- a/transports/http/src/main/resources/META-INF/mule-http.xsd
+++ b/transports/http/src/main/resources/META-INF/mule-http.xsd
@@ -384,13 +384,6 @@
                 <xsd:documentation>Controls if the connection is kept alive.</xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="connectionTimeout" type="mule:substitutableInt">
-            <xsd:annotation>
-                <xsd:documentation>
-                    Number of milliseconds to wait until a connection to a remote server is successfully created. When no value is specified a default timeout of 2000ms is used
-                </xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
     </xsd:attributeGroup>
 
     <xsd:simpleType name="httpMethodTypes">


### PR DESCRIPTION
_ Removing unused attribute from HTTP endpoint
