### PR TITLE
Fixes MULE-8217 and MULE-6427

### DIFF
--- a/core/src/main/java/org/mule/el/mvel/MessageVariableResolverFactory.java
+++ b/core/src/main/java/org/mule/el/mvel/MessageVariableResolverFactory.java
@@ -74,7 +74,8 @@ public class MessageVariableResolverFactory extends MuleBaseVariableResolverFact
             }
             else if (PAYLOAD.equals(name))
             {
-                return new MuleVariableResolver<Object>(PAYLOAD, muleMessage.getPayload(), null,
+                return new MuleVariableResolver<Object>(PAYLOAD, new MessageContext(
+                        muleMessage).getPayload(), null,
                     new VariableAssignmentCallback<Object>()
                     {
                         @Override

--- a/core/src/test/java/org/mule/el/context/MessageContextTestCase.java
+++ b/core/src/test/java/org/mule/el/context/MessageContextTestCase.java
@@ -156,6 +156,7 @@ public class MessageContextTestCase extends AbstractELTestCase
         MuleMessage mockMessage = Mockito.mock(MuleMessage.class);
         Mockito.when(mockMessage.getPayload()).thenReturn(NullPayload.getInstance());
         assertEquals(true, evaluate("message.payload == null", mockMessage));
+        assertEquals(true, evaluate("payload == null", mockMessage));
         assertEquals(false, evaluate("message.payload is NullPayload", mockMessage));
         assertEquals(true, evaluate("message.payload == empty", mockMessage));
     }


### PR DESCRIPTION
Updates MessageVariableResolverFactory to resolve “payload” expression
via the MessageContext so that “payload” and “message.payload” are
treated equally.