### PR TITLE
MULE-7996: clear the deployment class loader once the application is dis...

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
@@ -299,6 +299,7 @@ public class DefaultMuleApplication implements Application
         {
             // kill any refs to the old classloader to avoid leaks
             Thread.currentThread().setContextClassLoader(null);
+            deploymentClassLoader = null;
         }
     }
 


### PR DESCRIPTION
...posed. This avoid logging issues when the application is being redeployed.
