### PR TITLE
MULE-7929: WS Consumer support for using new HTTP Connector

### DIFF
--- a/modules/ws/src/test/resources/ws-consumer-http-module-config.xml
+++ b/modules/ws/src/test/resources/ws-consumer-http-module-config.xml
@@ -19,7 +19,7 @@
                http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-current.xsd">
 
     <http:request-config host="localhost" port="${port}" name="customConfig">
-        <http:basic-auth username="user" password="pass" />
+        <http:basic-authentication username="user" password="pass" />
     </http:request-config>
 
     <ws:consumer-config wsdlLocation="Test.wsdl" service="TestService" port="TestPort"


### PR DESCRIPTION
Fixed WS consumer test because of changes in the HTTP connector
