### PR TITLE
MULE-8626: HTTP listener should ignore Connection outbound property a…

### DIFF
--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -4,6 +4,10 @@ MIGRATION GUIDE
 The following is a list of changes you have to execute to migrate from Mule ESB Community edition version 3.4.x to version 3.7.x
 Please check http://www.mulesoft.org/documentation/display/current/Mule+Release+Notes for more details.
 
+Migration changes from 3.7.x to 3.8.x
+MULE-8626: The HTTP Connector will now ignore a "Connection" outbound property when responding to a request (listener) or making one (request), instead of transforming it to a header. This means that:
+if such property is desired, it should be explicitly added as a header using a response/request builder.
+
 Migration changes from 3.6.x to 3.7.x
 
 MULE-8298: Spring dependency was upgraded to version 4.1.6.RELEASE.

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -7,6 +7,7 @@
 package org.mule.module.http.internal.listener;
 
 import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_PREFIX;
+import static org.mule.module.http.api.HttpHeaders.Names.CONNECTION;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_LENGTH;
 import static org.mule.module.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
 import static org.mule.module.http.api.HttpHeaders.Values.CHUNKED;
@@ -89,7 +90,7 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
         {
             for (String outboundPropertyName : outboundProperties)
             {
-                if (!outboundPropertyName.startsWith(HTTP_PREFIX))
+                if (isNotIgnoredProperty(outboundPropertyName))
                 {
                     final Object outboundPropertyValue = event.getMessage().getOutboundProperty(outboundPropertyName);
                     httpResponseHeaderBuilder.addHeader(outboundPropertyName, outboundPropertyValue);
@@ -211,6 +212,11 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
         }
         httpResponseBuilder.setEntity(httpEntity);
         return httpResponseBuilder.build();
+    }
+
+    private boolean isNotIgnoredProperty(String outboundPropertyName)
+    {
+        return !outboundPropertyName.startsWith(HTTP_PREFIX) && !outboundPropertyName.equalsIgnoreCase(CONNECTION);
     }
 
     private void setupContentLengthEncoding(HttpResponseHeaderBuilder httpResponseHeaderBuilder, int contentLength)

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/BaseResponseCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/BaseResponseCompletionHandler.java
@@ -6,6 +6,8 @@
  */
 package org.mule.module.http.internal.listener.grizzly;
 
+import static org.mule.module.http.api.HttpHeaders.Names.CONNECTION;
+import static org.mule.module.http.api.HttpHeaders.Values.CLOSE;
 import org.mule.module.http.api.HttpHeaders;
 import org.mule.module.http.internal.domain.response.HttpResponse;
 
@@ -38,6 +40,10 @@ public abstract class BaseResponseCompletionHandler extends EmptyCompletionHandl
         if (httpResponse.getHeaderValue(HttpHeaders.Names.TRANSFER_ENCODING) != null)
         {
             httpResponsePacket.setChunked(true);
+        }
+        if (CLOSE.equalsIgnoreCase(httpResponsePacket.getHeader(CONNECTION)))
+        {
+            httpResponsePacket.getProcessingState().setKeepAlive(false);
         }
         return httpResponsePacket;
     }

--- a/modules/http/src/main/java/org/mule/module/http/internal/request/MuleEventToHttpRequest.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/MuleEventToHttpRequest.java
@@ -7,6 +7,7 @@
 package org.mule.module.http.internal.request;
 
 import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_PREFIX;
+import static org.mule.module.http.api.HttpHeaders.Names.CONNECTION;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_LENGTH;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import static org.mule.module.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
@@ -80,7 +81,7 @@ public class MuleEventToHttpRequest
 
         for (String outboundProperty : event.getMessage().getOutboundPropertyNames())
         {
-            if (!outboundProperty.startsWith(HTTP_PREFIX))
+            if (isNotIgnoredProperty(outboundProperty))
             {
                 builder.addHeader(outboundProperty, event.getMessage().getOutboundProperty(outboundProperty).toString());
             }
@@ -98,6 +99,11 @@ public class MuleEventToHttpRequest
         builder.setEntity(createRequestEntity(builder, event, resolvedMethod));
 
         return builder;
+    }
+
+    private boolean isNotIgnoredProperty(String outboundProperty)
+    {
+        return !outboundProperty.startsWith(HTTP_PREFIX) && !outboundProperty.equalsIgnoreCase(CONNECTION);
     }
 
 

--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestKeepAliveTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestKeepAliveTestCase.java
@@ -44,12 +44,6 @@ public class HttpRequestKeepAliveTestCase extends AbstractHttpRequestTestCase
     }
 
     @Test
-    public void persistentRequestWithClosePropertySendsCloseHeader() throws Exception
-    {
-        assertConnectionHeader("persistentRequestFlow", CLOSE, CLOSE);
-    }
-
-    @Test
     public void nonPersistentRequestWithKeepAlivePropertySendsCloseHeader() throws Exception
     {
         assertConnectionHeader("nonPersistentRequestFlow", KEEP_ALIVE, CLOSE);

--- a/modules/http/src/test/resources/http-listener-persistent-connections-config.xml
+++ b/modules/http/src/test/resources/http-listener-persistent-connections-config.xml
@@ -17,4 +17,21 @@
         <echo-component/>
     </flow>
 
+    <http:listener-config name="persistentConfigCloseHeader" host="localhost" port="${persistentPortCloseHeader}" usePersistentConnections="true" connectionIdleTimeout="1000" />
+    <flow name="persistentCloseHeader">
+        <http:listener path="/" config-ref="persistentConfigCloseHeader" >
+            <http:response-builder>
+                <http:header headerName="Connection" value="close"/>
+            </http:response-builder>
+                </http:listener>
+        <echo-component/>
+    </flow>
+
+    <http:listener-config name="persistentConfigCloseProperty" host="localhost" port="${persistentPortCloseProperty}" usePersistentConnections="true" connectionIdleTimeout="1000" />
+    <flow name="persistentCloseProperty">
+        <http:listener path="/" config-ref="persistentConfigCloseProperty"/>
+        <set-property propertyName="Connection" value="close"/>
+        <echo-component/>
+    </flow>
+
 </mule>

--- a/modules/http/src/test/resources/http-request-headers-config.xml
+++ b/modules/http/src/test/resources/http-request-headers-config.xml
@@ -42,4 +42,16 @@
         </http:request>
     </flow>
 
+    <flow name="connectionHeader">
+        <http:request config-ref="config" path="testPath" >
+            <http:request-builder>
+                <http:header headerName="Connection" value="close" />
+            </http:request-builder>
+        </http:request>
+    </flow>
+
+    <flow name="outboundProperties">
+        <http:request config-ref="config" path="testPath" />
+    </flow>
+
 </mule>


### PR DESCRIPTION
…nd act accordingly if it's an explicit header.