### PR TITLE
MULE-7623: Keep original directory name at originalDirectory inbound pro...

### DIFF
--- a/transports/file/src/main/java/org/mule/transport/file/FileConnector.java
+++ b/transports/file/src/main/java/org/mule/transport/file/FileConnector.java
@@ -64,8 +64,9 @@ public class FileConnector extends AbstractConnector
     // message properties
     public static final String PROPERTY_FILENAME = "filename";
     public static final String PROPERTY_ORIGINAL_FILENAME = "originalFilename";
-    public static final String PROPERTY_SOURCE_FILENAME = "sourceFileName";
+    public static final String PROPERTY_ORIGINAL_DIRECTORY = "originalDirectory";
     public static final String PROPERTY_DIRECTORY = "directory";
+    public static final String PROPERTY_SOURCE_FILENAME = "sourceFileName";
     public static final String PROPERTY_SOURCE_DIRECTORY = "sourceDirectory";
     public static final String PROPERTY_WRITE_TO_DIRECTORY = "writeToDirectoryName";
     public static final String PROPERTY_FILE_SIZE = "fileSize";

--- a/transports/file/src/main/java/org/mule/transport/file/FileMessageReceiver.java
+++ b/transports/file/src/main/java/org/mule/transport/file/FileMessageReceiver.java
@@ -283,20 +283,21 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
             logger.info("Lock obtained on file: " + file.getAbsolutePath());
         }
 
+        // The file may get moved/renamed here so store the original file info.
+        final String originalSourceFilePath = file.getAbsolutePath();
+        final String originalSourceFileName = file.getName();
+        final String originalSourceDirectory = file.getParent();
+
         // This isn't nice but is needed as MuleMessage is required to resolve
         // destination file name
         DefaultMuleMessage fileParserMessasge = new DefaultMuleMessage(null, getEndpoint().getMuleContext());
-        fileParserMessasge.setInboundProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, file.getName());
+        fileParserMessasge.setInboundProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, originalSourceFileName);
+        fileParserMessasge.setInboundProperty(FileConnector.PROPERTY_ORIGINAL_DIRECTORY, originalSourceDirectory);
 
-        // The file may get moved/renamed here so store the original file info.
-        final String originalSourceFile = file.getAbsolutePath();
-        final String originalSourceFileName = file.getName();
         final File sourceFile;
         if (workDir != null)
         {
-            String workFileName = file.getName();
-
-            workFileName = fileConnector.getFilenameParser().getFilename(fileParserMessasge, workFileNamePattern);
+            String workFileName = fileConnector.getFilenameParser().getFilename(fileParserMessasge, workFileNamePattern);
             // don't use new File() directly, see MULE-1112
             File workFile = FileUtils.newFile(workDir, workFileName);
 
@@ -316,8 +317,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
             String destinationFileName = originalSourceFileName;
             if (moveToPattern != null)
             {
-                destinationFileName = fileConnector.getFilenameParser().getFilename(fileParserMessasge,
-                                                                                    moveToPattern);
+                destinationFileName = fileConnector.getFilenameParser().getFilename(fileParserMessasge, moveToPattern);
             }
             // don't use new File() directly, see MULE-1112
             destinationFile = FileUtils.newFile(moveDir, destinationFileName);
@@ -357,7 +357,12 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
             message.setProperty(FileConnector.PROPERTY_SOURCE_FILENAME, file.getName(), PropertyScope.INBOUND);
         }
 
+        message.setProperty(FileConnector.PROPERTY_ORIGINAL_DIRECTORY, originalSourceDirectory, PropertyScope.INBOUND);
+        message.setProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, originalSourceFileName, PropertyScope.INBOUND);
+
+        message.setInvocationProperty(FileConnector.PROPERTY_ORIGINAL_DIRECTORY, originalSourceDirectory);
         message.setInvocationProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, originalSourceFileName);
+
         if (forceSync)
         {
             message.setProperty(MuleProperties.MULE_FORCE_SYNC_PROPERTY, Boolean.TRUE, PropertyScope.INBOUND);
@@ -374,7 +379,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
         }
         else
         {
-            processWithoutStreaming(originalSourceFile, originalSourceFileName, sourceFile, destinationFile, executionTemplate, finalMessage);
+            processWithoutStreaming(originalSourceFilePath, originalSourceFileName, originalSourceDirectory, sourceFile, destinationFile, executionTemplate, finalMessage);
         }
     }
 
@@ -421,7 +426,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
         }
     }
 
-    private void processWithoutStreaming(String originalSourceFile, final String originalSourceFileName, final File sourceFile,final File destinationFile, ExecutionTemplate<MuleEvent> executionTemplate, final MuleMessage finalMessage) throws DefaultMuleException
+    private void processWithoutStreaming(String originalSourceFile, final String originalSourceFileName, final String originalSourceDirectory, final File sourceFile,final File destinationFile, ExecutionTemplate<MuleEvent> executionTemplate, final MuleMessage finalMessage) throws DefaultMuleException
     {
         try
         {
@@ -430,7 +435,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
                 @Override
                 public MuleEvent process() throws Exception
                 {
-                    moveAndDelete(sourceFile, destinationFile, originalSourceFileName, finalMessage);
+                    moveAndDelete(sourceFile, destinationFile, originalSourceFileName, originalSourceDirectory, finalMessage);
                     return null;
                 }
             });
@@ -543,7 +548,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
     }
 
     private void moveAndDelete(final File sourceFile, File destinationFile,
-                               String sourceFileOriginalName, MuleMessage message) throws MuleException
+                               String originalSourceFileName, String originalSourceDirectory, MuleMessage message) throws MuleException
     {
         // If we are moving the file to a read directory, move it there now and
         // hand over a reference to the
@@ -565,7 +570,8 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
             // create new Message for destinationFile
             message = createMuleMessage(destinationFile, endpoint.getEncoding());
             message.setProperty(FileConnector.PROPERTY_FILENAME, destinationFile.getName(), PropertyScope.INBOUND);
-            message.setProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, sourceFileOriginalName, PropertyScope.INBOUND);
+            message.setProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, originalSourceFileName, PropertyScope.INBOUND);
+            message.setProperty(FileConnector.PROPERTY_ORIGINAL_DIRECTORY, originalSourceDirectory, PropertyScope.INBOUND);
         }
 
         // finally deliver the file message

--- a/transports/file/src/main/java/org/mule/transport/file/FileMessageRequester.java
+++ b/transports/file/src/main/java/org/mule/transport/file/FileMessageRequester.java
@@ -126,12 +126,13 @@ public class FileMessageRequester extends AbstractMessageRequester
                 }
 
                 // Don't we need to try to obtain a file lock as we do with receiver
-                String sourceFileOriginalName = result.getName();
+                String originalSourceFileName = result.getName();
+                String originalSourceDirectory = result.getParent();
 
                 File workFile = null;
                 if (workDir != null)
                 {
-                    String workFileName = formatUsingFilenameParser(sourceFileOriginalName, workFileNamePattern);
+                    String workFileName = formatUsingFilenameParser(originalSourceFileName, originalSourceDirectory, workFileNamePattern);
 
                     // don't use new File() directly, see MULE-1112
                     workFile = FileUtils.newFile(workDir, workFileName);
@@ -147,11 +148,11 @@ public class FileMessageRequester extends AbstractMessageRequester
                 String movDir = getMoveDirectory();
                 if (movDir != null)
                 {
-                    String destinationFileName = sourceFileOriginalName;
+                    String destinationFileName = originalSourceFileName;
                     String moveToPattern = getMoveToPattern();
                     if (moveToPattern != null)
                     {
-                        destinationFileName = formatUsingFilenameParser(sourceFileOriginalName, moveToPattern);
+                        destinationFileName = formatUsingFilenameParser(originalSourceFileName, originalSourceDirectory, moveToPattern);
                     }
                     // don't use new File() directly, see MULE-1112
                     destinationFile = FileUtils.newFile(movDir, destinationFileName);
@@ -179,7 +180,8 @@ public class FileMessageRequester extends AbstractMessageRequester
                     logger.error("File being read disappeared!", e);
                     return null;
                 }
-                returnMessage.setProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, sourceFileOriginalName, PropertyScope.INBOUND);
+                returnMessage.setProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, originalSourceFileName, PropertyScope.INBOUND);
+                returnMessage.setProperty(FileConnector.PROPERTY_ORIGINAL_DIRECTORY, originalSourceDirectory, PropertyScope.INBOUND);
 
                 if (!fileConnector.isStreaming())
                 {
@@ -194,12 +196,13 @@ public class FileMessageRequester extends AbstractMessageRequester
         return null;
     }
 
-    protected String formatUsingFilenameParser(String originalName, String pattern)
+    protected String formatUsingFilenameParser(String originalFileName, String originalDirectory, String pattern)
     {
         // This isn't nice but is needed as MuleMessage is required to resolve
         // destination file name
         DefaultMuleMessage fileParserMessasge = new DefaultMuleMessage(null, getEndpoint().getMuleContext());
-        fileParserMessasge.setInboundProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, originalName);
+        fileParserMessasge.setInboundProperty(FileConnector.PROPERTY_ORIGINAL_FILENAME, originalFileName);
+        fileParserMessasge.setInboundProperty(FileConnector.PROPERTY_ORIGINAL_DIRECTORY, originalDirectory);
 
         return fileConnector.getFilenameParser().getFilename(fileParserMessasge, pattern);
     }

--- a/transports/file/src/test/java/org/mule/transport/file/KeepOriginalFilePropertiesTestCase.java
+++ b/transports/file/src/test/java/org/mule/transport/file/KeepOriginalFilePropertiesTestCase.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.file;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.mule.api.MuleException;
+import org.mule.api.MuleMessage;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.util.FileUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KeepOriginalFilePropertiesTestCase extends FunctionalTestCase
+{
+    private static final String OUT_QUEUE = "vm://file.outbox";
+    private static final String TEST_FILENAME = "original.txt";
+    private static final String PROCESSED_PREFIX = "processed-";
+    private static final String INPUT_DIRECTORY = "input";
+    private static final String OUTPUT_DIRECTORY = "output";
+    private static final String CUSTOM_PROPERTY_ORIGINAL_FILENAME = "aux-" + FileConnector.PROPERTY_ORIGINAL_FILENAME;
+    private static final String CUSTOM_PROPERTY_ORIGINAL_DIRECTORY = "aux-" + FileConnector.PROPERTY_ORIGINAL_DIRECTORY;
+    private static final String PRIVATE_PATH = "/private";
+
+    @Test
+    public void moveToPatternWithDirectory() throws Exception
+    {
+        MuleMessage msg = waitUntilMessageIsProcessed();
+        assertNotNull(msg);
+
+        assertPropertiesAvailableAtPatternResolution(msg);
+
+        assertEquals(TEST_FILENAME, getProperty(msg, CUSTOM_PROPERTY_ORIGINAL_FILENAME));
+
+        assertOriginalDirectoryIsCorrectlySet(msg);
+    }
+
+    private MuleMessage waitUntilMessageIsProcessed() throws MuleException
+    {
+        return muleContext.getClient().request(OUT_QUEUE, 3000);
+    }
+
+    private String getProperty(MuleMessage msg, String propertyName)
+    {
+        return msg.getInboundProperty(propertyName);
+    }
+
+    private void assertPropertiesAvailableAtPatternResolution(MuleMessage msg)
+    {
+        assertTrue(new File(getFileInsideWorkingDirectory(OUTPUT_DIRECTORY), PROCESSED_PREFIX + getProperty(msg, CUSTOM_PROPERTY_ORIGINAL_FILENAME)).exists());
+    }
+
+    private void assertOriginalDirectoryIsCorrectlySet(MuleMessage msg)
+    {
+        String originalDirectory = getFileInsideWorkingDirectory(INPUT_DIRECTORY).getPath();
+        String originalDirectoryPropertyValue = getProperty(msg, CUSTOM_PROPERTY_ORIGINAL_DIRECTORY);
+        try
+        {
+            assertEquals(originalDirectory, originalDirectoryPropertyValue);
+        } catch(Throwable t)
+        {
+            originalDirectory = removePrivatePath(originalDirectory);
+            originalDirectoryPropertyValue = removePrivatePath(originalDirectoryPropertyValue);
+            assertEquals(originalDirectory, originalDirectoryPropertyValue);
+        }
+    }
+
+    private String removePrivatePath(String path)
+    {
+        if(path.startsWith(PRIVATE_PATH))
+        {
+            path = path.substring(PRIVATE_PATH.length());
+        }
+        return path;
+    }
+
+    @After
+    public void clearDirectories()
+    {
+        assertTrue(FileUtils.deleteTree(getWorkingDirectory()));
+    }
+
+    @Before
+    public void writeTestMessageToInputDirectory() throws IOException
+    {
+        File outFile = new File(getFileInsideWorkingDirectory(INPUT_DIRECTORY), TEST_FILENAME);
+        FileOutputStream out = new FileOutputStream(outFile);
+        try
+        {
+            out.write(TEST_MESSAGE.getBytes());
+        }
+        finally
+        {
+            out.close();
+        }
+    }
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "keep-original-file-properties-config.xml";
+    }
+}

--- a/transports/file/src/test/resources/keep-original-file-properties-config.xml
+++ b/transports/file/src/test/resources/keep-original-file-properties-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:file="http://www.mulesoft.org/schema/mule/file"
+    xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd">
+
+    <file:connector name="fileConnector"
+                    moveToDirectory="${workingDirectory}/output"
+                    streaming="true"
+                    pollingFrequency="100"
+                    workDirectory="${workingDirectory}/work"
+                    moveToPattern="processed-#[message.inboundProperties['originalFilename']]"
+                    autoDelete="false" />
+
+    <file:endpoint path="${workingDirectory}/input"
+                   name="get"
+                   connector-ref="fileConnector" />
+
+    <flow name="relay" >
+        <inbound-endpoint ref="get" />
+        <set-property propertyName="aux-originalFilename" value="#[message.inboundProperties['originalFilename']]" />
+        <set-property propertyName="aux-originalDirectory" value="#[message.inboundProperties['originalDirectory']]" />
+        <echo-component/>
+        <outbound-endpoint address="vm://file.outbox" />
+    </flow>
+</mule>


### PR DESCRIPTION
...prty and make originalFilename and originalDirectory properties available when the moveToPattern is resolved.
