### PR TITLE
MULE-8565: Add support for preemptive basic authentication in the HTTP module

### DIFF
--- a/modules/http/src/main/resources/META-INF/mule-httpn.xsd
+++ b/modules/http/src/main/resources/META-INF/mule-httpn.xsd
@@ -774,7 +774,7 @@
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="preemptive" type="mule:substitutableBoolean" use="optional">
+                <xsd:attribute name="preemptive" type="mule:substitutableBoolean" default="false" use="optional">
                     <xsd:annotation>
                         <xsd:documentation>
                             Configures if authentication should be preemptive or not. Preemptive authentication will send


### PR DESCRIPTION
Added default value in the schema