### PR TITLE
Update Smack to 4.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <saajVersion>1.3</saajVersion>
         <saxonVersion>9.6.0-1</saxonVersion>
         <slf4jVersion>1.7.7</slf4jVersion>
-        <smackVersion>3.1.0</smackVersion>
+        <smackVersion>4.0.6</smackVersion>
         <springOsgiVersion>1.0.2</springOsgiVersion>
         <!-- see http://www.springsource.com/security/cve-2010-1622 -->
         <springVersion>3.2.10.RELEASE</springVersion>

--- a/transports/xmpp/pom.xml
+++ b/transports/xmpp/pom.xml
@@ -23,13 +23,23 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jivesoftware</groupId>
-            <artifactId>smack</artifactId>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-core</artifactId>
             <version>${smackVersion}</version>
         </dependency>
         <dependency>
-            <groupId>jivesoftware</groupId>
-            <artifactId>smackx</artifactId>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-extensions</artifactId>
+            <version>${smackVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-tcp</artifactId>
+            <version>${smackVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-resolver-javax</artifactId>
             <version>${smackVersion}</version>
         </dependency>
 

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/AbstractXmppConversation.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/AbstractXmppConversation.java
@@ -7,13 +7,15 @@
 package org.mule.transport.xmpp;
 
 import org.mule.api.endpoint.ImmutableEndpoint;
-import org.mule.transport.ConnectException;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jivesoftware.smack.PacketCollector;
 import org.jivesoftware.smack.PacketListener;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.SmackException.NoResponseException;
+import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.filter.PacketFilter;
 import org.jivesoftware.smack.packet.Message;
 
@@ -34,7 +36,7 @@ public abstract class AbstractXmppConversation implements XmppConversation
     }
 
     @Override
-    public void connect() throws ConnectException
+    public void connect() throws NoResponseException, SmackException, XMPPException
     {
         doConnect();
         packetCollector = createPacketCollector();
@@ -42,8 +44,11 @@ public abstract class AbstractXmppConversation implements XmppConversation
 
     /**
      * Subclasses can override this method to create their conversation specific connection.
+     * @throws SmackException 
+     * @throws NoResponseException 
+     * @throws XMPPException 
      */
-    protected void doConnect() throws ConnectException
+    protected void doConnect() throws NoResponseException, SmackException, XMPPException
     {
         // template method
     }
@@ -68,7 +73,7 @@ public abstract class AbstractXmppConversation implements XmppConversation
     }
 
     @Override
-    public void disconnect()
+    public void disconnect() throws NotConnectedException
     {
         if (packetCollector != null)
         {
@@ -80,8 +85,9 @@ public abstract class AbstractXmppConversation implements XmppConversation
 
     /**
      * Subclasses can override this method to perform custom disconnect actions.
+     * @throws NotConnectedException 
      */
-    protected void doDisconnect()
+    protected void doDisconnect() throws NotConnectedException
     {
         // template method
     }

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/SaslAuthFixBean.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/SaslAuthFixBean.java
@@ -6,21 +6,10 @@
  */
 package org.mule.transport.xmpp;
 
-import org.jivesoftware.smack.SASLAuthentication;
-
 /**
- * Instantiate this bean in your spring config to work around a known issue with the SMACK
- * API: http://www.igniterealtime.org/issues/browse/SMACK-264
+ * This bean is no longer required
  */
+@Deprecated
 public class SaslAuthFixBean
 {
-    public SaslAuthFixBean()
-    {
-        super();
-        
-        // fix SASL auth
-        SASLAuthentication.supportSASLMechanism("PLAIN", 0);
-    }
 }
-
-

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppChatConversation.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppChatConversation.java
@@ -7,8 +7,9 @@
 package org.mule.transport.xmpp;
 
 import org.mule.api.endpoint.ImmutableEndpoint;
-
 import org.jivesoftware.smack.Chat;
+import org.jivesoftware.smack.ChatManager;
+import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.filter.AndFilter;
 import org.jivesoftware.smack.filter.FromMatchesFilter;
@@ -31,7 +32,7 @@ public class XmppChatConversation extends AbstractXmppConversation
     @Override
     protected void doConnect()
     {
-        chat = connection.getChatManager().createChat(recipient, null);
+        chat = ChatManager.getInstanceFor(connection).createChat(recipient, null);
     }
 
     @Override
@@ -44,7 +45,7 @@ public class XmppChatConversation extends AbstractXmppConversation
         // thread id would then prevent the PacketCollector to see incoming chat messages.
         // We create our own PacketFilter here which matches only our chat partner's JID and
         // the message type, just in case.
-        PacketFilter recipientFilter = new FromMatchesFilter(recipient);
+        PacketFilter recipientFilter = FromMatchesFilter.create(recipient);
         PacketFilter messageTypeFilter = new MessageTypeFilter(Message.Type.chat);
         return new AndFilter(recipientFilter, messageTypeFilter);
     }
@@ -56,7 +57,7 @@ public class XmppChatConversation extends AbstractXmppConversation
     }
 
     @Override
-    public void dispatch(Message message) throws XMPPException
+    public void dispatch(Message message) throws XMPPException, NotConnectedException
     {
         message.setType(Message.Type.chat);
         chat.sendMessage(message);

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppConnector.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppConnector.java
@@ -6,16 +6,21 @@
  */
 package org.mule.transport.xmpp;
 
+import java.io.IOException;
+
 import org.mule.api.MuleContext;
 import org.mule.api.MuleException;
 import org.mule.api.endpoint.ImmutableEndpoint;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.transport.AbstractConnector;
-
 import org.jivesoftware.smack.AccountManager;
 import org.jivesoftware.smack.ConnectionConfiguration;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.SmackException.NoResponseException;
+import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.tcp.XMPPTCPConnection;
 
 /**
  * <code>XmppConnector</code> represents a connection to a Jabber server.
@@ -41,7 +46,7 @@ public class XmppConnector extends AbstractConnector
     private String resource;
     private boolean createAccount = false;
     
-    private XMPPConnection connection;
+    private XMPPTCPConnection connection;
     private XmppConversationFactory conversationFactory = new XmppConversationFactory();
     
     public XmppConnector(MuleContext context)
@@ -125,10 +130,10 @@ public class XmppConnector extends AbstractConnector
         // no need to load the roster (this is not an interactive app)
         connectionConfig.setRosterLoadedAtLogin(false);
         
-        connection = new XMPPConnection(connectionConfig);
+        connection = new XMPPTCPConnection(connectionConfig);
     }
 
-    protected void connectToJabberServer() throws XMPPException
+    protected void connectToJabberServer() throws XMPPException, SmackException, IOException
     {
         connection.connect();
         
@@ -147,11 +152,11 @@ public class XmppConnector extends AbstractConnector
         }
     }
 
-    private void createAccount()
+    private void createAccount() throws NoResponseException, NotConnectedException
     {
         try
         {
-            AccountManager accountManager = new AccountManager(connection);
+            AccountManager accountManager = AccountManager.getInstance(connection);
             accountManager.createAccount(user, password);
         }
         catch (XMPPException ex)

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppConversation.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppConversation.java
@@ -6,10 +6,11 @@
  */
 package org.mule.transport.xmpp;
 
-import org.mule.transport.ConnectException;
-
 import org.jivesoftware.smack.PacketListener;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.packet.Message;
 
 /**
@@ -20,18 +21,22 @@ public interface XmppConversation
 {
     /**
      * Connect to the Jabber conversation, e.g. join a chat.
+     * @throws SmackException 
+     * @throws NoResponseException 
+     * @throws XMPPException 
      */
-    void connect() throws ConnectException;
+    void connect() throws NoResponseException, SmackException, XMPPException;
 
     /**
      * Disconnect from the Jabber conversation, e.g. leave a chat.
+     * @throws NotConnectedException 
      */
-    void disconnect();
+    void disconnect() throws NotConnectedException;
 
     /**
      * Asynchronously dispatch <code>message</code> via the Jabber conversation.
      */
-    void dispatch(Message message) throws XMPPException;
+    void dispatch(Message message) throws XMPPException, NotConnectedException;
 
     /**
      * Adds <code>listener</code> to this conversation's XMPP connection.

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppMessageConversation.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppMessageConversation.java
@@ -7,7 +7,7 @@
 package org.mule.transport.xmpp;
 
 import org.mule.api.endpoint.ImmutableEndpoint;
-
+import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.filter.AndFilter;
 import org.jivesoftware.smack.filter.FromMatchesFilter;
 import org.jivesoftware.smack.filter.MessageTypeFilter;
@@ -27,12 +27,13 @@ public class XmppMessageConversation extends AbstractXmppConversation
     @Override
     protected PacketFilter createPacketFilter()
     {
-        PacketFilter recipientFilter = new FromMatchesFilter(recipient);
+        PacketFilter recipientFilter = FromMatchesFilter.create(recipient);
         PacketFilter messageTypeFilter = new MessageTypeFilter(Message.Type.normal);
         return new AndFilter(recipientFilter, messageTypeFilter);
     }
-    
-    public void dispatch(Message message)
+
+    @Override
+    public void dispatch(Message message) throws NotConnectedException
     {
         message.setType(Message.Type.normal);
         message.setTo(recipient);

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppMuleMessageFactory.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/XmppMuleMessageFactory.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Packet;
+import org.jivesoftware.smackx.jiveproperties.JivePropertiesManager;
 
 public class XmppMuleMessageFactory extends AbstractMuleMessageFactory
 {
@@ -53,9 +54,10 @@ public class XmppMuleMessageFactory extends AbstractMuleMessageFactory
 
     private void addXmppPacketProperties(Packet packet, Map<String, Object> properties)
     {
-        for (String key : packet.getPropertyNames())
+        Map<String, Object> packetProperties = JivePropertiesManager.getProperties(packet);
+        for (Map.Entry<String, Object> entry : packetProperties.entrySet())
         {
-            properties.put(key, packet.getProperty(key));
+            properties.put(entry.getKey(), entry.getValue());
         }        
     }
 

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/filters/XmppPacketTypeFilter.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/filters/XmppPacketTypeFilter.java
@@ -7,32 +7,32 @@
 package org.mule.transport.xmpp.filters;
 
 import org.mule.util.ClassUtils;
-
 import org.jivesoftware.smack.filter.PacketFilter;
+import org.jivesoftware.smack.packet.Packet;
 
 /**
  * <code>XmppPacketTypeFilter</code> is an Xmpp PacketTypeFilter adapter.
  */
 public class XmppPacketTypeFilter extends AbstractXmppFilter
 {
-    private volatile Class<?> expectedType;
+    private volatile Class<? extends Packet> expectedType;
 
     public XmppPacketTypeFilter()
     {
         super();
     }
 
-    public XmppPacketTypeFilter(Class<?> expectedType)
+    public XmppPacketTypeFilter(Class<? extends Packet> expectedType)
     {
         setExpectedType(expectedType);
     }
 
-    public Class<?> getExpectedType()
+    public Class<? extends Packet> getExpectedType()
     {
         return expectedType;
     }
 
-    public void setExpectedType(Class<?> expectedType)
+    public void setExpectedType(Class<? extends Packet> expectedType)
     {
         this.expectedType = expectedType;
     }

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/filters/XmppToContainsFilter.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/filters/XmppToContainsFilter.java
@@ -7,7 +7,7 @@
 package org.mule.transport.xmpp.filters;
 
 import org.jivesoftware.smack.filter.PacketFilter;
-import org.jivesoftware.smack.filter.ToContainsFilter;
+import org.jivesoftware.smack.packet.Packet;
 
 /**
  * <code>XmppToContainsFilter</code> is an Xmpp ToContainsfilter adapter.
@@ -27,6 +27,17 @@ public class XmppToContainsFilter extends XmppFromContainsFilter
     @Override
     protected PacketFilter createFilter()
     {
-        return new ToContainsFilter(pattern);
+        return new PacketFilter() {
+
+            @Override
+            public boolean accept(Packet packet) {
+                String to = packet.getTo();
+                if (to == null) {
+                    return false;
+                }
+                return to.contains(pattern);
+            }
+
+        };
     }
 }

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/transformers/ObjectToXmppPacket.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/transformers/ObjectToXmppPacket.java
@@ -11,9 +11,9 @@ import org.mule.api.transformer.DataType;
 import org.mule.transformer.AbstractMessageTransformer;
 import org.mule.transformer.types.DataTypeFactory;
 import org.mule.transport.xmpp.XmppConnector;
-
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.XMPPError;
+import org.jivesoftware.smackx.jiveproperties.JivePropertiesManager;
 
 /**
  * Creates an Xmpp message packet from a MuleMessage
@@ -70,7 +70,7 @@ public class ObjectToXmppPacket extends AbstractMessageTransformer
             }
             else
             {
-                result.setProperty(propertyName, muleMessage.<Object>getOutboundProperty(propertyName));
+                JivePropertiesManager.addProperty(result, propertyName, muleMessage.<Object>getOutboundProperty(propertyName));
             }
         }
 

--- a/transports/xmpp/src/main/java/org/mule/transport/xmpp/transformers/XmppPacketToObject.java
+++ b/transports/xmpp/src/main/java/org/mule/transport/xmpp/transformers/XmppPacketToObject.java
@@ -6,14 +6,16 @@
  */
 package org.mule.transport.xmpp.transformers;
 
+import java.util.Map;
+
 import org.mule.api.MuleMessage;
 import org.mule.api.transport.PropertyScope;
 import org.mule.transformer.AbstractMessageTransformer;
 import org.mule.transformer.types.DataTypeFactory;
 import org.mule.transport.xmpp.XmppConnector;
 import org.mule.util.StringUtils;
-
 import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smackx.jiveproperties.JivePropertiesManager;
 
 public class XmppPacketToObject extends AbstractMessageTransformer
 {
@@ -53,9 +55,9 @@ public class XmppPacketToObject extends AbstractMessageTransformer
 
     private void copyProperties(Message xmppMessage, MuleMessage muleMessage)
     {
-        for (String propertyName : xmppMessage.getPropertyNames())
-        {
-            muleMessage.setOutboundProperty(propertyName, xmppMessage.getProperty(propertyName));
+        for (Map.Entry<String, Object> entry : JivePropertiesManager
+                .getProperties(xmppMessage).entrySet()) {
+            muleMessage.setOutboundProperty(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/transports/xmpp/src/test/java/org/mule/transport/xmpp/XmppMuleMessageFactoryTestCase.java
+++ b/transports/xmpp/src/test/java/org/mule/transport/xmpp/XmppMuleMessageFactoryTestCase.java
@@ -10,8 +10,8 @@ import org.mule.api.MuleMessage;
 import org.mule.api.transport.MuleMessageFactory;
 import org.mule.transport.AbstractMuleMessageFactoryTestCase;
 import org.mule.util.UUID;
-
 import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smackx.jiveproperties.JivePropertiesManager;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -46,7 +46,7 @@ public class XmppMuleMessageFactoryTestCase extends AbstractMuleMessageFactoryTe
         
         Message payload = (Message) getValidTransportMessage();
         payload.setSubject("the subject");
-        payload.setProperty("foo", "foo-value");
+        JivePropertiesManager.addProperty(payload, "foo", "foo-value");
         payload.setPacketID(uuid);
      
         MuleMessageFactory factory = createMuleMessageFactory();


### PR DESCRIPTION
I'm aware that the changes to the method signatures regarding exceptions means an API breakage. I leave it up to the mule devs to decide how to proceed. Basically I see three options:

- Use the "new" API in the next major Mule version (that's my prefered solution)
- Use the "new" API in the current Mule version
- Wrap the exceptions so that the API stays the same