### PR TITLE
MULE-8310: FTP client not timing out

### DIFF
--- a/transports/ftp/src/test/java/org/mule/transport/ftp/FtpConnectionTimeoutTestCase.java
+++ b/transports/ftp/src/test/java/org/mule/transport/ftp/FtpConnectionTimeoutTestCase.java
@@ -21,9 +21,11 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
+@Ignore("Can' rely on server socket constructor parameter 'backlog' as its behaviour is implementation dependant")
 public class FtpConnectionTimeoutTestCase extends FunctionalTestCase
 {
 


### PR DESCRIPTION
_ Ignoring test: need to find another way to test this as this test behaviour varies depending on the used JVM