### PR TITLE
MULE-7491: JDBC reconnect policy is not working when setting blocking=true

### DIFF
--- a/transports/jdbc/src/test/java/org/mule/transport/jdbc/functional/JdbcReconnectionTestCase.java
+++ b/transports/jdbc/src/test/java/org/mule/transport/jdbc/functional/JdbcReconnectionTestCase.java
@@ -7,85 +7,47 @@
 package org.mule.transport.jdbc.functional;
 
 
-import static org.junit.Assert.assertTrue;
-import org.mule.api.MuleEventContext;
+import static org.junit.Assert.assertNotNull;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.MuleClient;
 import org.mule.context.notification.ConnectionNotification;
-import org.mule.tck.functional.EventCallback;
-import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.listener.ConnectionListener;
-import org.mule.tck.util.MuleDerbyTestUtils;
-import org.mule.transport.jdbc.JdbcConnector;
 
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.dbutils.QueryRunner;
-import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class JdbcReconnectionTestCase extends FunctionalTestCase
+public class JdbcReconnectionTestCase extends AbstractJdbcFunctionalTestCase
 {
 
-    private String configFile;
-
-    public JdbcReconnectionTestCase(String configFile)
+    public JdbcReconnectionTestCase(ConfigVariant variant, String configResources)
     {
-        setStartContext(false);
-        this.configFile = configFile;
+        super(variant, configResources);
     }
 
     @Parameterized.Parameters
     public static Collection<Object[]> parameters()
     {
-        return Arrays.asList(new Object[] {"jdbc-reconnection-blocking-config.xml"},
-                             new Object[] {"jdbc-reconnection-nonblocking-config.xml"});
-    }
-
-    @Override
-    protected String getConfigFile()
-    {
-        return configFile;
-    }
-
-    @AfterClass
-    public static void stopDatabase() throws SQLException
-    {
-        MuleDerbyTestUtils.stopDatabase();
+        return Arrays.asList(new Object[][] {
+                {ConfigVariant.FLOW, "jdbc-reconnection-blocking-config.xml"},
+                {ConfigVariant.FLOW, "jdbc-reconnection-nonblocking-config.xml"}});
     }
 
     @Test
     public void reconnectsAfterConnectException() throws Exception
     {
-        final CountDownLatch messageReceivedLatch = new CountDownLatch(1);
-        final CountDownLatch connectFailedLatch = new CountDownLatch(3);
-        final CountDownLatch reconnectedLatch = new CountDownLatch(1);
+        MuleClient client = muleContext.getClient();
 
-        getFunctionalTestComponent("test").setEventCallback(new EventCallback()
-        {
-            @Override
-            public void eventReceived(MuleEventContext context, Object component) throws Exception
-            {
-                messageReceivedLatch.countDown();
-            }
-        });
+        // Assert messages are received correctly
+        MuleMessage message = client.request("vm://out", RECEIVE_TIMEOUT);
+        assertNotNull("No message received", message);
 
         ConnectionListener connectionListener = new ConnectionListener(muleContext)
                 .setExpectedAction(ConnectionNotification.CONNECTION_FAILED).setNumberOfExecutionsRequired(3);
-
-        // Load data so that messages are received in the test flow.
-        MuleDerbyTestUtils.defaultDerbyCleanAndInit("derby.properties", "database.name");
-        initializeDatabase();
-
-        muleContext.start();
-
-        // Wait until one message is successfully received.
-        assertTrue("No message received", messageReceivedLatch.await(LOCK_TIMEOUT, TimeUnit.MILLISECONDS));
 
         // Stop the database, Mule should try to reconnect
         stopDatabase();
@@ -93,36 +55,14 @@ public class JdbcReconnectionTestCase extends FunctionalTestCase
         // Wait for reconnect attempts ("connect failed" notifications)
         connectionListener.waitUntilNotificationsAreReceived();
 
-        getFunctionalTestComponent("test").setEventCallback(new EventCallback()
-        {
-            @Override
-            public void eventReceived(MuleEventContext context, Object component) throws Exception
-            {
-                reconnectedLatch.countDown();
-            }
-        });
-
         // Restart the database
-        MuleDerbyTestUtils.defaultDerbyCleanAndInit("derby.properties", "database.name");
-        initializeDatabase();
+        startDatabase();
+        createTable();
+        populateTable();
 
         // Wait for a message to arrive
-        assertTrue("Reconnection failed", reconnectedLatch.await(LOCK_TIMEOUT, TimeUnit.MILLISECONDS));
-
-        stopDatabase();
-    }
-
-
-    /**
-     * Creates a test table and inserts a row in it.
-     */
-    private void initializeDatabase() throws Exception
-    {
-        JdbcConnector jdbcConnector = (JdbcConnector) muleContext.getRegistry().lookupConnector("jdbcConnector");
-
-        QueryRunner qr = jdbcConnector.getQueryRunner();
-        qr.update(jdbcConnector.getConnection(), "CREATE TABLE TEST(ID INTEGER GENERATED BY DEFAULT AS IDENTITY(START WITH 0) NOT NULL PRIMARY KEY, DATA VARCHAR(255))");
-        qr.update(jdbcConnector.getConnection(), "INSERT INTO TEST(DATA) VALUES ('a')");
+        message = client.request("vm://out", RECEIVE_TIMEOUT);
+        assertNotNull("Reconnection failed", message);
     }
 
 }

--- a/transports/jdbc/src/test/resources/jdbc-reconnection-blocking-config.xml
+++ b/transports/jdbc/src/test/resources/jdbc-reconnection-blocking-config.xml
@@ -2,10 +2,10 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:jdbc="http://www.mulesoft.org/schema/mule/jdbc"
-      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
       xsi:schemaLocation="
-       http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
        http://www.mulesoft.org/schema/mule/jdbc http://www.mulesoft.org/schema/mule/jdbc/current/mule-jdbc.xsd">
 
     <jdbc:derby-data-source name="jdbcDataSource" url="jdbc:derby:muleEmbeddedDB;create=true"/>
@@ -19,7 +19,7 @@
 
     <flow name="test">
         <jdbc:inbound-endpoint queryKey="testQuery" exchange-pattern="one-way" connector-ref="jdbcConnector" />
-        <test:component />
+        <vm:outbound-endpoint path="out" />
     </flow>
 
 </mule>

--- a/transports/jdbc/src/test/resources/jdbc-reconnection-nonblocking-config.xml
+++ b/transports/jdbc/src/test/resources/jdbc-reconnection-nonblocking-config.xml
@@ -2,9 +2,9 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:jdbc="http://www.mulesoft.org/schema/mule/jdbc"
-      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
       xsi:schemaLocation="
-       http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+       http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/jdbc http://www.mulesoft.org/schema/mule/jdbc/current/mule-jdbc.xsd">
 
@@ -19,7 +19,7 @@
 
     <flow name="test">
         <jdbc:inbound-endpoint queryKey="testQuery" exchange-pattern="one-way" connector-ref="jdbcConnector" />
-        <test:component />
+        <vm:outbound-endpoint path="out" />
     </flow>
 
 </mule>


### PR DESCRIPTION
Improving test case using AbstractJdbcFunctionalTestCase instead of FunctionalTestCase
