### PR TITLE
MULE-7789: Update mule-transports-http to tomcat 6+, fix whitelists

### DIFF
--- a/distributions/standalone-light/assembly-whitelist.txt
+++ b/distributions/standalone-light/assembly-whitelist.txt
@@ -348,8 +348,8 @@
 /mule-standalone-nodocs-${productVersion}/lib/opt/sxc-core-0.7.3.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/sxc-runtime-0.7.3.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/sxc-xpath-0.7.3.jar
-/mule-standalone-nodocs-${productVersion}/lib/opt/tomcat-apr-5.5.23.jar
-/mule-standalone-nodocs-${productVersion}/lib/opt/tomcat-util-5.5.23.jar
+/mule-standalone-nodocs-${productVersion}/lib/opt/catalina-6.0.29.jar
+/mule-standalone-nodocs-${productVersion}/lib/opt/coyote-6.0.29.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/uuid-3.4.0.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/woodstox-core-asl-4.1.4.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/wsdl4j-1.6.2.jar

--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -693,8 +693,8 @@
 /mule-standalone-${productVersion}/lib/opt/sxc-core-0.7.3.jar
 /mule-standalone-${productVersion}/lib/opt/sxc-runtime-0.7.3.jar
 /mule-standalone-${productVersion}/lib/opt/sxc-xpath-0.7.3.jar
-/mule-standalone-${productVersion}/lib/opt/tomcat-apr-5.5.23.jar
-/mule-standalone-${productVersion}/lib/opt/tomcat-util-5.5.23.jar
+/mule-standalone-${productVersion}/lib/opt/catalina-6.0.29.jar
+/mule-standalone-${productVersion}/lib/opt/coyote-6.0.29.jar
 /mule-standalone-${productVersion}/lib/opt/uuid-3.4.0.jar
 /mule-standalone-${productVersion}/lib/opt/woodstox-core-asl-4.1.4.jar
 /mule-standalone-${productVersion}/lib/opt/wsdl4j-1.6.2.jar


### PR DESCRIPTION
Correct distrubutions whitelist
