### PR TITLE
MULE-7443: Move SimpleLoggingTable to core so that it can be reused by o...

### DIFF
--- a/core/src/main/java/org/mule/util/SimpleLoggingTable.java
+++ b/core/src/main/java/org/mule/util/SimpleLoggingTable.java
@@ -4,9 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.module.launcher;
-
-import org.mule.util.StringUtils;
+package org.mule.util;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/modules/launcher/src/main/java/org/mule/module/launcher/StartupSummaryDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/StartupSummaryDeploymentListener.java
@@ -6,6 +6,8 @@
  */
 package org.mule.module.launcher;
 
+import org.mule.util.SimpleLoggingTable;
+
 import java.util.Map;
 
 import org.apache.commons.logging.Log;


### PR DESCRIPTION
...ther components without depending on launcher
