### PR TITLE
MULE-7599 - Add GPG signature to artifacts\

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <skipDistributions>true</skipDistributions>
         <skipVerifications>false</skipVerifications>
         <skipInstalls>false</skipInstalls>
+        <skipGpg>true</skipGpg>
 
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <licensePath>LICENSE_HEADER.txt</licensePath>
@@ -2182,6 +2183,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <skip>${skipGpg}</skip>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
By default artifacts are not signed. In order to add signature use -DskipGpg=false
