### PR TITLE
MULE-7845: Basic functionality for new HTTP Connector - Outbound part

### DIFF
--- a/distributions/standalone-light/assembly-whitelist.txt
+++ b/distributions/standalone-light/assembly-whitelist.txt
@@ -116,6 +116,7 @@
 /mule-standalone-nodocs-${productVersion}/lib/mule/mule-module-db-${productVersion}.jar
 /mule-standalone-nodocs-${productVersion}/lib/mule/mule-module-devkit-support-${productVersion}.jar
 /mule-standalone-nodocs-${productVersion}/lib/mule/mule-module-drools-${productVersion}.jar
+/mule-standalone-nodocs-${productVersion}/lib/mule/mule-module-http-${productVersion}.jar
 /mule-standalone-nodocs-${productVersion}/lib/mule/mule-module-jaas-${productVersion}.jar
 /mule-standalone-nodocs-${productVersion}/lib/mule/mule-module-jbossts-${productVersion}.jar
 /mule-standalone-nodocs-${productVersion}/lib/mule/mule-module-jbpm-${productVersion}.jar
@@ -283,6 +284,7 @@
 /mule-standalone-nodocs-${productVersion}/lib/opt/jersey-server-2.11.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/jettison-1.3.3.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/jetty-annotations-9.0.7.v20131107.jar
+/mule-standalone-nodocs-${productVersion}/lib/opt/jetty-client-9.0.7.v20131107.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/jetty-continuation-9.0.7.v20131107.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/jetty-deploy-9.0.7.v20131107.jar
 /mule-standalone-nodocs-${productVersion}/lib/opt/jetty-http-9.0.7.v20131107.jar

--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -460,6 +460,7 @@
 /mule-standalone-${productVersion}/lib/mule/mule-module-db-${productVersion}.jar
 /mule-standalone-${productVersion}/lib/mule/mule-module-devkit-support-${productVersion}.jar
 /mule-standalone-${productVersion}/lib/mule/mule-module-drools-${productVersion}.jar
+/mule-standalone-${productVersion}/lib/mule/mule-module-http-${productVersion}.jar
 /mule-standalone-${productVersion}/lib/mule/mule-module-jaas-${productVersion}.jar
 /mule-standalone-${productVersion}/lib/mule/mule-module-jbossts-${productVersion}.jar
 /mule-standalone-${productVersion}/lib/mule/mule-module-jbpm-${productVersion}.jar
@@ -627,6 +628,7 @@
 /mule-standalone-${productVersion}/lib/opt/jersey-server-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jettison-1.3.3.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-annotations-9.0.7.v20131107.jar
+/mule-standalone-${productVersion}/lib/opt/jetty-client-9.0.7.v20131107.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-continuation-9.0.7.v20131107.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-deploy-9.0.7.v20131107.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-http-9.0.7.v20131107.jar

--- a/distributions/standalone/assembly.xml
+++ b/distributions/standalone/assembly.xml
@@ -234,6 +234,7 @@
                 <include>org.mule.modules:mule-module-db</include>
                 <include>org.mule.modules:mule-module-devkit-support</include>
                 <include>org.mule.modules:mule-module-drools</include>
+                <include>org.mule.modules:mule-module-http</include>
                 <include>org.mule.modules:mule-module-jaas</include>
                 <include>org.mule.modules:mule-module-jersey</include>
                 <include>org.mule.modules:mule-module-jbossts</include>
@@ -307,6 +308,7 @@
                 <exclude>org.mule.modules:mule-module-db</exclude>
                 <exclude>org.mule.modules:mule-module-devkit-support</exclude>
                 <exclude>org.mule.modules:mule-module-drools</exclude>
+                <exclude>org.mule.modules:mule-module-http</exclude>
                 <exclude>org.mule.modules:mule-module-jaas</exclude>
                 <exclude>org.mule.modules:mule-module-jersey</exclude>
                 <exclude>org.mule.modules:mule-module-jbossts</exclude>

--- a/transports/http/pom.xml
+++ b/transports/http/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>joda-time</artifactId>
             <version>${jodaTimeVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mule.modules</groupId>
+            <artifactId>mule-module-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Unit tests -->
         <dependency>

--- a/transports/http/src/main/java/org/mule/transport/http/builder/HttpHeaderDefinitionParser.java
+++ b/transports/http/src/main/java/org/mule/transport/http/builder/HttpHeaderDefinitionParser.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.http.builder;
+
+import org.mule.config.spring.parsers.collection.ChildMapEntryDefinitionParser;
+import org.mule.config.spring.parsers.delegate.ParentContextDefinitionParser;
+import org.mule.module.http.config.HttpRequestSingleParamDefinitionParser;
+import org.mule.module.http.request.HttpParamType;
+import org.mule.module.http.request.HttpSingleParam;
+
+/**
+ * Custom bean definition parser for the "header" element that works for both the old "header" element in the
+ * HTTP transport (inside the response builder) and the new "header" element in the HTTP module (inside the
+ * request builder).
+ */
+public class HttpHeaderDefinitionParser extends ParentContextDefinitionParser
+{
+    public HttpHeaderDefinitionParser()
+    {
+        super("response-builder", new ChildMapEntryDefinitionParser("headers", "name", "value"));
+        otherwise(new HttpRequestSingleParamDefinitionParser(HttpSingleParam.class, HttpParamType.HEADER));
+    }
+
+}

--- a/transports/http/src/main/java/org/mule/transport/http/config/HttpNamespaceHandler.java
+++ b/transports/http/src/main/java/org/mule/transport/http/config/HttpNamespaceHandler.java
@@ -8,7 +8,6 @@ package org.mule.transport.http.config;
 
 
 
-import org.mule.config.spring.handlers.AbstractMuleNamespaceHandler;
 import org.mule.config.spring.parsers.collection.ChildListEntryDefinitionParser;
 import org.mule.config.spring.parsers.collection.ChildMapEntryDefinitionParser;
 import org.mule.config.spring.parsers.generic.ChildDefinitionParser;
@@ -27,6 +26,7 @@ import org.mule.transport.http.HttpConnector;
 import org.mule.transport.http.HttpConstants;
 import org.mule.transport.http.HttpPollingConnector;
 import org.mule.transport.http.builder.HttpCookiesDefinitionParser;
+import org.mule.transport.http.builder.HttpHeaderDefinitionParser;
 import org.mule.transport.http.builder.HttpResponseDefinitionParser;
 import org.mule.transport.http.components.HttpResponseBuilder;
 import org.mule.transport.http.components.RestServiceWrapper;
@@ -41,8 +41,11 @@ import org.mule.transport.http.transformers.ObjectToHttpClientMethodRequest;
 
 /**
  * Reigsters a Bean Definition Parser for handling <code><http:connector></code> elements.
+ *
+ * This namespace handler now extends HttpNamespaceHandler from mule-module-http so that both projects can
+ * register bean definition parsers for the same namespace (http).
  */
-public class HttpNamespaceHandler extends AbstractMuleNamespaceHandler
+public class HttpNamespaceHandler extends org.mule.module.http.config.HttpNamespaceHandler
 {
     public void init()
     {
@@ -72,15 +75,13 @@ public class HttpNamespaceHandler extends AbstractMuleNamespaceHandler
                 new MessageProcessorDefinitionParser(StaticResourceMessageProcessor.class));
 
         registerBeanDefinitionParser("response-builder", new MessageProcessorDefinitionParser(HttpResponseBuilder.class));
-        registerMuleBeanDefinitionParser("header", new ChildMapEntryDefinitionParser("headers", "name", "value")).addCollection("headers");
+        registerMuleBeanDefinitionParser("header", new HttpHeaderDefinitionParser()).addCollection("headers");
         registerMuleBeanDefinitionParser("set-cookie", new HttpCookiesDefinitionParser("cookie", CookieWrapper.class)).registerPreProcessor(new CheckExclusiveAttributes(new String[][] {new String[] {"maxAge"}, new String[] {"expiryDate"}}));
         registerMuleBeanDefinitionParser("body", new TextDefinitionParser("body"));
         registerMuleBeanDefinitionParser("location", new HttpResponseDefinitionParser("header"));
         registerMuleBeanDefinitionParser("cache-control", new ChildDefinitionParser("cacheControl", CacheControlHeader.class));
         registerMuleBeanDefinitionParser("expires", new HttpResponseDefinitionParser("header"));
 
-
-
-
+        super.init();
     }
 }

--- a/transports/http/src/main/resources/META-INF/mule-http.xsd
+++ b/transports/http/src/main/resources/META-INF/mule-http.xsd
@@ -16,6 +16,11 @@
     <xsd:import namespace = "http://www.mulesoft.org/schema/mule/schemadoc"
                 schemaLocation = "http://www.mulesoft.org/schema/mule/schemadoc/3.5/mule-schemadoc.xsd"/>
 
+    <!--
+    We include all the elements defined in the schema of the new HTTP connector into this namespace.
+    -->
+    <xsd:include schemaLocation="http://www.mulesoft.org/schema/mule/httpn/current/mule-httpn.xsd" />
+
     <xsd:annotation>
         <xsd:documentation>The HTTP transport provides support for exposing services over HTTP and making HTTP client requests from Mule services to external services as part of service event flows. Mule supports inbound, outbound, and polling HTTP endpooints. These endpoints support all common features of the HTTP spec, such as ETag processing, cookies, and keepalive. Both HTTP 1.0 and 1.1 are supported.</xsd:documentation>
         <xsd:appinfo>

--- a/transports/http/src/main/resources/META-INF/spring.schemas
+++ b/transports/http/src/main/resources/META-INF/spring.schemas
@@ -10,3 +10,6 @@ http\://www.mulesoft.org/schema/mule/http/3.5/mule-http.xsd=META-INF/mule-http.x
 http\://www.mulesoft.org/schema/mule/https/3.5/mule-https.xsd=META-INF/mule-https.xsd
 http\://www.mulesoft.org/schema/mule/http/current/mule-http.xsd=META-INF/mule-http.xsd
 http\://www.mulesoft.org/schema/mule/https/current/mule-https.xsd=META-INF/mule-https.xsd
+
+# We need to define a schemaLocation for the new HTTP connector schema, so that it can be included from mule-http.xsd
+http\://www.mulesoft.org/schema/mule/httpn/current/mule-httpn.xsd=META-INF/mule-httpn.xsd


### PR DESCRIPTION
Added mule-module-http as a dependency of the HTTP transport, and changed the schema and namespace handler so that the XML elements of the new module are added to the HTTP namespace.
