### PR TITLE
MULE-7996: clear the deployment class loader once the application is dis...

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
@@ -299,6 +299,7 @@ public class DefaultMuleApplication implements Application
         {
             // kill any refs to the old classloader to avoid leaks
             Thread.currentThread().setContextClassLoader(null);
+            deploymentClassLoader = null;
         }
     }
 

--- a/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationStatusTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationStatusTestCase.java
@@ -7,9 +7,16 @@
 package org.mule.module.launcher.application;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import org.mule.context.notification.MuleContextNotification;
+import org.mule.module.launcher.artifact.ArtifactClassLoader;
+import org.mule.module.launcher.descriptor.ApplicationDescriptor;
+import org.mule.module.launcher.domain.Domain;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.probe.JUnitProbe;
 import org.mule.tck.probe.PollingProber;
@@ -70,6 +77,22 @@ public class DefaultMuleApplicationStatusTestCase extends AbstractMuleContextTes
     {
         muleContext.dispose();
         assertStatus(ApplicationStatus.DESTROYED);
+    }
+
+    @Test
+    public void nullDeploymentClassLoaderAfterDispose()
+    {
+        ApplicationDescriptor descriptor = mock(ApplicationDescriptor.class);
+        when(descriptor.getAbsoluteResourcePaths()).thenReturn(new String[] {});
+
+        ApplicationClassLoaderFactory classLoaderFactory = mock(ApplicationClassLoaderFactory.class);
+        when(classLoaderFactory.create(descriptor)).thenReturn(mock(ArtifactClassLoader.class));
+
+        DefaultMuleApplication application = new DefaultMuleApplication(descriptor, classLoaderFactory, mock(Domain.class));
+        application.install();
+        assertThat(application.deploymentClassLoader, is(notNullValue()));
+        application.dispose();
+        assertThat(application.deploymentClassLoader, is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
...posed. This avoid logging issues when the application is being redeployed.
