### PR TITLE
MULE-8377: Passing doclint arguments as a system property so that build ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2189,7 +2189,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <additionalparam>${xDocLint}</additionalparam>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
...doesn't fail in JDK7 and is configurable in JDK8