### PR TITLE
MULE-8641: Add OOTB performance parameters in wrapper.conf

### DIFF
--- a/distributions/standalone/src/main/resources/conf/wrapper.conf
+++ b/distributions/standalone/src/main/resources/conf/wrapper.conf
@@ -26,21 +26,12 @@ wrapper.java.additional.7=-XX:PermSize=256m
 wrapper.java.additional.8=-XX:MaxPermSize=256m
 
 # GC settings
-wrapper.java.additional.9=-XX:+PrintGCApplicationStoppedTime
-wrapper.java.additional.10=-XX:+PrintGCDetails
-wrapper.java.additional.11=-XX:+PrintGCDateStamps
-wrapper.java.additional.12=-XX:+PrintTenuringDistribution
-wrapper.java.additional.13=-Xloggc:%MULE_HOME%/logs/gc.log
-wrapper.java.additional.14=-XX:+UseGCLogFileRotation
-wrapper.java.additional.15=-XX:NumberOfGCLogFiles=5
-wrapper.java.additional.16=-XX:GCLogFileSize=1M
-wrapper.java.additional.17=-XX:ErrorFile=%MULE_HOME%/logs/err.log
-wrapper.java.additional.18=-XX:+HeapDumpOnOutOfMemoryError
-wrapper.java.additional.19=-XX:+AlwaysPreTouch
-wrapper.java.additional.20=-XX:+UseParNewGC
-wrapper.java.additional.21=-XX:NewSize=512m
-wrapper.java.additional.22=-XX:MaxNewSize=512m
-wrapper.java.additional.23=-XX:MaxTenuringThreshold=8
+wrapper.java.additional.9=-XX:+HeapDumpOnOutOfMemoryError
+wrapper.java.additional.10=-XX:+AlwaysPreTouch
+wrapper.java.additional.11=-XX:+UseParNewGC
+wrapper.java.additional.12=-XX:NewSize=512m
+wrapper.java.additional.13=-XX:MaxNewSize=512m
+wrapper.java.additional.14=-XX:MaxTenuringThreshold=8
 
 # *** IMPORTANT ***
 # If you enable any of the options below, you _must_ change the <n> to be a 
@@ -99,9 +90,18 @@ wrapper.java.additional.23=-XX:MaxTenuringThreshold=8
 #wrapper.java.additional.<n>=-Dmule.transform.autoWrap=true
 
 # Performance settings
-# wrapper.java.additional.<n>=-XX:+UseConcMarkSweepGC
-# wrapper.java.additional.<n>=-XX:CMSInitiatingOccupancyFraction=65
-# wrapper.java.additional.<n>=-XX:+UseCMSInitiatingOccupancyOnly
+#wrapper.java.additional.<n>=-XX:+UseConcMarkSweepGC
+#wrapper.java.additional.<n>=-XX:CMSInitiatingOccupancyFraction=65
+#wrapper.java.additional.<n>=-XX:+UseCMSInitiatingOccupancyOnly
+#wrapper.java.additional.<n>=-XX:+PrintGCApplicationStoppedTime
+#wrapper.java.additional.<n>=-XX:+PrintGCDetails
+#wrapper.java.additional.<n>=-XX:+PrintGCDateStamps
+#wrapper.java.additional.<n>=-XX:+PrintTenuringDistribution
+#wrapper.java.additional.<n>=-Xloggc:%MULE_HOME%/logs/gc.log
+#wrapper.java.additional.<n>=-XX:+UseGCLogFileRotation
+#wrapper.java.additional.<n>=-XX:NumberOfGCLogFiles=5
+#wrapper.java.additional.<n>=-XX:GCLogFileSize=1M
+#wrapper.java.additional.<n>=-XX:ErrorFile=%MULE_HOME%/logs/err.log
 
 #********************************************************************
 # Wrapper Properties


### PR DESCRIPTION
Commented GC parameters in wrapper.conf file that are not supported by some JVMs.