### PR TITLE
MULE-8043: Query parameters are incorrectly processed when defined in di...

### DIFF
--- a/modules/db/src/test/java/org/mule/module/db/integration/template/TemplateQueryConfigTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/template/TemplateQueryConfigTestCase.java
@@ -148,6 +148,29 @@ public class TemplateQueryConfigTestCase extends FunctionalTestCase
         assertEquals(1, param1.getIndex());
     }
 
+    @Test
+    public void overridesDisorderedParams() throws Exception
+    {
+        Object queryTemplateBean = muleContext.getRegistry().get("disorderedParams");
+        assertTrue(queryTemplateBean instanceof QueryTemplate);
+        QueryTemplate queryTemplate = (QueryTemplate) queryTemplateBean;
+        assertEquals(QueryType.SELECT, queryTemplate.getType());
+        assertEquals("SELECT * FROM PLANET WHERE POSITION = ? AND NAME = ?", queryTemplate.getSqlText());
+        assertEquals(2, queryTemplate.getInputParams().size());
+
+        InputQueryParam param1 = queryTemplate.getInputParams().get(0);
+        assertEquals(UnknownDbType.getInstance(), param1.getType());
+        assertEquals("position", param1.getName());
+        assertEquals("0", param1.getValue());
+        assertEquals(1, param1.getIndex());
+
+        InputQueryParam param2 = queryTemplate.getInputParams().get(1);
+        assertEquals(UnknownDbType.getInstance(), param2.getType());
+        assertEquals("name", param2.getName());
+        assertEquals("mars", param2.getValue());
+        assertEquals(2, param2.getIndex());
+    }
+
     private void doQueryFromFileTest(Object queryTemplateBean, String paramValue)
     {
         assertTrue(queryTemplateBean instanceof QueryTemplate);

--- a/modules/db/src/test/java/org/mule/module/db/internal/config/domain/query/ParameterizedQueryTemplateFactoryBeanTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/config/domain/query/ParameterizedQueryTemplateFactoryBeanTestCase.java
@@ -13,12 +13,18 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.mule.module.db.internal.domain.param.DefaultInOutQueryParam;
 import org.mule.module.db.internal.domain.param.DefaultInputQueryParam;
+import org.mule.module.db.internal.domain.param.DefaultOutputQueryParam;
+import org.mule.module.db.internal.domain.param.InOutQueryParam;
 import org.mule.module.db.internal.domain.param.InputQueryParam;
+import org.mule.module.db.internal.domain.param.OutputQueryParam;
 import org.mule.module.db.internal.domain.param.QueryParam;
 import org.mule.module.db.internal.domain.query.QueryTemplate;
 import org.mule.module.db.internal.domain.query.QueryType;
+import org.mule.module.db.internal.domain.type.DbType;
 import org.mule.module.db.internal.domain.type.JdbcTypes;
+import org.mule.module.db.internal.domain.type.UnknownDbType;
 import org.mule.module.db.internal.parser.QueryTemplateParser;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -36,6 +42,9 @@ public class ParameterizedQueryTemplateFactoryBeanTestCase extends AbstractMuleT
     public static final String QUERY = "select * from test";
     public static final String PARAMETERIZED_QUERY = "select * from test where position = :position";
     public static final String PARSED_PARAMETERIZED_QUERY = "select * from test where position = ?";
+    public static final String POSITION_PARAM_NAME = "position";
+    public static final String TEMPLATE_PARAM_VALUE = "5";
+    public static final String OVERRIDDEN_PARAM_VALUE = "10";
 
     @Test
     public void createsQueryWithNoParams() throws Exception
@@ -54,11 +63,10 @@ public class ParameterizedQueryTemplateFactoryBeanTestCase extends AbstractMuleT
         assertThat(createdQueryTemplate.getParams(), is(empty()));
     }
 
-
     @Test
     public void createsQueryWithDefaultParams() throws Exception
     {
-        List<QueryParam> defaultParams = Collections.<QueryParam>singletonList(new DefaultInputQueryParam(1, JdbcTypes.INTEGER_DB_TYPE, "5", "position"));
+        List<QueryParam> defaultParams = Collections.<QueryParam>singletonList(new DefaultInputQueryParam(1, JdbcTypes.INTEGER_DB_TYPE, TEMPLATE_PARAM_VALUE, POSITION_PARAM_NAME));
         QueryTemplate queryTemplate = new QueryTemplate(PARSED_PARAMETERIZED_QUERY, QueryType.SELECT, defaultParams);
 
         QueryTemplateParser queryParser = mock(QueryTemplateParser.class);
@@ -72,27 +80,120 @@ public class ParameterizedQueryTemplateFactoryBeanTestCase extends AbstractMuleT
         assertThat(createdQueryTemplate.getType(), equalTo(QueryType.SELECT));
         assertThat(createdQueryTemplate.getParams().size(), equalTo(1));
         InputQueryParam inputQueryParam = createdQueryTemplate.getInputParams().get(0);
-        assertThat(inputQueryParam.getValue(), IsEqual.<Object>equalTo("5"));
+        assertThat(inputQueryParam.getValue(), IsEqual.<Object>equalTo(TEMPLATE_PARAM_VALUE));
     }
 
     @Test
-    public void createsQueryWithOverridenParams() throws Exception
+    public void createsQueryWithOverriddenParams() throws Exception
     {
-        List<QueryParam> defaultParams = Collections.<QueryParam>singletonList(new DefaultInputQueryParam(1, JdbcTypes.INTEGER_DB_TYPE, "5", "position"));
-        QueryTemplate queryTemplate = new QueryTemplate(PARSED_PARAMETERIZED_QUERY, QueryType.SELECT, defaultParams);
-
-        QueryTemplateParser queryParser = mock(QueryTemplateParser.class);
-        when(queryParser.parse(PARAMETERIZED_QUERY)).thenReturn(queryTemplate);
-
-        List<QueryParam> overriddenParams = Collections.<QueryParam>singletonList(new DefaultInputQueryParam(1, JdbcTypes.INTEGER_DB_TYPE, "10", "position"));
-        ParameterizedQueryTemplateFactoryBean factoryBean = new ParameterizedQueryTemplateFactoryBean(PARAMETERIZED_QUERY, overriddenParams, queryParser);
-
-        QueryTemplate createdQueryTemplate = factoryBean.getObject();
+        QueryTemplate createdQueryTemplate = doOverriddenParamTest(JdbcTypes.INTEGER_DB_TYPE, new DefaultInputQueryParam(1, JdbcTypes.INTEGER_DB_TYPE, OVERRIDDEN_PARAM_VALUE, POSITION_PARAM_NAME));
 
         assertThat(createdQueryTemplate.getSqlText(), equalTo(PARSED_PARAMETERIZED_QUERY));
         assertThat(createdQueryTemplate.getType(), equalTo(QueryType.SELECT));
         assertThat(createdQueryTemplate.getParams().size(), equalTo(1));
         InputQueryParam inputQueryParam = createdQueryTemplate.getInputParams().get(0);
-        assertThat(inputQueryParam.getValue(), IsEqual.<Object>equalTo("10"));
+        assertThat(inputQueryParam.getValue(), IsEqual.<Object>equalTo(OVERRIDDEN_PARAM_VALUE));
+    }
+
+    @Test
+    public void overrideInputParamUsingTemplateType() throws Exception
+    {
+        doInputParamOverrideTest(JdbcTypes.INTEGER_DB_TYPE, UnknownDbType.getInstance(), JdbcTypes.INTEGER_DB_TYPE);
+    }
+
+    @Test
+    public void overrideInputParamUsingOverriddenType() throws Exception
+    {
+        doInputParamOverrideTest(UnknownDbType.getInstance(), JdbcTypes.INTEGER_DB_TYPE, JdbcTypes.INTEGER_DB_TYPE);
+    }
+
+    @Test
+    public void overrideInOutParamUsingTemplateType() throws Exception
+    {
+        doInOutParamOverrideTest(JdbcTypes.INTEGER_DB_TYPE, UnknownDbType.getInstance(), JdbcTypes.INTEGER_DB_TYPE);
+    }
+
+    @Test
+    public void overrideInOutParamUsingOverriddenType() throws Exception
+    {
+        doInOutParamOverrideTest(UnknownDbType.getInstance(), JdbcTypes.INTEGER_DB_TYPE, JdbcTypes.INTEGER_DB_TYPE);
+    }
+
+    @Test
+    public void overrideOutputParamUsingTemplateType() throws Exception
+    {
+        doOutputParamOverrideTest(JdbcTypes.INTEGER_DB_TYPE, UnknownDbType.getInstance(), JdbcTypes.INTEGER_DB_TYPE);
+    }
+
+    @Test
+    public void overrideOutputParamUsingOverriddenType() throws Exception
+    {
+        doOutputParamOverrideTest(UnknownDbType.getInstance(), JdbcTypes.INTEGER_DB_TYPE, JdbcTypes.INTEGER_DB_TYPE);
+    }
+
+    private void doInputParamOverrideTest(DbType templateParamType, DbType overriddenParamType, DbType expectedParamType) throws Exception
+    {
+        QueryParam overriddenParam = new DefaultInputQueryParam(2, overriddenParamType, OVERRIDDEN_PARAM_VALUE, POSITION_PARAM_NAME);
+
+        QueryTemplate createdQueryTemplate = doOverriddenParamTest(templateParamType, overriddenParam);
+
+        assertThat(createdQueryTemplate.getParams().size(), equalTo(1));
+        InputQueryParam inputQueryParam = createdQueryTemplate.getInputParams().get(0);
+        assertThat(inputQueryParam.getIndex(), equalTo(1));
+        assertThat(inputQueryParam.getType(), equalTo(expectedParamType));
+        assertThat(inputQueryParam.getName(), equalTo(POSITION_PARAM_NAME));
+        assertThat(inputQueryParam.getValue(), IsEqual.<Object>equalTo(OVERRIDDEN_PARAM_VALUE));
+    }
+
+    private void doInOutParamOverrideTest(DbType templateParamType, DbType overriddenParamType, DbType expectedParamType) throws Exception
+    {
+        QueryParam overriddenParam = new DefaultInOutQueryParam(2, overriddenParamType, POSITION_PARAM_NAME, OVERRIDDEN_PARAM_VALUE);
+
+        QueryTemplate createdQueryTemplate = doOverriddenParamTest(templateParamType, overriddenParam);
+
+        assertThat(createdQueryTemplate.getParams().size(), equalTo(1));
+        InOutQueryParam queryParam = (InOutQueryParam) createdQueryTemplate.getParams().get(0);
+        assertThat(queryParam.getIndex(), equalTo(1));
+        assertThat(queryParam.getType(), equalTo(expectedParamType));
+        assertThat(queryParam.getName(), equalTo(POSITION_PARAM_NAME));
+        assertThat(queryParam.getValue(), IsEqual.<Object>equalTo(OVERRIDDEN_PARAM_VALUE));
+    }
+
+    private QueryTemplate doOverriddenParamTest(DbType templateParamType, QueryParam overriddenParam) throws Exception
+    {
+        List<QueryParam> defaultParams = Collections.<QueryParam>singletonList(new DefaultInputQueryParam(1, templateParamType, TEMPLATE_PARAM_VALUE, POSITION_PARAM_NAME));
+        QueryTemplate queryTemplate = new QueryTemplate(PARSED_PARAMETERIZED_QUERY, QueryType.SELECT, defaultParams);
+
+        QueryTemplateParser queryParser = mock(QueryTemplateParser.class);
+        when(queryParser.parse(PARAMETERIZED_QUERY)).thenReturn(queryTemplate);
+
+        List<QueryParam> overriddenParams = Collections.<QueryParam>singletonList(overriddenParam);
+
+        ParameterizedQueryTemplateFactoryBean factoryBean = new ParameterizedQueryTemplateFactoryBean(PARAMETERIZED_QUERY, overriddenParams, queryParser);
+
+        return factoryBean.getObject();
+    }
+
+    private void doOutputParamOverrideTest(DbType templateParamType, DbType overriddenParamType, DbType expectedParamType) throws Exception
+    {
+        QueryParam overriddenParam = new DefaultOutputQueryParam(2, overriddenParamType, POSITION_PARAM_NAME);
+
+        List<QueryParam> defaultParams = Collections.<QueryParam>singletonList(new DefaultInputQueryParam(1, templateParamType, TEMPLATE_PARAM_VALUE, POSITION_PARAM_NAME));
+        QueryTemplate queryTemplate = new QueryTemplate(PARSED_PARAMETERIZED_QUERY, QueryType.SELECT, defaultParams);
+
+        QueryTemplateParser queryParser = mock(QueryTemplateParser.class);
+        when(queryParser.parse(PARAMETERIZED_QUERY)).thenReturn(queryTemplate);
+
+        List<QueryParam> overriddenParams = Collections.singletonList(overriddenParam);
+
+        ParameterizedQueryTemplateFactoryBean factoryBean = new ParameterizedQueryTemplateFactoryBean(PARAMETERIZED_QUERY, overriddenParams, queryParser);
+
+        QueryTemplate createdQueryTemplate = factoryBean.getObject();
+
+        assertThat(createdQueryTemplate.getParams().size(), equalTo(1));
+        OutputQueryParam queryParam = createdQueryTemplate.getOutputParams().get(0);
+        assertThat(queryParam.getIndex(), equalTo(1));
+        assertThat(queryParam.getType(), equalTo(expectedParamType));
+        assertThat(queryParam.getName(), equalTo(POSITION_PARAM_NAME));
     }
 }

--- a/modules/db/src/test/resources/integration/template/template-config.xml
+++ b/modules/db/src/test/resources/integration/template/template-config.xml
@@ -58,5 +58,11 @@
     <db:template-query name="testNullParamsQuery">
         <db:parameterized-query>SELECT * FROM PLANET WHERE POSITION = :position</db:parameterized-query>
     </db:template-query>
+
+    <db:template-query name="disorderedParams">
+        <db:parameterized-query>SELECT * FROM PLANET WHERE POSITION = :position AND NAME = :name</db:parameterized-query>
+        <db:in-param name="name" defaultValue="mars"/>
+        <db:in-param name="position" defaultValue="0"/>
+    </db:template-query>
 </mule>
 


### PR DESCRIPTION
...fferent order than in the query text
