### PR TITLE
MULE-7929: WS Consumer support for using new HTTP Connector

### DIFF
--- a/modules/ws/src/main/java/org/mule/module/ws/config/WSNamespaceHandler.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/config/WSNamespaceHandler.java
@@ -26,7 +26,7 @@ public class WSNamespaceHandler extends AbstractMuleNamespaceHandler
     {
         // Flow Constructs
         registerBeanDefinitionParser("proxy", new WSProxyDefinitionParser());
-        registerBeanDefinitionParser("consumer-config", (OrphanDefinitionParser) new OrphanDefinitionParser(WSConsumerConfig.class, true).addReference("connector-config"));
+        registerBeanDefinitionParser("consumer-config", (OrphanDefinitionParser) new OrphanDefinitionParser(WSConsumerConfig.class, true).addReference("connectorConfig"));
         registerBeanDefinitionParser("consumer", new MessageProcessorDefinitionParser(WSConsumer.class));
         registerBeanDefinitionParser("security", new ChildDefinitionParser("security", WSSecurity.class));
         registerBeanDefinitionParser("wss-username-token", new ChildDefinitionParser("strategy", WssUsernameTokenSecurityStrategy.class));

--- a/modules/ws/src/main/resources/META-INF/mule-ws.xsd
+++ b/modules/ws/src/main/resources/META-INF/mule-ws.xsd
@@ -290,7 +290,7 @@
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="connector-config" type="xsd:string">
+                <xsd:attribute name="connectorConfig" type="xsd:string">
                     <xsd:annotation>
                         <xsd:documentation>
                             A reference to a connector config that will be used by this component.

--- a/modules/ws/src/test/resources/ws-consumer-http-module-config.xml
+++ b/modules/ws/src/test/resources/ws-consumer-http-module-config.xml
@@ -23,7 +23,7 @@
     </http:request-config>
 
     <ws:consumer-config wsdlLocation="Test.wsdl" service="TestService" port="TestPort"
-                        serviceAddress="http://localhost:${port}/services/Test" connector-config="customConfig" name="globalConfig"/>
+                        serviceAddress="http://localhost:${port}/services/Test" connectorConfig="customConfig" name="globalConfig"/>
 
     <flow name="client">
         <inbound-endpoint address="vm://in" exchange-pattern="request-response"/>


### PR DESCRIPTION
Renamed connector-config attribute to connectorConfig
