### PR TITLE
MULE-7804 - Mule adds an empty inbound property when receiving an HTTP r...

### DIFF
--- a/core/src/main/java/org/mule/util/PropertiesUtils.java
+++ b/core/src/main/java/org/mule/util/PropertiesUtils.java
@@ -267,7 +267,7 @@ public final class PropertiesUtils
     {
         Properties props = new Properties();
 
-        if (query == null)
+        if (StringUtils.isEmpty(query))
         {
             return props;
         }

--- a/core/src/test/java/org/mule/util/PropertiesUtilsTestCase.java
+++ b/core/src/test/java/org/mule/util/PropertiesUtilsTestCase.java
@@ -128,4 +128,11 @@ public class PropertiesUtilsTestCase extends AbstractMuleTestCase
         assertThat(properties.isEmpty(), is(true));
     }
 
+    @Test
+    public void noPropertiesAreFoundOnEmptyQueryString()
+    {
+        Properties properties = PropertiesUtils.getPropertiesFromQueryString("");
+        assertThat(properties.size(), is(0));
+    }
+
 }


### PR DESCRIPTION
...equest with an empty query string
