### PR TITLE
MULE-8209 - Mule Integration QA build is failing because of wrong sxc de...

### DIFF
--- a/modules/sxc/pom.xml
+++ b/modules/sxc/pom.xml
@@ -61,9 +61,24 @@
 
         <dependency>
             <groupId>com.envoisolutions.sxc</groupId>
+            <artifactId>sxc-core</artifactId>
+            <version>${sxcVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>stax</groupId>
+                    <artifactId>stax-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.envoisolutions.sxc</groupId>
             <artifactId>sxc-xpath</artifactId>
             <version>${sxcVersion}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.envoisolutions.sxc</groupId>
+                    <artifactId>sxc-core</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>stax</groupId>
                     <artifactId>stax-api</artifactId>
@@ -76,16 +91,9 @@
             <version>${sxcVersion}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>stax</groupId>
-                    <artifactId>stax-api</artifactId>
+                    <groupId>com.envoisolutions.sxc</groupId>
+                    <artifactId>sxc-core</artifactId>
                 </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.envoisolutions.sxc</groupId>
-            <artifactId>sxc-core</artifactId>
-            <version>${sxcVersion}</version>
-            <exclusions>
                 <exclusion>
                     <groupId>stax</groupId>
                     <artifactId>stax-api</artifactId>


### PR DESCRIPTION
...pendency version\

Excluding sxc-core transitive dependency from sxc module so it grabs the right one