### PR TITLE
MULE-8284: Making HTTP listener fail if the trust store specified does n...

### DIFF
--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConfigTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpListenerConfigTestCase.java
@@ -6,32 +6,40 @@
  */
 package org.mule.module.http.internal.listener;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
+import static org.mule.module.http.api.HttpConstants.Protocols.HTTPS;
 import org.mule.api.MuleContext;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 import org.mule.transport.ssl.api.TlsContextFactory;
 
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Answers;
+import org.junit.rules.ExpectedException;
 
 @SmallTest
 public class HttpListenerConfigTestCase extends AbstractMuleTestCase
 {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
-    @Test(expected = InitialisationException.class)
+    @Test
     public void initializationFailsWhenNoTlsKeyStoreConfigured() throws Exception
     {
         final DefaultHttpListenerConfig httpListenerConfig = new DefaultHttpListenerConfig();
-        final MuleContext mockMuleContext = mock(MuleContext.class, Answers.RETURNS_DEEP_STUBS.get());
+        httpListenerConfig.setProtocol(HTTPS);
+        final MuleContext mockMuleContext = mock(MuleContext.class, RETURNS_DEEP_STUBS.get());
         httpListenerConfig.setMuleContext(mockMuleContext);
         final TlsContextFactory mockTlsContextFactory = mock(TlsContextFactory.class);
         httpListenerConfig.setTlsContext(mockTlsContextFactory);
         when(mockMuleContext.getRegistry().lookupObject(HttpListenerConnectionManager.class)).thenReturn(mock(HttpListenerConnectionManager.class));
         when(mockTlsContextFactory.isKeyStoreConfigured()).thenReturn(false);
+        expectedException.expect(InitialisationException.class);
+        expectedException.expectMessage(containsString("KeyStore must be configured for server side SSL"));
         httpListenerConfig.initialise();
     }
 

--- a/transports/ssl/src/main/java/org/mule/transport/ssl/DefaultTlsContextFactory.java
+++ b/transports/ssl/src/main/java/org/mule/transport/ssl/DefaultTlsContextFactory.java
@@ -10,6 +10,7 @@ package org.mule.transport.ssl;
 import org.mule.api.lifecycle.CreateException;
 import org.mule.api.security.tls.TlsConfiguration;
 import org.mule.transport.ssl.api.TlsContextFactory;
+import org.mule.util.FileUtils;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -97,6 +98,11 @@ public class DefaultTlsContextFactory implements TlsContextFactory
 
     public void setTrustStorePath(String trustStorePath) throws IOException
     {
+        String trustStoreResource = FileUtils.getResourcePath(trustStorePath, getClass());
+        if (trustStoreResource == null)
+        {
+            throw new IOException(String.format("Resource %s could not be found", trustStorePath));
+        }
         tlsConfiguration.setTrustStore(trustStorePath);
     }
 

--- a/transports/ssl/src/test/java/org/mule/transport/ssl/DefaultTlsContextFactoryTestCase.java
+++ b/transports/ssl/src/test/java/org/mule/transport/ssl/DefaultTlsContextFactoryTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.ssl;
+
+import static org.hamcrest.Matchers.containsString;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DefaultTlsContextFactoryTestCase extends AbstractMuleTestCase
+{
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void failIfTrustStoreIsNonexistent() throws Exception
+    {
+        DefaultTlsContextFactory tlsContextFactory = new DefaultTlsContextFactory();
+        expectedException.expect(IOException.class);
+        expectedException.expectMessage(containsString("Resource non-existent-trust-store could not be found"));
+        tlsContextFactory.setTrustStorePath("non-existent-trust-store");
+    }
+
+}


### PR DESCRIPTION
...ot exist. Fixing test for key store that does not exist scenario.