### PR TITLE
MULE-7097: Provide a way to specify valid cipher specs for SSL on transports that support the protocol

### DIFF
--- a/core/src/main/java/org/mule/api/security/tls/RestrictedSSLServerSocketFactory.java
+++ b/core/src/main/java/org/mule/api/security/tls/RestrictedSSLServerSocketFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.api.security.tls;
+
+import org.mule.util.ArrayUtils;
+
+import com.google.common.base.Joiner;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * SSLServerSocketFactory decorator that restricts the available protocols and cipher suites
+ * in the sockets that are created.
+ */
+public class RestrictedSSLServerSocketFactory extends SSLServerSocketFactory
+{
+
+    private static final Logger logger = LoggerFactory.getLogger(RestrictedSSLServerSocketFactory.class);
+
+    private final SSLServerSocketFactory sslServerSocketFactory;
+    private final String[] enabledCipherSuites;
+    private final String[] enabledProtocols;
+    private final String[] defaultCipherSuites;
+
+    public RestrictedSSLServerSocketFactory(SSLContext sslContext, String[] cipherSuites, String[] protocols)
+    {
+        this.sslServerSocketFactory = sslContext.getServerSocketFactory();
+
+        if (cipherSuites == null)
+        {
+            cipherSuites = sslServerSocketFactory.getDefaultCipherSuites();
+        }
+        this.enabledCipherSuites = ArrayUtils.intersection(cipherSuites, sslServerSocketFactory.getSupportedCipherSuites());
+        this.defaultCipherSuites = ArrayUtils.intersection(cipherSuites, sslServerSocketFactory.getDefaultCipherSuites());
+
+        if (protocols == null)
+        {
+            protocols = sslContext.getDefaultSSLParameters().getProtocols();
+        }
+        this.enabledProtocols = ArrayUtils.intersection(protocols, sslContext.getSupportedSSLParameters().getProtocols());
+
+        if (this.enabledProtocols.length != protocols.length)
+        {
+            logger.warn("Current context supports less SSL protocols than configured. Only the following are enabled: [{}]", Joiner.on(", ").join(this.enabledProtocols));
+        }
+    }
+
+    @Override
+    public ServerSocket createServerSocket() throws IOException
+    {
+        return restrictCipherSuites((SSLServerSocket) sslServerSocketFactory.createServerSocket());
+    }
+
+    @Override
+    public ServerSocket createServerSocket(int port) throws IOException
+    {
+        return restrictCipherSuites((SSLServerSocket) sslServerSocketFactory.createServerSocket(port));
+    }
+
+    @Override
+    public ServerSocket createServerSocket(int port, int backlog) throws IOException
+    {
+        return restrictCipherSuites((SSLServerSocket) sslServerSocketFactory.createServerSocket(port, backlog));
+    }
+
+    @Override
+    public ServerSocket createServerSocket(int port, int backlog, InetAddress ifAddress) throws IOException
+    {
+        return restrictCipherSuites((SSLServerSocket) sslServerSocketFactory.createServerSocket(port, backlog, ifAddress));
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites()
+    {
+        return defaultCipherSuites;
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites()
+    {
+        return enabledCipherSuites;
+    }
+
+    private SSLServerSocket restrictCipherSuites(SSLServerSocket sslServerSocket)
+    {
+        sslServerSocket.setEnabledCipherSuites(enabledCipherSuites);
+        sslServerSocket.setEnabledProtocols(enabledProtocols);
+        return sslServerSocket;
+    }
+}

--- a/core/src/main/java/org/mule/api/security/tls/RestrictedSSLSocketFactory.java
+++ b/core/src/main/java/org/mule/api/security/tls/RestrictedSSLSocketFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.api.security.tls;
+
+import org.mule.util.ArrayUtils;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * SSLSocketFactory decorator that restricts the available protocols and cipher suites
+ * in the sockets that are created.
+ */
+public class RestrictedSSLSocketFactory extends SSLSocketFactory
+{
+
+    private final SSLSocketFactory sslSocketFactory;
+    private final String[] enabledCipherSuites;
+    private final String[] enabledProtocols;
+    private final String[] defaultCipherSuites;
+
+    public RestrictedSSLSocketFactory(SSLContext sslContext, String[] cipherSuites, String[] protocols)
+    {
+        this.sslSocketFactory = sslContext.getSocketFactory();
+
+        if (cipherSuites == null)
+        {
+            cipherSuites = sslSocketFactory.getDefaultCipherSuites();
+        }
+        this.enabledCipherSuites = ArrayUtils.intersection(cipherSuites, sslSocketFactory.getSupportedCipherSuites());
+        this.defaultCipherSuites = ArrayUtils.intersection(cipherSuites, sslSocketFactory.getDefaultCipherSuites());
+
+        if (protocols == null)
+        {
+            protocols = sslContext.getDefaultSSLParameters().getProtocols();
+        }
+        this.enabledProtocols = ArrayUtils.intersection(protocols, sslContext.getSupportedSSLParameters().getProtocols());
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException
+    {
+        return restrictCipherSuites((SSLSocket) sslSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress clientAddress, int clientPort) throws IOException
+    {
+        return restrictCipherSuites((SSLSocket) sslSocketFactory.createSocket(host, port, clientAddress, clientPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port) throws IOException
+    {
+        return restrictCipherSuites((SSLSocket) sslSocketFactory.createSocket(address, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress clientAddress, int clientPort) throws IOException
+    {
+        return restrictCipherSuites((SSLSocket) sslSocketFactory.createSocket(address, port, clientAddress, clientPort));
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites()
+    {
+        return defaultCipherSuites;
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites()
+    {
+        return enabledCipherSuites;
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException
+    {
+        return restrictCipherSuites((SSLSocket) sslSocketFactory.createSocket(socket, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket() throws IOException
+    {
+        return restrictCipherSuites((SSLSocket) sslSocketFactory.createSocket());
+    }
+
+    private SSLSocket restrictCipherSuites(SSLSocket socket)
+    {
+        socket.setEnabledCipherSuites(enabledCipherSuites);
+        socket.setEnabledProtocols(enabledProtocols);
+        return socket;
+    }
+}

--- a/core/src/main/java/org/mule/api/security/tls/TlsConfiguration.java
+++ b/core/src/main/java/org/mule/api/security/tls/TlsConfiguration.java
@@ -15,6 +15,7 @@ import org.mule.api.security.provider.AutoDiscoverySecurityProviderFactory;
 import org.mule.api.security.provider.SecurityProviderFactory;
 import org.mule.api.security.provider.SecurityProviderInfo;
 import org.mule.config.i18n.CoreMessages;
+import org.mule.util.ArrayUtils;
 import org.mule.util.FileUtils;
 import org.mule.util.IOUtils;
 import org.mule.util.StringUtils;
@@ -115,6 +116,7 @@ public final class TlsConfiguration
     public static final String DEFAULT_KEYSTORE = ".keystore";
     public static final String DEFAULT_KEYSTORE_TYPE = KeyStore.getDefaultType();
     public static final String JSSE_NAMESPACE = "javax.net";
+    public static final String DEFAULT_PROPERTIES_FILE = "tls-default.conf";
 
     private Log logger = LogFactory.getLog(getClass());
 
@@ -154,6 +156,8 @@ public final class TlsConfiguration
     private TrustManagerFactory trustManagerFactory = null;
     private boolean explicitTrustStoreOnly = false;
     private boolean requireClientAuthentication = false;
+
+    private TlsProperties tlsProperties = new TlsProperties();
 
     /**
      * Support for TLS connections with a given initial value for the key store
@@ -195,6 +199,8 @@ public final class TlsConfiguration
         {
             new TlsPropertiesMapper(namespace).writeToProperties(System.getProperties(), this);
         }
+
+        tlsProperties.load(DEFAULT_PROPERTIES_FILE);
     }
 
     private void validate(boolean anon) throws CreateException
@@ -347,13 +353,24 @@ public final class TlsConfiguration
 
     public SSLSocketFactory getSocketFactory() throws NoSuchAlgorithmException, KeyManagementException
     {
-        return getSslContext().getSocketFactory();
+        return new RestrictedSSLSocketFactory(getSslContext(), getEnabledCipherSuites(), getEnabledProtocols());
     }
 
     public SSLServerSocketFactory getServerSocketFactory()
             throws NoSuchAlgorithmException, KeyManagementException
     {
-        return getSslContext().getServerSocketFactory();
+        return new RestrictedSSLServerSocketFactory(getSslContext(), getEnabledCipherSuites(), getEnabledProtocols());
+    }
+
+
+    public String[] getEnabledCipherSuites()
+    {
+        return tlsProperties.getEnabledCipherSuites();
+    }
+
+    public String[] getEnabledProtocols()
+    {
+        return tlsProperties.getEnabledProtocols();
     }
 
     public SSLContext getSslContext() throws NoSuchAlgorithmException, KeyManagementException
@@ -376,6 +393,13 @@ public final class TlsConfiguration
 
     public void setSslType(String sslType)
     {
+        String[] enabledProtocols = tlsProperties.getEnabledProtocols();
+
+        if (enabledProtocols != null && !ArrayUtils.contains(enabledProtocols, sslType))
+        {
+            throw new IllegalArgumentException(String.format("Protocol %s is not allowed in current configuration", sslType));
+        }
+
         this.sslType = sslType;
     }
 

--- a/core/src/main/java/org/mule/api/security/tls/TlsProperties.java
+++ b/core/src/main/java/org/mule/api/security/tls/TlsProperties.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.api.security.tls;
+
+
+import org.mule.util.IOUtils;
+import org.mule.util.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TlsProperties
+{
+
+    private static final Logger logger = LoggerFactory.getLogger(TlsProperties.class);
+
+    private String[] enabledCipherSuites;
+    private String[] enabledProtocols;
+
+    public String[] getEnabledCipherSuites()
+    {
+        return enabledCipherSuites;
+    }
+
+    public String[] getEnabledProtocols()
+    {
+        return enabledProtocols;
+    }
+
+    public void load(String fileName)
+    {
+        Properties properties = new Properties();
+        try
+        {
+            InputStream config = IOUtils.getResourceAsStream(fileName, TlsProperties.class);
+
+            if (config == null)
+            {
+                logger.warn(String.format("File %s not found, using default configuration.", fileName));
+            }
+            else
+            {
+                properties.load(config);
+
+                String enabledCipherSuitesProperty = properties.getProperty("enabledCipherSuites");
+                String enabledProtocolsProperty = properties.getProperty("enabledProtocols");
+
+                if (enabledCipherSuitesProperty != null)
+                {
+                    enabledCipherSuites = StringUtils.splitAndTrim(enabledCipherSuitesProperty, ",");
+
+                }
+                if (enabledProtocolsProperty != null)
+                {
+                    enabledProtocols = StringUtils.splitAndTrim(enabledProtocolsProperty, ",");
+                }
+            }
+        }
+        catch (IOException e)
+        {
+            logger.warn(String.format("Cannot read file %s, using default configuration", fileName), e);
+        }
+    }
+}

--- a/core/src/main/java/org/mule/util/ArrayUtils.java
+++ b/core/src/main/java/org/mule/util/ArrayUtils.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 // @ThreadSafe
 public class ArrayUtils extends org.apache.commons.lang.ArrayUtils
@@ -124,6 +125,18 @@ public class ArrayUtils extends org.apache.commons.lang.ArrayUtils
         String[] copy = new String[ugly.length];
         System.arraycopy(ugly, 0, copy, 0, ugly.length);
         return copy;
+    }
+
+    /**
+     * Calculates the intersection between two arrays, as if they were sets.
+     * @return A new array with the intersection.
+     */
+    public static String[] intersection(String[] a, String[] b)
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(Arrays.asList(a));
+        result.retainAll(Arrays.asList(b));
+        return result.toArray(new String[result.size()]);
     }
     
 }

--- a/core/src/test/java/org/mule/api/TlsConfigurationTestCase.java
+++ b/core/src/test/java/org/mule/api/TlsConfigurationTestCase.java
@@ -6,23 +6,32 @@
  */
 package org.mule.api;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.mule.api.lifecycle.CreateException;
 import org.mule.api.security.tls.TlsConfiguration;
 import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.util.ClassUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.URL;
 
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 public class TlsConfigurationTestCase extends AbstractMuleTestCase
 {
+
+    private static final String SUPPORTED_CIPHER_SUITE = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA";
+    private static final String SUPPORTED_PROTOCOL = "TLSv1";
+
     @Test
     public void testEmptyConfiguration() throws Exception
     {
@@ -91,4 +100,64 @@ public class TlsConfigurationTestCase extends AbstractMuleTestCase
             assertTrue(ce.getCause() instanceof IllegalStateException);
         }
     }
+
+
+    @Test
+    public void testCipherSuitesFromConfigFile() throws Exception
+    {
+        File configFile = createConfigFile();
+
+        try
+        {
+            TlsConfiguration tlsConfiguration = new TlsConfiguration(TlsConfiguration.DEFAULT_KEYSTORE);
+            tlsConfiguration.initialise(true, TlsConfiguration.JSSE_NAMESPACE);
+
+            SSLSocket socket = (SSLSocket) tlsConfiguration.getSocketFactory().createSocket();
+            SSLServerSocket serverSocket = (SSLServerSocket) tlsConfiguration.getServerSocketFactory().createServerSocket();
+
+            assertArrayEquals(new String[] {SUPPORTED_CIPHER_SUITE}, socket.getEnabledCipherSuites());
+            assertArrayEquals(new String[] {SUPPORTED_CIPHER_SUITE}, serverSocket.getEnabledCipherSuites());
+        }
+        finally
+        {
+            configFile.delete();
+        }
+    }
+
+    @Test
+    public void testProtocolsFromConfigFile() throws Exception
+    {
+        File configFile = createConfigFile();
+
+        try
+        {
+            TlsConfiguration tlsConfiguration = new TlsConfiguration(TlsConfiguration.DEFAULT_KEYSTORE);
+            tlsConfiguration.initialise(true, TlsConfiguration.JSSE_NAMESPACE);
+
+            SSLSocket socket = (SSLSocket) tlsConfiguration.getSocketFactory().createSocket();
+            SSLServerSocket serverSocket = (SSLServerSocket) tlsConfiguration.getServerSocketFactory().createServerSocket();
+
+            assertArrayEquals(new String[] {SUPPORTED_PROTOCOL}, socket.getEnabledProtocols());
+            assertArrayEquals(new String[] {SUPPORTED_PROTOCOL}, serverSocket.getEnabledProtocols());
+        }
+        finally
+        {
+            configFile.delete();
+        }
+    }
+
+
+    private File createConfigFile() throws IOException
+    {
+        String path = ClassUtils.getClassPathRoot(getClass()).getPath();
+        File file = new File(path, TlsConfiguration.DEFAULT_PROPERTIES_FILE);
+
+        PrintWriter writer = new PrintWriter(file, "UTF-8");
+        writer.println("enabledCipherSuites=UNSUPPORTED," + SUPPORTED_CIPHER_SUITE);
+        writer.println("enabledProtocols=UNSUPPORTED," + SUPPORTED_PROTOCOL);
+        writer.close();
+
+        return file;
+    }
+
 }

--- a/distributions/standalone-light/assembly-whitelist.txt
+++ b/distributions/standalone-light/assembly-whitelist.txt
@@ -34,6 +34,7 @@
 #
 /mule-standalone-nodocs-${productVersion}/conf/log4j.properties
 /mule-standalone-nodocs-${productVersion}/conf/wrapper.conf
+/mule-standalone-nodocs-${productVersion}/conf/tls-default.conf
 
 
 #

--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -37,6 +37,7 @@
 #
 /mule-standalone-${productVersion}/conf/log4j.properties
 /mule-standalone-${productVersion}/conf/wrapper.conf
+/mule-standalone-${productVersion}/conf/tls-default.conf
 
 
 #

--- a/distributions/standalone/src/main/resources/conf/tls-default.conf
+++ b/distributions/standalone/src/main/resources/conf/tls-default.conf
@@ -1,0 +1,50 @@
+
+# This file allows to restrict SSL behavior in Mule. If the file doesn't exist or a property is not defined,
+# default values of the current security provider will be used.
+
+
+# Cipher suites that will be enabled in SSL. If this property is set, SSL sockets will
+# only use cipher suites that are provided in this list and supported by the current security provider.
+#enabledCipherSuites=TLS_KRB5_WITH_3DES_EDE_CBC_MD5,        \
+#                    TLS_KRB5_WITH_RC4_128_SHA,             \
+#                    SSL_DH_anon_WITH_DES_CBC_SHA,          \
+#                    TLS_DH_anon_WITH_AES_128_CBC_SHA,      \
+#                    TLS_DHE_RSA_WITH_AES_128_CBC_SHA,      \
+#                    SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA, \
+#                    SSL_RSA_EXPORT_WITH_RC4_40_MD5,        \
+#                    SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA,     \
+#                    TLS_DHE_RSA_WITH_AES_256_CBC_SHA,      \
+#                    TLS_KRB5_WITH_3DES_EDE_CBC_SHA,        \
+#                    SSL_RSA_WITH_RC4_128_SHA,              \
+#                    TLS_KRB5_WITH_DES_CBC_MD5,             \
+#                    TLS_KRB5_EXPORT_WITH_RC4_40_MD5,       \
+#                    TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5,   \
+#                    SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA, \
+#                    TLS_KRB5_EXPORT_WITH_RC4_40_SHA,       \
+#                    SSL_DH_anon_EXPORT_WITH_RC4_40_MD5,    \
+#                    SSL_DHE_DSS_WITH_DES_CBC_SHA,          \
+#                    TLS_KRB5_WITH_DES_CBC_SHA,             \
+#                    SSL_RSA_WITH_NULL_MD5,                 \
+#                    TLS_DHE_DSS_WITH_AES_256_CBC_SHA,      \
+#                    SSL_DH_anon_WITH_3DES_EDE_CBC_SHA,     \
+#                    TLS_RSA_WITH_AES_128_CBC_SHA,          \
+#                    SSL_DHE_RSA_WITH_DES_CBC_SHA,          \
+#                    TLS_DH_anon_WITH_AES_256_CBC_SHA,      \
+#                    TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA,   \
+#                    SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA, \
+#                    SSL_RSA_WITH_NULL_SHA,                 \
+#                    TLS_KRB5_WITH_RC4_128_MD5,             \
+#                    TLS_RSA_WITH_AES_256_CBC_SHA,          \
+#                    SSL_RSA_WITH_DES_CBC_SHA,              \
+#                    TLS_EMPTY_RENEGOTIATION_INFO_SCSV,     \
+#                    SSL_RSA_EXPORT_WITH_DES40_CBC_SHA,     \
+#                    SSL_DH_anon_WITH_RC4_128_MD5,          \
+#                    SSL_RSA_WITH_RC4_128_MD5,              \
+#                    TLS_DHE_DSS_WITH_AES_128_CBC_SHA,      \
+#                    SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,     \
+#                    SSL_RSA_WITH_3DES_EDE_CBC_SHA
+
+
+# Protocols that will be enabled in SSL. If this property is set, SSL sockets will only use protocols
+# that are provided in this list and supported by the current security provider.
+enabledProtocols=TLSv1,TLSv1.1,TLSv1.2

--- a/transports/jetty/src/main/java/org/mule/transport/servlet/jetty/JettyHttpsConnector.java
+++ b/transports/jetty/src/main/java/org/mule/transport/servlet/jetty/JettyHttpsConnector.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.security.Provider;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import org.mortbay.jetty.AbstractConnector;
@@ -281,7 +282,13 @@ public class JettyHttpsConnector extends JettyHttpConnector implements TlsDirect
     @Override
     protected AbstractConnector createJettyConnector()
     {
-        SslSocketConnector cnn = new SslSocketConnector();
+        SslSocketConnector cnn = new SslSocketConnector() {
+            @Override
+            protected SSLServerSocketFactory createFactory() throws Exception
+            {
+                return tls.getServerSocketFactory();
+            }
+        };
 
         if (SystemUtils.isIbmJDK())
         {
@@ -291,16 +298,6 @@ public class JettyHttpsConnector extends JettyHttpConnector implements TlsDirect
         // get (from parent Mule connector) and set number of acceptor threads into the underlying SSL connector
         cnn.setAcceptors(getAcceptors());
 
-        // set trust and keystore params
-        if (tls.getKeyStore() != null) cnn.setKeystore(tls.getKeyStore());
-        if (tls.getKeyPassword() != null) cnn.setKeyPassword(tls.getKeyPassword());
-        if (tls.getKeyStoreType() != null) cnn.setKeystoreType(tls.getKeyStoreType());
-        if (tls.getKeyManagerAlgorithm() != null) cnn.setSslKeyManagerFactoryAlgorithm(tls.getKeyManagerAlgorithm());
-        if (tls.getProvider() != null) cnn.setProvider(tls.getProvider().getName());
-        if (tls.getTrustStorePassword() != null) cnn.setTrustPassword(tls.getTrustStorePassword());
-        if (tls.getTrustStore() != null) cnn.setTruststore(tls.getTrustStore());
-        if (tls.getTrustStoreType() != null) cnn.setTruststoreType(tls.getTrustStoreType());
-        if (tls.getTrustManagerAlgorithm() != null) cnn.setSslTrustManagerFactoryAlgorithm(tls.getTrustManagerAlgorithm());
         cnn.setNeedClientAuth(tls.isRequireClientAuthentication());
 
         return cnn;

--- a/transports/jetty/src/test/java/org/mule/transport/servlet/jetty/functional/JettyHttpsCustomTlsConfigTestCase.java
+++ b/transports/jetty/src/test/java/org/mule/transport/servlet/jetty/functional/JettyHttpsCustomTlsConfigTestCase.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.servlet.jetty.functional;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.mule.api.security.tls.TlsConfiguration;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.util.ClassUtils;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.HandshakeCompletedEvent;
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class JettyHttpsCustomTlsConfigTestCase extends FunctionalTestCase
+{
+
+    @Rule
+    public DynamicPort httpsPort = new DynamicPort("port");
+
+    private static final String SERVER_CIPHER_SUITE_ENABLED = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA";
+    private static final String SERVER_CIPHER_SUITE_DISABLED = "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA";
+
+    private static final String SERVER_PROTOCOL_ENABLED = "TLSv1";
+    private static final String SERVER_PROTOCOL_DISABLED = "SSLv3";
+
+    @Override
+    protected String getConfigResources()
+    {
+        return "jetty-https-custom-tls-config-test.xml";
+    }
+
+    @BeforeClass
+    public static void createTlsPropertiesFile() throws Exception
+    {
+        PrintWriter writer = new PrintWriter(getTlsPropertiesFile(), "UTF-8");
+        writer.println("enabledCipherSuites=" + SERVER_CIPHER_SUITE_ENABLED);
+        writer.println("enabledProtocols=" + SERVER_PROTOCOL_ENABLED);
+        writer.close();
+    }
+
+    @AfterClass
+    public static void removeTlsPropertiesFile()
+    {
+        getTlsPropertiesFile().delete();
+    }
+
+    private static File getTlsPropertiesFile()
+    {
+        String path = ClassUtils.getClassPathRoot(JettyHttpsCustomTlsConfigTestCase.class).getPath();
+        return new File(path, TlsConfiguration.DEFAULT_PROPERTIES_FILE);
+    }
+
+    @Test
+    public void handshakeSuccessWhenUsingEnabledCipherSpec() throws Exception
+    {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        SSLSocket socket = createSocket(new String[] {SERVER_CIPHER_SUITE_ENABLED, SERVER_CIPHER_SUITE_DISABLED},
+                                        new String[] {SERVER_PROTOCOL_ENABLED, SERVER_PROTOCOL_DISABLED});
+
+        socket.addHandshakeCompletedListener(new HandshakeCompletedListener()
+        {
+            @Override
+            public void handshakeCompleted(HandshakeCompletedEvent handshakeCompletedEvent)
+            {
+                latch.countDown();
+            }
+        });
+
+        socket.startHandshake();
+
+        assertTrue(latch.await(LOCK_TIMEOUT, TimeUnit.MILLISECONDS));
+        assertEquals(SERVER_CIPHER_SUITE_ENABLED, socket.getSession().getCipherSuite());
+        assertEquals(SERVER_PROTOCOL_ENABLED, socket.getSession().getProtocol());
+
+        socket.close();
+    }
+
+
+    @Test(expected = SSLException.class)
+    public void handshakeFailureWithDisabledCipherSuite() throws Exception
+    {
+        SSLSocket socket = createSocket(new String[] {SERVER_CIPHER_SUITE_DISABLED}, new String[] {SERVER_PROTOCOL_ENABLED});
+        socket.startHandshake();
+    }
+
+    @Test(expected = SSLException.class)
+    public void handshakeFailureWithDisabledProtocol() throws Exception
+    {
+        SSLSocket socket = createSocket(new String[] {SERVER_CIPHER_SUITE_ENABLED}, new String[] {SERVER_PROTOCOL_DISABLED});
+        socket.startHandshake();
+    }
+
+
+    private SSLSocket createSocket(String[] cipherSuites, String[] enabledProtocols) throws Exception
+    {
+        SSLContext sslContext = SSLContext.getInstance(SERVER_PROTOCOL_ENABLED);
+        sslContext.init(null, null, null);
+
+        SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+        SSLSocket socket = (SSLSocket) socketFactory.createSocket("localhost", httpsPort.getNumber());
+
+        socket.setEnabledCipherSuites(cipherSuites);
+        socket.setEnabledProtocols(enabledProtocols);
+
+        return socket;
+    }
+}

--- a/transports/jetty/src/test/resources/jetty-https-custom-tls-config-test.xml
+++ b/transports/jetty/src/test/resources/jetty-https-custom-tls-config-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:jetty-ssl="http://www.mulesoft.org/schema/mule/jetty-ssl"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/jetty-ssl http://www.mulesoft.org/schema/mule/jetty-ssl/current/mule-jetty-ssl.xsd">
+
+    <jetty-ssl:connector name="jettyConnector">
+        <jetty-ssl:tls-client path="clientKeystore" storePassword="mulepassword"/>
+        <jetty-ssl:tls-key-store path="serverKeystore" keyPassword="mulepassword" storePassword="storepassword"/>
+        <jetty-ssl:tls-server path="trustStore" storePassword="mulepassword"/>
+    </jetty-ssl:connector>
+
+    <flow name="serverFlow">
+        <inbound-endpoint address="jetty-ssl:https://localhost:${port}" exchange-pattern="request-response"
+                          connector-ref="jettyConnector"/>
+        <echo-component/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
Backport of the feature that enables to configure enabled protocols and ciphers for SSL by adding the tls-default file in the conf folder. This is a cherry pick of: ea8b6af, 28a9c07 and f886a2d, with manual changes required in the Jetty transport because of the version of the library.
