### PR TITLE
MULE-7367: Updated build so that compile and release exclude test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,10 @@
         <skipIntegrationTests>false</skipIntegrationTests>
         <skipPerformanceTests>true</skipPerformanceTests>
         <skipArchetypeTests>true</skipArchetypeTests>
+
         <skipDistributions>true</skipDistributions>
         <skipVerifications>false</skipVerifications>
+        <skipInstalls>false</skipInstalls>
 
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <licensePath>LICENSE_HEADER.txt</licensePath>
@@ -1385,6 +1387,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.4</version>
+                    <configuration>
+                        <skip>${skipInstalls}</skip>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1668,6 +1673,9 @@
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -2026,32 +2034,46 @@
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>true</skipDistributions>
                 <skipVerifications>false</skipVerifications>
+                <skipInstalls>false</skipInstalls>
+                <skipTests>true</skipTests>
             </properties>
         </profile>
         <profile>
             <id>unit</id>
             <!-- will eventually toggle running only @SmallTests -->
+            <build>
+                <defaultGoal>test</defaultGoal>
+            </build>
             <properties>
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>true</skipDistributions>
                 <skipVerifications>true</skipVerifications>
+                <skipInstalls>true</skipInstalls>
             </properties>
         </profile>
         <profile>
             <id>functional</id>
             <!-- will eventually toggle running all but @SmallTests -->
+            <build>
+                <defaultGoal>test</defaultGoal>
+            </build>
             <properties>
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>true</skipDistributions>
                 <skipVerifications>true</skipVerifications>
+                <skipInstalls>true</skipInstalls>
             </properties>
         </profile>
         <profile>
             <id>integration</id>
+            <build>
+                <defaultGoal>test</defaultGoal>
+            </build>
             <properties>
                 <skipIntegrationTests>false</skipIntegrationTests>
                 <skipDistributions>true</skipDistributions>
                 <skipVerifications>true</skipVerifications>
+                <skipInstalls>true</skipInstalls>
             </properties>
         </profile>
         <profile>
@@ -2060,8 +2082,11 @@
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>false</skipDistributions>
                 <skipVerifications>true</skipVerifications>
+                <skipInstalls>true</skipInstalls>
+                <skipTests>true</skipTests>
             </properties>
             <build>
+                <defaultGoal>deploy</defaultGoal>
                 <plugins>
                     <plugin>
                         <inherited>false</inherited>


### PR DESCRIPTION
All CI profiles but compile will skip installation, to have only one stage that modifies the local repo.
Each CI profile defines a sensible default build goal, so that goal can be omitted from commandline
