### PR TITLE
MULE-7198: Build fails due to error downloading dependencies of jBPM mod...

### DIFF
--- a/modules/jbpm/pom.xml
+++ b/modules/jbpm/pom.xml
@@ -111,7 +111,7 @@
         <repository>
             <id>atlassian</id>
             <name>Atlassian Repository</name>
-            <url>http://maven.atlassian.com/repository/public</url>
+            <url>https://maven.atlassian.com/repository/public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
...ule. Fixed repository location since it was moved.
