### PR TITLE
MULE-8436 - TestCase: Dates should be independent of locale settings

### DIFF
--- a/core/src/test/java/org/mule/el/datetime/DateTimeDateTestCase.java
+++ b/core/src/test/java/org/mule/el/datetime/DateTimeDateTestCase.java
@@ -16,6 +16,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import javax.xml.bind.DatatypeConverter;
@@ -92,7 +93,7 @@ public class DateTimeDateTestCase extends AbstractMuleTestCase
     @Test
     public void withLocale()
     {
-        SimpleDateFormat df = new SimpleDateFormat("E");
+        SimpleDateFormat df = new SimpleDateFormat("E", Locale.US);
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
         assertEquals(df.format(new Date()), now.withLocale("en_US").format("E"));
     }


### PR DESCRIPTION
TestCase breaks down if the default locale is not en_US. Issue affects all mule branches. JIRA issue MULE-8436.