### PR TITLE
Adding missing close of the input stream to the StaticResourceMessagePro...

### DIFF
--- a/transports/http/src/main/java/org/mule/transport/http/components/StaticResourceMessageProcessor.java
+++ b/transports/http/src/main/java/org/mule/transport/http/components/StaticResourceMessageProcessor.java
@@ -112,6 +112,10 @@ public class StaticResourceMessageProcessor implements MessageProcessor, Initial
         {
             throw new ResourceNotFoundException(HttpMessages.fileNotFound(resourceBase + path),event);
         }
+        finally
+        {
+            IOUtils.closeQuietly(in);
+        }
 
         return resultEvent;
     }


### PR DESCRIPTION
...cessor

Title says it all. StaticResourceMessageProcessor was keeping locks to statically served files. This fixes the issue.
