### PR TITLE
MULE-8170: Redesign context builder discovery for OSGi

### DIFF
--- a/core/src/main/java/org/mule/config/builders/AbstractConfigurationBuilderFactory.java
+++ b/core/src/main/java/org/mule/config/builders/AbstractConfigurationBuilderFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.config.builders;
+
+import org.mule.api.MuleContext;
+import org.mule.api.MuleRuntimeException;
+import org.mule.api.config.ConfigurationBuilder;
+import org.mule.api.config.ConfigurationException;
+import org.mule.api.config.DomainMuleContextAwareConfigurationBuilder;
+import org.mule.config.ConfigResource;
+import org.mule.config.i18n.CoreMessages;
+import org.mule.config.i18n.MessageFactory;
+import org.mule.util.ClassUtils;
+
+import java.util.List;
+
+/**
+ * Base class for @{@link ConfigurationBuilderFactory}
+ */
+public abstract class AbstractConfigurationBuilderFactory implements ConfigurationBuilderFactory
+{
+
+    @Override
+    public ConfigurationBuilder createConfigurationBuilder(MuleContext domainContext, List<ConfigResource> configs) throws ConfigurationException
+    {
+        String className = getClassName();
+        if (className == null || !ClassUtils.isClassOnPath(className, this.getClass()))
+        {
+            throw new ConfigurationException(MessageFactory.createStaticMessage("Configuration builder class not found: " + className));
+        }
+
+        ConfigResource[] constructorArg = new ConfigResource[configs.size()];
+        System.arraycopy(configs.toArray(), 0, constructorArg, 0, configs.size());
+
+        ConfigurationBuilder cb = instantiateConfigurationBuilder(className, constructorArg);
+
+        if (domainContext != null && cb instanceof DomainMuleContextAwareConfigurationBuilder)
+        {
+            ((DomainMuleContextAwareConfigurationBuilder) cb).setDomainContext(domainContext);
+        }
+        else if (domainContext != null)
+        {
+            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format("ConfigurationBuilder %s does not support domain context", cb.getClass().getCanonicalName())));
+        }
+
+        return cb;
+    }
+
+    protected abstract String getClassName();
+
+    private ConfigurationBuilder instantiateConfigurationBuilder(String className, ConfigResource[] constructorArg) throws ConfigurationException
+    {
+        try
+        {
+            return (ConfigurationBuilder) ClassUtils.instanciateClass(className, new Object[] {constructorArg}, this.getClass().getClassLoader());
+        }
+        catch (Exception e)
+        {
+            throw new ConfigurationException(e);
+        }
+    }
+}

--- a/core/src/main/java/org/mule/config/builders/ConfigurationBuilderFactory.java
+++ b/core/src/main/java/org/mule/config/builders/ConfigurationBuilderFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.config.builders;
+
+import org.mule.api.MuleContext;
+import org.mule.api.config.ConfigurationBuilder;
+import org.mule.api.config.ConfigurationException;
+import org.mule.config.ConfigResource;
+
+import java.util.List;
+
+/**
+ * Creates {@link ConfigurationBuilder}
+ */
+public interface ConfigurationBuilderFactory
+{
+
+    /**
+     * Creates a configuration builder for an application's context
+     *
+     * @param domainContext context for application domain
+     * @param configs application configuration resources
+     * @return a {@link ConfigurationBuilder} for the application context
+     * @throws ConfigurationException when builder cannot be created
+     */
+    ConfigurationBuilder createConfigurationBuilder(MuleContext domainContext, List<ConfigResource> configs) throws ConfigurationException;
+}

--- a/core/src/main/java/org/mule/config/builders/ConfigurationBuilderService.java
+++ b/core/src/main/java/org/mule/config/builders/ConfigurationBuilderService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.config.builders;
+
+import org.mule.api.MuleContext;
+import org.mule.api.config.ConfigurationBuilder;
+import org.mule.api.config.ConfigurationException;
+import org.mule.config.ConfigResource;
+
+import java.util.List;
+
+/**
+ * Provides {@link ConfigurationBuilder} for a given file extension
+ */
+public interface ConfigurationBuilderService
+{
+
+    /**
+     * Creates a configuration builder for an application context
+     *
+     * @param fileExtension configuration file extension
+     * @param domainContext context for application domain
+     * @param configs application configuration resources
+     * @return a {@link ConfigurationBuilder} for the application context
+     * @throws ConfigurationException when builder cannot be created
+     */
+    ConfigurationBuilder createConfigurationBuilder(String fileExtension, MuleContext domainContext, List<ConfigResource> configs) throws ConfigurationException;
+}

--- a/core/src/main/java/org/mule/config/builders/MuleConfigurationBuilderFactory.java
+++ b/core/src/main/java/org/mule/config/builders/MuleConfigurationBuilderFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.config.builders;
+
+/**
+ * Creates {@link org.mule.api.config.ConfigurationBuilder} instances of a given class
+ */
+public class MuleConfigurationBuilderFactory extends AbstractConfigurationBuilderFactory
+{
+
+    private final String className;
+
+    public MuleConfigurationBuilderFactory(String className)
+    {
+        this.className = className;
+    }
+
+    @Override
+    protected String getClassName()
+    {
+        return className;
+    }
+}

--- a/core/src/main/java/org/mule/config/builders/MuleConfigurationBuilderService.java
+++ b/core/src/main/java/org/mule/config/builders/MuleConfigurationBuilderService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.config.builders;
+
+import org.mule.api.MuleContext;
+import org.mule.api.config.ConfigurationBuilder;
+import org.mule.api.config.ConfigurationException;
+import org.mule.config.ConfigResource;
+import org.mule.util.ClassUtils;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Provides {@link ConfigurationBuilder} instances that are declared in the configuration-builders.properties
+ * file.
+ */
+public class MuleConfigurationBuilderService implements ConfigurationBuilderService
+{
+
+    private final LoadingCache<String, ConfigurationBuilderFactory> configurationBuilderFactories = CacheBuilder.newBuilder().build(new CacheLoader<String, ConfigurationBuilderFactory>()
+    {
+        @Override
+        public ConfigurationBuilderFactory load(String fileExtension) throws Exception
+        {
+            return createConfigurationBuilderFactory(fileExtension);
+        }
+    });
+
+    @Override
+    public ConfigurationBuilder createConfigurationBuilder(String fileExtension, MuleContext domainContext, List<ConfigResource> configs) throws ConfigurationException
+    {
+        try
+        {
+            ConfigurationBuilderFactory configurationBuilderFactory = configurationBuilderFactories.get(fileExtension);
+
+            return configurationBuilderFactory.createConfigurationBuilder(domainContext, configs);
+        }
+        catch (ExecutionException e)
+        {
+            if (e.getCause() instanceof ConfigurationException)
+            {
+                throw (ConfigurationException) e.getCause();
+            }
+            else
+            {
+                throw new ConfigurationException(e);
+            }
+        }
+    }
+
+    private ConfigurationBuilderFactory createConfigurationBuilderFactory(String fileExtension) throws ConfigurationException
+    {
+        Properties props = new Properties();
+        try
+        {
+            props.load(ClassUtils.getResource("configuration-builders.properties", this.getClass()).openStream());
+        }
+        catch (IOException e)
+        {
+            throw new ConfigurationException(e);
+        }
+
+        String className = (String) props.get(fileExtension);
+
+        return new MuleConfigurationBuilderFactory(className);
+    }
+
+}

--- a/core/src/main/java/org/mule/context/DefaultMuleContextFactory.java
+++ b/core/src/main/java/org/mule/context/DefaultMuleContextFactory.java
@@ -20,7 +20,9 @@ import org.mule.config.DefaultMuleConfiguration;
 import org.mule.config.bootstrap.MuleRegistryBootstrapService;
 import org.mule.config.bootstrap.RegistryBootstrapService;
 import org.mule.config.builders.AutoConfigurationBuilder;
+import org.mule.config.builders.ConfigurationBuilderService;
 import org.mule.config.builders.DefaultsConfigurationBuilder;
+import org.mule.config.builders.MuleConfigurationBuilderService;
 import org.mule.config.builders.SimpleConfigurationBuilder;
 
 import java.util.LinkedList;
@@ -44,6 +46,7 @@ public class DefaultMuleContextFactory implements MuleContextFactory
 
     private RegistryBootstrapService registryBootstrapService = new MuleRegistryBootstrapService();
     private TransportDescriptorService transportDescriptorService = new MuleTransportDescriptorService();
+    private ConfigurationBuilderService configurationBuilderService = new MuleConfigurationBuilderService();
 
     /**
      * Use default ConfigurationBuilder, default MuleContextBuilder
@@ -160,7 +163,9 @@ public class DefaultMuleContextFactory implements MuleContextFactory
 
                 // Automatically resolve Configuration to be used and delegate configuration
                 // to it.
-                new AutoConfigurationBuilder(configResources).configure(muleContext);
+                AutoConfigurationBuilder configurationBuilder = new AutoConfigurationBuilder(configResources);
+                configurationBuilder.setConfigurationBuilderService(configurationBuilderService);
+                configurationBuilder.configure(muleContext);
 
                 notifyMuleContextConfiguration(muleContext);
             }
@@ -299,6 +304,11 @@ public class DefaultMuleContextFactory implements MuleContextFactory
     public void setTransportDescriptorService(TransportDescriptorService transportDescriptorService)
     {
         this.transportDescriptorService = transportDescriptorService;
+    }
+
+    public void setConfigurationBuilderService(ConfigurationBuilderService configurationBuilderService)
+    {
+        this.configurationBuilderService = configurationBuilderService;
     }
 
     private abstract class ContextConfigurator

--- a/core/src/test/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
+++ b/core/src/test/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
@@ -32,7 +32,9 @@ import org.mule.config.DefaultMuleConfiguration;
 import org.mule.config.bootstrap.MuleRegistryBootstrapService;
 import org.mule.config.bootstrap.RegistryBootstrapService;
 import org.mule.config.bootstrap.RegistryBootstrapServiceUtil;
+import org.mule.config.builders.ConfigurationBuilderService;
 import org.mule.config.builders.DefaultsConfigurationBuilder;
+import org.mule.config.builders.MuleConfigurationBuilderService;
 import org.mule.config.builders.SimpleConfigurationBuilder;
 import org.mule.construct.Flow;
 import org.mule.context.DefaultMuleContextBuilder;
@@ -130,6 +132,8 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase
 
     protected TransportDescriptorService transportDescriptorService;
 
+    protected ConfigurationBuilderService configurationBuilderService;
+
     protected boolean isDisposeContextPerClass()
     {
         return disposeContextPerClass;
@@ -226,8 +230,11 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase
 
             transportDescriptorService = createTransportDescriptorService();
 
+            configurationBuilderService = createConfigurationBuilderService();
+
             DefaultMuleContextFactory muleContextFactory = new DefaultMuleContextFactory();
             muleContextFactory.setTransportDescriptorService(transportDescriptorService);
+            muleContextFactory.setConfigurationBuilderService(configurationBuilderService);
             List<ConfigurationBuilder> builders = new ArrayList<ConfigurationBuilder>();
             builders.add(new SimpleConfigurationBuilder(getStartUpProperties()));
             //If the annotations module is on the classpath, add the annotations config builder to the list
@@ -255,6 +262,11 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase
             }
         }
         return context;
+    }
+
+    private ConfigurationBuilderService createConfigurationBuilderService()
+    {
+        return new MuleConfigurationBuilderService();
     }
 
     protected RegistryBootstrapService createRegistryBootstrapService()


### PR DESCRIPTION
_ Initial change to enable using a different context builder discovery on an OSGi container