### PR TITLE
MULE-7515 - using buffered input stream instead of socket input stream d...

### DIFF
--- a/transports/http/src/main/java/org/mule/transport/http/HttpServerConnection.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpServerConnection.java
@@ -12,6 +12,7 @@ import org.mule.api.transport.OutputHandler;
 import org.mule.util.SystemUtils;
 import org.mule.util.concurrent.Latch;
 
+import java.io.BufferedInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -89,7 +90,7 @@ public class HttpServerConnection implements HandshakeCompletedListener
             socket.setSoTimeout(connector.getServerSoTimeout());
         }
 
-        this.in = socket.getInputStream();
+        this.in = new BufferedInputStream(socket.getInputStream());
         this.out = new DataOutputStream(socket.getOutputStream());
         this.encoding = encoding;
     }

--- a/transports/http/src/test/java/org/mule/transport/http/HttpServerConnectionTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/HttpServerConnectionTestCase.java
@@ -20,6 +20,7 @@ import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.size.SmallTest;
 import org.mule.transport.tcp.TcpConnector;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import javax.net.ssl.HandshakeCompletedEvent;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLSocket;
 
+import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.IsNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,6 +87,14 @@ public class HttpServerConnectionTestCase extends AbstractMuleContextTestCase
         verify(mockSslSocket, times(1)).addHandshakeCompletedListener(httpServerConnection);
         assertThat(httpServerConnection.getLocalCertificateChain(), is(mockLocalCertificate));
         assertThat(httpServerConnection.getPeerCertificateChain(), is(mockPeerCertificates));
+    }
+
+
+    @Test
+    public void inputStreamIsWrappedWithBufferedInputStream() throws Exception
+    {
+        HttpServerConnection httpServerConnection = new HttpServerConnection(mockSocket, muleContext.getConfiguration().getDefaultEncoding(), mockHttpConnector);
+        assertThat(httpServerConnection.getInputStream(), IsInstanceOf.instanceOf(BufferedInputStream.class));
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
...irectly to prevent performance issue caused by HttpParser from HttpClient that is using read() calls to read the header and the request line
