### PR TITLE
MULE-7729: Possible deadlock when handling concurrent requests in a transaction with more than one outbound endpoint

### DIFF
--- a/core/src/main/java/org/mule/transport/KeyedPoolMessageDispatcherFactoryAdapter.java
+++ b/core/src/main/java/org/mule/transport/KeyedPoolMessageDispatcherFactoryAdapter.java
@@ -8,9 +8,6 @@ package org.mule.transport;
 
 import org.mule.api.MuleException;
 import org.mule.api.endpoint.OutboundEndpoint;
-import org.mule.api.lifecycle.Disposable;
-import org.mule.api.lifecycle.Startable;
-import org.mule.api.lifecycle.Stoppable;
 import org.mule.api.transport.MessageDispatcher;
 import org.mule.api.transport.MessageDispatcherFactory;
 import org.mule.config.i18n.CoreMessages;
@@ -108,23 +105,7 @@ public class KeyedPoolMessageDispatcherFactoryAdapter
 
     protected void applyLifecycle(MessageDispatcher dispatcher) throws MuleException
     {
-        String phase = ((AbstractConnector)dispatcher.getConnector()).getLifecycleManager().getCurrentPhase();
-        if(phase.equals(Startable.PHASE_NAME) && !dispatcher.getLifecycleState().isStarted())
-        {
-            if(!dispatcher.getLifecycleState().isInitialised())
-            {
-                dispatcher.initialise();
-            }
-            dispatcher.start();
-        }
-        else if(phase.equals(Stoppable.PHASE_NAME) && dispatcher.getLifecycleState().isStarted())
-        {
-            dispatcher.stop();
-        }
-        else if(Disposable.PHASE_NAME.equals(phase))
-        {
-            dispatcher.dispose();
-        }
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
     }
 
 }

--- a/core/src/main/java/org/mule/transport/MessageDispatcherUtils.java
+++ b/core/src/main/java/org/mule/transport/MessageDispatcherUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport;
+
+
+import org.mule.api.MuleException;
+import org.mule.api.lifecycle.Disposable;
+import org.mule.api.lifecycle.Startable;
+import org.mule.api.lifecycle.Stoppable;
+import org.mule.api.transport.MessageDispatcher;
+
+public class MessageDispatcherUtils
+{
+
+    /**
+     * Applies lifecycle to a MessageDispatcher based on the lifecycle state of its connector.
+     */
+    public static void applyLifecycle(MessageDispatcher dispatcher) throws MuleException
+    {
+        String phase = ((AbstractConnector)dispatcher.getConnector()).getLifecycleManager().getCurrentPhase();
+        if(phase.equals(Startable.PHASE_NAME) && !dispatcher.getLifecycleState().isStarted())
+        {
+            if(!dispatcher.getLifecycleState().isInitialised())
+            {
+                dispatcher.initialise();
+            }
+            dispatcher.start();
+        }
+        else if(phase.equals(Stoppable.PHASE_NAME) && dispatcher.getLifecycleState().isStarted())
+        {
+            dispatcher.stop();
+        }
+        else if(Disposable.PHASE_NAME.equals(phase))
+        {
+            dispatcher.dispose();
+        }
+    }
+
+}

--- a/core/src/test/java/org/mule/transport/MessageDispatcherUtilsTestCase.java
+++ b/core/src/test/java/org/mule/transport/MessageDispatcherUtilsTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mule.api.MuleException;
+import org.mule.api.lifecycle.Disposable;
+import org.mule.api.lifecycle.LifecycleState;
+import org.mule.api.lifecycle.Startable;
+import org.mule.api.lifecycle.Stoppable;
+import org.mule.api.transport.MessageDispatcher;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@SmallTest
+@RunWith(MockitoJUnitRunner.class)
+public class MessageDispatcherUtilsTestCase extends AbstractMuleTestCase
+{
+
+    @Mock
+    private AbstractConnector connector;
+
+    @Mock
+    private ConnectorLifecycleManager connectorLifecycleManager;
+
+    @Mock
+    private MessageDispatcher dispatcher;
+
+    @Mock
+    private LifecycleState dispatcherLifecycleState;
+
+    @Before
+    public void setUp()
+    {
+        when(dispatcher.getConnector()).thenReturn(connector);
+        when(dispatcher.getLifecycleState()).thenReturn(dispatcherLifecycleState);
+        when(connector.getLifecycleManager()).thenReturn(connectorLifecycleManager);
+    }
+
+    @Test
+    public void startsAndInitialisesDispatcherWhenStartingConnector() throws MuleException
+    {
+        when(connectorLifecycleManager.getCurrentPhase()).thenReturn(Startable.PHASE_NAME);
+        when(dispatcherLifecycleState.isStarted()).thenReturn(false);
+        when(dispatcherLifecycleState.isInitialised()).thenReturn(false);
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
+        verify(dispatcher).initialise();
+        verify(dispatcher).start();
+    }
+
+    @Test
+    public void startsInitialisedDispatcherWhenStartingConnector() throws MuleException
+    {
+        when(connectorLifecycleManager.getCurrentPhase()).thenReturn(Startable.PHASE_NAME);
+        when(dispatcherLifecycleState.isStarted()).thenReturn(false);
+        when(dispatcherLifecycleState.isInitialised()).thenReturn(true);
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
+        verify(dispatcher).start();
+    }
+
+    @Test
+    public void doesntStartAlreadyStartedDispatcher() throws MuleException
+    {
+        when(connectorLifecycleManager.getCurrentPhase()).thenReturn(Startable.PHASE_NAME);
+        when(dispatcherLifecycleState.isStarted()).thenReturn(true);
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
+        verify(dispatcher, never()).start();
+    }
+
+    @Test
+    public void stopsDispatcherWhenStoppingConnector() throws MuleException
+    {
+        when(connectorLifecycleManager.getCurrentPhase()).thenReturn(Stoppable.PHASE_NAME);
+        when(dispatcherLifecycleState.isStarted()).thenReturn(true);
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
+        verify(dispatcher).stop();
+    }
+
+    @Test
+    public void doesntStopAlreadyStoppedDispatcher() throws MuleException
+    {
+        when(connectorLifecycleManager.getCurrentPhase()).thenReturn(Stoppable.PHASE_NAME);
+        when(dispatcherLifecycleState.isStarted()).thenReturn(false);
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
+        verify(dispatcher, never()).stop();
+    }
+
+    @Test
+    public void disposesDispatcherWhenDisposingConnector() throws MuleException
+    {
+        when(connectorLifecycleManager.getCurrentPhase()).thenReturn(Disposable.PHASE_NAME);
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
+        verify(dispatcher).dispose();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <commonsCliVersion>1.2</commonsCliVersion>
         <commonsCodecVersion>1.3</commonsCodecVersion>
         <commonsCollectionsVersion>3.2.1</commonsCollectionsVersion>
+        <commonsDbcpVersion>1.4</commonsDbcpVersion>
         <commonsDbUtilsVersion>1.2</commonsDbUtilsVersion>
         <commonsHttpClientVersion>3.1</commonsHttpClientVersion>
         <commonsIoVersion>2.4</commonsIoVersion>
@@ -1276,6 +1277,13 @@
                 <artifactId>guava</artifactId>
                 <version>${guavaVersion}</version>        
             </dependency>
+
+            <dependency>
+                <groupId>commons-dbcp</groupId>
+                <artifactId>commons-dbcp</artifactId>
+                <version>${commonsDbcpVersion}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -154,7 +154,6 @@
 		<dependency>
 			<groupId>commons-dbcp</groupId>
 			<artifactId>commons-dbcp</artifactId>
-			<version>1.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.experlog</groupId>

--- a/transports/http/src/main/java/org/mule/transport/http/HttpConnector.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpConnector.java
@@ -16,15 +16,13 @@ import org.mule.api.endpoint.EndpointURI;
 import org.mule.api.endpoint.ImmutableEndpoint;
 import org.mule.api.endpoint.InboundEndpoint;
 import org.mule.api.endpoint.OutboundEndpoint;
-import org.mule.api.lifecycle.Disposable;
 import org.mule.api.lifecycle.InitialisationException;
-import org.mule.api.lifecycle.Startable;
-import org.mule.api.lifecycle.Stoppable;
 import org.mule.api.processor.MessageProcessor;
 import org.mule.api.transport.MessageDispatcher;
 import org.mule.api.transport.MessageReceiver;
 import org.mule.api.transport.NoReceiverForEndpointException;
 import org.mule.config.i18n.CoreMessages;
+import org.mule.transport.MessageDispatcherUtils;
 import org.mule.transport.http.i18n.HttpMessages;
 import org.mule.transport.http.ntlm.NTLMScheme;
 import org.mule.transport.tcp.TcpConnector;
@@ -740,22 +738,6 @@ public class HttpConnector extends TcpConnector
 
     protected void applyDispatcherLifecycle(MessageDispatcher dispatcher) throws MuleException
     {
-        String phase = lifecycleManager.getCurrentPhase();
-        if (phase.equals(Startable.PHASE_NAME) && !dispatcher.getLifecycleState().isStarted())
-        {
-            if (!dispatcher.getLifecycleState().isInitialised())
-            {
-                dispatcher.initialise();
-            }
-            dispatcher.start();
-        }
-        else if (phase.equals(Stoppable.PHASE_NAME) && dispatcher.getLifecycleState().isStarted())
-        {
-            dispatcher.stop();
-        }
-        else if (Disposable.PHASE_NAME.equals(phase))
-        {
-            dispatcher.dispose();
-        }
+        MessageDispatcherUtils.applyLifecycle(dispatcher);
     }
 }

--- a/transports/jdbc/pom.xml
+++ b/transports/jdbc/pom.xml
@@ -74,6 +74,11 @@
             <version>1.8.0.7</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-dbcp</groupId>
+            <artifactId>commons-dbcp</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/transports/jdbc/src/test/java/org/mule/transport/jdbc/functional/JdbcTxOutboundEndpointsTestCase.java
+++ b/transports/jdbc/src/test/java/org/mule/transport/jdbc/functional/JdbcTxOutboundEndpointsTestCase.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.jdbc.functional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.mule.api.MuleEvent;
+import org.mule.construct.Flow;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.util.MuleDerbyTestDatabase;
+import org.mule.util.concurrent.Latch;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JdbcTxOutboundEndpointsTestCase extends FunctionalTestCase
+{
+
+    private static MuleDerbyTestDatabase derbyTestDatabase = new MuleDerbyTestDatabase("database.name");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "jdbc-tx-outbound-endpoints-config.xml";
+    }
+
+    @BeforeClass
+    public static void startDatabase() throws Exception
+    {
+        derbyTestDatabase.startDatabase();
+    }
+
+    @AfterClass
+    public static void stopDatabase() throws SQLException
+    {
+        derbyTestDatabase.stopDatabase();
+    }
+
+    /**
+     * This test simulates a deadlock scenario processing two concurrent requests in a flow that contains
+     * a transaction with two outbound endpoints (MULE-7729)
+     * This indirectly verifies that the default behavior of the JdbcConnector is not to use a pool of dispatcher
+     * threads (instead the same MessageDispatcher will be used per endpoint). If a dispatcher pool is used, the
+     * deadlock happens and the test fails.
+     */
+    @Test
+    public void concurrentRequestsDoNotGenerateDeadlock() throws Exception
+    {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        // Send first event through the flow (thread 1)
+        processEvent(executorService, true);
+
+        // Wait until the first query is executed (now thread 1 holds a connection to the DB as the flow is transactional)
+        Latch firstQueryExecutedLatch = muleContext.getRegistry().lookupObject("firstQueryExecutedLatch");
+        firstQueryExecutedLatch.await();
+
+        // Send second event through the flow (thread 2)
+        processEvent(executorService, false);
+
+        // Thread 2 will skip the first outbound endpoint and will try to execute the second one. It will borrow
+        // a dispatcher from the pool (the only one, which is available because thread 1 already released it), but
+        // it will block when trying to get a connection from the data source pool (as there is only 1 connection
+        // that is held by thread 1). When requesting this connection to the data source, the connectionRequestedLatch
+        // is released. Now thread 1 tries to execute the second outbound endpoint. If there is a pool of dispatchers
+        // with only 1 dispatcher, it will block because the only dispatcher is already held by thread 2.
+
+        // Wait until both threads finish successfully.
+        CountDownLatch finishedLatch = muleContext.getRegistry().lookupObject("finishedLatch");
+        assertThat(finishedLatch.await(RECEIVE_TIMEOUT, TimeUnit.MILLISECONDS), is(true));
+
+    }
+
+
+    private void processEvent(ExecutorService executorService, final boolean executeFirstQuery)
+    {
+        executorService.submit(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    Flow flow = (Flow) getFlowConstruct("test");
+                    MuleEvent event = getTestEvent(TEST_MESSAGE);
+                    event.setFlowVariable("executeFirstQuery", executeFirstQuery);
+                    flow.process(event);
+                }
+                catch (Exception e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+
+    /**
+     * Custom data source pool that holds a latch and releases it after "connectionRequestsUntilRelease" connections
+     * are requested to this pool.
+     */
+    public static class LatchReleasingDataSource extends BasicDataSource
+    {
+
+        private AtomicInteger connectionRequestsCount = new AtomicInteger(0);
+        private int connectionRequestsUntilRelease;
+        private Latch latch;
+
+        @Override
+        public Connection getConnection() throws SQLException
+        {
+            if (connectionRequestsCount.incrementAndGet() == connectionRequestsUntilRelease)
+            {
+                latch.release();
+            }
+            return super.getConnection();
+        }
+
+        public void setLatch(Latch latch)
+        {
+            this.latch = latch;
+        }
+
+        public void setConnectionRequestsUntilRelease(int connectionRequestsUntilRelease)
+        {
+            this.connectionRequestsUntilRelease = connectionRequestsUntilRelease;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException
+        {
+            throw new SQLFeatureNotSupportedException();
+        }
+    }
+
+}

--- a/transports/jdbc/src/test/resources/jdbc-tx-outbound-endpoints-config.xml
+++ b/transports/jdbc/src/test/resources/jdbc-tx-outbound-endpoints-config.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:jdbc="http://www.mulesoft.org/schema/mule/jdbc"
+      xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/jdbc http://www.mulesoft.org/schema/mule/jdbc/current/mule-jdbc.xsd">
+
+    <spring:bean id="connectionRequestedLatch" class="org.mule.util.concurrent.Latch"/>
+    <spring:bean id="firstQueryExecutedLatch" class="org.mule.util.concurrent.Latch"/>
+    <spring:bean id="finishedLatch" class="java.util.concurrent.CountDownLatch">
+        <spring:constructor-arg index="0" value="2"/>
+    </spring:bean>
+
+    <spring:bean id="jdbcDataSource"
+                 class="org.mule.transport.jdbc.functional.JdbcTxOutboundEndpointsTestCase.LatchReleasingDataSource">
+        <spring:property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver"/>
+        <spring:property name="url" value="jdbc:derby:muleEmbeddedDB"/>
+        <spring:property name="maxActive" value="1"/>
+        <spring:property name="maxIdle" value="1"/>
+        <spring:property name="minIdle" value="1"/>
+
+        <!--
+        Custom latch that will be released after 3 connections are requested to this pool. The first connection is needed
+        to set up the test. The second one is requested by the first thread, and the third one is requested by the
+        second thread, that may generate a deadlock.
+        -->
+        <spring:property name="latch" ref="connectionRequestedLatch"/>
+        <spring:property name="connectionRequestsUntilRelease" value="3"/>
+    </spring:bean>
+
+    <jdbc:connector name="jdbcConnector" dataSource-ref="jdbcDataSource">
+        <dispatcher-threading-profile maxThreadsActive="1" poolExhaustedAction="WAIT"/>
+        <jdbc:query key="query" value="SELECT * FROM TEST"/>
+    </jdbc:connector>
+
+
+    <!--
+    Two threads will concurrently execute this flow, simulating the deadlock that may happen when we are
+    using a dispatcher pool. The DB pool has only one connection, and the dispatcher pool one dispatcher.
+    The test starts with thread 1 sending one event through the flow.
+    -->
+
+    <flow name="test">
+
+        <transactional action="ALWAYS_BEGIN">
+
+            <choice>
+                <when expression="#[executeFirstQuery]">
+
+                    <!--
+                    Thread 1 will execute this outbound endpoint (borrows a dispatcher, borrows a connection,
+                    then returns the dispatcher but holds the connection because of the transaction).
+                     -->
+                    <jdbc:outbound-endpoint queryKey="query" exchange-pattern="request-response">
+                        <jdbc:transaction action="ALWAYS_JOIN"/>
+                    </jdbc:outbound-endpoint>
+
+                    <!--
+                    When this latch is released, the test will start a second thread with executeFirstQuery=false.
+                    -->
+                    <invoke object-ref="firstQueryExecutedLatch" method="release"/>
+
+                    <!--
+                    Wait until thread 2 tries to borrow a connection from the DB pool
+                    -->
+                    <invoke object-ref="connectionRequestedLatch" method="await"/>
+
+                </when>
+                <otherwise>
+                    <!-- Do nothing (thread 2). -->
+                    <echo-component/>
+                </otherwise>
+            </choice>
+
+            <!--
+            At this point thread 1 and 2 enter in a deadlock if there is a dispatcher pool. Thread 1 is holding the only
+            connection and is waiting for a dispatcher to execute this endpoint. Thread 2 already borrowed the dispatcher
+            for this endpoint and is waiting for a connection.
+            -->
+            <jdbc:outbound-endpoint queryKey="query" exchange-pattern="request-response">
+                <jdbc:transaction action="ALWAYS_JOIN"/>
+            </jdbc:outbound-endpoint>
+
+        </transactional>
+
+        <invoke object-ref="finishedLatch" method="countDown"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
Added a system property to define whether the JdbcConnector will use a pool of dispatcher objects or will use a single dispatcher per endpoint. Changed default behavior to use a single dispatcher.
