### PR TITLE
MULE-7841: In some cases if the host name is like "*.host" the InetSocke...

### DIFF
--- a/transports/http/src/test/java/org/mule/transport/http/HttpServerConnectionTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/HttpServerConnectionTestCase.java
@@ -144,8 +144,8 @@ public class HttpServerConnectionTestCase extends AbstractMuleContextTestCase
     public void getRemoteSocketAddress() throws Exception
     {
         HttpServerConnection httpServerConnection = new HttpServerConnection(mockSocket, muleContext.getConfiguration().getDefaultEncoding(), mockHttpConnector);
-        when(mockSocket.getRemoteSocketAddress()).thenReturn(new InetSocketAddress("host", 1000));
-        assertThat(httpServerConnection.getRemoteClientAddress(), is("host:1000"));
+        when(mockSocket.getRemoteSocketAddress()).thenReturn(new InetSocketAddress("host_abc", 1000));
+        assertThat(httpServerConnection.getRemoteClientAddress(), is("host_abc:1000"));
     }
 
     @Test

--- a/transports/tcp/src/test/java/org/mule/transport/tcp/TcpSocketKeyTestCase.java
+++ b/transports/tcp/src/test/java/org/mule/transport/tcp/TcpSocketKeyTestCase.java
@@ -12,11 +12,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import org.junit.Test;
 import org.mule.api.MuleException;
 import org.mule.api.endpoint.EndpointURI;
 import org.mule.api.endpoint.ImmutableEndpoint;
+
+import org.junit.Test;
 
 public class TcpSocketKeyTestCase 
 {
@@ -49,7 +49,7 @@ public class TcpSocketKeyTestCase
         final TcpConnector tcpConnector = mock(TcpConnector.class);
         when(tcpConnector.isFailOnUnresolvedHost()).thenReturn(Boolean.TRUE);
         
-        final ImmutableEndpoint endpoint = createEndpoint(tcpConnector, "some.invented.host", 8080);
+        final ImmutableEndpoint endpoint = createEndpoint(tcpConnector, "some.invented.host_abc", 8080);
         @SuppressWarnings("unused")
         final TcpSocketKey key = new TcpSocketKey(endpoint);
     }


### PR DESCRIPTION
...tAddress resolves to "_.host/127.0.53.53" instead of just "_.host".
