### PR TITLE
MULE-7399: Flows can start processing messages before referenced flows a...

### DIFF
--- a/core/src/main/java/org/mule/api/MuleContext.java
+++ b/core/src/main/java/org/mule/api/MuleContext.java
@@ -316,5 +316,14 @@ public interface MuleContext extends Lifecycle
      * @return {@link {ProcessingTimeWatcher} used to compute processing time of finalized events
      */
     ProcessingTimeWatcher getProcessorTimeWatcher();
+
+    /**
+     * Makes the caller wait until the {@link MuleContext} was started
+     *
+     * @param timeout maximum number of milliseconds that will be waiting
+     * @return true if the context started before the timeout, false otherwise
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     */
+    boolean waitUtilStarted(int timeout) throws InterruptedException;
 }
 

--- a/core/src/main/java/org/mule/transport/AbstractMessageDispatcher.java
+++ b/core/src/main/java/org/mule/transport/AbstractMessageDispatcher.java
@@ -7,8 +7,9 @@
 package org.mule.transport;
 
 import org.mule.DefaultMuleEvent;
-import org.mule.VoidMuleEvent;
 import org.mule.RequestContext;
+import org.mule.VoidMuleEvent;
+import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
 import org.mule.api.MuleMessage;
@@ -20,6 +21,7 @@ import org.mule.api.service.Service;
 import org.mule.api.transformer.Transformer;
 import org.mule.api.transport.DispatchException;
 import org.mule.api.transport.MessageDispatcher;
+import org.mule.config.i18n.MessageFactory;
 import org.mule.service.ServiceAsyncReplyCompositeMessageSource;
 
 import java.util.List;
@@ -74,6 +76,11 @@ public abstract class AbstractMessageDispatcher extends AbstractTransportMessage
 
             if (hasResponse)
             {
+                if (!event.getMuleContext().waitUtilStarted(event.getTimeout()))
+                {
+                    throw new MessagingException(MessageFactory.createStaticMessage("Timeout waiting for mule context to be completely started"), event);
+                }
+
                 MuleMessage resultMessage = doSend(event);
                 if (resultMessage != null)
                 {

--- a/core/src/test/java/org/mule/construct/BridgeTestCase.java
+++ b/core/src/test/java/org/mule/construct/BridgeTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.construct;
 
+import static org.junit.Assert.assertEquals;
 import org.mule.MessageExchangePattern;
 import org.mule.api.MuleEvent;
 import org.mule.api.endpoint.OutboundEndpoint;
@@ -15,8 +16,6 @@ import org.mule.tck.MuleTestUtils;
 import java.util.Collections;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class BridgeTestCase extends AbstractFlowConstuctTestCase
 {
@@ -48,10 +47,12 @@ public class BridgeTestCase extends AbstractFlowConstuctTestCase
     @Test
     public void testProcess() throws Exception
     {
+        muleContext.start();
+
         bridge.initialise();
         bridge.start();
-        MuleEvent response = directInboundMessageSource.process(MuleTestUtils.getTestEvent("hello",
-            muleContext));
+        MuleEvent testEvent = MuleTestUtils.getTestEvent("hello", muleContext);
+        MuleEvent response = directInboundMessageSource.process(testEvent);
 
         assertEquals("hello", response.getMessageAsString());
     }

--- a/core/src/test/java/org/mule/transport/ConnectorLifecycleTestCase.java
+++ b/core/src/test/java/org/mule/transport/ConnectorLifecycleTestCase.java
@@ -387,6 +387,8 @@ public class ConnectorLifecycleTestCase extends AbstractMuleContextTestCase
     @Test
     public void testDispatchersLifecycle() throws Exception
     {
+        muleContext.start();
+
         //using sync endpoint so that any calls to 'process()' will be blocking and avoid timing issues
         OutboundEndpoint out = getTestOutboundEndpoint("out",
                                                        "test://out?exchangePattern=request-response", null, null, null, connector);

--- a/modules/ws/src/test/java/org/mule/module/ws/construct/AbstractWSProxyTestCase.java
+++ b/modules/ws/src/test/java/org/mule/module/ws/construct/AbstractWSProxyTestCase.java
@@ -59,6 +59,7 @@ public abstract class AbstractWSProxyTestCase extends AbstractFlowConstuctTestCa
     {
         wsProxy.initialise();
         wsProxy.start();
+        muleContext.start();
     }
 
     @Test

--- a/tests/functional/src/main/java/org/mule/tck/util/endpoint/InboundEndpointWrapper.java
+++ b/tests/functional/src/main/java/org/mule/tck/util/endpoint/InboundEndpointWrapper.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.tck.util.endpoint;
+
+import org.mule.MessageExchangePattern;
+import org.mule.api.MuleContext;
+import org.mule.api.MuleException;
+import org.mule.api.MuleMessage;
+import org.mule.api.construct.FlowConstruct;
+import org.mule.api.endpoint.EndpointMessageProcessorChainFactory;
+import org.mule.api.endpoint.EndpointURI;
+import org.mule.api.endpoint.InboundEndpoint;
+import org.mule.api.processor.MessageProcessor;
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.api.routing.filter.Filter;
+import org.mule.api.security.EndpointSecurityFilter;
+import org.mule.api.transaction.TransactionConfig;
+import org.mule.api.transformer.Transformer;
+import org.mule.api.transport.Connector;
+import org.mule.processor.AbstractRedeliveryPolicy;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wraps an {@link InboundEndpoint} enabling subclasses to override only those
+ * methods which add extra behaviour.
+ */
+public abstract class InboundEndpointWrapper implements InboundEndpoint
+{
+
+    private InboundEndpoint delegate;
+
+    public InboundEndpointWrapper(InboundEndpoint delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    public AbstractRedeliveryPolicy createDefaultRedeliveryPolicy(int maxRedelivery)
+    {
+        return delegate.createDefaultRedeliveryPolicy(maxRedelivery);
+    }
+
+    public void setFlowConstruct(FlowConstruct flowConstruct)
+    {
+        delegate.setFlowConstruct(flowConstruct);
+    }
+
+    public EndpointURI getEndpointURI()
+    {
+        return delegate.getEndpointURI();
+    }
+
+    public String getAddress()
+    {
+        return delegate.getAddress();
+    }
+
+    public String getEncoding()
+    {
+        return delegate.getEncoding();
+    }
+
+    public Connector getConnector()
+    {
+        return delegate.getConnector();
+    }
+
+    public List<Transformer> getTransformers()
+    {
+        return delegate.getTransformers();
+    }
+
+    public List<Transformer> getResponseTransformers()
+    {
+        return delegate.getResponseTransformers();
+    }
+
+    public Map getProperties()
+    {
+        return delegate.getProperties();
+    }
+
+    public Object getProperty(Object key)
+    {
+        return delegate.getProperty(key);
+    }
+
+    public String getProtocol()
+    {
+        return delegate.getProtocol();
+    }
+
+    public boolean isReadOnly()
+    {
+        return delegate.isReadOnly();
+    }
+
+    public TransactionConfig getTransactionConfig()
+    {
+        return delegate.getTransactionConfig();
+    }
+
+    public Filter getFilter()
+    {
+        return delegate.getFilter();
+    }
+
+    public boolean isDeleteUnacceptedMessages()
+    {
+        return delegate.isDeleteUnacceptedMessages();
+    }
+
+    public EndpointSecurityFilter getSecurityFilter()
+    {
+        return delegate.getSecurityFilter();
+    }
+
+    public EndpointMessageProcessorChainFactory getMessageProcessorsFactory()
+    {
+        return delegate.getMessageProcessorsFactory();
+    }
+
+    public List<MessageProcessor> getMessageProcessors()
+    {
+        return delegate.getMessageProcessors();
+    }
+
+    public List<MessageProcessor> getResponseMessageProcessors()
+    {
+        return delegate.getResponseMessageProcessors();
+    }
+
+    public MessageExchangePattern getExchangePattern()
+    {
+        return delegate.getExchangePattern();
+    }
+
+    public int getResponseTimeout()
+    {
+        return delegate.getResponseTimeout();
+    }
+
+    public String getInitialState()
+    {
+        return delegate.getInitialState();
+    }
+
+    public MuleContext getMuleContext()
+    {
+        return delegate.getMuleContext();
+    }
+
+    public RetryPolicyTemplate getRetryPolicyTemplate()
+    {
+        return delegate.getRetryPolicyTemplate();
+    }
+
+    public String getEndpointBuilderName()
+    {
+        return delegate.getEndpointBuilderName();
+    }
+
+    public boolean isProtocolSupported(String protocol)
+    {
+        return delegate.isProtocolSupported(protocol);
+    }
+
+    public String getMimeType()
+    {
+        return delegate.getMimeType();
+    }
+
+    public AbstractRedeliveryPolicy getRedeliveryPolicy()
+    {
+        return delegate.getRedeliveryPolicy();
+    }
+
+    public boolean isDisableTransportTransformer()
+    {
+        return delegate.isDisableTransportTransformer();
+    }
+
+    public MuleMessage request(long timeout) throws Exception
+    {
+        return delegate.request(timeout);
+    }
+
+    public void setListener(MessageProcessor listener)
+    {
+        delegate.setListener(listener);
+    }
+
+    public String getName()
+    {
+        return delegate.getName();
+    }
+
+    public void start() throws MuleException
+    {
+        delegate.start();
+    }
+
+    public void stop() throws MuleException
+    {
+        delegate.stop();
+    }
+
+    public InboundEndpoint getDelegate()
+    {
+        return delegate;
+    }
+}

--- a/tests/integration/src/test/java/org/mule/test/routing/SynchronizedMuleContextStartTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/routing/SynchronizedMuleContextStartTestCase.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.test.routing;
+
+import org.mule.DefaultMuleEvent;
+import org.mule.DefaultMuleMessage;
+import org.mule.MessageExchangePattern;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleException;
+import org.mule.api.endpoint.EndpointBuilder;
+import org.mule.api.endpoint.InboundEndpoint;
+import org.mule.api.store.ObjectStore;
+import org.mule.api.store.ObjectStoreException;
+import org.mule.construct.Flow;
+import org.mule.endpoint.DefaultEndpointFactory;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.probe.PollingProber;
+import org.mule.tck.probe.Probe;
+import org.mule.tck.probe.Prober;
+import org.mule.tck.util.endpoint.InboundEndpointWrapper;
+import org.mule.util.concurrent.Latch;
+
+import org.junit.Test;
+
+public class SynchronizedMuleContextStartTestCase extends FunctionalTestCase
+{
+
+    private static volatile int processedMessageCounter = 0;
+    private static Latch waitMessageInProgress = new Latch();
+
+    public SynchronizedMuleContextStartTestCase()
+    {
+        setStartContext(false);
+    }
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "synchronized-mule-context-start-config.xml";
+    }
+
+    @Test
+    public void waitsForStartedMuleContextBeforeAttemptingToSendMessageToEndpoint() throws Exception
+    {
+        prePopulateObjectStore();
+
+        muleContext.start();
+
+        Prober prober = new PollingProber(RECEIVE_TIMEOUT, 50);
+
+        prober.check(new Probe()
+        {
+            public boolean isSatisfied()
+            {
+                return processedMessageCounter == 1;
+            }
+
+            public String describeFailure()
+            {
+                return "Did not wait for mule context started before attempting to process event";
+            }
+        });
+    }
+
+    private void prePopulateObjectStore() throws ObjectStoreException
+    {
+        ObjectStore<MuleEvent> objectStore = muleContext.getRegistry().lookupObject("objectStore");
+
+        DefaultMuleMessage testMessage = new DefaultMuleMessage(TEST_MESSAGE, muleContext);
+        Flow clientFlow = muleContext.getRegistry().get("flow2");
+        DefaultMuleEvent testMuleEvent = new DefaultMuleEvent(testMessage, MessageExchangePattern.REQUEST_RESPONSE, clientFlow);
+        objectStore.store(testMuleEvent.getId(), testMuleEvent);
+    }
+
+    public static class ProcessedMessageCounter
+    {
+
+        public String count(String value)
+        {
+            processedMessageCounter++;
+            return value;
+        }
+    }
+
+    public static class UnblockEndpointStart
+    {
+
+        public void unclockEndpoint(String value)
+        {
+            waitMessageInProgress.release();
+        }
+    }
+
+    public static class DelayedStartEndpointFactory extends DefaultEndpointFactory
+    {
+
+        public InboundEndpoint getInboundEndpoint(EndpointBuilder builder) throws MuleException
+        {
+            InboundEndpoint endpoint = builder.buildInboundEndpoint();
+
+            if (endpoint.getName().equals("endpoint.vm.flow2"))
+            {
+                InboundEndpointWrapper wrappedEndpoint = new DelayedStartInboundEndpointWrapper(endpoint);
+
+                return (InboundEndpoint) registerEndpoint(wrappedEndpoint);
+            }
+            else
+            {
+                return (InboundEndpoint) registerEndpoint(endpoint);
+            }
+        }
+    }
+
+    public static class DelayedStartInboundEndpointWrapper extends InboundEndpointWrapper
+    {
+
+        public DelayedStartInboundEndpointWrapper(InboundEndpoint delegate)
+        {
+            super(delegate);
+        }
+
+        @Override
+        public void start() throws MuleException
+        {
+            try
+            {
+                // Need to wait some time so the outbound endpoint from the first flow attempts to send the message.
+                // Waiting on the latch ensures that the until successful from the first flow is processing the event.
+                // Need the sleep to give us some time to let the dispatcher to try to send the event and ther eis no way
+                // to do that without a Thread.sleep
+                waitMessageInProgress.await();
+                Thread.sleep(1000);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return;
+            }
+
+            super.start();
+        }
+    }
+}

--- a/tests/integration/src/test/resources/synchronized-mule-context-start-config.xml
+++ b/tests/integration/src/test/resources/synchronized-mule-context-start-config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <spring:bean name="_muleEndpointFactory" class="org.mule.test.routing.SynchronizedMuleContextStartTestCase$DelayedStartEndpointFactory"/>
+    <spring:bean id="objectStore" class="org.mule.util.store.SimpleMemoryObjectStore" />
+
+    <flow name="flow1">
+        <vm:inbound-endpoint path="testInput"/>
+
+        <until-successful maxRetries="0" objectStore-ref="objectStore">
+            <processor-chain>
+                <component class="org.mule.test.routing.SynchronizedMuleContextStartTestCase$UnblockEndpointStart"/>
+                <vm:outbound-endpoint path="flow2" exchange-pattern="request-response"/>
+            </processor-chain>
+        </until-successful>
+    </flow>
+
+    <flow name="flow2">
+        <vm:inbound-endpoint path="flow2" exchange-pattern="request-response"/>
+
+        <component class="org.mule.test.routing.SynchronizedMuleContextStartTestCase$ProcessedMessageCounter"/>
+    </flow>
+</mule>


### PR DESCRIPTION
...re completely started

_ Adding a new method in MuleContext to let callers to wait until it is started
_ Updating AbstractMessageDispatcher to wait until mule context is started before sending a message
_ Updating tests that need to send a message but never started mule context
