### PR TITLE
MULE-7478: All test log4j.properties should have the rootLogger at WARN ...

### DIFF
--- a/modules/db/src/test/resources/log4j.properties
+++ b/modules/db/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # default properties to initialise log4j
-log4j.rootLogger=INFO, A1
+log4j.rootLogger=WARN, A1
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=[%d{MM-dd HH:mm:ss}] %-5p %c{1} [%t]: %m%n


### PR DESCRIPTION
...level
