### PR TITLE
HttpUtilImpl fixes to retrieve the body even after a failure

### DIFF
--- a/modules/devkit-support/src/main/java/org/mule/security/oauth/util/HttpUtilImpl.java
+++ b/modules/devkit-support/src/main/java/org/mule/security/oauth/util/HttpUtilImpl.java
@@ -69,7 +69,18 @@ public class HttpUtilImpl implements HttpUtil
             OutputStreamWriter out = new OutputStreamWriter(conn.getOutputStream());
             out.write(body);
             out.close();
-            return IOUtils.toString(conn.getInputStream());
+            String response = "";
+
+            if (conn.getResponseCode() == 200) {
+                response = IOUtils.toString(conn.getInputStream());
+            } else {
+                response = IOUtils.toString(conn.getErrorStream());
+            }
+            if (logger.isDebugEnabled())
+            {
+                logger.debug(String.format("Received [%d] for body [%s]", conn.getResponseCode(), response));
+            }
+            return response;
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Workaround to retrieve the contents of the body even when the HTTP status is other than 200. Needed to log and understand authentication issues when retrieving the oAuth token from the provider. 
