### PR TITLE
MULE-7367: Removed forking a vm per test on management, jms and loanbrok...

### DIFF
--- a/examples/loanbroker-legacy/esn/dist/pom.xml
+++ b/examples/loanbroker-legacy/esn/dist/pom.xml
@@ -53,13 +53,6 @@
         <plugins>        
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkMode>pertest</forkMode>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>

--- a/examples/loanbroker-legacy/esn/pom.xml
+++ b/examples/loanbroker-legacy/esn/pom.xml
@@ -57,15 +57,4 @@
             <artifactId>geronimo-annotation_1.1_spec</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkMode>pertest</forkMode>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/modules/management/pom.xml
+++ b/modules/management/pom.xml
@@ -80,13 +80,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!--
-                        Fork each test in its own VM to minimize side effects e.g.
-                        with registered agents, JMX startup etc.
-                    -->
-                    <forkMode>pertest</forkMode>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/transports/jms/pom.xml
+++ b/transports/jms/pom.xml
@@ -23,7 +23,6 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkMode>pertest</forkMode>
                     <includes>
                         <!--
                             This module has some classes which begin with 'Test' and that are


### PR DESCRIPTION
...er example

Having them fork a new vm caused problems with executing unit tests only in the unit pass
