### PR TITLE
MULE-7650: DynamicClassLoader leaking classloaders

### DIFF
--- a/distributions/deb-package/mule/wrapper.conf
+++ b/distributions/deb-package/mule/wrapper.conf
@@ -10,6 +10,9 @@ wrapper.java.additional.2.stripquotes=TRUE
 # Sets IPv4 addresses in order to avoid multicasting issues
 wrapper.java.additional.3=-Djava.net.preferIPv4Stack=TRUE
 
+# Needed to avoid a memory leak on mvel (see MULE-7650)
+wrapper.java.additional.4=-Dmvel2.disable.jit=TRUE
+
 # *** IMPORTANT ***
 # If you enable any of the options below, you _must_ change the <n> to be a 
 # consecutive number (based on the number of additional properties) otherwise 

--- a/distributions/standalone/src/main/resources/conf/wrapper.conf
+++ b/distributions/standalone/src/main/resources/conf/wrapper.conf
@@ -11,6 +11,10 @@ wrapper.java.additional.2.stripquotes=TRUE
 # Sets IPv4 addresses in order to avoid multicasting issues
 wrapper.java.additional.3=-Djava.net.preferIPv4Stack=TRUE
 
+# Needed to avoid a memory leak on mvel (see MULE-7650)
+wrapper.java.additional.4=-Dmvel2.disable.jit=TRUE
+
+
 # *** IMPORTANT ***
 # If you enable any of the options below, you _must_ change the <n> to be a 
 # consecutive number (based on the number of additional properties) otherwise 


### PR DESCRIPTION
Mvel's DynamicOptimizer contains a static field of type DynamicClassLoader. That field is initialized on creating a DynamicClassLoader that has the current thread's classloader as the parent. In our case, that classloader is a MuleApplicationClassLoader.
This means that when the app is undeployed, the reference to the app classloader will be still live because of this reference.
We are not using dynamic optimization, but that optimizer is created/initialized before we configure the default optimizer.
The only way to avoid this problem is to set a System property
