### PR TITLE
MULE-7773: Fixed the special case when the referenced flow is flowConstr...

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/config/spring/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/factories/FlowRefFactoryBean.java
@@ -127,11 +127,15 @@ public class FlowRefFactoryBean
             MessageProcessor referencedFlow = lookupReferencedFlowInApplicationContext(name);
             if (referencedFlow instanceof Initialisable)
             {
-                if(referencedFlow instanceof MessageProcessorChain)
+                if (referencedFlow instanceof FlowConstructAware)
                 {
-                    for(MessageProcessor processor : ((MessageProcessorChain) referencedFlow).getMessageProcessors())
+                    ((FlowConstructAware) referencedFlow).setFlowConstruct(flowConstruct);
+                }
+                if (referencedFlow instanceof MessageProcessorChain)
+                {
+                    for (MessageProcessor processor : ((MessageProcessorChain) referencedFlow).getMessageProcessors())
                     {
-                        if(processor instanceof FlowConstructAware)
+                        if (processor instanceof FlowConstructAware)
                         {
                             ((FlowConstructAware) processor).setFlowConstruct(flowConstruct);
                         }
@@ -139,7 +143,7 @@ public class FlowRefFactoryBean
                 }
                 ((Initialisable) referencedFlow).initialise();
             }
-            if(referencedFlow instanceof Startable)
+            if (referencedFlow instanceof Startable)
             {
                 ((Startable) referencedFlow).start();
             }


### PR DESCRIPTION
...uctAware. This is requiered in 3.3.x, but is better to include it in all branches. The DynamicSubFlowTestCase fails in 3.3.x without this.
