### PR TITLE
MULE-8308: Upgrade JRuby

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -211,6 +211,7 @@
 /mule-standalone-${productVersion}/lib/opt/bcprov-jdk16-1.46.jar
 /mule-standalone-${productVersion}/lib/opt/bctsp-jdk16-1.46.jar
 /mule-standalone-${productVersion}/lib/opt/btf-1.2.jar
+/mule-standalone-${productVersion}/lib/opt/bytelist-1.0.10.jar
 /mule-standalone-${productVersion}/lib/opt/cglib-nodep-2.2.jar
 /mule-standalone-${productVersion}/lib/opt/cometd-api-1.1.1.jar
 /mule-standalone-${productVersion}/lib/opt/cometd-server-6.1.26.jar
@@ -275,6 +276,7 @@
 /mule-standalone-${productVersion}/lib/opt/hk2-api-2.3.0-b05.jar
 /mule-standalone-${productVersion}/lib/opt/hk2-locator-2.3.0-b05.jar
 /mule-standalone-${productVersion}/lib/opt/hk2-utils-2.3.0-b05.jar
+/mule-standalone-${productVersion}/lib/opt/invokebinder-1.2.jar
 /mule-standalone-${productVersion}/lib/opt/isorelax-20030108.jar
 /mule-standalone-${productVersion}/lib/opt/jackson-annotations-2.4.0.jar
 /mule-standalone-${productVersion}/lib/opt/jackson-core-2.4.3.jar
@@ -301,6 +303,7 @@
 /mule-standalone-${productVersion}/lib/opt/jbpm-log-4.4.jar
 /mule-standalone-${productVersion}/lib/opt/jbpm-pvm-4.4.jar
 /mule-standalone-${productVersion}/lib/opt/jcifs-1.3.3.jar
+/mule-standalone-${productVersion}/lib/opt/jcodings-1.0.10.jar
 /mule-standalone-${productVersion}/lib/opt/jdom-1.1.3.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-client-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-common-2.11.jar
@@ -324,10 +327,22 @@
 /mule-standalone-${productVersion}/lib/opt/jetty-xml-9.0.7.v20131107.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-util-6.1.26.jar
 /mule-standalone-${productVersion}/lib/opt/jetty-util5-6.1.26.jar
+/mule-standalone-${productVersion}/lib/opt/jffi-1.2.5.jar
+/mule-standalone-${productVersion}/lib/opt/jffi-1.2.7-native.jar
 /mule-standalone-${productVersion}/lib/opt/jgrapht-jdk1.5-0.7.3.jar
+/mule-standalone-${productVersion}/lib/opt/jline-2.7.jar
+/mule-standalone-${productVersion}/lib/opt/jnr-constants-0.8.4.jar
+/mule-standalone-${productVersion}/lib/opt/jnr-enxio-0.4.jar
+/mule-standalone-${productVersion}/lib/opt/jnr-ffi-1.0.4.jar
+/mule-standalone-${productVersion}/lib/opt/jnr-netdb-1.1.2.jar
+/mule-standalone-${productVersion}/lib/opt/jnr-posix-2.5.2.jar
+/mule-standalone-${productVersion}/lib/opt/jnr-unixsocket-0.3.jar
+/mule-standalone-${productVersion}/lib/opt/jnr-x86asm-1.0.2.jar
 /mule-standalone-${productVersion}/lib/opt/joda-time-2.5.jar
+/mule-standalone-${productVersion}/lib/opt/joni-2.0.0.jar
 /mule-standalone-${productVersion}/lib/opt/jopt-simple-4.6.jar
-/mule-standalone-${productVersion}/lib/opt/jruby-complete-1.0.jar
+/mule-standalone-${productVersion}/lib/opt/jruby-core-1.7.4.jar
+/mule-standalone-${productVersion}/lib/opt/jruby-stdlib-1.7.4.jar
 /mule-standalone-${productVersion}/lib/opt/jruby-engine-1.1-jdk14.jar
 /mule-standalone-${productVersion}/lib/opt/jsch-0.1.51.jar
 /mule-standalone-${productVersion}/lib/opt/js-engine-1.1-jdk14.jar
@@ -340,6 +355,7 @@
 /mule-standalone-${productVersion}/lib/opt/juel-impl-2.2.1.jar
 /mule-standalone-${productVersion}/lib/opt/juli-6.0.41.jar
 /mule-standalone-${productVersion}/lib/opt/jython-standalone-2.7-b3.jar
+/mule-standalone-${productVersion}/lib/opt/jzlib-1.1.2.jar
 /mule-standalone-${productVersion}/lib/opt/libphonenumber-6.0.jar
 /mule-standalone-${productVersion}/lib/opt/livetribe-jsr223-2.0.5.jar
 /mule-standalone-${productVersion}/lib/opt/mail-1.4.3.jar
@@ -365,6 +381,7 @@
 /mule-standalone-${productVersion}/lib/opt/signpost-core-1.2.1.2.jar
 /mule-standalone-${productVersion}/lib/opt/smack-3.1.0.jar
 /mule-standalone-${productVersion}/lib/opt/smackx-3.1.0.jar
+/mule-standalone-${productVersion}/lib/opt/snakeyaml-1.11.jar
 /mule-standalone-${productVersion}/lib/opt/spring-aop-4.1.5.RELEASE.jar
 /mule-standalone-${productVersion}/lib/opt/spring-beans-4.1.5.RELEASE.jar
 /mule-standalone-${productVersion}/lib/opt/spring-context-4.1.5.RELEASE.jar

--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -8,6 +8,7 @@ Migration changes from 3.6.x to 3.7.x
 MULE-8298: Spring dependency was upgraded to version 4.1.5.RELEASE.
 MULE-8315: the following Apache Tomcat libraries were upgraded form version 6.0.29 to version 6.0.41: annotations-api, coyote, el-api, jasper, jasper-el, jsp-api, juli. Removed catalina-6.0.29.jar as is not needed anymore.
 MULE-8340: TLS configuration is not mapped anymore to the default JVM system properties. In order to keep this behavior, define the following system property: mule.tls.disableSystemPropertiesMapping=false
+MULE-8308: jruby was upgraded to version 1.7.4 because of a security issue with previous version. Artifact jruby-complete was removed and replaced with jruby-core and its dependencies.
 
 Migration changes from 3.5.x to 3.6.x
 

--- a/modules/scripting/pom.xml
+++ b/modules/scripting/pom.xml
@@ -76,8 +76,8 @@
         <!--Ruby-->
         <dependency>
             <groupId>org.jruby</groupId>
-            <artifactId>jruby-complete</artifactId>
-            <version>1.0</version>
+            <artifactId>jruby-core</artifactId>
+            <version>1.7.4</version>
         </dependency>
         <dependency>
             <groupId>javax.script</groupId>


### PR DESCRIPTION
_ Jruby was updagraded because of security issues with previous used version
_ Replaced jruby-complete with jruby-core and its dependencies because jruby-complete contains joda-time and asm classes without properly shading.
_ Upgraded to version 1.7.4 because is the last version that used asm 3.3.1 which is the version we are using right now.