### PR TITLE
MULE-8307: HTTP requester throws timeout errors with POST request

### DIFF
--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestTimeoutTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestTimeoutTestCase.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.requester;
+
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import org.mule.api.MessagingException;
+import org.mule.api.MuleEvent;
+import org.mule.construct.Flow;
+import org.mule.util.concurrent.Latch;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.junit.Test;
+
+public class HttpRequestTimeoutTestCase extends AbstractHttpRequestTestCase
+{
+
+    private static int TEST_TIMEOUT = 2000;
+
+    private Latch serverLatch = new Latch();
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-request-timeout-config.xml";
+    }
+
+    @Test
+    public void throwsExceptionWhenRequesterTimeoutIsExceeded() throws Exception
+    {
+        assertTimeout("requestFlow", 1, -1);
+    }
+
+    @Test
+    public void throwsExceptionWhenEventTimeoutIsExceeded() throws Exception
+    {
+        assertTimeout("requestFlowNoTimeout", -1, 1);
+    }
+
+    @Test
+    public void requesterTimeoutOverridesEventTimeout() throws Exception
+    {
+        assertTimeout("requestFlow", 1, TEST_TIMEOUT * 2);
+    }
+
+    private void assertTimeout(final String flowName, final int responseTimeoutRequester, final int responseTimeoutEvent) throws Exception
+    {
+        final Latch requestTimeoutLatch = new Latch();
+
+        Thread thread = new Thread()
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    Flow flow = (Flow) getFlowConstruct(flowName);
+                    MuleEvent event = getTestEvent(TEST_MESSAGE);
+                    event.setTimeout(responseTimeoutEvent);
+                    event.setFlowVariable("timeout", responseTimeoutRequester);
+
+                    try
+                    {
+                        flow.process(event);
+                    }
+                    catch (MessagingException e)
+                    {
+                        assertThat(e.getCauseException(), instanceOf(TimeoutException.class));
+                        requestTimeoutLatch.release();
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        thread.start();
+
+        // Wait for the request to timeout (the thread sending the request will release the latch.
+        assertTrue(requestTimeoutLatch.await(TEST_TIMEOUT, TimeUnit.MILLISECONDS));
+        thread.join();
+
+        // Release the server latch so that the server thread can finish.
+        serverLatch.release();
+    }
+
+    @Override
+    protected void handleRequest(Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+    {
+        try
+        {
+            // Block until the end of the test in order to make the request timeout.
+            serverLatch.await();
+        }
+        catch (InterruptedException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestWithMuleClientTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestWithMuleClientTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.module.http.functional.requester;
 
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -31,7 +32,6 @@ import org.mule.transport.ssl.api.TlsContextFactory;
 import org.mule.util.concurrent.Latch;
 
 import java.io.ByteArrayInputStream;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.hamcrest.core.Is;
@@ -46,7 +46,9 @@ public class HttpRequestWithMuleClientTestCase extends FunctionalTestCase
 
     public static final String PUT_HTTP_METHOD = "PUT";
     private static final long RESPONSE_TIMEOUT = 100;
+    private static final long SERVER_TIMEOUT = 2000;
     public static final String TEST_RESPONSE = "test-response";
+
     @Rule
     public DynamicPort port = new DynamicPort("port");
     @Rule
@@ -166,7 +168,7 @@ public class HttpRequestWithMuleClientTestCase extends FunctionalTestCase
         {
             try
             {
-                latch.await(RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS);
+                latch.await(SERVER_TIMEOUT, MILLISECONDS);
             }
             catch (InterruptedException e)
             {

--- a/modules/http/src/test/resources/http-request-timeout-config.xml
+++ b/modules/http/src/test/resources/http-request-timeout-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <http:request-config name="requestConfig" host="localhost" port="${httpPort}" />
+
+    <flow name="requestFlow">
+        <http:request config-ref="requestConfig" method="POST" path="/" responseTimeout="#[timeout]" />
+    </flow>
+
+    <flow name="requestFlowNoTimeout">
+        <http:request config-ref="requestConfig" method="POST" path="/" />
+    </flow>
+
+</mule>


### PR DESCRIPTION
Fixed timeout in requester. Updated the CustomTimeoutThrottleRequestFilter based on the ThrottleRequestFilter of the updated version of AHC.