### PR TITLE
provide support for (userName + password + identityFile) authentication

### DIFF
--- a/transports/sftp/src/main/java/org/mule/transport/sftp/SftpClient.java
+++ b/transports/sftp/src/main/java/org/mule/transport/sftp/SftpClient.java
@@ -121,6 +121,36 @@ public class SftpClient
         return path;
     }
 
+    public void login(String user, String password, File identityFile) throws IOException
+    {
+        try
+        {
+            Properties hash = new Properties();
+            hash.put(STRICT_HOST_KEY_CHECKING, "no");
+            if (!StringUtils.isEmpty(preferredAuthenticationMethods))
+            {
+                hash.put(PREFERRED_AUTHENTICATION_METHODS, preferredAuthenticationMethods);
+            }
+            session = jsch.getSession(user, host);
+            jsch.addIdentity(identityFile.getAbsolutePath());
+            session.setConfig(hash);
+            session.setPort(port);
+            session.setPassword(password);
+            session.connect();
+            Channel channel = session.openChannel(CHANNEL_SFTP);
+            channel.connect();
+            channelSftp = (ChannelSftp) channel;
+            setHome(channelSftp.pwd());
+        }
+        catch (JSchException e)
+        {
+            logAndThrowLoginError(user, e);
+        }
+        catch (SftpException e)
+        {
+            logAndThrowLoginError(user, e);
+        }
+    }        
     public void login(String user, String password) throws IOException
     {
         try

--- a/transports/sftp/src/main/java/org/mule/transport/sftp/SftpConnectionFactory.java
+++ b/transports/sftp/src/main/java/org/mule/transport/sftp/SftpConnectionFactory.java
@@ -6,6 +6,7 @@
  */
 package org.mule.transport.sftp;
 
+import java.io.File;
 import org.mule.api.endpoint.EndpointURI;
 import org.mule.api.endpoint.ImmutableEndpoint;
 import org.mule.util.StringUtils;
@@ -95,7 +96,20 @@ public class SftpConnectionFactory implements PoolableObjectFactory
             // {
             // try
             // {
-            if (identityFile != null)
+            if (identityFile != null && endpointURI.getPassword() != null && sftpUtil.getPassphrase() != null)
+            {
+              throw new UnsupportedOperationException("SFTP connector does not currently support login with (userID + password + SSH-keyfile + passphrase). Logins supported are: (userID + password), (userID + SSH-keyfile + passphrase), (userID + SSH-keyfile + password)");
+            }
+            if (identityFile != null && endpointURI.getPassword() != null)
+            {
+              File idFile = new File(identityFile);
+              if (!idFile.exists() ){
+                 throw new IOException(String.format("file '%s' does not exist", identityFile));
+              }
+              logger.info(String.format("using multi-auth: userName '%s', password (not logged), ssh key-file '%s'", endpointURI.getUser(), idFile.getAbsolutePath()));
+              client.login(endpointURI.getUser(), endpointURI.getPassword(), idFile);
+            }
+            else if (identityFile != null)
             {
                 String passphrase = sftpUtil.getPassphrase();
 


### PR DESCRIPTION
see https://www.mulesoft.org/jira/browse/MULE-7584

Note: I have manually tested the dual (password + identityFile) authentication against a real SFTP server configured with 

AuthenticationMethods publickey,password           //(supported by OpenSSH 6.2+). 

I have not written unit-tests for this because Apache SSHD does not support dual-authentication as far as I can see in the documentation.

See JIRA https://www.mulesoft.org/jira/browse/MULE-7584.
