### PR TITLE
Scatter-Gather loses the exception cause

### DIFF
--- a/core/src/main/java/org/mule/routing/ScatterGatherRouter.java
+++ b/core/src/main/java/org/mule/routing/ScatterGatherRouter.java
@@ -176,7 +176,7 @@ public class ScatterGatherRouter extends AbstractMessageProcessorOwner implement
             catch (Exception e)
             {
                 exception = new DispatchException(MessageFactory.createStaticMessage(String.format(
-                    "route number %d failed to be executed", routeIndex)), event, route, exception);
+                    "route number %d failed to be executed", routeIndex)), event, route, e);
             }
 
             remainingTimeout -= System.currentTimeMillis() - startedAt;


### PR DESCRIPTION
Looks like the wrong variable is used in this constructor which causes the original exception, that caused the error, to be lost which renders any sort of error handling useless.

I am not seeing a unit test for this class to add an assertion to...
