### PR TITLE
MULE-8261: Avoid to re set the same MessageListener in the MessageConsum...

### DIFF
--- a/transports/jms/src/main/java/org/mule/transport/jms/MultiConsumerJmsMessageReceiver.java
+++ b/transports/jms/src/main/java/org/mule/transport/jms/MultiConsumerJmsMessageReceiver.java
@@ -307,7 +307,11 @@ public class MultiConsumerJmsMessageReceiver extends AbstractMessageReceiver
 
             try
             {
-                consumer.setMessageListener(this);
+                MessageListener currentMessageListener = consumer.getMessageListener();
+                if (currentMessageListener == null || currentMessageListener != this)
+                {
+                    consumer.setMessageListener(this);
+                }
                 started = true;
             }
             catch (JMSException e)

--- a/transports/jms/src/test/java/org/mule/transport/jms/MultiConsumerJmsMessageReceiverTest.java
+++ b/transports/jms/src/test/java/org/mule/transport/jms/MultiConsumerJmsMessageReceiverTest.java
@@ -6,22 +6,39 @@
  */
 package org.mule.transport.jms;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mule.api.config.MuleProperties;
+import org.mule.api.construct.FlowConstruct;
+import org.mule.api.endpoint.InboundEndpoint;
+import org.mule.execution.MessageProcessingManager;
+import org.mule.retry.policies.SimpleRetryPolicyTemplate;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.Session;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mule.api.construct.FlowConstruct;
-import org.mule.api.endpoint.InboundEndpoint;
-import org.mule.tck.junit4.AbstractMuleTestCase;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class MultiConsumerJmsMessageReceiverTest extends AbstractMuleTestCase {
-
+public class MultiConsumerJmsMessageReceiverTest extends AbstractMuleTestCase
+{
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private JmsConnector mockJmsConnector;
@@ -33,7 +50,7 @@ public class MultiConsumerJmsMessageReceiverTest extends AbstractMuleTestCase {
     @Test
     public void testTopicReceiverShouldBeStartedOnlyInPrimaryNode() throws Exception
     {
-        when(mockJmsConnector.getTopicResolver().isTopic(mockInboundEndpoint,true)).thenReturn(true);
+        when(mockJmsConnector.getTopicResolver().isTopic(mockInboundEndpoint, true)).thenReturn(true);
         when(mockInboundEndpoint.getConnector()).thenReturn(mockJmsConnector);
         MultiConsumerJmsMessageReceiver messageReceiver = new MultiConsumerJmsMessageReceiver(mockJmsConnector, mockFlowConstruct, mockInboundEndpoint);
         assertThat("receiver must be started only in primary node", messageReceiver.shouldConsumeInEveryNode(), is(false));
@@ -42,10 +59,55 @@ public class MultiConsumerJmsMessageReceiverTest extends AbstractMuleTestCase {
     @Test
     public void testQueueReceiverShouldBeStartedInEveryNode() throws Exception
     {
-        when(mockJmsConnector.getTopicResolver().isTopic(mockInboundEndpoint,true)).thenReturn(false);
+        when(mockJmsConnector.getTopicResolver().isTopic(mockInboundEndpoint, true)).thenReturn(false);
         when(mockInboundEndpoint.getConnector()).thenReturn(mockJmsConnector);
         MultiConsumerJmsMessageReceiver messageReceiver = new MultiConsumerJmsMessageReceiver(mockJmsConnector, mockFlowConstruct, mockInboundEndpoint);
         assertThat("receiver must be started only in primary node", messageReceiver.shouldConsumeInEveryNode(), is(true));
+    }
+
+    @Test
+    public void messageListenerNotSetTwiceOnMessageReceiver() throws Exception
+    {
+        when(mockJmsConnector.getTopicResolver().isTopic(mockInboundEndpoint, true)).thenReturn(false);
+        when(mockJmsConnector.getNumberOfConsumers()).thenReturn(1);
+
+        MessageConsumer mockMessageConsumer = mock(TestMessageConsumer.class, CALLS_REAL_METHODS);
+        when(mockJmsConnector.getJmsSupport()
+                    .createConsumer(any(Session.class), any(Destination.class), anyString(), anyBoolean(), anyString(), anyBoolean(), any(InboundEndpoint.class)))
+                    .thenReturn(mockMessageConsumer);
+        when(mockInboundEndpoint.getConnector()).thenReturn(mockJmsConnector);
+        when(mockInboundEndpoint.getMuleContext().getRegistry().get(MuleProperties.OBJECT_DEFAULT_MESSAGE_PROCESSING_MANAGER)).thenReturn(mock(MessageProcessingManager.class));
+        SimpleRetryPolicyTemplate retryPolicyTemplate = new SimpleRetryPolicyTemplate();
+        retryPolicyTemplate.setMuleContext(mockJmsConnector.getMuleContext());
+        when(mockInboundEndpoint.getRetryPolicyTemplate()).thenReturn(retryPolicyTemplate);
+        when(mockInboundEndpoint.getProperties().get(JmsConstants.DURABLE_PROPERTY)).thenReturn("false");
+        when(mockInboundEndpoint.getProperties().get(JmsConstants.DURABLE_NAME_PROPERTY)).thenReturn(null);
+
+        MultiConsumerJmsMessageReceiver messageReceiver = new MultiConsumerJmsMessageReceiver(mockJmsConnector, mockFlowConstruct, mockInboundEndpoint);
+        messageReceiver.initialise();
+        messageReceiver.doStart();
+        verify(mockMessageConsumer).setMessageListener(any(MessageListener.class));
+        reset(mockMessageConsumer);
+        messageReceiver.startSubReceivers();
+        verify(mockMessageConsumer, never()).setMessageListener(any(MessageListener.class));
+    }
+
+    private abstract class TestMessageConsumer implements MessageConsumer
+    {
+
+        private MessageListener messageListener;
+
+        @Override
+        public MessageListener getMessageListener() throws JMSException
+        {
+            return messageListener;
+        }
+
+        @Override
+        public void setMessageListener(MessageListener messageListener) throws JMSException
+        {
+            this.messageListener = messageListener;
+        }
     }
 
 


### PR DESCRIPTION
...er because some JMS implementations raise an error if this occurs (as Qpid for example).