### PR TITLE
MULE-7395: adding new file to assembly-whitelist of standlone-light

### DIFF
--- a/distributions/standalone-light/assembly-whitelist.txt
+++ b/distributions/standalone-light/assembly-whitelist.txt
@@ -10,7 +10,7 @@
 /mule-standalone-nodocs-${productVersion}/logs
 /mule-standalone-nodocs-${productVersion}/LICENSE.txt
 /mule-standalone-nodocs-${productVersion}/README.txt
-
+/mule-standalone-nodocs-${productVersion}/MIGRATION.txt
 
 #
 # /apps


### PR DESCRIPTION
This is a missing change of MULE-7395 that caused the standalone-light distribution build to fail
