### PR TITLE
MULE-7258: Request reply does not work when using specific connector

### DIFF
--- a/transports/vm/src/main/java/org/mule/transport/vm/VMConnector.java
+++ b/transports/vm/src/main/java/org/mule/transport/vm/VMConnector.java
@@ -116,7 +116,13 @@ public class VMConnector extends AbstractConnector
     public String getCanonicalURI(EndpointURI uri)
     {
         String canonicalURI = super.getCanonicalURI(uri);
-        return String.format("%s?connector=%s", canonicalURI, getName());
+
+        if (!canonicalURI.contains("?connector="))
+        {
+            canonicalURI = String.format("%s?connector=%s", canonicalURI, getName());
+        }
+
+        return canonicalURI;
     }
 
     public QueueProfile getQueueProfile()


### PR DESCRIPTION
Fix issue when the path already contains a connector reference
