### PR TITLE
MULE-7540: Migrated codehaus repos to mulesoft.org

### DIFF
--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -15,15 +15,6 @@
         <licensePath>../LICENSE_HEADER.txt</licensePath>
     </properties>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>mule-dist-snapshots</id>
-            <name>Mule Distributions Snapshot Repository</name>
-            <url>dav:https://dav.codehaus.org/snapshots.dist/mule/</url>
-            <uniqueVersion>false</uniqueVersion>
-        </snapshotRepository>
-    </distributionManagement>
-
     <build>
         <plugins>
             <plugin>
@@ -31,8 +22,6 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>${skipDistributions}</skip>
-                    <repositoryId>mule-dist-releases</repositoryId>
-                    <snapshotRepositoryId>mule-dist-snapshots</snapshotRepositoryId>
                 </configuration>
             </plugin>
             <plugin>
@@ -43,39 +32,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <!-- Mule Assembly Verifier Plugin snapshots hosted here -->
-            <id>codehaus-plugin-snapshots</id>
-            <name>Codehaus Plugin Snapshot Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <repositories>
-        <repository>
-            <!--
-                standalone-light needs this repo declared as a regular one now for maven 3,
-                dependency-unpack downloads and repackages full distro
-             -->
-            <id>codehaus-dist-snapshots</id>
-            <name>Codehaus Distribution Snapshots</name>
-            <url>http://snapshots.dist.codehaus.org/mule/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
 
     <modules>
         <module>embedded</module>

--- a/examples/bookstore/dist/pom.xml
+++ b/examples/bookstore/dist/pom.xml
@@ -128,34 +128,16 @@
         </plugins>
     </build>
 
-    <distributionManagement>
-        <downloadUrl>http://mule.mulesoft.org/display/MULE/Download</downloadUrl>
-        <repository>
-            <id>mule-releases</id>
-            <name>Mule Release Repository</name>
-            <url>dav:https://dav.codehaus.org/repository/mule/</url>
-        </repository>
-        <snapshotRepository>
-            <id>mule-snapshots</id>
-            <name>Mule Snapshot Repository</name>
-            <url>dav:https://dav.codehaus.org/snapshots.repository/mule/</url>
-            <uniqueVersion>false</uniqueVersion>
-        </snapshotRepository>
-    </distributionManagement>
-
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/cep/dist/pom.xml
+++ b/examples/cep/dist/pom.xml
@@ -63,17 +63,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/echo/dist/pom.xml
+++ b/examples/echo/dist/pom.xml
@@ -51,17 +51,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Maven 2.x Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Maven 2.x Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/errorhandler/dist/pom.xml
+++ b/examples/errorhandler/dist/pom.xml
@@ -225,17 +225,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/flight-reservation/dist/pom.xml
+++ b/examples/flight-reservation/dist/pom.xml
@@ -63,17 +63,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Maven 2.x Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Maven 2.x Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/foreach/dist/pom.xml
+++ b/examples/foreach/dist/pom.xml
@@ -230,17 +230,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/gpswalker/dist/pom.xml
+++ b/examples/gpswalker/dist/pom.xml
@@ -60,17 +60,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/hello/dist/pom.xml
+++ b/examples/hello/dist/pom.xml
@@ -67,17 +67,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Maven 2.x Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Maven 2.x Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/loanbroker-bpm/dist/pom.xml
+++ b/examples/loanbroker-bpm/dist/pom.xml
@@ -109,17 +109,14 @@
             </snapshots>
         </repository>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/loanbroker-legacy/dist/pom.xml
+++ b/examples/loanbroker-legacy/dist/pom.xml
@@ -57,17 +57,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Maven 2.x Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Maven 2.x Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/loanbroker-simple/dist/pom.xml
+++ b/examples/loanbroker-simple/dist/pom.xml
@@ -82,17 +82,14 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/notifications/dist/pom.xml
+++ b/examples/notifications/dist/pom.xml
@@ -65,17 +65,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/scripting/dist/pom.xml
+++ b/examples/scripting/dist/pom.xml
@@ -71,17 +71,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Maven 2.x Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Maven 2.x Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/examples/stockquote/dist/pom.xml
+++ b/examples/stockquote/dist/pom.xml
@@ -70,17 +70,14 @@
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Maven 2.x Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Maven 2.x Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -1279,40 +1279,37 @@
         <repository>
             <id>mule-releases</id>
             <name>Mule Release Repository</name>
-            <url>dav:https://dav.codehaus.org/repository/mule/</url>
+            <url>https://repository-master.mulesoft.org/nexus/content/repositories/releases</url>
         </repository>
         <snapshotRepository>
             <id>mule-snapshots</id>
             <name>Mule Snapshot Repository</name>
-            <url>dav:https://dav.codehaus.org/snapshots.repository/mule/</url>
+            <url>https://repository-master.mulesoft.org/nexus/content/repositories/snapshots</url>
             <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
-        <site>
-            <id>mule-site</id>
-            <name>Mule Website</name>
-            <url>dav:https://dav.codehaus.org/mule/docs/${project.version}</url>
-        </site>
     </distributionManagement>
 
     <repositories>
         <repository>
-            <id>codehaus</id>
-            <name>Codehaus Maven 2.x Release Repository</name>
-            <url>http://repository.codehaus.org</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>mule-releases</id>
+            <name>Mule Dependencies</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
-            <id>codehaus-snapshots</id>
-            <name>Codehaus Maven 2.x Snapshots Repository</name>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <id>mule-snapshots</id>
+            <name>Mule snapshots</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
             <releases>
                 <enabled>false</enabled>
             </releases>
+        </repository>
+        <repository>
+            <id>mule-deps</id>
+            <name>Mule dependencies</name>
+            <url>http://dist.codehaus.org/mule/dependencies/maven2/</url>
         </repository>
         <repository>
             <id>java-net</id>
@@ -1325,26 +1322,17 @@
             <url>http://repository.jboss.org/nexus/content/groups/public-jboss</url>
         </repository>
         <repository>
-            <id>mule-deps</id>
-            <name>Mule Dependencies</name>
-            <url>http://dist.codehaus.org/mule/dependencies/maven2</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
+            <id>codehaus</id>
+            <name>Codehaus Maven Repository</name>
+            <url>http://repository.codehaus.org</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
-            <id>mule-deps</id>
+            <id>mule-plugin-deps</id>
             <name>Mule Dependencies</name>
-            <url>http://dist.codehaus.org/mule/dependencies/maven2</url>
-        </pluginRepository>
-        <!-- this is needed to download dependencies of plugins from our custom repo -->
-        <pluginRepository>
-            <id>mule-plugins-deps</id>
-            <name>Mule Plugin Dependencies</name>
-            <url>http://dist.codehaus.org/mule/dependencies/maven2</url>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Migrated deploy information to use the new repositories
Merged distribution and artifact deployment info as they now end in the same repo
