### PR TITLE
MULE-7991: Migrate HTTP request element to use grizzly

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -526,6 +526,7 @@
 /mule-standalone-${productVersion}/lib/opt/asm-tree-3.1.jar
 /mule-standalone-${productVersion}/lib/opt/aspectjrt-1.7.3.jar
 /mule-standalone-${productVersion}/lib/opt/aspectjweaver-1.7.3.jar
+/mule-standalone-${productVersion}/lib/opt/async-http-client-1.8.14.jar
 /mule-standalone-${productVersion}/lib/opt/axiom-api-1.2.5.jar
 /mule-standalone-${productVersion}/lib/opt/axiom-impl-1.2.5.jar
 /mule-standalone-${productVersion}/lib/opt/bcmail-jdk16-1.46.jar
@@ -586,6 +587,7 @@
 /mule-standalone-${productVersion}/lib/opt/grizzly-framework-2.3.16.jar
 /mule-standalone-${productVersion}/lib/opt/grizzly-http-2.3.16.jar
 /mule-standalone-${productVersion}/lib/opt/grizzly-http-server-2.3.16.jar
+/mule-standalone-${productVersion}/lib/opt/grizzly-websockets-2.3.16.jar
 /mule-standalone-${productVersion}/lib/opt/groovy-all-2.3.7-indy.jar
 /mule-standalone-${productVersion}/lib/opt/guava-18.0.jar
 /mule-standalone-${productVersion}/lib/opt/hamcrest-core-1.3.jar
@@ -631,7 +633,6 @@
 /mule-standalone-${productVersion}/lib/opt/jersey-server-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jettison-1.3.3.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-annotations-9.0.7.v20131107.jar
-/mule-standalone-${productVersion}/lib/opt/jetty-client-9.0.7.v20131107.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-continuation-9.0.7.v20131107.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-deploy-9.0.7.v20131107.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-http-9.0.7.v20131107.jar


### PR DESCRIPTION
Replaced Jetty client with Grizzly in the white list
