### PR TITLE
MULE-7213: Updated mule-mvel release to 2.1.8.Final

### DIFF
--- a/core/src/main/java/org/mule/el/mvel/GlobalVariableResolverFactory.java
+++ b/core/src/main/java/org/mule/el/mvel/GlobalVariableResolverFactory.java
@@ -14,6 +14,7 @@ import java.util.Map.Entry;
 
 import org.mule.mvel2.ParserContext;
 import org.mule.mvel2.ast.Function;
+import org.mule.mvel2.ast.FunctionInstance;
 
 public class GlobalVariableResolverFactory extends MVELExpressionLanguageContext
 {
@@ -43,7 +44,7 @@ public class GlobalVariableResolverFactory extends MVELExpressionLanguageContext
         }
         for (Entry<String, Function> function : el.globalFunctions.entrySet())
         {
-            addFinalVariable(function.getKey(), function.getValue());
+            addFinalVariable(function.getKey(), new FunctionInstance(function.getValue()));
         }
     }
 

--- a/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguage.java
+++ b/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguage.java
@@ -18,6 +18,7 @@ import org.mule.api.lifecycle.Initialisable;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.api.transformer.DataType;
 import org.mule.config.i18n.CoreMessages;
+import org.mule.mvel2.ast.FunctionInstance;
 import org.mule.transformer.types.DataTypeFactory;
 import org.mule.transport.NullPayload;
 import org.mule.util.IOUtils;

--- a/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguageContext.java
+++ b/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguageContext.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.mule.mvel2.ImmutableElementException;
 import org.mule.mvel2.ParserContext;
 import org.mule.mvel2.UnresolveablePropertyException;
+import org.mule.mvel2.ast.FunctionInstance;
 import org.mule.mvel2.integration.VariableResolver;
 import org.mule.mvel2.integration.VariableResolverFactory;
 import org.mule.mvel2.integration.impl.BaseVariableResolverFactory;
@@ -233,7 +234,7 @@ public class MVELExpressionLanguageContext extends BaseVariableResolverFactory
     @Override
     public void declareFunction(String name, ExpressionLanguageFunction function)
     {
-        addFinalVariable(name, new MVELFunctionAdaptor(name, function, parserContext));
+        addFinalVariable(name, new FunctionInstance(new MVELFunctionAdaptor(name, function, parserContext)));
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
         <!-- TODO EE-1395 -->
         <mqSeriesVersion>6.0</mqSeriesVersion>
         <mvelVersion>2.1.3.Final</mvelVersion>
+        <muleMvelVersion>2.1.8.Final-MULE-001</muleMvelVersion>
         <mx4jVersion>2.1.1</mx4jVersion>
         <ognlVersion>2.7.3</ognlVersion>
         <oroVersion>2.0.8</oroVersion>
@@ -1244,7 +1245,7 @@
             <dependency>
                 <groupId>org.mule.mvel</groupId>
                 <artifactId>mule-mvel2</artifactId>
-                <version>${mvelVersion}</version>
+                <version>${muleMvelVersion}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The change required turning Function objects to FunctionInstance objects (wrappers around former Function instances) for the optimizing compiler to work.

Note that we keep the mvel version (non shaded version) unchanged to avoid introducing friction to the Drools Module
