### PR TITLE
extended SFTPConnectionFactory  for multi-auth username&password PLUS key-file

### DIFF
--- a/transports/sftp/src/main/java/org/mule/transport/sftp/SftpClient.java
+++ b/transports/sftp/src/main/java/org/mule/transport/sftp/SftpClient.java
@@ -121,6 +121,48 @@ public class SftpClient
         return path;
     }
 
+    /**
+     * This method supports multi-factor authentication - in particular, 
+     * username+password AND ssh-key
+     * @param user the userID whose SSH credentials are being used
+     * @param password the user's password - not to be confused with SSH-key passphrase
+     * @param identityFile the SSH-key for the user 
+     * @throws IOException 
+     */
+    public void login(String user, String password, String identityFile) throws IOException
+    {
+        try
+        {
+            Properties hash = new Properties();
+            hash.put(STRICT_HOST_KEY_CHECKING, "no");
+            if (!StringUtils.isEmpty(preferredAuthenticationMethods))
+            {
+                hash.put(PREFERRED_AUTHENTICATION_METHODS, preferredAuthenticationMethods);
+            }
+
+            session = jsch.getSession(user, host);
+            jsch.addIdentity(new File(identityFile).getAbsolutePath());
+            session.setConfig(hash);
+            session.setPort(port);
+            session.setPassword(password);
+            session.connect();
+
+            Channel channel = session.openChannel(CHANNEL_SFTP);
+            channel.connect();
+
+            channelSftp = (ChannelSftp) channel;
+            setHome(channelSftp.pwd());
+        }
+        catch (JSchException e)
+        {
+            logAndThrowLoginError(user, e);
+        }
+        catch (SftpException e)
+        {
+            logAndThrowLoginError(user, e);
+        }
+    }    
+    
     public void login(String user, String password) throws IOException
     {
         try

--- a/transports/sftp/src/main/java/org/mule/transport/sftp/SftpConnectionFactory.java
+++ b/transports/sftp/src/main/java/org/mule/transport/sftp/SftpConnectionFactory.java
@@ -95,12 +95,22 @@ public class SftpConnectionFactory implements PoolableObjectFactory
             // {
             // try
             // {
-            if (identityFile != null)
+            // this first case is when a key-file AND password have been provided. 
+            //  Note - not caring about passphrase. We are covering here the case 
+            // where username/password AND key-file are provided only.
+            //See javadoc on the 3-argument client.login
+            if (identityFile != null && endpointURI.getPassword() != null)
+            {
+                client.login(endpointURI.getUser(), endpointURI.getPassword(), identityFile);
+            }
+            //this next case is where a only a key-file is provided
+            else if (identityFile != null)
             {
                 String passphrase = sftpUtil.getPassphrase();
 
                 client.login(endpointURI.getUser(), identityFile, passphrase);
             }
+            //lastly, if there is a username and password
             else
             {
                 client.login(endpointURI.getUser(), endpointURI.getPassword());


### PR DESCRIPTION
multi-auth is becoming more common. Large US bank wants username/password PLUS key-file for authentication. Could be done with a service-override (?) and we may need to do that anyway to support client, but this extensioncan be used by other clients as well.

To see this working, edit an OpenSSH configuration file (see http://serverfault.com/a/562899 ) to add this:
AuthenticationMethods publickey,password

behavior in the commandline or scp tool will appear as follows
![uname pwd key](https://cloud.githubusercontent.com/assets/6012630/2806898/d01837de-ccd6-11e3-8e8e-5f95437e8f50.png)
