### PR TITLE
MULE-8146: Grizzly thread leaks

### DIFF
--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConnectionManagerTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConnectionManagerTestCase.java
@@ -61,6 +61,14 @@ public class HttpListenerConnectionManagerTestCase extends AbstractMuleTestCase
         connectionManager.createServer(new ServerAddress(firstIp, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
         expectedException.expect(MuleRuntimeException.class);
         expectedException.expectMessage(String.format(HttpListenerConnectionManager.SERVER_ALREADY_EXISTS_FORMAT, PORT, secondIp));
-        connectionManager.createServer(new ServerAddress(secondIp, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
+
+        try
+        {
+            connectionManager.createServer(new ServerAddress(secondIp, PORT), mockWorkManagerSource, false, CONNECTION_IDLE_TIMEOUT);
+        }
+        finally
+        {
+            connectionManager.dispose();
+        }
     }
 }


### PR DESCRIPTION
Changed GrizzlyServerManager so that the transport is initialized when the first server is registered. Otherwise, Grizzly threads are created just by having the module as a dependency, even if no listener-config is defined in the application.
