### PR TITLE
MULE-7367: Release profile creates test jars, javadocs and source jars a...

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,22 +14,12 @@
     <description>Mule server and core classes</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../LICENSE_HEADER.txt</licensePath>
     </properties>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>

--- a/core/src/main/java/org/mule/api/context/notification/TransactionNotificationListener.java
+++ b/core/src/main/java/org/mule/api/context/notification/TransactionNotificationListener.java
@@ -1,13 +1,9 @@
 /*
-* $Id:TransactionNotificationListener.java 7275 2007-06-28 02:51:31Z aperepel $
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
-
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.api.context.notification;
 
 import org.mule.context.notification.TransactionNotification;

--- a/core/src/main/java/org/mule/api/processor/InternalMessageProcessor.java
+++ b/core/src/main/java/org/mule/api/processor/InternalMessageProcessor.java
@@ -1,12 +1,9 @@
 /*
-* $Id$
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.api.processor;
 
 /**

--- a/core/src/main/java/org/mule/api/processor/ProcessingDescriptor.java
+++ b/core/src/main/java/org/mule/api/processor/ProcessingDescriptor.java
@@ -1,11 +1,9 @@
 /*
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-
 package org.mule.api.processor;
 
 /**

--- a/core/src/main/java/org/mule/execution/ResponseDispatchException.java
+++ b/core/src/main/java/org/mule/execution/ResponseDispatchException.java
@@ -1,8 +1,5 @@
 /*
- * $Id: HttpsHandshakeTimingTestCase.java 25119 2012-12-10 21:20:57Z pablo.lagreca $
- * --------------------------------------------------------------------------------------
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.

--- a/core/src/main/java/org/mule/streaming/ProvidesTotalHint.java
+++ b/core/src/main/java/org/mule/streaming/ProvidesTotalHint.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.

--- a/core/src/main/java/org/mule/util/Preconditions.java
+++ b/core/src/main/java/org/mule/util/Preconditions.java
@@ -1,8 +1,5 @@
 /*
- * $Id$
- * --------------------------------------------------------------------------------------
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.

--- a/core/src/test/java/org/mule/routing/outbound/SequenceRouterTestCase.java
+++ b/core/src/test/java/org/mule/routing/outbound/SequenceRouterTestCase.java
@@ -1,12 +1,9 @@
 /*
-* $Id$
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 
 package org.mule.routing.outbound;
 

--- a/core/src/test/java/org/mule/util/PreconditionsTest.java
+++ b/core/src/test/java/org/mule/util/PreconditionsTest.java
@@ -1,13 +1,9 @@
 /*
- * $Id$
- * --------------------------------------------------------------------------------------
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-
 package org.mule.util;
 
 

--- a/examples/echo/pom.xml
+++ b/examples/echo/pom.xml
@@ -13,24 +13,9 @@
     <description>This example shows how to add message processing components, in this example Logger and Echo, to a Flow. By doing so, you can perform custom logging in your Mule application. Logging is useful to introspect the current message and create logging events for your specific needs.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/examples/loanbroker-simple/pom.xml
+++ b/examples/loanbroker-simple/pom.xml
@@ -12,24 +12,9 @@
     <description>A simple implementation of the loanbroker example from the Enterprise Integration Patterns book using the new constructs in Mule 3</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/modules/annotations/pom.xml
+++ b/modules/annotations/pom.xml
@@ -17,25 +17,9 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <!-- Mule Dependencies -->

--- a/modules/bpm/pom.xml
+++ b/modules/bpm/pom.xml
@@ -13,24 +13,9 @@
     <description>Allows Mule events to initiate and/or advance processes in an external or embedded Business Process Management System (BPMS). It also allows executing processes to generate Mule events.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/modules/cxf/pom.xml
+++ b/modules/cxf/pom.xml
@@ -12,6 +12,7 @@
     <description>A Mule module for web service connectivity using CXF.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -82,60 +83,7 @@
                     <forkMode>always</forkMode>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.cxf</groupId>
-                                        <artifactId>cxf-codegen-plugin</artifactId>
-                                        <versionRange>[2.5.9,)</versionRange>
-                                        <goals>
-                                            <goal>wsdl2java</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore></ignore>
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-enforcer-plugin</artifactId>
-                                        <versionRange>[1.0-alpha-4,)</versionRange>
-                                        <goals>
-                                            <goal>enforce</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore></ignore>
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 
     <dependencies>

--- a/modules/devkit-support/pom.xml
+++ b/modules/devkit-support/pom.xml
@@ -16,6 +16,7 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 

--- a/modules/devkit-support/src/main/java/org/mule/security/oauth/processor/AbstractExpressionEvaluator.java
+++ b/modules/devkit-support/src/main/java/org/mule/security/oauth/processor/AbstractExpressionEvaluator.java
@@ -1,9 +1,9 @@
 /*
-  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-  * The software in this package is published under the terms of the CPAL v1.0
-  * license, a copy of which has been included with this distribution in the
-  * LICENSE.txt file.
-  */
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
  package org.mule.security.oauth.processor;
  
  import org.mule.devkit.processor.ExpressionEvaluatorSupport;

--- a/modules/guice/src/main/java/org/guiceyfruit/mule/support/DisposableCloser.java
+++ b/modules/guice/src/main/java/org/guiceyfruit/mule/support/DisposableCloser.java
@@ -1,12 +1,9 @@
 /*
-* $Id$
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.guiceyfruit.mule.support;
 
 import org.mule.api.MuleContext;

--- a/modules/launcher/pom.xml
+++ b/modules/launcher/pom.xml
@@ -12,6 +12,7 @@
     <name>Mule 3 Launcher</name>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -78,76 +79,6 @@
             </build>
         </profile>
     </profiles>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-        <pluginManagement>
-        	<plugins>
-        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        		<plugin>
-        			<groupId>org.eclipse.m2e</groupId>
-        			<artifactId>lifecycle-mapping</artifactId>
-        			<version>1.0.0</version>
-        			<configuration>
-        				<lifecycleMappingMetadata>
-        					<pluginExecutions>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									org.codehaus.mojo
-        								</groupId>
-        								<artifactId>
-        									shitty-maven-plugin
-        								</artifactId>
-        								<versionRange>
-        									[1.0-alpha-3,)
-        								</versionRange>
-        								<goals>
-        									<goal>clean</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									org.apache.maven.plugins
-        								</groupId>
-        								<artifactId>
-        									maven-enforcer-plugin
-        								</artifactId>
-        								<versionRange>
-        									[1.0-alpha-4,)
-        								</versionRange>
-        								<goals>
-        									<goal>enforce</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        					</pluginExecutions>
-        				</lifecycleMappingMetadata>
-        			</configuration>
-        		</plugin>
-        	</plugins>
-        </pluginManagement>
-    </build>
 
     <dependencies>
         <dependency>

--- a/modules/spring-config/src/main/java/org/mule/config/spring/MuleApplicationContext.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/MuleApplicationContext.java
@@ -1,11 +1,9 @@
 /*
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-
 package org.mule.config.spring;
 
 import org.mule.api.MuleContext;

--- a/modules/spring-config/src/main/java/org/mule/config/spring/parsers/specific/InheritedModelDefinitionParser.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/parsers/specific/InheritedModelDefinitionParser.java
@@ -1,12 +1,9 @@
 /*
- * $Id$
-  * --------------------------------------------------------------------------------------
-  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-  *
-  * The software in this package is published under the terms of the CPAL v1.0
-  * license, a copy of which has been included with this distribution in the
-  * LICENSE.txt file.
-  */
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.config.spring.parsers.specific;
 
 import org.springframework.beans.factory.support.AbstractBeanDefinition;

--- a/modules/spring-extras/pom.xml
+++ b/modules/spring-extras/pom.xml
@@ -14,6 +14,7 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -104,20 +105,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/modules/spring-security/pom.xml
+++ b/modules/spring-security/pom.xml
@@ -16,6 +16,7 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -143,20 +144,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/NamespaceRestorerXMLStreamReader.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/NamespaceRestorerXMLStreamReader.java
@@ -1,11 +1,9 @@
 /*
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-
 package org.mule.module.ws.consumer;
 
 import java.util.ArrayList;

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/ScopeSaverXMLStreamReader.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/ScopeSaverXMLStreamReader.java
@@ -1,11 +1,9 @@
 /*
  * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
- *
  * The software in this package is published under the terms of the CPAL v1.0
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-
 package org.mule.module.ws.consumer;
 
 import org.mule.module.xml.stax.DelegateXMLStreamReader;

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,9 @@
     </modules>
 
     <properties>
+        <!-- Properties that can be overriden in submodules -->
+        <skipExportTests>true</skipExportTests>
+
         <!-- Properties that can be used to enable/disable parts of the build via cmd line or profiles -->
         <skipIntegrationTests>false</skipIntegrationTests>
         <skipPerformanceTests>true</skipPerformanceTests>
@@ -1393,6 +1396,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.8</version>
                 </plugin>
@@ -1466,7 +1474,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1.2</version>
+                    <version>2.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1580,9 +1588,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>com.mycila.maven-license-plugin</groupId>
-                    <artifactId>maven-license-plugin</artifactId>
-                    <version>1.9.0</version>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>2.6</version>
                     <configuration>
                         <skip>${skipVerifications}</skip>
                         <header>${licensePath}</header>
@@ -1671,13 +1679,30 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipExportTests}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+
             <!-- Global test exclusions -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -2031,7 +2056,7 @@
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>true</skipDistributions>
                 <skipVerifications>false</skipVerifications>
-                <skipInstalls>false</skipInstalls>
+                <skipInstalls>true</skipInstalls>
                 <skipTests>true</skipTests>
             </properties>
         </profile>
@@ -2091,6 +2116,7 @@
                 <skipDistributions>true</skipDistributions>
                 <skipVerifications>true</skipVerifications>
                 <skipInstalls>true</skipInstalls>
+                <skipTests>true</skipTests>
             </properties>
         </profile>
         <profile>
@@ -2099,7 +2125,7 @@
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>false</skipDistributions>
                 <skipVerifications>true</skipVerifications>
-                <skipInstalls>true</skipInstalls>
+                <skipInstalls>false</skipInstalls>
                 <skipTests>true</skipTests>
             </properties>
             <build>
@@ -2115,6 +2141,24 @@
                                 <phase>install</phase>
                                 <goals>
                                     <goal>javadoc</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/tests/integration-axis/pom.xml
+++ b/tests/integration-axis/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
+        <skipTests>${skipIntegrationTests}</skipTests>
     </properties>
 
     <build>
@@ -24,7 +25,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>${skipIntegrationTests}</skip>
                     <argLine>-Xmx512m -XX:MaxPermSize=128m</argLine>
                 </configuration>
             </plugin>

--- a/tests/integration-jdk6/pom.xml
+++ b/tests/integration-jdk6/pom.xml
@@ -12,7 +12,9 @@
     <packaging>jar</packaging>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
+        <skipTests>${skipIntegrationTests}</skipTests>
     </properties>
 
     <build>
@@ -21,20 +23,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>${skipIntegrationTests}</skip>
                     <argLine>-Xmx512m -XX:MaxPermSize=128m</argLine>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -13,7 +13,9 @@
 	<packaging>jar</packaging>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
+        <skipTests>${skipIntegrationTests}</skipTests>
     </properties>
 
 	<build>
@@ -22,21 +24,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skip>${skipIntegrationTests}</skip>
                     <argLine>-Xmx512m -XX:MaxPermSize=128m</argLine>
                 </configuration>
             </plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/tools/anttasks/src/main/java/org/mule/tools/anttasks/FileChecker.java
+++ b/tools/anttasks/src/main/java/org/mule/tools/anttasks/FileChecker.java
@@ -1,12 +1,9 @@
 /*
-* $Id$
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc. All rights reserved. http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.tools.anttasks;
 
 import org.apache.tools.ant.BuildException;

--- a/tools/anttasks/src/main/java/org/mule/tools/anttasks/MuleDeploy.java
+++ b/tools/anttasks/src/main/java/org/mule/tools/anttasks/MuleDeploy.java
@@ -1,12 +1,9 @@
 /*
-* $Id$
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc. All rights reserved. http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.tools.anttasks;
 
 import org.apache.tools.ant.BuildException;

--- a/tools/anttasks/src/main/java/org/mule/tools/anttasks/MulePackage.java
+++ b/tools/anttasks/src/main/java/org/mule/tools/anttasks/MulePackage.java
@@ -1,12 +1,9 @@
 /*
-* $Id$
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc. All rights reserved. http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.tools.anttasks;
 
 import org.apache.tools.ant.taskdefs.Zip;

--- a/transports/email/pom.xml
+++ b/transports/email/pom.xml
@@ -14,6 +14,7 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -22,17 +23,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/transports/file/pom.xml
+++ b/transports/file/pom.xml
@@ -16,24 +16,9 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/transports/ftp/pom.xml
+++ b/transports/ftp/pom.xml
@@ -12,22 +12,12 @@
     <description>A Mule transport for Ftp Connectivity.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- create a defined directory that's used by the unit tests -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/transports/http/pom.xml
+++ b/transports/http/pom.xml
@@ -14,22 +14,12 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>native2ascii-maven-plugin</artifactId>

--- a/transports/jdbc/pom.xml
+++ b/transports/jdbc/pom.xml
@@ -12,24 +12,9 @@
     <description>A Mule transport for JDBC connectivity.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-         <plugins>
-             <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-jar-plugin</artifactId>
-                 <executions>
-                     <execution>
-                         <goals>
-                             <goal>test-jar</goal>
-                         </goals>
-                     </execution>
-                 </executions>
-             </plugin>
-         </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/transports/jdbc/src/test/java/org/mule/transport/jdbc/JdbcConnectorTestCase.java
+++ b/transports/jdbc/src/test/java/org/mule/transport/jdbc/JdbcConnectorTestCase.java
@@ -1,9 +1,9 @@
 /*
-* Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.transport.jdbc;
 
 import static org.hamcrest.core.Is.is;

--- a/transports/jms/pom.xml
+++ b/transports/jms/pom.xml
@@ -14,6 +14,7 @@
     <description>A Mule transport for Jms Connectivity.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -32,17 +33,6 @@
                         <include>**/*Test.java</include>
                     </includes>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/transports/rmi/pom.xml
+++ b/transports/rmi/pom.xml
@@ -12,24 +12,9 @@
     <description>A Mule transport for RMI Connectivity.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-         </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/transports/servlet/pom.xml
+++ b/transports/servlet/pom.xml
@@ -14,24 +14,9 @@
     </description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/transports/sftp/pom.xml
+++ b/transports/sftp/pom.xml
@@ -13,6 +13,7 @@
     <description>A Mule transport for SFTP connectivity</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -38,21 +39,6 @@
                                 </resource>
                             </resources>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <!-- ensure that source jar files are created and installed
-                    as well -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/transports/ssl/pom.xml
+++ b/transports/ssl/pom.xml
@@ -12,6 +12,7 @@
     <description>A Mule transport for Socket connectivity using SSL authentication. This transport supplies a tcp Server and client implementation over SSL.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
@@ -35,20 +36,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/transports/tcp/pom.xml
+++ b/transports/tcp/pom.xml
@@ -12,24 +12,9 @@
     <description>A Mule transport for Tcp Connectivity. This transport supplies a tcp Server and client implementation.</description>
 
     <properties>
+        <skipExportTests>false</skipExportTests>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>

--- a/transports/tcp/src/main/java/org/mule/transport/tcp/protocols/AbstractByteProtocol.java
+++ b/transports/tcp/src/main/java/org/mule/transport/tcp/protocols/AbstractByteProtocol.java
@@ -1,12 +1,9 @@
 /*
-* $Id$
-* --------------------------------------------------------------------------------------
-* Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
-*
-* The software in this package is published under the terms of the CPAL v1.0
-* license, a copy of which has been included with this distribution in the
-* LICENSE.txt file.
-*/
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 
 package org.mule.transport.tcp.protocols;
 


### PR DESCRIPTION
...utomatically

Removed duplicate test jar generation. It can now be enaled on each module through a property.
Upgraded license-check plugin, enabled strict mode, and fixed wrong licenses.
Integration profile skips tests in non-integration modules (can be safely run from root).
