### PR TITLE
MULE-8219 Speed up mule multi module build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ activemq-data/
 testdir/
 hostkey.ser
 *.h2.db
+*.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -1505,6 +1505,8 @@
                         <maxmem>512m</maxmem>
                         <source>1.7</source>
                         <target>1.7</target>
+                        <!-- Slightly faster builds, see https://jira.codehaus.org/browse/MCOMPILER-209 -->
+                        <useIncrementalCompilation>false</useIncrementalCompilation>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Three clean commits here.  Please feel free to cherry pick to solve MULE-8219.

Due to a bug in maven, incremental compilations are set to true by default but things do not really work out that way.  The flag appears to be reversed.  As a way to see if this impacts mule in any positive way as I've seen on smaller scale projects, added travis CI to mule skipping unit tests (it will run too long otherwise violating travisCI rules).  By doing so, it improves the overall build in a completely isolated instance from 40 minutes to between 25 to 30 minutes.  Being that this was repeatable and a 25% improvement in build time, it seems like a nice little win for mule.  Therefore, this pull request includes the setting change in the maven build on the compiler plugin in one location.  It additionally includes the used travisCI settings.  And finally, a simple gitignore in case developers are using factory path settings via m2e which I happen to be doing.  That all said, feel free to cherry pick if only the improvement is wanted but by all means give this a go and see if similar results are seen.  Thanks.