### PR TITLE
MULE-7789 Update mule-transports-http to tomcat 6+

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -714,7 +714,6 @@
 /mule-standalone-${productVersion}/lib/opt/uri-template-0.9.jar
 /mule-standalone-${productVersion}/lib/opt/catalina-6.0.29.jar
 /mule-standalone-${productVersion}/lib/opt/coyote-6.0.29.jar
-/mule-standalone-${productVersion}/lib/opt/servlet-api-6.0.29.jar
 /mule-standalone-${productVersion}/lib/opt/uuid-3.4.0.jar
 /mule-standalone-${productVersion}/lib/opt/woodstox-core-asl-4.4.1.jar
 /mule-standalone-${productVersion}/lib/opt/wsdl4j-1.6.2.jar

--- a/transports/http/pom.xml
+++ b/transports/http/pom.xml
@@ -80,6 +80,12 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>coyote</artifactId>
             <version>${tomcatVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.samba.jcifs</groupId>


### PR DESCRIPTION
Don't allow the import of the servlet API
