### PR TITLE
MULE-6889: Concurrent Modification Exception when using the Async Messag...

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleEvent.java
+++ b/core/src/main/java/org/mule/DefaultMuleEvent.java
@@ -274,12 +274,17 @@ public class DefaultMuleEvent implements MuleEvent, ThreadSafeAccess, Deserializ
     public DefaultMuleEvent(MuleEvent rewriteEvent, FlowConstruct flowConstruct, ReplyToHandler replyToHandler, Object replyToDestination)
     {
         this(rewriteEvent.getMessage(), rewriteEvent, flowConstruct, rewriteEvent.getSession(),
-             rewriteEvent.isSynchronous(), replyToHandler, replyToDestination);
+             rewriteEvent.isSynchronous(), replyToHandler, replyToDestination, true);
     }
 
     public DefaultMuleEvent(MuleMessage message, MuleEvent rewriteEvent, boolean synchronus)
     {
         this(message, rewriteEvent, rewriteEvent.getFlowConstruct(), rewriteEvent.getSession(), synchronus);
+    }
+
+    public DefaultMuleEvent(MuleMessage message, MuleEvent rewriteEvent, boolean synchronus, boolean shareFlowVars)
+    {
+        this(message, rewriteEvent, rewriteEvent.getFlowConstruct(), rewriteEvent.getSession(), synchronus, shareFlowVars);
     }
 
     /**
@@ -299,7 +304,17 @@ public class DefaultMuleEvent implements MuleEvent, ThreadSafeAccess, Deserializ
                                MuleSession session,
                                boolean synchronous)
     {
-        this(message, rewriteEvent, flowConstruct, session, synchronous, rewriteEvent.getReplyToHandler(), rewriteEvent.getReplyToDestination());
+        this(message, rewriteEvent, flowConstruct, session, synchronous, rewriteEvent.getReplyToHandler(), rewriteEvent.getReplyToDestination(), true);
+    }
+
+    protected DefaultMuleEvent(MuleMessage message,
+                               MuleEvent rewriteEvent,
+                               FlowConstruct flowConstruct,
+                               MuleSession session,
+                               boolean synchronous,
+                               boolean shareFlowVars)
+    {
+        this(message, rewriteEvent, flowConstruct, session, synchronous, rewriteEvent.getReplyToHandler(), rewriteEvent.getReplyToDestination(), shareFlowVars);
     }
 
     protected DefaultMuleEvent(MuleMessage message,
@@ -308,7 +323,8 @@ public class DefaultMuleEvent implements MuleEvent, ThreadSafeAccess, Deserializ
                                MuleSession session,
                                boolean synchronous,
                                ReplyToHandler replyToHandler,
-                               Object replyToDestination)
+                               Object replyToDestination,
+                               boolean shareFlowVars)
     {
         this.id = rewriteEvent.getId();
         this.flowConstruct = flowConstruct;
@@ -323,7 +339,14 @@ public class DefaultMuleEvent implements MuleEvent, ThreadSafeAccess, Deserializ
         if (rewriteEvent instanceof DefaultMuleEvent)
         {
             this.processingTime = ((DefaultMuleEvent) rewriteEvent).processingTime;
-            this.flowVariables = ((DefaultMuleEvent) rewriteEvent).flowVariables;
+            if (shareFlowVars)
+            {
+                this.flowVariables = ((DefaultMuleEvent) rewriteEvent).flowVariables;
+            }
+            else
+            {
+                this.flowVariables.putAll(((DefaultMuleEvent) rewriteEvent).flowVariables);
+            }
         }
         else
         {

--- a/core/src/main/java/org/mule/processor/AsyncDelegateMessageProcessor.java
+++ b/core/src/main/java/org/mule/processor/AsyncDelegateMessageProcessor.java
@@ -127,7 +127,7 @@ public class AsyncDelegateMessageProcessor extends AbstractMessageProcessorOwner
         {
             // Clone event and make it async
             MuleEvent newEvent = new DefaultMuleEvent(
-                    (MuleMessage) ((ThreadSafeAccess) event.getMessage()).newThreadCopy(), event, false);
+                    (MuleMessage) ((ThreadSafeAccess) event.getMessage()).newThreadCopy(), event, false, false);
             target.process(newEvent);
         }
         if (muleContext.getConfiguration().isFlowEndingWithOneWayEndpointReturnsNull())

--- a/core/src/test/java/org/mule/MuleEventTestCase.java
+++ b/core/src/test/java/org/mule/MuleEventTestCase.java
@@ -14,6 +14,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.mule.api.MuleEvent;
+import org.mule.api.MuleMessage;
+import org.mule.api.ThreadSafeAccess;
 import org.mule.api.endpoint.EndpointBuilder;
 import org.mule.api.endpoint.ImmutableEndpoint;
 import org.mule.api.endpoint.InboundEndpoint;
@@ -331,6 +333,47 @@ public class MuleEventTestCase extends AbstractMuleContextTestCase
         muleContext.getRegistry().registerEndpointBuilder("epBuilderTest", endpointBuilder);
 
         getTestService();
+    }
+
+
+    @Test
+    public void testFlowVarsNotShared() throws Exception
+    {
+        MuleEvent event = getTestEvent("whatever");
+        MuleMessage message = event.getMessage();
+        message.setInvocationProperty("foo", "bar");
+
+        MuleEvent copy = new DefaultMuleEvent(
+            (MuleMessage) ((ThreadSafeAccess) event.getMessage()).newThreadCopy(), event, false, false);
+
+        MuleMessage messageCopy = copy.getMessage();
+        messageCopy.setInvocationProperty("foo", "bar2");
+
+        assertEquals("bar", event.getFlowVariable("foo"));
+        assertEquals("bar", message.getInvocationProperty("foo"));
+
+        assertEquals("bar2", copy.getFlowVariable("foo"));
+        assertEquals("bar2", messageCopy.getInvocationProperty("foo"));
+    }
+
+    @Test
+    public void testFlowVarsShared() throws Exception
+    {
+        MuleEvent event = getTestEvent("whatever");
+        MuleMessage message = event.getMessage();
+        message.setInvocationProperty("foo", "bar");
+
+        MuleEvent copy = new DefaultMuleEvent(
+                (MuleMessage) ((ThreadSafeAccess) event.getMessage()).newThreadCopy(), event, false);
+
+        MuleMessage messageCopy = copy.getMessage();
+        messageCopy.setInvocationProperty("foo", "bar2");
+
+        assertEquals("bar2", event.getFlowVariable("foo"));
+        assertEquals("bar2", message.getInvocationProperty("foo"));
+
+        assertEquals("bar2", copy.getFlowVariable("foo"));
+        assertEquals("bar2", messageCopy.getInvocationProperty("foo"));
     }
 
     private static class TestEventTransformer extends AbstractTransformer


### PR DESCRIPTION
...e Proccessor inside a foreach. This fix relies on adding a new constructor to the MuleEvent
