### PR TITLE
MULE-7986: Adding 0.0.0.0 lookup if no specific filter/server found and ...

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/api/HttpConstants.java
+++ b/modules/http/src/main/java/org/mule/module/http/api/HttpConstants.java
@@ -45,4 +45,5 @@ public abstract class HttpConstants
         public static final String HTTP_STATUS_PROPERTY = RequestProperties.HTTP_STATUS_PROPERTY;
     }
 
+    public static final String ALL_INTERFACES_IP = "0.0.0.0";
 }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerConnectionManager.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerConnectionManager.java
@@ -10,7 +10,6 @@ package org.mule.module.http.internal.listener;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleRuntimeException;
 import org.mule.api.context.MuleContextAware;
-import org.mule.api.context.WorkManager;
 import org.mule.api.context.WorkManagerSource;
 import org.mule.api.lifecycle.Disposable;
 import org.mule.api.lifecycle.Initialisable;
@@ -26,12 +25,12 @@ import com.google.common.collect.Iterables;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.concurrent.ExecutorService;
 
 public class HttpListenerConnectionManager implements Initialisable, Disposable, MuleContextAware
 {
 
     public static final String HTTP_LISTENER_CONNECTION_MANAGER = "_httpListenerConnectionManager";
+    public static final String SERVER_ALREADY_EXISTS_FORMAT = "A server in port(%s) already exists for host(%s) or one overlapping it (0.0.0.0).";
 
     private HttpListenerRegistry httpListenerRegistry = new HttpListenerRegistry();
     private HttpServerManager httpServerManager;
@@ -91,7 +90,7 @@ public class HttpListenerConnectionManager implements Initialisable, Disposable,
         }
         else
         {
-            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format("A server for host(%s) and port(%s) already exists", serverAddress.getHost(), serverAddress.getPort())));
+            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format(SERVER_ALREADY_EXISTS_FORMAT, serverAddress.getPort(), serverAddress.getHost())));
         }
     }
 
@@ -110,7 +109,7 @@ public class HttpListenerConnectionManager implements Initialisable, Disposable,
         }
         else
         {
-            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format("A server for host(%s) and port(%s) already exists", serverAddress.getHost(), serverAddress.getPort())));
+            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format(SERVER_ALREADY_EXISTS_FORMAT, serverAddress.getPort(), serverAddress.getHost())));
         }
     }
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerRegistry.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerRegistry.java
@@ -34,7 +34,7 @@ public class HttpListenerRegistry implements RequestHandlerProvider
     private static final String SLASH = "/";
     private Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final Map<ServerAddress, Server> serverAddressToServerMap = new HashMap<>();
+    private final ServerAddressMap<Server> serverAddressToServerMap = new ServerAddressMap<>();
     private final Map<Server, ServerAddressRequestHandlerRegistry> requestHandlerPerServerAddress = new HashMap<>();
 
     public synchronized RequestHandlerManager addRequestHandler(final Server server, final RequestHandler requestHandler, final ListenerRequestMatcher requestMatcher)

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpServerManager.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpServerManager.java
@@ -20,7 +20,7 @@ public interface HttpServerManager
 
     /**
      * @param serverAddress address of the server
-     * @return true if there's a server created for that host and port already, false otherwise.
+     * @return true if there's already a server created for that port and either the same host or an overlapping one (0.0.0.0 or any other if the serverAddress host is 0.0.0.0), false otherwise.
      */
     boolean containsServerFor(ServerAddress serverAddress);
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/ServerAddress.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/ServerAddress.java
@@ -8,6 +8,8 @@ package org.mule.module.http.internal.listener;
 
 import org.mule.api.MuleRuntimeException;
 import org.mule.util.NetworkUtils;
+import org.mule.module.http.api.HttpConstants;
+
 
 import java.net.UnknownHostException;
 
@@ -45,6 +47,17 @@ public class ServerAddress
     public String getIp()
     {
         return ip;
+    }
+
+    public boolean overlaps(ServerAddress serverAddress)
+    {
+        return (port == serverAddress.getPort()) &&
+               (isAllInterfaces() || serverAddress.isAllInterfaces());
+    }
+
+    public boolean isAllInterfaces()
+    {
+        return host.equals(HttpConstants.ALL_INTERFACES_IP);
     }
 
     @Override

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/ServerAddressMap.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/ServerAddressMap.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.internal.listener;
+
+import org.mule.module.http.api.HttpConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is a wrapper for a map whose keys are {@link org.mule.module.http.internal.listener.ServerAddress}s.
+ * It makes sure that if an entry is not found we instead search for an entry with that same port but host 0.0.0.0.
+ */
+public class ServerAddressMap<T>
+{
+    private Map<ServerAddress, T> internalMap;
+
+    public ServerAddressMap()
+    {
+        this(new HashMap<ServerAddress, T>());
+    }
+
+    public ServerAddressMap(Map<ServerAddress, T> internalMap)
+    {
+        this.internalMap = internalMap;
+    }
+
+    public void put(ServerAddress serverAddress, T value)
+    {
+        internalMap.put(serverAddress, value);
+    }
+
+    public T get(Object key)
+    {
+        T value = internalMap.get(key);
+        if (value == null)
+        {
+            //if there's no entry for the specific address, we need to check if there's one for all interfaces address.
+            value = internalMap.get(new ServerAddress(HttpConstants.ALL_INTERFACES_IP, ((ServerAddress) key).getPort()));
+        }
+        return value;
+    }
+}

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyAddressDelegateFilter.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyAddressDelegateFilter.java
@@ -6,12 +6,11 @@
  */
 package org.mule.module.http.internal.listener.grizzly;
 
+import org.mule.module.http.internal.listener.ServerAddressMap;
 import org.mule.module.http.internal.listener.ServerAddress;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.filterchain.BaseFilter;
@@ -31,7 +30,7 @@ import org.glassfish.grizzly.filterchain.NextAction;
 public class GrizzlyAddressDelegateFilter<F extends BaseFilter> extends BaseFilter
 {
 
-    private Map<ServerAddress, F> filters = new HashMap<>();
+    private ServerAddressMap<F> filters = new ServerAddressMap<>();
 
     @Override
     public void onAdded(FilterChain filterChain)

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyServerManager.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyServerManager.java
@@ -132,7 +132,19 @@ public class GrizzlyServerManager implements HttpServerManager
     @Override
     public boolean containsServerFor(final ServerAddress serverAddress)
     {
-        return servers.containsKey(serverAddress);
+        return servers.containsKey(serverAddress) || containsOverlappingServerFor(serverAddress);
+    }
+
+    private boolean containsOverlappingServerFor(ServerAddress newServerAddress)
+    {
+        for (ServerAddress serverAddress : servers.keySet())
+        {
+            if (serverAddress.overlaps(newServerAddress))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Server createSslServerFor(TlsContextFactory tlsContextFactory, WorkManagerSource workManagerSource, final ServerAddress serverAddress, boolean usePersistentConnections, int connectionIdleTimeout) throws IOException
@@ -141,7 +153,7 @@ public class GrizzlyServerManager implements HttpServerManager
         {
             logger.debug("Creating https server socket for host %s and path %s", serverAddress.getHost(), serverAddress.getPort());
         }
-        if (servers.containsKey(servers))
+        if (servers.containsKey(serverAddress))
         {
             throw new IllegalStateException(String.format("Could not create a server for %s since there's already one.", serverAddress));
         }
@@ -159,7 +171,7 @@ public class GrizzlyServerManager implements HttpServerManager
         {
             logger.debug("Creating http server socket for host %s and path %s", serverAddress.getHost(), serverAddress.getPort());
         }
-        if (servers.containsKey(servers))
+        if (servers.containsKey(serverAddress))
         {
             throw new IllegalStateException(String.format("Could not create a server for %s since there's already one.", serverAddress));
         }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/WorkManagerSourceExecutorProvider.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/WorkManagerSourceExecutorProvider.java
@@ -9,9 +9,9 @@ package org.mule.module.http.internal.listener.grizzly;
 import org.mule.api.MuleException;
 import org.mule.api.MuleRuntimeException;
 import org.mule.api.context.WorkManagerSource;
+import org.mule.module.http.internal.listener.ServerAddressMap;
 import org.mule.module.http.internal.listener.ServerAddress;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 
@@ -22,7 +22,7 @@ import java.util.concurrent.Executor;
 public class WorkManagerSourceExecutorProvider implements ExecutorProvider
 {
 
-    private Map<ServerAddress, WorkManagerSource> executorPerServerAddress = new ConcurrentHashMap<>();
+    private ServerAddressMap<WorkManagerSource> executorPerServerAddress = new ServerAddressMap<>(new ConcurrentHashMap<ServerAddress, WorkManagerSource>());
 
     /**
      * Adds an {@link java.util.concurrent.Executor} to be used when a request is made to
@@ -41,13 +41,7 @@ public class WorkManagerSourceExecutorProvider implements ExecutorProvider
     {
         try
         {
-            Executor executorService = executorPerServerAddress.get(serverAddress).getWorkManager();
-            if (executorService == null)
-            {
-                //if there's no executor service found for the specific address, we need to check if there's one for all interfaces address.
-                executorService = executorPerServerAddress.get(new ServerAddress("0.0.0.0", serverAddress.getPort())).getWorkManager();
-            }
-            return executorService;
+            return executorPerServerAddress.get(serverAddress).getWorkManager();
         }
         catch (MuleException e)
         {

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpAllInterfacesTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpAllInterfacesTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+
+import java.io.IOException;
+
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class HttpAllInterfacesTestCase extends FunctionalTestCase
+{
+
+    private static final String PATH = "flowA";
+
+    @Rule
+    public DynamicPort listenPort = new DynamicPort("port");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-all-interfaces-config.xml";
+    }
+
+    @Test
+    public void testAllInterfaces() throws IOException
+    {
+        final String url = String.format("http://localhost:%s/%s", listenPort.getNumber(), PATH);
+        final Response response = Request.Get(url).connectTimeout(1000).execute();
+        assertThat(response.returnContent().asString(), is(PATH));
+    }
+
+}

--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConnectionManagerTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConnectionManagerTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.internal.listener;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mule.api.MuleContext;
+import org.mule.api.MuleException;
+import org.mule.api.MuleRuntimeException;
+import org.mule.api.context.WorkManagerSource;
+import org.mule.module.http.api.HttpConstants;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.transport.tcp.TcpServerSocketProperties;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Answers;
+
+public class HttpListenerConnectionManagerTestCase extends AbstractMuleTestCase
+{
+
+    private static final String SPECIFIC_IP = "172.24.24.1";
+    public static final int PORT = 5555;
+    public static final int CONNECTION_IDLE_TIMEOUT = 1000;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void initializationFailsWhenHostIsRepeated() throws Exception
+    {
+        testInitialization(SPECIFIC_IP, SPECIFIC_IP);
+    }
+
+    @Test
+    public void initializationFailsWhenSpecificHostIsOverlapping() throws Exception
+    {
+        testInitialization(HttpConstants.ALL_INTERFACES_IP, SPECIFIC_IP);
+    }
+
+    @Test
+    public void initializationFailsWhenAllInterfacesIsOverlapping() throws Exception
+    {
+        testInitialization(SPECIFIC_IP, HttpConstants.ALL_INTERFACES_IP);
+    }
+
+    private void testInitialization(String firstHost, String secondHost) throws MuleException
+    {
+        final HttpListenerConnectionManager connectionManager = new HttpListenerConnectionManager();
+        final MuleContext mockMuleContext = mock(MuleContext.class, Answers.RETURNS_DEEP_STUBS.get());
+        connectionManager.setMuleContext(mockMuleContext);
+        WorkManagerSource mockWorkManagerSource = mock(WorkManagerSource.class);
+        when(mockMuleContext.getRegistry().lookupObject(TcpServerSocketProperties.class)).thenReturn(mock(TcpServerSocketProperties.class));
+
+        connectionManager.initialise();
+        connectionManager.createServer(new ServerAddress(firstHost, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
+        expectedException.expect(MuleRuntimeException.class);
+        expectedException.expectMessage(String.format(HttpListenerConnectionManager.SERVER_ALREADY_EXISTS_FORMAT, PORT, secondHost));
+        connectionManager.createServer(new ServerAddress(secondHost, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
+    }
+}

--- a/modules/http/src/test/resources/http-all-interfaces-config.xml
+++ b/modules/http/src/test/resources/http-all-interfaces-config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:tcp="http://www.mulesoft.org/schema/mule/tcp"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/tcp http://www.mulesoft.org/schema/mule/tcp/current/mule-tcp.xsd
+               http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <http:listener-config name="allInterfacesConfig" host="0.0.0.0" port="${port}"/>
+
+    <flow name="flowA">
+        <http:listener path="flowA" config-ref="allInterfacesConfig"/>
+        <set-payload value="flowA" />
+    </flow>
+
+</mule>


### PR DESCRIPTION
...test case to make sure that scenario works. Adding logic to prevent 0.0.0.0 and specific IPs on the same port and tests to verify this and that having 2 configs with the same port and host is not allowed. Fixing bug in GrizzlyServerManager.
