### PR TITLE
MULE-8620:  Add dynamic configurations for DB connector

### DIFF
--- a/modules/db/src/main/java/org/mule/module/db/internal/config/domain/database/DbConfigResolverFactoryBean.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/config/domain/database/DbConfigResolverFactoryBean.java
@@ -81,10 +81,14 @@ public class DbConfigResolverFactoryBean extends AbstractFactoryBean<DbConfigRes
         }
         else
         {
-            DataSource instanceDataSource = dataSource;
-            if (instanceDataSource == null)
+            DataSource instanceDataSource;
+            if (dataSource == null)
             {
                 instanceDataSource = dataSourceFactory.create(dataSourceConfig);
+            }
+            else
+            {
+                instanceDataSource = dataSourceFactory.decorateDataSource(dataSource, dataSourceConfig.getPoolingProfile(), muleContext);
             }
 
             DbConfig dbConfig = dbConfigFactory.create(name, instanceDataSource);

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/database/DataSourceFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/database/DataSourceFactory.java
@@ -73,7 +73,7 @@ public class DataSourceFactory implements MuleContextAware, Disposable
 
         if (dataSourceConfig.isUseXaTransactions())
         {
-            dataSource = decorateDataSource(dataSource, dataSourceConfig.getPoolingProfile());
+            dataSource = decorateDataSource(dataSource, dataSourceConfig.getPoolingProfile(), getMuleContext());
         }
 
         if (!(dataSourceConfig.getPoolingProfile() == null || dataSourceConfig.isUseXaTransactions()))
@@ -85,12 +85,12 @@ public class DataSourceFactory implements MuleContextAware, Disposable
         return dataSource;
     }
 
-    protected DataSource decorateDataSource(DataSource dataSource, DbPoolingProfile poolingProfile)
+    public DataSource decorateDataSource(DataSource dataSource, DbPoolingProfile poolingProfile, MuleContext muleContext)
     {
         CompositeDataSourceDecorator dataSourceDecorator = new CompositeDataSourceDecorator();
-        dataSourceDecorator.init(getMuleContext());
+        dataSourceDecorator.init(muleContext);
 
-        return dataSourceDecorator.decorate(dataSource, name, poolingProfile, getMuleContext());
+        return dataSourceDecorator.decorate(dataSource, name, poolingProfile, muleContext);
     }
 
     protected DataSource createSingleDataSource(DataSourceConfig resolvedDataSourceConfig) throws SQLException

--- a/modules/db/src/test/java/org/mule/module/db/integration/config/AbstractDynamicDatabaseConfigTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/config/AbstractDynamicDatabaseConfigTestCase.java
@@ -12,7 +12,7 @@ import org.mule.module.db.integration.model.AbstractTestDatabase;
 import org.mule.module.db.internal.domain.database.DbConfig;
 import org.mule.module.db.internal.resolver.database.DbConfigResolver;
 
-public class AbstractDynamicDatabaseConfigTestCase extends AbstractDatabaseConfigTestCase
+public abstract class AbstractDynamicDatabaseConfigTestCase extends AbstractDatabaseConfigTestCase
 {
 
     public AbstractDynamicDatabaseConfigTestCase(String dataSourceConfigResource, AbstractTestDatabase testDatabase)

--- a/modules/db/src/test/java/org/mule/module/db/internal/domain/database/DataSourceFactoryTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/domain/database/DataSourceFactoryTestCase.java
@@ -10,6 +10,7 @@ package org.mule.module.db.internal.domain.database;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import org.mule.api.MuleContext;
 import org.mule.module.db.internal.domain.connection.DbPoolingProfile;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -36,7 +37,7 @@ public class DataSourceFactoryTestCase extends AbstractMuleTestCase
         }
 
         @Override
-        protected DataSource decorateDataSource(DataSource dataSource, DbPoolingProfile poolingProfile)
+        public DataSource decorateDataSource(DataSource dataSource, DbPoolingProfile poolingProfile, MuleContext muleContext)
         {
             return dataSource;
         }


### PR DESCRIPTION
_ Adding missing datasource decoration when datasource was passed as a bean instead of created using the dataSourceFactory
_ Adding missing abstract keyword on AbstractDynamicDatabaseConfigTestCase