### PR TITLE
MULE-7534: JMS connector doesn't reconnect to ActiveMQ broker 5.6 when using blocking=true

### DIFF
--- a/transports/jms/src/test/java/org/mule/transport/jms/JmsReconnectionActiveMQTestCase.java
+++ b/transports/jms/src/test/java/org/mule/transport/jms/JmsReconnectionActiveMQTestCase.java
@@ -8,11 +8,15 @@ package org.mule.transport.jms;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.mule.api.MuleMessage;
 import org.mule.context.notification.ConnectionNotification;
 import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.listener.ConnectionListener;
+import org.mule.tck.probe.PollingProber;
+import org.mule.tck.probe.Probe;
+import org.mule.tck.probe.Prober;
 
 import javax.jms.Connection;
 import javax.jms.JMSException;
@@ -37,6 +41,8 @@ public class JmsReconnectionActiveMQTestCase extends FunctionalTestCase
     public DynamicPort port = new DynamicPort("port");
 
     private BrokerService broker;
+    private Prober prober = new PollingProber(3000, 200);
+    private JmsConnector jmsConnector;
 
     @Override
     protected String getConfigFile()
@@ -75,6 +81,8 @@ public class JmsReconnectionActiveMQTestCase extends FunctionalTestCase
     @Test
     public void reconnectsAfterRestartingActiveMQBroker() throws Exception
     {
+        jmsConnector = (JmsConnector) muleContext.getRegistry().lookupConnector("jmsConnector");
+
         assertMessageRouted();
 
         // Stop the broker, and make the connection factory return invalid connections.
@@ -85,15 +93,28 @@ public class JmsReconnectionActiveMQTestCase extends FunctionalTestCase
         stopBroker();
 
         connectionListener.waitUntilNotificationsAreReceived();
+        assertTrue(jmsConnector.isStopped());
+
 
         // Restart the broker
-        ConnectionListener reconnectionListener = new ConnectionListener(muleContext)
-                .setExpectedAction(ConnectionNotification.CONNECTION_CONNECTED).setNumberOfExecutionsRequired(1);
-
         CustomConnectionFactory.returnInvalidConnections = false;
         startBroker();
 
-        reconnectionListener.waitUntilNotificationsAreReceived();
+        // Wait until jmsConnector is reconnected and started.
+        prober.check(new Probe()
+        {
+            @Override
+            public boolean isSatisfied()
+            {
+                return jmsConnector.isStarted();
+            }
+
+            @Override
+            public String describeFailure()
+            {
+                return "JMS connector did not restart";
+            }
+        });
 
         // Check that reconnection worked
         assertMessageRouted();


### PR DESCRIPTION
Fixed flaky test. The condition used to check for reconnection was wrong, the jms connector might have been reconnected but not started yet.
