### PR TITLE
MULE-6566: Per App Classloader should clean all native libraries from th...

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/GoodCitizenClassLoader.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/GoodCitizenClassLoader.java
@@ -10,14 +10,12 @@ import org.mule.util.ClassUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import java.util.Collection;
-import java.util.Vector;
 import java.util.jar.JarFile;
 
 import sun.net.www.protocol.jar.Handler;
@@ -72,25 +70,6 @@ public class GoodCitizenClassLoader extends URLClassLoader implements Disposable
         catch (Throwable t)
         {
             // probably not a SUN VM
-        }
-
-        try
-        {
-            // now native libs
-            Class<ClassLoader> clazz = ClassLoader.class;
-            Field nativeLibraries = clazz.getDeclaredField("nativeLibraries");
-            nativeLibraries.setAccessible(true);
-            Vector<?> nativelib = (Vector<?>) nativeLibraries.get(this);
-            for (Object lib : nativelib)
-            {
-                Method finalize = lib.getClass().getDeclaredMethod("finalize");
-                finalize.setAccessible(true);
-                finalize.invoke(lib);
-            }
-        }
-        catch (Exception ex)
-        {
-            // ignore
         }
 
         try

--- a/modules/launcher/src/main/java/org/mule/module/launcher/MuleDeploymentService.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/MuleDeploymentService.java
@@ -19,6 +19,7 @@ import org.mule.module.launcher.domain.Domain;
 import org.mule.module.launcher.domain.DomainClassLoaderRepository;
 import org.mule.module.launcher.domain.DomainFactory;
 import org.mule.module.launcher.domain.MuleDomainClassLoaderRepository;
+import org.mule.module.launcher.nativelib.DefaultNativeLibraryFinderFactory;
 import org.mule.module.launcher.util.DebuggableReentrantLock;
 import org.mule.module.launcher.util.ObservableList;
 import org.mule.util.Preconditions;
@@ -68,7 +69,7 @@ public class MuleDeploymentService implements DeploymentService
     {
         DomainClassLoaderRepository domainClassLoaderRepository = new MuleDomainClassLoaderRepository();
 
-        ApplicationClassLoaderFactory applicationClassLoaderFactory = new MuleApplicationClassLoaderFactory(domainClassLoaderRepository);
+        ApplicationClassLoaderFactory applicationClassLoaderFactory = new MuleApplicationClassLoaderFactory(domainClassLoaderRepository, new DefaultNativeLibraryFinderFactory());
         applicationClassLoaderFactory = new CompositeApplicationClassLoaderFactory(applicationClassLoaderFactory, pluginClassLoaderManager);
 
         DefaultDomainFactory domainFactory = new DefaultDomainFactory(domainClassLoaderRepository);

--- a/modules/launcher/src/main/java/org/mule/module/launcher/MuleFoldersUtil.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/MuleFoldersUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher;
+
+import static org.mule.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
+
+import java.io.File;
+
+/**
+ *  Calculates folders for a mule server based on the
+ *  {@value org.mule.api.config.MuleProperties#MULE_HOME_DIRECTORY_PROPERTY} property
+ */
+public class MuleFoldersUtil
+{
+
+    public static final String EXECUTION_FOLDER = ".mule";
+    public static final String LIB_FOLDER = "lib";
+    public static final String APPS_FOLDER = "apps";
+
+    private MuleFoldersUtil()
+    {
+    }
+
+    public static File getMuleHomeFolder()
+    {
+        String muleHome = System.getProperty(MULE_HOME_DIRECTORY_PROPERTY, ".");
+
+        return new File(muleHome);
+    }
+
+    public static File getAppsFolder()
+    {
+        return new File(getMuleHomeFolder(), APPS_FOLDER);
+    }
+
+    public static File getAppFolder(String appName)
+    {
+        return new File(getAppsFolder(), appName);
+    }
+
+    public static File getAppLibFolder(String appName)
+    {
+        return new File(getAppFolder(appName), LIB_FOLDER);
+    }
+
+    public static File getExecutionFolder()
+    {
+        return new File(getMuleHomeFolder(), EXECUTION_FOLDER);
+    }
+
+    public static File getMuleLibFolder()
+    {
+        return new File(getMuleHomeFolder(), LIB_FOLDER);
+    }
+
+    public static File getAppTempFolder(String appName)
+    {
+        return new File(getExecutionFolder(), appName);
+    }
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/MuleApplicationClassLoaderFactory.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/MuleApplicationClassLoaderFactory.java
@@ -7,6 +7,7 @@
 package org.mule.module.launcher.application;
 
 import org.mule.module.launcher.MuleApplicationClassLoader;
+import org.mule.module.launcher.nativelib.NativeLibraryFinderFactory;
 import org.mule.module.launcher.artifact.ArtifactClassLoader;
 import org.mule.module.launcher.descriptor.ApplicationDescriptor;
 import org.mule.module.launcher.domain.DomainClassLoaderRepository;
@@ -23,10 +24,12 @@ public class MuleApplicationClassLoaderFactory implements ApplicationClassLoader
 {
 
     private final DomainClassLoaderRepository domainClassLoaderRepository;
+    private final NativeLibraryFinderFactory nativeLibraryFinderFactory;
 
-    public MuleApplicationClassLoaderFactory(DomainClassLoaderRepository domainClassLoaderRepository)
+    public MuleApplicationClassLoaderFactory(DomainClassLoaderRepository domainClassLoaderRepository, NativeLibraryFinderFactory nativeLibraryFinderFactory)
     {
         this.domainClassLoaderRepository = domainClassLoaderRepository;
+        this.nativeLibraryFinderFactory = nativeLibraryFinderFactory;
     }
 
     @Override
@@ -49,6 +52,6 @@ public class MuleApplicationClassLoaderFactory implements ApplicationClassLoader
             parent = new MulePluginsClassLoader(parent, plugins);
         }
 
-        return new MuleApplicationClassLoader(descriptor.getAppName(), parent, descriptor.getLoaderOverride());
+        return new MuleApplicationClassLoader(descriptor.getAppName(), parent, descriptor.getLoaderOverride(), nativeLibraryFinderFactory.create(descriptor.getAppName()));
     }
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/DefaultNativeLibraryFinderFactory.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/DefaultNativeLibraryFinderFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import org.mule.api.config.MuleProperties;
+import org.mule.module.launcher.MuleFoldersUtil;
+
+import java.io.File;
+
+/**
+ * Creates different {@link NativeLibraryFinder} instances depending on the
+ * value of system property {@value #COPY_APPLICATION_NATIVE_LIBRARIES},
+ * which value is true by default.
+ */
+public class DefaultNativeLibraryFinderFactory implements NativeLibraryFinderFactory
+{
+
+    public static final String COPY_APPLICATION_NATIVE_LIBRARIES = MuleProperties.SYSTEM_PROPERTY_PREFIX + "copyApplicationNativeLibraries";
+
+    @Override
+    public NativeLibraryFinder create(String appName)
+    {
+        File libDir = MuleFoldersUtil.getAppLibFolder(appName);
+
+        NativeLibraryFinder nativeLibraryFinder;
+        if (isCopyLibraries())
+        {
+            File perAppNativeLibs = new File(MuleFoldersUtil.getAppTempFolder(appName), MuleFoldersUtil.LIB_FOLDER);
+
+            nativeLibraryFinder = new PerAppCopyNativeLibraryFinder(libDir, perAppNativeLibs);
+        }
+        else
+        {
+            nativeLibraryFinder = new PerAppNativeLibraryFinder(libDir);
+        }
+
+        return nativeLibraryFinder;
+    }
+
+    private boolean isCopyLibraries()
+    {
+        String property = System.getProperty(COPY_APPLICATION_NATIVE_LIBRARIES, "true");
+        return Boolean.parseBoolean(property);
+    }
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/NativeLibraryFinder.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/NativeLibraryFinder.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+/**
+ * Finds native libraries in a particular class loading context
+ */
+public interface NativeLibraryFinder
+{
+
+    /**
+     * Finds a native library for the given name
+     *
+     * @param name        native library to find
+     * @param libraryPath library path for the given name in a parent class
+     *                    loading context. Can be null.
+     * @return library path to use for the given name. Can be null is no library was found.
+     */
+    String findLibrary(String name, String libraryPath);
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/NativeLibraryFinderFactory.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/NativeLibraryFinderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+/**
+ * Creates {@link NativeLibraryFinder} instances
+ */
+public interface NativeLibraryFinderFactory
+{
+
+    /**
+     * Creates a ntive library finder for the given application
+     *
+     * @param appName name of the application owning the finder
+     * @return a non null instance
+     */
+    NativeLibraryFinder create(String appName);
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/PerAppCopyNativeLibraryFinder.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/PerAppCopyNativeLibraryFinder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import org.mule.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * * Finds native libraries in an application's lib folder and creates a copy of
+ * each found library inside a temporal application folder.
+ */
+public class PerAppCopyNativeLibraryFinder extends PerAppNativeLibraryFinder
+{
+
+    protected Log logger = LogFactory.getLog(getClass());
+
+    private final File perAppNativeLibs;
+
+    public PerAppCopyNativeLibraryFinder(File libDir, File perAppNativeLibs)
+    {
+        super(libDir);
+
+        this.perAppNativeLibs = perAppNativeLibs;
+
+        if (this.perAppNativeLibs.exists())
+        {
+            cleanNativeLibs();
+        }
+        else
+        {
+            if (!this.perAppNativeLibs.mkdirs())
+            {
+                throw new IllegalStateException(String.format("Unable to create application '%s' folder", this.perAppNativeLibs.getAbsolutePath()));
+            }
+        }
+    }
+
+    @Override
+    public String findLibrary(String name, String parentLibraryPath)
+    {
+        String libraryPath = parentLibraryPath;
+
+        if (null == libraryPath)
+        {
+            libraryPath = findLibraryLocally(name);
+        }
+
+        if (libraryPath != null)
+        {
+            if (logger.isDebugEnabled())
+            {
+                logger.debug(String.format("Found native library for '%s' on '%s", name, libraryPath));
+            }
+
+            final File tempLibrary = copyNativeLibrary(name, libraryPath);
+            libraryPath = tempLibrary.getAbsolutePath();
+
+            if (logger.isDebugEnabled())
+            {
+                logger.debug(String.format("Created native library copy for '%s' on '%s", name, libraryPath));
+            }
+        }
+        return libraryPath;
+    }
+
+    private void cleanNativeLibs()
+    {
+        String[] list = perAppNativeLibs.list();
+
+        if (list != null)
+        {
+            for (String library : list)
+            {
+                new File(perAppNativeLibs, library).delete();
+            }
+        }
+    }
+
+    private File copyNativeLibrary(String name, String libraryPath)
+    {
+        final String nativeLibName = System.mapLibraryName(name);
+        final File tempLibrary = new File(perAppNativeLibs, nativeLibName + System.currentTimeMillis());
+
+        try
+        {
+            final File library = new File(libraryPath);
+            FileUtils.copyFile(library, tempLibrary);
+
+            return tempLibrary;
+        }
+        catch (IOException e)
+        {
+            throw new IllegalStateException(String.format("Unable to generate copy for native library '%s' at '%s'", nativeLibName, tempLibrary.getAbsolutePath()), e);
+        }
+    }
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/PerAppNativeLibraryFinder.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/nativelib/PerAppNativeLibraryFinder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import org.mule.module.launcher.MuleApplicationClassLoader;
+import org.mule.util.SystemUtils;
+
+import java.io.File;
+
+/**
+ * Finds native libraries in an application's lib folder
+ */
+public class PerAppNativeLibraryFinder implements NativeLibraryFinder
+{
+
+    private final File libDir;
+
+    public PerAppNativeLibraryFinder(File libDir)
+    {
+        this.libDir = libDir;
+    }
+
+    @Override
+    public String findLibrary(String name, String libraryPath)
+    {
+        if (null == libraryPath)
+        {
+            libraryPath = findLibraryLocally(name);
+        }
+
+        return libraryPath;
+    }
+
+    protected String findLibraryLocally(String name)
+    {
+        String nativeLibName = System.mapLibraryName(name);
+        File library = new File(libDir, nativeLibName);
+
+        if (!library.exists() && SystemUtils.IS_OS_MAC)
+        {
+            nativeLibName = nativeLibName.replace(MuleApplicationClassLoader.DYLIB_EXTENSION, MuleApplicationClassLoader.JNILIB_EXTENSION);
+            library = new File(libDir, nativeLibName);
+        }
+
+        if (library.exists())
+        {
+            return library.getAbsolutePath();
+        }
+        else
+        {
+            return null;
+        }
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
@@ -37,6 +37,7 @@ import org.mule.module.launcher.application.TestApplicationFactory;
 import org.mule.module.launcher.domain.Domain;
 import org.mule.module.launcher.domain.MuleDomainClassLoaderRepository;
 import org.mule.module.launcher.domain.TestDomainFactory;
+import org.mule.module.launcher.nativelib.DefaultNativeLibraryFinderFactory;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.tck.probe.JUnitProbe;
@@ -918,7 +919,7 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
     {
         addPackedAppFromResource(emptyAppDescriptor.zipPath);
 
-        TestApplicationFactory appFactory = new TestApplicationFactory(new MuleApplicationClassLoaderFactory(new MuleDomainClassLoaderRepository()));
+        TestApplicationFactory appFactory = new TestApplicationFactory(new MuleApplicationClassLoaderFactory(new MuleDomainClassLoaderRepository(), new DefaultNativeLibraryFinderFactory()));
         appFactory.setFailOnStopApplication(true);
 
         deploymentService.setAppFactory(appFactory);
@@ -940,7 +941,7 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
     {
         addPackedAppFromResource(emptyAppDescriptor.zipPath);
 
-        TestApplicationFactory appFactory = new TestApplicationFactory(new MuleApplicationClassLoaderFactory(new MuleDomainClassLoaderRepository()));
+        TestApplicationFactory appFactory = new TestApplicationFactory(new MuleApplicationClassLoaderFactory(new MuleDomainClassLoaderRepository(), new DefaultNativeLibraryFinderFactory()));
         appFactory.setFailOnDisposeApplication(true);
         deploymentService.setAppFactory(appFactory);
         deploymentService.start();

--- a/modules/launcher/src/test/java/org/mule/module/launcher/MuleApplicationClassLoaderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/MuleApplicationClassLoaderTestCase.java
@@ -77,7 +77,7 @@ public class MuleApplicationClassLoaderTestCase extends AbstractMuleTestCase
 
         // Create app class loader
         domainCL = new MuleSharedDomainClassLoader(DOMAIN_NAME, Thread.currentThread().getContextClassLoader());
-        appCL = new MuleApplicationClassLoader(APP_NAME, domainCL);
+        appCL = new MuleApplicationClassLoader(APP_NAME, domainCL, null);
     }
 
     private File createDirectory(String format, Object... args)

--- a/modules/launcher/src/test/java/org/mule/module/launcher/MuleFoldersUtilTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/MuleFoldersUtilTestCase.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import org.mule.api.config.MuleProperties;
+import org.mule.tck.MuleTestUtils;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+@SmallTest
+public class MuleFoldersUtilTestCase extends AbstractMuleTestCase
+{
+
+    public static final String TEST_APP = "testApp";
+
+    @Rule
+    public TemporaryFolder muleHome = new TemporaryFolder();
+
+    @Test
+    public void getsMuleHome() throws Exception
+    {
+        doFolderTest(new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                File folder = MuleFoldersUtil.getMuleHomeFolder();
+                assertThat(folder.getAbsolutePath(), equalTo(muleHome.getRoot().getAbsolutePath()));
+            }
+        });
+    }
+
+    @Test
+    public void getsAppsFolder() throws Exception
+    {
+        doFolderTest(new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                File folder = MuleFoldersUtil.getAppsFolder();
+                assertThat(folder.getAbsolutePath(), equalTo(getAppsFolder()));
+            }
+        });
+    }
+
+    @Test
+    public void getsAppFolder() throws Exception
+    {
+        doFolderTest(new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                File folder = MuleFoldersUtil.getAppFolder(TEST_APP);
+                assertThat(folder.getAbsolutePath(), equalTo(getTestAppFolder()));
+            }
+        });
+    }
+
+    @Test
+    public void getsAppLibFolder() throws Exception
+    {
+        doFolderTest(new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                File folder = MuleFoldersUtil.getAppLibFolder(TEST_APP);
+                assertThat(folder.getAbsolutePath(), equalTo(getTestAppFolder() + File.separator + MuleFoldersUtil.LIB_FOLDER));
+            }
+        });
+    }
+
+    @Test
+    public void getsAppTempFolder() throws Exception
+    {
+        doFolderTest(new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                File folder = MuleFoldersUtil.getAppTempFolder(TEST_APP);
+                assertThat(folder.getAbsolutePath(), equalTo(getMuleExecutionFolder() + File.separator + TEST_APP));
+            }
+        });
+    }
+
+    @Test
+    public void getsMuleExecutionFolder() throws Exception
+    {
+        doFolderTest(new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                File folder = MuleFoldersUtil.getExecutionFolder();
+                assertThat(folder.getAbsolutePath(), equalTo(getMuleExecutionFolder()));
+            }
+        });
+    }
+
+    @Test
+    public void getsMuleLibFolder() throws Exception
+    {
+        doFolderTest(new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                File folder = MuleFoldersUtil.getMuleLibFolder();
+                assertThat(folder.getAbsolutePath(), equalTo(muleHome.getRoot().getAbsolutePath() + File.separator + MuleFoldersUtil.LIB_FOLDER));
+            }
+        });
+    }
+
+    private String getMuleExecutionFolder()
+    {
+        return muleHome.getRoot().getAbsolutePath() + File.separator + MuleFoldersUtil.EXECUTION_FOLDER;
+    }
+
+    private void doFolderTest(MuleTestUtils.TestCallback callback) throws Exception
+    {
+        MuleTestUtils.testWithSystemProperty(MuleProperties.MULE_HOME_DIRECTORY_PROPERTY, muleHome.getRoot().getAbsolutePath(), callback);
+    }
+
+    private String getAppsFolder()
+    {
+        return muleHome.getRoot().getAbsolutePath() + File.separator + MuleFoldersUtil.APPS_FOLDER;
+    }
+
+    private String getTestAppFolder()
+    {
+        return getAppsFolder() + File.separator + TEST_APP;
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/SynchronizedClassLoaderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/SynchronizedClassLoaderTestCase.java
@@ -33,7 +33,7 @@ public class SynchronizedClassLoaderTestCase extends AbstractMuleTestCase
     @Test
     public void synchronizesLoadClassInMuleApplicationClassLoader() throws Exception
     {
-        doLoadClassSynchronizationTest(new MuleApplicationClassLoader("test", new TestClassLoader()));
+        doLoadClassSynchronizationTest(new MuleApplicationClassLoader("test", new TestClassLoader(), null));
     }
 
     private void doLoadClassSynchronizationTest(ClassLoader classLoader) throws InterruptedException

--- a/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/AbstractNativeLibraryFinderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/AbstractNativeLibraryFinderTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import org.mule.module.launcher.MuleApplicationClassLoader;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public class AbstractNativeLibraryFinderTestCase extends AbstractMuleTestCase
+{
+
+    public static final String TEST_LIB_NAME = "test";
+
+    @Rule
+    public TemporaryFolder libFolder = new TemporaryFolder();
+
+    protected File createDefaultNativeLibraryFile(String libName) throws IOException
+    {
+        return createNativeLibraryFile(libFolder.getRoot(), System.mapLibraryName(libName));
+    }
+
+    protected File createNativeLibraryFile(File folder, String libFileName) throws IOException
+    {
+
+        File libraryFile = new File(folder, libFileName);
+        FileUtils.write(libraryFile, "SOME.NATIVE.CODE");
+
+        return libraryFile;
+    }
+
+    protected String getJniLibFileName()
+    {
+        String libraryFileName = System.mapLibraryName(TEST_LIB_NAME);
+        int index = libraryFileName.lastIndexOf(".");
+        libraryFileName = libraryFileName.substring(0, index) + MuleApplicationClassLoader.JNILIB_EXTENSION;
+        return libraryFileName;
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/DefaultNativeLibraryFinderFactoryTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/DefaultNativeLibraryFinderFactoryTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+import org.mule.api.config.MuleProperties;
+import org.mule.tck.MuleTestUtils;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+@SmallTest
+public class DefaultNativeLibraryFinderFactoryTestCase extends AbstractMuleTestCase
+{
+
+    @Rule
+    public TemporaryFolder muleHomeFolder = new TemporaryFolder();
+
+    private final DefaultNativeLibraryFinderFactory nativeLibraryFinderFactory = new DefaultNativeLibraryFinderFactory();
+
+    @Test
+    public void createsPerAppCopyNativeLibraryFinderWhenPropertyIsTrue() throws Exception
+    {
+        doCreateNativeLibraryFinderTest("true", PerAppCopyNativeLibraryFinder.class);
+    }
+
+    @Test
+    public void createsPerAppCopyNativeLibraryFinderWhenPropertyIsNull() throws Exception
+    {
+        doCreateNativeLibraryFinderTest(null, PerAppCopyNativeLibraryFinder.class);
+    }
+
+    @Test
+    public void createsPerAppNativeLibraryFinderWhenPropertyIsFalse() throws Exception
+    {
+        doCreateNativeLibraryFinderTest("false", PerAppNativeLibraryFinder.class);
+    }
+
+    private void doCreateNativeLibraryFinderTest(String copyApplicationNativeLibrariesProperty, final Class<? extends NativeLibraryFinder> expectedNativeLibraryFinderClass) throws Exception
+    {
+        MuleTestUtils.testWithSystemProperty(DefaultNativeLibraryFinderFactory.COPY_APPLICATION_NATIVE_LIBRARIES, copyApplicationNativeLibrariesProperty, new MuleTestUtils.TestCallback()
+        {
+            @Override
+            public void run() throws Exception
+            {
+                MuleTestUtils.testWithSystemProperty(MuleProperties.MULE_HOME_DIRECTORY_PROPERTY, muleHomeFolder.getRoot().getAbsolutePath(), new MuleTestUtils.TestCallback()
+                {
+                    @Override
+                    public void run() throws Exception
+                    {
+                        NativeLibraryFinder nativeLibraryFinder = nativeLibraryFinderFactory.create("testApp");
+
+                        assertThat(nativeLibraryFinder, instanceOf(expectedNativeLibraryFinderClass));
+                    }
+                });
+            }
+        });
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/MacOsMatcher.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/MacOsMatcher.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.util.SystemUtils;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+public class MacOsMatcher extends BaseMatcher<AbstractMuleTestCase>
+{
+
+    @Override
+    public boolean matches(Object o)
+    {
+        return SystemUtils.IS_OS_MAC;
+    }
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("Need a Mac Os to run");
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/PerAppCopyNativeLibraryFinderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/PerAppCopyNativeLibraryFinderTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
+import org.mule.tck.size.SmallTest;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+@SmallTest
+public class PerAppCopyNativeLibraryFinderTestCase extends AbstractNativeLibraryFinderTestCase
+{
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+
+    @Test
+    public void createsTempFolder() throws Exception
+    {
+        tempFolder.getRoot().delete();
+
+        new PerAppCopyNativeLibraryFinder(libFolder.getRoot(), tempFolder.getRoot());
+
+        assertThat(tempFolder.getRoot().exists(), equalTo(true));
+    }
+
+    @Test
+    public void cleansTempFolder() throws Exception
+    {
+        File libraryFile = createNativeLibraryFile(tempFolder.getRoot(), "tempfile.jar");
+
+        new PerAppCopyNativeLibraryFinder(libFolder.getRoot(), tempFolder.getRoot());
+
+        assertThat(libraryFile.exists(), equalTo(false));
+    }
+
+    @Test
+    public void returnsNullWhenLibraryNotFound() throws Exception
+    {
+        NativeLibraryFinder nativeLibraryFinder = new PerAppCopyNativeLibraryFinder(libFolder.getRoot(), tempFolder.getRoot());
+
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, null);
+
+        assertThat(testLibPath, equalTo(null));
+    }
+
+    @Test
+    public void returnsParentLocalLibrary() throws Exception
+    {
+        File parentNativeLibrary = createDefaultNativeLibraryFile(TEST_LIB_NAME);
+
+        NativeLibraryFinder nativeLibraryFinder = new PerAppCopyNativeLibraryFinder(libFolder.getRoot(), tempFolder.getRoot());
+
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, parentNativeLibrary.getAbsolutePath());
+
+        assertThat(testLibPath, startsWith(tempFolder.getRoot().getAbsolutePath()));
+        assertThat(testLibPath, containsString(TEST_LIB_NAME));
+    }
+
+    @Test
+    public void findsLocalLibrary() throws Exception
+    {
+        createDefaultNativeLibraryFile(TEST_LIB_NAME);
+
+        NativeLibraryFinder nativeLibraryFinder = new PerAppCopyNativeLibraryFinder(libFolder.getRoot(), tempFolder.getRoot());
+
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, null);
+
+        assertThat(testLibPath, startsWith(tempFolder.getRoot().getAbsolutePath()));
+        assertThat(testLibPath, containsString(TEST_LIB_NAME));
+    }
+
+    @Test
+    public void findsJnilibInMac() throws Exception
+    {
+        assumeThat(this, new MacOsMatcher());
+
+        String libraryFileName = getJniLibFileName();
+
+        createNativeLibraryFile(libFolder.getRoot(), libraryFileName);
+
+        NativeLibraryFinder nativeLibraryFinder = new PerAppCopyNativeLibraryFinder(libFolder.getRoot(), tempFolder.getRoot());
+
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, null);
+
+        assertThat(testLibPath, startsWith(tempFolder.getRoot().getAbsolutePath()));
+        assertThat(testLibPath, containsString(TEST_LIB_NAME));
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/PerAppNativeLibraryFinderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/nativelib/PerAppNativeLibraryFinderTestCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.nativelib;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
+import org.mule.tck.size.SmallTest;
+
+import java.io.File;
+
+import org.junit.Test;
+
+@SmallTest
+public class PerAppNativeLibraryFinderTestCase extends AbstractNativeLibraryFinderTestCase
+{
+
+    @Test
+    public void returnsNullWhenLibraryNotFound() throws Exception
+    {
+        PerAppNativeLibraryFinder nativeLibraryFinder = new PerAppNativeLibraryFinder(libFolder.getRoot());
+
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, null);
+
+        assertThat(testLibPath, equalTo(null));
+    }
+
+    @Test
+    public void returnsParentLocalLibrary() throws Exception
+    {
+        PerAppNativeLibraryFinder nativeLibraryFinder = new PerAppNativeLibraryFinder(libFolder.getRoot());
+
+        final String parentLibraryPath = "parent library path";
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, parentLibraryPath);
+
+        assertThat(testLibPath, equalTo(parentLibraryPath));
+    }
+
+    @Test
+    public void findsLocalLibrary() throws Exception
+    {
+        File libraryFile = createDefaultNativeLibraryFile(TEST_LIB_NAME);
+
+        PerAppNativeLibraryFinder nativeLibraryFinder = new PerAppNativeLibraryFinder(libFolder.getRoot());
+
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, null);
+
+        assertThat(testLibPath, equalTo(libraryFile.getAbsolutePath()));
+    }
+
+    @Test
+    public void findsJnilibInMac() throws Exception
+    {
+        assumeThat(this, new MacOsMatcher());
+
+        String libraryFileName = getJniLibFileName();
+
+        File libraryFile = createNativeLibraryFile(libFolder.getRoot(), libraryFileName);
+
+        PerAppNativeLibraryFinder nativeLibraryFinder = new PerAppNativeLibraryFinder(libFolder.getRoot());
+
+        String testLibPath = nativeLibraryFinder.findLibrary(TEST_LIB_NAME, null);
+
+        assertThat(testLibPath, equalTo(libraryFile.getAbsolutePath()));
+    }
+}


### PR DESCRIPTION
...e classloader on redeploy

_ Removing reflection invocation of native library’s finalize
_ Adding NativeLibraryFinder
_Creating two native library finder versions: one that works as the original code and another one thats creates copies of each used native library file
_Adding a flag to diable native library copy
