### PR TITLE
MULE-7442: Bulk Update fails using a file as a source when the file was ...

### DIFF
--- a/modules/db/src/main/java/org/mule/module/db/internal/resolver/query/AbstractBulkQueryResolver.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/resolver/query/AbstractBulkQueryResolver.java
@@ -18,7 +18,7 @@ import org.mule.module.db.internal.parser.QueryTemplateParser;
 public abstract class AbstractBulkQueryResolver implements BulkQueryResolver
 {
 
-    public static final String BULK_QUERY_SEPARATOR = ";\n";
+    private static final String BULK_QUERY_SEPARATOR = ";[\\r\\n]+";
 
     protected final String bulkQueryText;
     private final QueryTemplateParser parser;

--- a/modules/db/src/test/java/org/mule/module/db/internal/resolver/query/AbstractBulkQueryResolverTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/resolver/query/AbstractBulkQueryResolverTestCase.java
@@ -11,7 +11,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mule.module.db.internal.resolver.query.AbstractBulkQueryResolver.BULK_QUERY_SEPARATOR;
 import org.mule.api.MuleEvent;
 import org.mule.module.db.internal.domain.param.QueryParam;
 import org.mule.module.db.internal.domain.query.BulkQuery;
@@ -27,7 +26,7 @@ public class AbstractBulkQueryResolverTestCase extends AbstractMuleTestCase
 
     public static final String STATIC_SQL_1 = "delete from test1";
     public static final String STATIC_SQL_2 = "delete from test2";
-    public static final String BULK_SQL_QUERY = STATIC_SQL_1 + BULK_QUERY_SEPARATOR + STATIC_SQL_2;
+    public static final String BULK_SQL_QUERY = STATIC_SQL_1 + ";\n" + STATIC_SQL_2;
 
     protected final MuleEvent muleEvent = mock(MuleEvent.class);
 

--- a/modules/db/src/test/java/org/mule/module/db/internal/resolver/query/FileBulkQueryResolverTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/resolver/query/FileBulkQueryResolverTestCase.java
@@ -35,13 +35,30 @@ public class FileBulkQueryResolverTestCase extends AbstractBulkQueryResolverTest
     }
 
     @Test
-    public void resolvesBulkQuery() throws Exception
+    public void resolvesBulkQueryWithLinuxLineSeparator() throws Exception
+    {
+        doResolveBulkQueryTest(BULK_SQL_QUERY);
+    }
+
+    @Test
+    public void resolvesBulkQueryWithWindowsLineSeparator() throws Exception
+    {
+        doResolveBulkQueryTest(STATIC_SQL_1 + ";\r\n" + STATIC_SQL_2);
+    }
+
+    @Test
+    public void resolvesBulkQueryWithOldMacLineSeparator() throws Exception
+    {
+        doResolveBulkQueryTest(STATIC_SQL_1 + ";\r" + STATIC_SQL_2);
+    }
+
+    private void doResolveBulkQueryTest(String bulkSqlQuery) throws IOException
     {
         String fileName = "fileName";
 
         QueryTemplateParser queryTemplateParser = createQueryTemplateParser();
         FileReader fileReader = mock(FileReader.class);
-        when(fileReader.getResourceAsString(fileName)).thenReturn(BULK_SQL_QUERY);
+        when(fileReader.getResourceAsString(fileName)).thenReturn(bulkSqlQuery);
 
         BulkQueryResolver bulkQueryResolver = new FileBulkQueryResolver(fileName, queryTemplateParser, fileReader);
 


### PR DESCRIPTION
...generated in Windows due to \r at the end of the line
