### PR TITLE
MULE-7097: Provide a way to specify valid cipher specs for SSL on transports that support the protocol

### DIFF
--- a/distributions/standalone/src/main/resources/conf/tls-default.conf
+++ b/distributions/standalone/src/main/resources/conf/tls-default.conf
@@ -47,6 +47,4 @@
 
 # Protocols that will be enabled in SSL. If this property is set, SSL sockets will only use protocols
 # that are provided in this list and supported by the current security provider.
-#enabledProtocols=SSLv2Hello, \
-#                 TLSv1,      \
-#                 SSLv3
+enabledProtocols=TLSv1,TLSv1.1,TLSv1.2


### PR DESCRIPTION
Changed value of the enabledProtocols property in the tls-default.conf file so that SSLv3 is not used by default.
