### PR TITLE
MULE-7789: Update mule-transports-http to tomcat 6+

### DIFF
--- a/transports/http/pom.xml
+++ b/transports/http/pom.xml
@@ -77,16 +77,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>tomcat</groupId>
-            <artifactId>tomcat-util</artifactId>
-            <version>5.5.23</version>
-            <exclusions>
-                <!-- we use slf4j -->
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging-api</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>coyote</artifactId>
+            <version>${tomcatVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.samba.jcifs</groupId>

--- a/transports/http/src/main/java/org/mule/transport/http/CookieHelper.java
+++ b/transports/http/src/main/java/org/mule/transport/http/CookieHelper.java
@@ -317,7 +317,7 @@ public class CookieHelper
     {
         StringBuffer sb = new StringBuffer();
         ServerCookie.appendCookieValue(sb, cookie.getVersion(), cookie.getName(), cookie.getValue(),
-            cookie.getPath(), cookie.getDomain(), cookie.getComment(), -1, cookie.getSecure());
+            cookie.getPath(), cookie.getDomain(), cookie.getComment(), -1, cookie.getSecure(), false);
 
         Date expiryDate = cookie.getExpiryDate();
         if (expiryDate != null)


### PR DESCRIPTION
mule-transports-http depends on tomcat 5.5.23 for cookie processing.
Upgraded to tomcat 6 version used by mule elsewhere using
${tomcatVersion}.  Tomcat moved this into coyote.  Verified working in
tomcat 6+.  Defaulted httpOnly to false in this instance since it was
not part of tomcat 5 and not part of cookie from commons-httpclient and
thus was naturally already false.  In tomcat 6, httpOnly is configurable
and default in tomcat 7+.  This seemed most appropriate way to get onto
tomcat 6+ as tomcat 5 is end of life and solved use case we had running
mule within tomcat 7 & 8.
