### PR TITLE
MULE-8154: Module: Tomcat hard-coded version

### DIFF
--- a/modules/tomcat/pom.xml
+++ b/modules/tomcat/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>catalina</artifactId>
-            <version>6.0.20</version>
+            <version>${tomcatVersion}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Used the ${tomcatVersion} defined for usages elsewhere in mule.
Currently modules/tomcat/pom.xml is hard-coded to tomcat 6.0.20.
