### PR TITLE
MULE-7703: Add a way to configure default threading profile

### DIFF
--- a/core/src/main/java/org/mule/api/config/DefaultThreadingProfileConfig.java
+++ b/core/src/main/java/org/mule/api/config/DefaultThreadingProfileConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.api.config;
+
+public class DefaultThreadingProfileConfig
+{
+
+    public static final String MAX_THREADS_ACTIVE_PROPERTY = MuleProperties.SYSTEM_PROPERTY_PREFIX + "defaultThreadingProfile.maxThreadsActive";
+    public static final String MAX_THREADS_IDLE_PROPERTY = MuleProperties.SYSTEM_PROPERTY_PREFIX + "defaultThreadingProfile.maxThreadsIdle";
+    public static final String MAX_BUFFER_SIZE_PROPERTY = MuleProperties.SYSTEM_PROPERTY_PREFIX + "defaultThreadingProfile.maxBufferSize";
+    public static final String MAX_THREAD_TTL_PROPERTY = MuleProperties.SYSTEM_PROPERTY_PREFIX + "defaultThreadingProfile.maxThreadTTL";
+    public static final String MAX_WAIT_TIMEOUT_PROPERTY = MuleProperties.SYSTEM_PROPERTY_PREFIX + "defaultThreadingProfile.maxWaitTimeout";
+
+    /**
+     * Default value for MAX_THREADS_ACTIVE
+     */
+    public static final int DEFAULT_MAX_THREADS_ACTIVE = Integer.parseInt(System.getProperty(MAX_THREADS_ACTIVE_PROPERTY, "16"));
+
+    /**
+     * Default value for MAX_THREADS_IDLE
+     */
+    public static final int DEFAULT_MAX_THREADS_IDLE = Integer.parseInt(System.getProperty(MAX_THREADS_IDLE_PROPERTY, "1"));
+
+    /**
+     * Default value for MAX_BUFFER_SIZE
+     */
+    public static final int DEFAULT_MAX_BUFFER_SIZE = Integer.parseInt(System.getProperty(MAX_BUFFER_SIZE_PROPERTY, "0"));
+
+    /**
+     * Default value for MAX_THREAD_TTL
+     */
+    public static final long DEFAULT_MAX_THREAD_TTL = Integer.parseInt(System.getProperty(MAX_THREAD_TTL_PROPERTY, "60000"));
+
+    /**
+     * Default value for DEFAULT_THREAD_WAIT_TIMEOUT
+     */
+    public static final long DEFAULT_THREAD_WAIT_TIMEOUT = Long.parseLong(System.getProperty(MAX_WAIT_TIMEOUT_PROPERTY, "30000"));
+
+    private DefaultThreadingProfileConfig()
+    {
+    }
+}

--- a/core/src/main/java/org/mule/api/config/ThreadingProfile.java
+++ b/core/src/main/java/org/mule/api/config/ThreadingProfile.java
@@ -41,30 +41,31 @@ import org.apache.commons.collections.map.CaseInsensitiveMap;
  */
 public interface ThreadingProfile extends MuleContextAware
 {
+
     /**
      * Default value for MAX_THREADS_ACTIVE
      */
-    int DEFAULT_MAX_THREADS_ACTIVE = 16;
+    int DEFAULT_MAX_THREADS_ACTIVE = DefaultThreadingProfileConfig.DEFAULT_MAX_THREADS_ACTIVE;
 
     /**
      * Default value for MAX_THREADS_IDLE
      */
-    int DEFAULT_MAX_THREADS_IDLE = 1;
+    int DEFAULT_MAX_THREADS_IDLE = DefaultThreadingProfileConfig.DEFAULT_MAX_THREADS_IDLE;
 
     /**
      * Default value for MAX_BUFFER_SIZE
      */
-    int DEFAULT_MAX_BUFFER_SIZE = 0;
+    int DEFAULT_MAX_BUFFER_SIZE = DefaultThreadingProfileConfig.DEFAULT_MAX_BUFFER_SIZE;
 
     /**
      * Default value for MAX_THREAD_TTL
      */
-    long DEFAULT_MAX_THREAD_TTL = 60000;
+    long DEFAULT_MAX_THREAD_TTL = DefaultThreadingProfileConfig.DEFAULT_MAX_THREAD_TTL;
 
     /**
      * Default value for DEFAULT_THREAD_WAIT_TIMEOUT
      */
-    long DEFAULT_THREAD_WAIT_TIMEOUT = 30000L;
+    long DEFAULT_THREAD_WAIT_TIMEOUT = DefaultThreadingProfileConfig.DEFAULT_THREAD_WAIT_TIMEOUT;
 
     /**
      * Default value for do threading

--- a/core/src/test/java/org/mule/api/config/DefaultThreadingProfileConfigTestCase.java
+++ b/core/src/test/java/org/mule/api/config/DefaultThreadingProfileConfigTestCase.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.api.config;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mule.tck.MuleTestUtils.testWithSystemProperty;
+import org.mule.tck.MuleTestUtils;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+import org.mule.util.ClassUtils;
+
+import java.lang.reflect.Field;
+import java.net.URLClassLoader;
+
+import org.junit.Test;
+
+@SmallTest
+public class DefaultThreadingProfileConfigTestCase extends AbstractMuleTestCase
+{
+
+    public static final int MAX_THREADS_ACTIVE = 16;
+    public static final int MAX_THREADS_IDLE = 1;
+    public static final int MAX_BUFFER_SIZE = 0;
+    public static final long MAX_THREAD_TTL = 60000;
+    public static final long THREAD_WAIT_TIMEOUT = 30000;
+    public static final String INVALID_PROPERTY_VALUE = "test";
+
+    @Test
+    public void usesDefaultMaxThreadsActive() throws Exception
+    {
+        checkMaxThreadsActive(MAX_THREADS_ACTIVE);
+    }
+
+    @Test
+    public void usesCustomMaxThreadsActive() throws Exception
+    {
+        final int customValue = MAX_THREADS_ACTIVE + 1;
+
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_THREADS_ACTIVE_PROPERTY, Integer.toString(customValue),
+                               new MuleTestUtils.TestCallback()
+                               {
+                                   @Override
+                                   public void run() throws Exception
+                                   {
+                                       checkMaxThreadsActive(customValue);
+                                   }
+                               });
+    }
+
+    @Test(expected = ExceptionInInitializerError.class)
+    public void failsOnInvalidCustomMaxThreadsActive() throws Exception
+    {
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_THREADS_ACTIVE_PROPERTY, INVALID_PROPERTY_VALUE, new MuleTestUtils.TestCallback()
+        {
+            public void run() throws Exception
+            {
+                getMaxThreadsActive();
+            }
+        });
+    }
+
+    @Test
+    public void usesDefaultMaxThreadsIdle() throws Exception
+    {
+        checkMaxThreadsIdle(MAX_THREADS_IDLE);
+    }
+
+    @Test
+    public void usesCustomMaxThreadsIdle() throws Exception
+    {
+        final int customValue = MAX_THREADS_IDLE + 1;
+
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_THREADS_IDLE_PROPERTY, Integer.toString(customValue),
+                               new MuleTestUtils.TestCallback()
+                               {
+                                   @Override
+                                   public void run() throws Exception
+                                   {
+                                       checkMaxThreadsIdle(customValue);
+                                   }
+                               });
+    }
+
+    @Test(expected = ExceptionInInitializerError.class)
+    public void failsOnInvalidCustomMaxThreadsIdle() throws Exception
+    {
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_THREADS_IDLE_PROPERTY, INVALID_PROPERTY_VALUE, new MuleTestUtils.TestCallback()
+        {
+            public void run() throws Exception
+            {
+                getMaxThreadsIdle();
+            }
+        });
+    }
+
+    @Test
+    public void usesDefaultMaxBufferSize() throws Exception
+    {
+        checkMaxBufferSize(MAX_BUFFER_SIZE);
+    }
+
+    @Test
+    public void usesCustomMaxBufferSize() throws Exception
+    {
+        final int customValue = MAX_BUFFER_SIZE + 1;
+
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_BUFFER_SIZE_PROPERTY, Integer.toString(customValue),
+                               new MuleTestUtils.TestCallback()
+                               {
+                                   @Override
+                                   public void run() throws Exception
+                                   {
+                                       checkMaxBufferSize(customValue);
+                                   }
+                               });
+    }
+
+    @Test(expected = ExceptionInInitializerError.class)
+    public void failsOnInvalidCustomMaxBufferSize() throws Exception
+    {
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_BUFFER_SIZE_PROPERTY, INVALID_PROPERTY_VALUE, new MuleTestUtils.TestCallback()
+        {
+            public void run() throws Exception
+            {
+                getMaxBufferSize();
+            }
+        });
+    }
+
+    @Test
+    public void usesDefaultMaxThreadTTL() throws Exception
+    {
+        checkMaxThreadTTL(MAX_THREAD_TTL);
+    }
+
+    @Test
+    public void usesCustomMaxThreadTTL() throws Exception
+    {
+        final long customValue = MAX_THREAD_TTL + 1;
+
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_THREAD_TTL_PROPERTY, Long.toString(customValue),
+                               new MuleTestUtils.TestCallback()
+                               {
+                                   @Override
+                                   public void run() throws Exception
+                                   {
+                                       checkMaxThreadTTL(customValue);
+                                   }
+                               });
+    }
+
+    @Test(expected = ExceptionInInitializerError.class)
+    public void failsOnInvalidCustomMaxThreadsTTL() throws Exception
+    {
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_THREAD_TTL_PROPERTY, INVALID_PROPERTY_VALUE, new MuleTestUtils.TestCallback()
+        {
+            public void run() throws Exception
+            {
+                getMaxThreadTTL();
+            }
+        });
+    }
+
+    @Test
+    public void usesDefaultThreadWaitTimeout() throws Exception
+    {
+        checkThreadWaitTimeout(THREAD_WAIT_TIMEOUT);
+    }
+
+    @Test
+    public void usesCustomThreadWaitTimeout() throws Exception
+    {
+        final long customValue = THREAD_WAIT_TIMEOUT + 1;
+
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_WAIT_TIMEOUT_PROPERTY, Long.toString(customValue),
+                               new MuleTestUtils.TestCallback()
+                               {
+                                   @Override
+                                   public void run() throws Exception
+                                   {
+                                       checkThreadWaitTimeout(customValue);
+                                   }
+                               });
+    }
+
+    @Test(expected = ExceptionInInitializerError.class)
+    public void failsOnInvalidCustomThreadWaitTimeout() throws Exception
+    {
+        testWithSystemProperty(DefaultThreadingProfileConfig.MAX_WAIT_TIMEOUT_PROPERTY, INVALID_PROPERTY_VALUE, new MuleTestUtils.TestCallback()
+        {
+            public void run() throws Exception
+            {
+                getThreadWaitTimeout();
+            }
+        });
+    }
+
+    private void checkMaxThreadsActive(int expected) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        assertThat(getMaxThreadsActive(), equalTo(expected));
+    }
+
+    private void checkMaxThreadsIdle(int expected) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        assertThat(getMaxThreadsIdle(), equalTo(expected));
+    }
+
+    private void checkMaxBufferSize(int expected) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        assertThat(getMaxBufferSize(), equalTo(expected));
+    }
+
+    private void checkMaxThreadTTL(long expected) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        assertThat(getMaxThreadTTL(), equalTo(expected));
+    }
+
+    private void checkThreadWaitTimeout(long expected) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        assertThat(getThreadWaitTimeout(), equalTo(expected));
+    }
+
+    private int getMaxThreadsActive() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        return getIntegerConstant("DEFAULT_MAX_THREADS_ACTIVE");
+    }
+
+    private int getMaxThreadsIdle() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        return getIntegerConstant("DEFAULT_MAX_THREADS_IDLE");
+    }
+
+    private int getMaxBufferSize() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        return getIntegerConstant("DEFAULT_MAX_BUFFER_SIZE");
+    }
+
+    private long getMaxThreadTTL() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        return getLongConstant("DEFAULT_MAX_THREAD_TTL");
+    }
+
+    private long getThreadWaitTimeout() throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        return getLongConstant("DEFAULT_THREAD_WAIT_TIMEOUT");
+    }
+
+    private int getIntegerConstant(String fieldName) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        Class clazz = loadDefaultThreadingProfileClass();
+        Field field = clazz.getDeclaredField(fieldName);
+
+        return field.getInt(clazz);
+    }
+
+    private long getLongConstant(String fieldName) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        Class clazz = loadDefaultThreadingProfileClass();
+        Field field = clazz.getDeclaredField(fieldName);
+
+        return field.getLong(clazz);
+    }
+
+    private Class loadDefaultThreadingProfileClass() throws ClassNotFoundException
+    {
+        URLClassLoader classLoader = new URLClassLoader(((URLClassLoader) Thread.currentThread().getContextClassLoader()).getURLs(), null);
+
+        return ClassUtils.loadClass(DefaultThreadingProfileConfig.class.getCanonicalName(), classLoader);
+    }
+}


### PR DESCRIPTION
_ Adding system properties to configure the default threading profile
_ Creating DefaultThreadingProfileConfig to resolve default constant values
_ Unit test use reflection as there is no other way to check whether or not the system properties were properly resolved
