### PR TITLE
MULE-7673: DatabaseMuleArtifactTestCase broken after maven changes

### DIFF
--- a/tests/integration/src/test/java/org/mule/test/integration/transport/jdbc/JdbcTransactionalXaFunctionalTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/transport/jdbc/JdbcTransactionalXaFunctionalTestCase.java
@@ -15,8 +15,9 @@ import javax.sql.DataSource;
 import javax.transaction.TransactionManager;
 
 import org.enhydra.jdbc.standard.StandardXADataSource;
+import org.junit.Ignore;
 
-
+@Ignore
 public class JdbcTransactionalXaFunctionalTestCase extends AbstractJdbcTransactionalFunctionalTestCase
 {
     private TransactionManager txManager;


### PR DESCRIPTION
There is a problem in the way JDBC functional tests manage Derby database. Apparently, problem occurs when the test shuts down the DB instance, killing the driver.
The problem dissappears when JdbcTransactionalXaFunctionalTestCase, the test shutting down the DB, is removed frmo the test suite.
This test is already excluded using the old mule-test-exclusions.txt file. The problem is that that exclusion system causes that the @BeforeClass/@AfterClass methods are still being invoked.
Excluding the test using @Ignore fixes the problem.
