### PR TITLE
MULE-7399: Flows can start processing messages before referenced flows a...

### DIFF
--- a/tests/integration/src/test/java/org/mule/test/integration/CompositeSourceStartDelayTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/CompositeSourceStartDelayTestCase.java
@@ -6,27 +6,31 @@
  */
 package org.mule.test.integration;
 
-import static org.junit.Assert.assertEquals;
-
-import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
-import org.mule.api.MuleMessage;
-import org.mule.api.client.LocalMuleClient;
-import org.mule.api.lifecycle.Startable;
-import org.mule.api.processor.MessageProcessor;
-import org.mule.api.transformer.TransformerException;
-import org.mule.endpoint.DefaultInboundEndpoint;
+import org.mule.api.endpoint.EndpointBuilder;
+import org.mule.api.endpoint.InboundEndpoint;
+import org.mule.api.lifecycle.StartException;
+import org.mule.endpoint.DefaultEndpointFactory;
 import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.probe.PollingProber;
 import org.mule.tck.probe.Probe;
-import org.mule.tck.probe.Prober;
-import org.mule.transformer.AbstractTransformer;
+import org.mule.tck.util.endpoint.InboundEndpointWrapper;
 
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class CompositeSourceStartDelayTestCase extends FunctionalTestCase
 {
-    public static volatile boolean awakeMessageSource;
+
+    public static final CountDownLatch startLatch = new CountDownLatch(1);
+
+    @Rule
+    public DynamicPort httpPort = new DynamicPort("httpPort");
 
     public CompositeSourceStartDelayTestCase()
     {
@@ -41,6 +45,21 @@ public class CompositeSourceStartDelayTestCase extends FunctionalTestCase
 
     @Test
     public void testProcessMessageWhenAnSourceIsNotStartedYet() throws Exception
+    {
+        try
+        {
+            asynchronousMuleContextStart();
+
+            PollingProber prober = new PollingProber(RECEIVE_TIMEOUT, 50);
+            prober.check(new ProcessMessageProbe());
+        }
+        finally
+        {
+            startLatch.countDown();
+        }
+    }
+
+    private void asynchronousMuleContextStart()
     {
         Thread thread = new Thread(new Runnable()
         {
@@ -59,68 +78,78 @@ public class CompositeSourceStartDelayTestCase extends FunctionalTestCase
         });
 
         thread.start();
-
-        waitUntilEndpointIsStarted("testInEndpoint");
-
-
-        LocalMuleClient client = muleContext.getClient();
-        MuleMessage response = client.send("vm://testIn", "TEST", null);
-        assertEquals("TEST received", response.getPayloadAsString());
     }
 
-    private void waitUntilEndpointIsStarted(final String endpointName)
+    private class ProcessMessageProbe implements Probe
     {
-        Prober prober = new PollingProber(30000, 50);
-        prober.check(new Probe()
+
+        private final HttpClient httpClient = new HttpClient();
+
+        public boolean isSatisfied()
         {
-            @Override
-            public boolean isSatisfied()
-            {
-                DefaultInboundEndpoint endpoint = (DefaultInboundEndpoint) muleContext.getRegistry().lookupObject(endpointName);
-                return endpoint.getConnector().isStarted();
-            }
+            GetMethod method = new GetMethod("http://localhost:" + httpPort.getValue());
 
-            @Override
-            public String describeFailure()
+            try
             {
-                return "Endpoint was not started";
-            }
-        });
-    }
+                int statusCode = httpClient.executeMethod(method);
+                String response = method.getResponseBodyAsString();
 
-    public static class AwakeSourceMessageProcessor implements MessageProcessor
-    {
-        @Override
-        public MuleEvent process(MuleEvent event) throws MuleException
+                return 200 == statusCode && "/Processed".equals(response);
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
+        }
+
+        public String describeFailure()
         {
-            awakeMessageSource = true;
-
-            return event;
+            return "Unable to process message when composite source was not completely started";
         }
     }
 
-    public static class StuckTransformer extends AbstractTransformer implements Startable
+    public static class DelayedStartEndpointFactory extends DefaultEndpointFactory
     {
-        @Override
-        protected Object doTransform(Object src, String enc) throws TransformerException
+
+        public InboundEndpoint getInboundEndpoint(EndpointBuilder builder) throws MuleException
         {
-            return null;
+            InboundEndpoint endpoint = builder.buildInboundEndpoint();
+
+            if (endpoint.getName().equals("sleepingTestIn"))
+            {
+                InboundEndpointWrapper wrappedEndpoint = new DelayedStartInboundEndpointWrapper(endpoint);
+
+                return (InboundEndpoint) registerEndpoint(wrappedEndpoint);
+            }
+            else
+            {
+                return (InboundEndpoint) registerEndpoint(endpoint);
+            }
+        }
+    }
+
+    public static class DelayedStartInboundEndpointWrapper extends InboundEndpointWrapper
+    {
+
+        public DelayedStartInboundEndpointWrapper(InboundEndpoint delegate)
+        {
+            super(delegate);
         }
 
         @Override
         public void start() throws MuleException
         {
-            while (!awakeMessageSource)
+            try
             {
-                try
-                {
-                    Thread.sleep(10);
-                }
-                catch (InterruptedException e)
-                {
-                    // Nothing to do
-                }
+                startLatch.await();
             }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                throw new StartException(e, this);
+            }
+
+            super.start();
         }
     }
 }

--- a/tests/integration/src/test/resources/composite-source-start-delay-config.xml
+++ b/tests/integration/src/test/resources/composite-source-start-delay-config.xml
@@ -2,24 +2,26 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
       xmlns:test="http://www.mulesoft.org/schema/mule/test"
       xsi:schemaLocation="
-       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-       http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
-       http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+            http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+            http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+            http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
-    <custom-transformer name="transformer1" class="org.mule.test.integration.CompositeSourceStartDelayTestCase$StuckTransformer" />
-
-    <endpoint name="sleepingTestIn" address="vm://sleepingTestIn" transformer-refs="transformer1"/>
+    <spring:bean name="_muleEndpointFactory" class="org.mule.test.integration.CompositeSourceStartDelayTestCase$DelayedStartEndpointFactory"/>
 
     <flow name="MainFlow">
         <composite-source>
-            <vm:inbound-endpoint name="testInEndpoint" path="testIn" exchange-pattern="request-response"/>
-            <vm:inbound-endpoint ref="sleepingTestIn" exchange-pattern="request-response"/>
+            <http:inbound-endpoint name="testInEndpoint" address="http://localhost:${httpPort}"
+                                   exchange-pattern="request-response"/>
+            <vm:inbound-endpoint name="sleepingTestIn" address="vm://sleepingTestIn"
+                                 exchange-pattern="request-response"/>
         </composite-source>
 
-        <custom-processor class="org.mule.test.integration.CompositeSourceStartDelayTestCase$AwakeSourceMessageProcessor"/>
-
-        <test:component appendString=" received"/>
+        <test:component appendString="Processed"/>
     </flow>
 </mule>


### PR DESCRIPTION
...re completely started

Broken test: cannot use mule client to exercise an inbound endpoint if mule context is not fully started.

Fix: use HttpClient to exercise an HTTP endpoint.
