### PR TITLE
MULE-8130: Null pointer exception on the first request causes the listener to close the connection

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerConnectionManager.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerConnectionManager.java
@@ -30,7 +30,7 @@ public class HttpListenerConnectionManager implements Initialisable, Disposable,
 {
 
     public static final String HTTP_LISTENER_CONNECTION_MANAGER = "_httpListenerConnectionManager";
-    public static final String SERVER_ALREADY_EXISTS_FORMAT = "A server in port(%s) already exists for host(%s) or one overlapping it (0.0.0.0).";
+    public static final String SERVER_ALREADY_EXISTS_FORMAT = "A server in port(%s) already exists for ip(%s) or one overlapping it (0.0.0.0).";
 
     private HttpListenerRegistry httpListenerRegistry = new HttpListenerRegistry();
     private HttpServerManager httpServerManager;
@@ -90,7 +90,7 @@ public class HttpListenerConnectionManager implements Initialisable, Disposable,
         }
         else
         {
-            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format(SERVER_ALREADY_EXISTS_FORMAT, serverAddress.getPort(), serverAddress.getHost())));
+            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format(SERVER_ALREADY_EXISTS_FORMAT, serverAddress.getPort(), serverAddress.getIp())));
         }
     }
 
@@ -109,7 +109,7 @@ public class HttpListenerConnectionManager implements Initialisable, Disposable,
         }
         else
         {
-            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format(SERVER_ALREADY_EXISTS_FORMAT, serverAddress.getPort(), serverAddress.getHost())));
+            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format(SERVER_ALREADY_EXISTS_FORMAT, serverAddress.getPort(), serverAddress.getIp())));
         }
     }
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerRegistry.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpListenerRegistry.java
@@ -52,13 +52,13 @@ public class HttpListenerRegistry implements RequestHandlerProvider
     }
 
     @Override
-    public RequestHandler getRequestHandler(String host, int port, final HttpRequest request)
+    public RequestHandler getRequestHandler(String ip, int port, final HttpRequest request)
     {
         if (logger.isDebugEnabled())
         {
             logger.debug("Looking RequestHandler for request: " + request.getPath());
         }
-        final Server server = serverAddressToServerMap.get(new ServerAddress(host, port));
+        final Server server = serverAddressToServerMap.get(new ServerAddress(ip, port));
         if ((!server.isStopping() && !server.isStopped()))
         {
             final ServerAddressRequestHandlerRegistry serverAddressRequestHandlerRegistry = requestHandlerPerServerAddress.get( server);

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/RequestHandlerProvider.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/RequestHandlerProvider.java
@@ -19,11 +19,11 @@ public interface RequestHandlerProvider
     /**
      * Retrieves a RequestHandler to handle the http request
      *
-     * @param host host in which the http request was made
+     * @param ip ip address in which the http request was made
      * @param port port in which the http request was made
      * @param request the http request content
      * @return a handler for the request
      */
-    RequestHandler getRequestHandler(String host, int port, HttpRequest request);
+    RequestHandler getRequestHandler(String ip, int port, HttpRequest request);
 
 }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/ServerAddress.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/ServerAddress.java
@@ -6,37 +6,18 @@
  */
 package org.mule.module.http.internal.listener;
 
-import org.mule.api.MuleRuntimeException;
-import org.mule.util.NetworkUtils;
 import org.mule.module.http.api.HttpConstants;
-
-
-import java.net.UnknownHostException;
 
 public class ServerAddress
 {
 
     private final String ip;
-    private String host;
     private int port;
 
-    public ServerAddress(String host, int port)
+    public ServerAddress(String ip, int port)
     {
-        try
-        {
-            this.host = host;
-            this.port = port;
-            this.ip = NetworkUtils.getLocalHostIp(host);
-        }
-        catch (UnknownHostException e)
-        {
-            throw new MuleRuntimeException(e);
-        }
-    }
-
-    public String getHost()
-    {
-        return host;
+        this.port = port;
+        this.ip = ip;
     }
 
     public int getPort()
@@ -57,7 +38,7 @@ public class ServerAddress
 
     public boolean isAllInterfaces()
     {
-        return host.equals(HttpConstants.ALL_INTERFACES_IP);
+        return ip.equals(HttpConstants.ALL_INTERFACES_IP);
     }
 
     @Override
@@ -99,7 +80,6 @@ public class ServerAddress
     {
         return "ServerAddress{" +
                "ip='" + ip + '\'' +
-               ", host='" + host + '\'' +
                ", port=" + port +
                '}';
     }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ExecutorPerServerAddressIOStrategy.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ExecutorPerServerAddressIOStrategy.java
@@ -83,9 +83,9 @@ public class ExecutorPerServerAddressIOStrategy extends AbstractIOStrategy
     {
         if (WORKER_THREAD_EVENT_SET.contains(ioEvent))
         {
-            final String hostName = ((InetSocketAddress) connection.getLocalAddress()).getHostName();
+            final String ip = ((InetSocketAddress) connection.getLocalAddress()).getAddress().getHostAddress();
             final int port = ((InetSocketAddress) connection.getLocalAddress()).getPort();
-            return executorProvider.getExecutor(new ServerAddress(hostName, port));
+            return executorProvider.getExecutor(new ServerAddress(ip, port));
         }
         else
         {

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyAddressDelegateFilter.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyAddressDelegateFilter.java
@@ -143,8 +143,8 @@ public class GrizzlyAddressDelegateFilter<F extends BaseFilter> extends BaseFilt
     {
         final InetSocketAddress inetAddress = (InetSocketAddress) connection.getLocalAddress();
         final int port = inetAddress.getPort();
-        final String host = inetAddress.getHostName();
-        return filters.get(new ServerAddress(host, port));
+        final String ip = inetAddress.getAddress().getHostAddress();
+        return filters.get(new ServerAddress(ip, port));
     }
 
     /**

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyRequestDispatcherFilter.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyRequestDispatcherFilter.java
@@ -7,7 +7,6 @@
 package org.mule.module.http.internal.listener.grizzly;
 
 import org.mule.module.http.api.HttpConstants;
-import org.mule.module.http.api.HttpHeaders;
 import org.mule.module.http.internal.domain.InputStreamHttpEntity;
 import org.mule.module.http.internal.domain.request.HttpRequestContext;
 import org.mule.module.http.internal.domain.response.HttpResponse;
@@ -24,7 +23,6 @@ import org.glassfish.grizzly.filterchain.FilterChainContext;
 import org.glassfish.grizzly.filterchain.NextAction;
 import org.glassfish.grizzly.http.HttpContent;
 import org.glassfish.grizzly.http.HttpRequestPacket;
-import org.glassfish.grizzly.utils.BufferInputStream;
 
 /**
  * Grizzly filter that dispatches the request to the right request handler
@@ -43,14 +41,14 @@ public class GrizzlyRequestDispatcherFilter extends BaseFilter
     public NextAction handleRead(final FilterChainContext ctx) throws IOException
     {
         final String scheme = (ctx.getAttributes().getAttribute(HttpConstants.Protocols.HTTPS) == null) ? HttpConstants.Protocols.HTTP : HttpConstants.Protocols.HTTPS;
-        final String hostName = ((InetSocketAddress) ctx.getConnection().getLocalAddress()).getHostName();
+        final String ip = ((InetSocketAddress) ctx.getConnection().getLocalAddress()).getAddress().getHostAddress();
         final int port = ((InetSocketAddress) ctx.getConnection().getLocalAddress()).getPort();
         final HttpContent httpContent = ctx.getMessage();
         final HttpRequestPacket request = (HttpRequestPacket) httpContent.getHttpHeader();
 
         final GrizzlyHttpRequestAdapter httpRequest = new GrizzlyHttpRequestAdapter(ctx, httpContent);
         HttpRequestContext requestContext = new HttpRequestContext(httpRequest, (InetSocketAddress) ctx.getConnection().getPeerAddress(), scheme);
-        final RequestHandler requestHandler = requestHandlerProvider.getRequestHandler(hostName, port, httpRequest);
+        final RequestHandler requestHandler = requestHandlerProvider.getRequestHandler(ip, port, httpRequest);
         requestHandler.handleRequest(requestContext, new HttpResponseReadyCallback()
         {
             @Override

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyServer.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyServer.java
@@ -38,7 +38,7 @@ public class GrizzlyServer implements Server
     @Override
     public synchronized void start() throws IOException
     {
-        serverConnection = transport.bind(serverAddress.getHost(), serverAddress.getPort());
+        serverConnection = transport.bind(serverAddress.getIp(), serverAddress.getPort());
         stopped = false;
     }
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyServerManager.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/GrizzlyServerManager.java
@@ -151,7 +151,7 @@ public class GrizzlyServerManager implements HttpServerManager
     {
         if (logger.isDebugEnabled())
         {
-            logger.debug("Creating https server socket for host %s and path %s", serverAddress.getHost(), serverAddress.getPort());
+            logger.debug("Creating https server socket for ip %s and path %s", serverAddress.getIp(), serverAddress.getPort());
         }
         if (servers.containsKey(serverAddress))
         {
@@ -169,7 +169,7 @@ public class GrizzlyServerManager implements HttpServerManager
     {
         if (logger.isDebugEnabled())
         {
-            logger.debug("Creating http server socket for host %s and path %s", serverAddress.getHost(), serverAddress.getPort());
+            logger.debug("Creating http server socket for ip %s and path %s", serverAddress.getIp(), serverAddress.getPort());
         }
         if (servers.containsKey(serverAddress))
         {

--- a/modules/http/src/test/java/org/mule/module/http/api/HttpListenerBuilderTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/api/HttpListenerBuilderTestCase.java
@@ -45,6 +45,7 @@ public class HttpListenerBuilderTestCase extends AbstractMuleTestCase
     public static final String PATH = "somePath";
     public static final int PORT = 1000;
     public static final String HOST = "localhost";
+    public static final String IP = "127.0.0.1";
 
     private MuleContext mockMuleContext = mock(MuleContext.class, Answers.RETURNS_DEEP_STUBS.get());
     private TlsContextFactory mockTlsContextFactory = mock(TlsContextFactory.class);
@@ -153,7 +154,7 @@ public class HttpListenerBuilderTestCase extends AbstractMuleTestCase
                 .setPort(PORT)
                 .setPath(PATH).build();
 
-        verify(mockListenerConnectionManager).createServer(eq(new ServerAddress(HOST, PORT)), any(WorkManagerSource.class), eq(true), eq(DefaultHttpListenerConfig.DEFAULT_CONNECTION_IDLE_TIMEOUT));
+        verify(mockListenerConnectionManager).createServer(eq(new ServerAddress(IP, PORT)), any(WorkManagerSource.class), eq(true), eq(DefaultHttpListenerConfig.DEFAULT_CONNECTION_IDLE_TIMEOUT));
     }
 
     @Test
@@ -172,7 +173,7 @@ public class HttpListenerBuilderTestCase extends AbstractMuleTestCase
                 .setPort(PORT)
                 .setPath(PATH).build();
 
-        verify(mockListenerConnectionManager).createSslServer(eq(new ServerAddress(HOST, PORT)), any(WorkManagerSource.class), eq(mockTlsContextFactory), eq(true), eq(DefaultHttpListenerConfig.DEFAULT_CONNECTION_IDLE_TIMEOUT));
+        verify(mockListenerConnectionManager).createSslServer(eq(new ServerAddress(IP, PORT)), any(WorkManagerSource.class), eq(mockTlsContextFactory), eq(true), eq(DefaultHttpListenerConfig.DEFAULT_CONNECTION_IDLE_TIMEOUT));
     }
 
     @Test

--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConnectionManagerTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConnectionManagerTestCase.java
@@ -49,7 +49,7 @@ public class HttpListenerConnectionManagerTestCase extends AbstractMuleTestCase
         testInitialization(SPECIFIC_IP, HttpConstants.ALL_INTERFACES_IP);
     }
 
-    private void testInitialization(String firstHost, String secondHost) throws MuleException
+    private void testInitialization(String firstIp, String secondIp) throws MuleException
     {
         final HttpListenerConnectionManager connectionManager = new HttpListenerConnectionManager();
         final MuleContext mockMuleContext = mock(MuleContext.class, Answers.RETURNS_DEEP_STUBS.get());
@@ -58,9 +58,9 @@ public class HttpListenerConnectionManagerTestCase extends AbstractMuleTestCase
         when(mockMuleContext.getRegistry().lookupObject(TcpServerSocketProperties.class)).thenReturn(mock(TcpServerSocketProperties.class));
 
         connectionManager.initialise();
-        connectionManager.createServer(new ServerAddress(firstHost, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
+        connectionManager.createServer(new ServerAddress(firstIp, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
         expectedException.expect(MuleRuntimeException.class);
-        expectedException.expectMessage(String.format(HttpListenerConnectionManager.SERVER_ALREADY_EXISTS_FORMAT, PORT, secondHost));
-        connectionManager.createServer(new ServerAddress(secondHost, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
+        expectedException.expectMessage(String.format(HttpListenerConnectionManager.SERVER_ALREADY_EXISTS_FORMAT, PORT, secondIp));
+        connectionManager.createServer(new ServerAddress(secondIp, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
     }
 }

--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerRegistryTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerRegistryTestCase.java
@@ -33,7 +33,7 @@ import org.junit.rules.ExpectedException;
 public class HttpListenerRegistryTestCase extends AbstractMuleTestCase
 {
 
-    public static final String TEST_HOST = "localhost";
+    public static final String TEST_IP = "127.0.0.1";
     public static final String URI_PARAM = "{uri-param}";
     public static final int TEST_PORT = 10000;
     public static final String ANOTHER_PATH = "/another-path";
@@ -71,7 +71,7 @@ public class HttpListenerRegistryTestCase extends AbstractMuleTestCase
     public final RequestHandler methodPathCatchAllGetRequestHandler = mock(RequestHandler.class);
     public final RequestHandler methodPathCatchAllPostRequestHandler = mock(RequestHandler.class);
 
-    private final ServerAddress testServerAddres = new ServerAddress(TEST_HOST, TEST_PORT);
+    private final ServerAddress testServerAddress = new ServerAddress(TEST_IP, TEST_PORT);
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -84,7 +84,7 @@ public class HttpListenerRegistryTestCase extends AbstractMuleTestCase
     public void createMockTestServer()
     {
         this.testServer = mock(Server.class);
-        when(testServer.getServerAddress()).thenReturn(testServerAddres);
+        when(testServer.getServerAddress()).thenReturn(testServerAddress);
     }
 
 
@@ -276,14 +276,14 @@ public class HttpListenerRegistryTestCase extends AbstractMuleTestCase
 
     private void routePath(String requestPath, String listenerPath)
     {
-        assertThat(httpListenerRegistry.getRequestHandler(TEST_HOST, TEST_PORT, createMockRequestWithPath(requestPath)), is(requestHandlerPerPath.get(listenerPath)));
+        assertThat(httpListenerRegistry.getRequestHandler(TEST_IP, TEST_PORT, createMockRequestWithPath(requestPath)), is(requestHandlerPerPath.get(listenerPath)));
     }
 
     private void routePath(String requestPath, String requestMethod,  RequestHandler expectedRequestHandler)
     {
         final HttpRequest mockRequest = createMockRequestWithPath(requestPath);
         when(mockRequest.getMethod()).thenReturn(requestMethod);
-        assertThat(httpListenerRegistry.getRequestHandler(TEST_HOST, TEST_PORT, mockRequest), is(expectedRequestHandler));
+        assertThat(httpListenerRegistry.getRequestHandler(TEST_IP, TEST_PORT, mockRequest), is(expectedRequestHandler));
     }
 
     private HttpRequest createMockRequestWithPath(String path)


### PR DESCRIPTION
Changed the listener so that only IP addresses are used internally instead of host names.
