### PR TITLE
MULE-7573: CXF java.lang.reflect.Method cannot be cast to java.lang.String

### DIFF
--- a/modules/cxf/src/main/java/org/mule/module/cxf/CxfOutboundMessageProcessor.java
+++ b/modules/cxf/src/main/java/org/mule/module/cxf/CxfOutboundMessageProcessor.java
@@ -331,7 +331,19 @@ public class CxfOutboundMessageProcessor extends AbstractInterceptingMessageProc
 
         if (method == null)
         {
-            method = event.getMessage().getInvocationProperty(MuleProperties.MULE_METHOD_PROPERTY);
+            Object muleMethodProperty = event.getMessage().getInvocationProperty(MuleProperties.MULE_METHOD_PROPERTY);
+
+            if (muleMethodProperty != null)
+            {
+                if (muleMethodProperty instanceof Method)
+                {
+                    method = ((Method) muleMethodProperty).getName();
+                }
+                else
+                {
+                    method = muleMethodProperty.toString();
+                }
+            }
         }
 
         if (method == null)

--- a/modules/cxf/src/test/java/org/mule/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
+++ b/modules/cxf/src/test/java/org/mule/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.cxf.functional;
+
+
+import static org.junit.Assert.assertEquals;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.MuleClient;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CxfJaxWsServiceAndClientTestCase extends FunctionalTestCase
+{
+    @Rule
+    public DynamicPort port = new DynamicPort("port");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "cxf-jaxws-service-and-client-config.xml";
+    }
+
+    @Test
+    public void jaxWsClientReadsMuleMethodPropertySetByJaxWsService() throws Exception
+    {
+        String url = "cxf:http://localhost:" + port.getNumber() + "/hello?method=sayHi";
+        MuleClient client = muleContext.getClient();
+
+        MuleMessage result = client.send(url, TEST_MESSAGE, null);
+
+        assertEquals("Hello\u2297 " + TEST_MESSAGE, result.getPayloadAsString());
+    }
+}

--- a/modules/cxf/src/test/resources/cxf-jaxws-service-and-client-config.xml
+++ b/modules/cxf/src/test/resources/cxf-jaxws-service-and-client-config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:cxf="http://www.mulesoft.org/schema/mule/cxf"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/cxf http://www.mulesoft.org/schema/mule/cxf/current/mule-cxf.xsd
+            http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <flow name="client">
+        <http:inbound-endpoint exchange-pattern="request-response" host="localhost" port="${port}" path="hello" />
+        <logger level="WARN" message="#[payload]" />
+        <cxf:jaxws-service serviceClass="org.mule.module.cxf.example.HelloWorld" />
+
+        <!-- The MULE_METHOD_PROPERTY invocation property set by the jaxws-service should override the "invalidOperation"
+            value of the operation attribute in jaxws-client -->
+        <cxf:jaxws-client serviceClass="org.mule.module.cxf.example.HelloWorld" operation="invalidOperation"/>
+        <logger level="WARN" message="#[payload]" />
+        <http:outbound-endpoint exchange-pattern="request-response" host="localhost" port="${port}" path="hello2" method="POST" />
+    </flow>
+
+
+    <flow name="server">
+        <http:inbound-endpoint exchange-pattern="request-response" host="localhost" port="${port}" path="hello2"/>
+        <cxf:jaxws-service serviceClass="org.mule.module.cxf.example.HelloWorld"/>
+        <component class="org.mule.module.cxf.example.HelloWorldImpl"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
Changed CxfOutboundMessageProcessor to allow MULE_MESSAGE_PROPERTY to be either String or Method
