### PR TITLE
Fix dependency duplication to mule-tests-functional.

### DIFF
--- a/modules/launcher/pom.xml
+++ b/modules/launcher/pom.xml
@@ -22,12 +22,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.mule.tests</groupId>
-            <artifactId>mule-tests-functional</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-reboot</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
This change fixes the following warning.

```
% mvn -Declipse.workspace=/Users/yyamano/work/workspace-mule-3.x eclipse:configure-workspace
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.modules:mule-module-launcher:jar:3.7.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.mule.tests:mule-tests-functional:jar -> duplicate declaration of version ${project.version} @ org.mule.modules:mule-module-launcher:[unknown-version], /Users/yyamano/work/mule/mule/modules/launcher/pom.xml, line 51, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```