### PR TITLE
MULE-7362: Enable nul safe get setting in MVEL compiler

### DIFF
--- a/core/src/main/java/org/mule/el/mvel/MVELExpressionExecutor.java
+++ b/core/src/main/java/org/mule/el/mvel/MVELExpressionExecutor.java
@@ -42,7 +42,9 @@ public class MVELExpressionExecutor implements ExpressionExecutor<MVELExpression
     public MVELExpressionExecutor(ParserConfiguration parserConfiguration)
     {
         this.parserConfiguration = parserConfiguration;
-        System.setProperty("mvel2.compiler.allow_override_all_prophandling", "true");
+
+        MVEL.COMPILER_OPT_NULL_SAFE_DEFAULT = true;
+
         // Use reflective optimizer rather than default to avoid concurrency issues with JIT complication.
         // See MULE-6630
         OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);

--- a/core/src/test/java/org/mule/el/mvel/MVELExpressionExecutorTestCase.java
+++ b/core/src/test/java/org/mule/el/mvel/MVELExpressionExecutorTestCase.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.mvel2.CompileException;
+import org.mule.mvel2.MVEL;
 import org.mule.mvel2.ParserConfiguration;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -58,6 +59,12 @@ public class MVELExpressionExecutorTestCase extends AbstractMuleTestCase
     public void invalidExpression()
     {
         mvel.validate("a9-#'");
+    }
+
+    @Test
+    public void nullSafeGetIsEnabled()
+    {
+        assertEquals(null, mvel.execute("['test1' : null].test1.test2", null));
     }
 
     @Test


### PR DESCRIPTION
Also removed a setting that was not being correctly initialized and was not seen by MVEL (allow_override_all_prophandling)
