### PR TITLE
MULE-7656 Reintroduce unused import removed in 3.x that is still required in 3.5.x

### DIFF
--- a/transports/jetty/src/main/java/org/mule/transport/servlet/jetty/JettyHttpConnector.java
+++ b/transports/jetty/src/main/java/org/mule/transport/servlet/jetty/JettyHttpConnector.java
@@ -17,6 +17,7 @@ import org.mule.api.endpoint.InboundEndpoint;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.api.lifecycle.LifecycleException;
 import org.mule.api.transport.MessageReceiver;
+import org.mule.api.transport.ReplyToHandler;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.context.notification.MuleContextNotification;
 import org.mule.context.notification.NotificationException;


### PR DESCRIPTION
Reintroduce unused import removed in 3.x that is still required in
3.5.x (these things wouldn’t happen if we worked on 3.5.x issues in
3.5.x branch)
