### PR TITLE
[MULE-7438] Add NuoDB JDBC Transport Adapter

### DIFF
--- a/transports/jdbc/src/main/java/org/mule/transport/jdbc/config/JdbcNamespaceHandler.java
+++ b/transports/jdbc/src/main/java/org/mule/transport/jdbc/config/JdbcNamespaceHandler.java
@@ -53,6 +53,7 @@ public class JdbcNamespaceHandler extends AbstractMuleNamespaceHandler
     {
         registerDerbyDataSourceDefinitionParser();
         registerMysqlDataSourceDefinitionParser();
+        registerNuoDBDataSourceDefinitionParser();
         registerInstanceDatasource("oracle-data-source", OracleDataSourceFactoryBean.class);
         registerPostgresqlDataSourceDefinitionParser();
         registerDb2DataSourceDefinitionParser();
@@ -73,6 +74,12 @@ public class JdbcNamespaceHandler extends AbstractMuleNamespaceHandler
     {
         registerHostAndPortTypeDefinitionParser(MysqlDataSourceFactoryBean.class,
                                                 "mysql-data-source");
+    }
+
+    protected void registerNuoDBDataSourceDefinitionParser()
+    {
+        registerHostAndPortTypeDefinitionParser(NuoDBDataSourceFactoryBean.class,
+                "nuodb-data-source");
     }
 
     protected void registerDb2DataSourceDefinitionParser()

--- a/transports/jdbc/src/main/java/org/mule/transport/jdbc/config/NuoDBDataSourceFactoryBean.java
+++ b/transports/jdbc/src/main/java/org/mule/transport/jdbc/config/NuoDBDataSourceFactoryBean.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.jdbc.config;
+
+public class NuoDBDataSourceFactoryBean extends AbstractHostPortDatabaseDataSourceFactoryBean
+{
+    private static final String DRIVER_CLASS_NAME = "com.nuodb.jdbc.Driver";
+    private static final String JDBC_URL_PREFIX = "jdbc:com.nuodb://";
+
+    public NuoDBDataSourceFactoryBean()
+    {
+        super();
+        driverClassName = DRIVER_CLASS_NAME;
+        updateUrl();
+    }
+
+    @Override
+    protected String getJdbcUrlPrefix()
+    {
+        return JDBC_URL_PREFIX;
+    }
+}

--- a/transports/jdbc/src/main/resources/META-INF/mule-jdbc.xsd
+++ b/transports/jdbc/src/main/resources/META-INF/mule-jdbc.xsd
@@ -452,6 +452,36 @@
         </xsd:complexContent>
     </xsd:complexType>
 
+    <xsd:element name="nuodb-data-source" type="nuodbDataSourceType" substitutionGroup="mule:abstract-extension"/>
+
+    <xsd:complexType name="nuodbDataSourceType">
+        <xsd:complexContent>
+            <xsd:extension base="abstractDataSourceMandatoryUserAndPasswordType">
+                <xsd:attribute name="database" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            The name of the database. Must be configured unless a full JDBC URL is configured.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="host" type="xsd:string" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Allows to configure just the host part of the JDBC URL (and leave the rest of the default JDBC URL untouched).
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="port" type="xsd:int" use="optional">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Allows to configure just the port part of the JDBC URL (and leave the rest of the default JDBC URL untouched).
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
     <xsd:element name="postgresql-data-source" type="postgresqlDataSourceType" substitutionGroup="mule:abstract-extension"/>
 
     <xsd:complexType name="postgresqlDataSourceType">

--- a/transports/jdbc/src/test/java/org/mule/transport/jdbc/config/JdbcDataSourceNamespaceHandlerTestCase.java
+++ b/transports/jdbc/src/test/java/org/mule/transport/jdbc/config/JdbcDataSourceNamespaceHandlerTestCase.java
@@ -119,6 +119,37 @@ public class JdbcDataSourceNamespaceHandlerTestCase extends FunctionalTestCase
     }
 
     @Test
+    public void testNuoDBDefaults()
+    {
+        StandardDataSource source = lookupDataSource("default-nuodb");
+        assertEquals("jdbc:com.nuodb://localhost/mule", source.getUrl());
+        assertEquals("com.nuodb.jdbc.Driver", source.getDriverName());
+        assertEquals("nuodb", source.getUser());
+        assertEquals("secret", source.getPassword());
+    }
+
+    @Test
+    public void testNuoDBCustomUrl()
+    {
+        StandardDataSource source = lookupDataSource("custom-url-nuodb");
+        assertEquals("jdbc:com.nuodb://mule-db-host:48004/mule", source.getUrl());
+    }
+
+    @Test
+    public void testNuoDBCustomHost()
+    {
+        StandardDataSource source = lookupDataSource("custom-host-nuodb");
+        assertEquals("jdbc:com.nuodb://some-other-host/mule", source.getUrl());
+    }
+
+    @Test
+    public void testNuoDBCustomPort()
+    {
+        StandardDataSource source = lookupDataSource("custom-port-nuodb");
+        assertEquals("jdbc:com.nuodb://localhost:4242/mule", source.getUrl());
+    }
+
+    @Test
     public void testPostgresqlDefaults()
     {
         StandardDataSource source = lookupDataSource("default-postgresql");

--- a/transports/jdbc/src/test/java/org/mule/transport/jdbc/config/NuoDBDataSourceConfigurationTestCase.java
+++ b/transports/jdbc/src/test/java/org/mule/transport/jdbc/config/NuoDBDataSourceConfigurationTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.jdbc.config;
+
+import org.junit.Test;
+import org.mule.api.MuleException;
+import org.mule.api.config.ConfigurationException;
+
+public class NuoDBDataSourceConfigurationTestCase extends AbstractDataSourceConfigurationTestCase
+{
+    @Test(expected=ConfigurationException.class)
+    public void failWhenUrlAndDatabaseConfigured() throws MuleException
+    {
+        tryBuildingMuleContextFromInvalidConfig("jdbc-data-source-nuodb-url-and-database.xml");
+    }
+
+    @Test(expected=ConfigurationException.class)
+    public void failWhenUrlAndHostConfigured() throws MuleException
+    {
+        tryBuildingMuleContextFromInvalidConfig("jdbc-data-source-nuodb-url-and-host.xml");
+    }
+}
+
+

--- a/transports/jdbc/src/test/resources/jdbc-data-source-namespace-config.xml
+++ b/transports/jdbc/src/test/resources/jdbc-data-source-namespace-config.xml
@@ -46,6 +46,23 @@
         user="mysql" database="mule" password="secret"/>
 
     <!--
+        NuoDB
+    -->
+
+    <!-- using the default url -->
+    <jdbc:nuodb-data-source name="default-nuodb" database="mule" user="nuodb" password="secret"/>
+
+    <!-- using a custom URL -->
+    <jdbc:nuodb-data-source name="custom-url-nuodb" url="jdbc:com.nuodb://mule-db-host:48004/mule"
+                            user="nuodb" password="secret"/>
+
+    <!-- custom parts of the nuodb url -->
+    <jdbc:nuodb-data-source name="custom-host-nuodb" host="some-other-host"
+                            database="mule" user="nuodb" password="secret"/>
+    <jdbc:nuodb-data-source name="custom-port-nuodb" port="4242"
+                            user="nuodb" database="mule" password="secret"/>
+
+    <!--
         PostgreSQL
     -->
 

--- a/transports/jdbc/src/test/resources/jdbc-data-source-nuodb-url-and-database.xml
+++ b/transports/jdbc/src/test/resources/jdbc-data-source-nuodb-url-and-database.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:jdbc="http://www.mulesoft.org/schema/mule/jdbc"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/jdbc http://www.mulesoft.org/schema/mule/jdbc/current/mule-jdbc.xsd">
+
+    <!-- this data source has both url and database configured, can only be one of both -->
+    <jdbc:nuodb-data-source name="nuodbDs" url="jdbc:com.nuodb://localhost/mule" database="mule"
+        user="nuodb" password="secret"/>
+</mule>

--- a/transports/jdbc/src/test/resources/jdbc-data-source-nuodb-url-and-host.xml
+++ b/transports/jdbc/src/test/resources/jdbc-data-source-nuodb-url-and-host.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:jdbc="http://www.mulesoft.org/schema/mule/jdbc"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/jdbc http://www.mulesoft.org/schema/mule/jdbc/current/mule-jdbc.xsd">
+
+    <!-- this data source has both url and host/port configured, can only be one of both -->
+    <jdbc:nuodb-data-source name="nuodbDs" url="jdbc:com.nuodb://localhost/mule"
+        host="localhost" port="5432"
+        user="nuodb" password="secret"/>
+</mule>


### PR DESCRIPTION
Add support for NuoDB to the JDBC transport.

I followed the same pattern as already implemented for other database vendors, added tests, and they pass.
