### PR TITLE
MULE-8676: HTTP listener should ignore 'Transfer-Encoding' property a…

### DIFF
--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -7,7 +7,7 @@ Please check http://www.mulesoft.org/documentation/display/current/Mule+Release+
 Migration changes from 3.7.x to 3.8.x
 MULE-8626: The HTTP Connector will now ignore a "Connection" outbound property when responding to a request (listener) or making one (request), instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a response/request builder.
 MULE-8678: The HTTP Connector will now ignore a "Host" outbound property when making a request, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a request builder.
-MULE-8676: The HTTP Connector will now ignore a "Transfer-Encoding" outbound property when responding a request, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a response builder.
+MULE-8676: The HTTP Connector will now ignore a "Transfer-Encoding" outbound property when sending a response, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a response builder.
 
 Migration changes from 3.6.x to 3.7.x
 

--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -7,6 +7,7 @@ Please check http://www.mulesoft.org/documentation/display/current/Mule+Release+
 Migration changes from 3.7.x to 3.8.x
 MULE-8626: The HTTP Connector will now ignore a "Connection" outbound property when responding to a request (listener) or making one (request), instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a response/request builder.
 MULE-8678: The HTTP Connector will now ignore a "Host" outbound property when making a request, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a request builder.
+MULE-8676: The HTTP Connector will now ignore a "Transfer-Encoding" outbound property when responding a request, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a response builder.
 
 Migration changes from 3.6.x to 3.7.x
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -174,7 +174,7 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
                 try
                 {
                     ByteArrayHttpEntity byteArrayHttpEntity = new ByteArrayHttpEntity(event.getMessage().getPayloadAsBytes());
-                    if (responseStreaming == ALWAYS || (responseStreaming == AUTO && CHUNKED.equals(existingTransferEncoding)))
+                    if (responseStreaming == ALWAYS || (responseStreaming == AUTO && existingContentLength == null && CHUNKED.equals(existingTransferEncoding)))
                     {
                         setupChunkedEncoding(httpResponseHeaderBuilder);
                     }
@@ -216,7 +216,7 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
 
     private boolean isNotIgnoredProperty(String outboundPropertyName)
     {
-        return !outboundPropertyName.startsWith(HTTP_PREFIX) && !outboundPropertyName.equalsIgnoreCase(CONNECTION);
+        return !outboundPropertyName.startsWith(HTTP_PREFIX) && !outboundPropertyName.equalsIgnoreCase(CONNECTION) && !outboundPropertyName.equalsIgnoreCase(TRANSFER_ENCODING);
     }
 
     private void setupContentLengthEncoding(HttpResponseHeaderBuilder httpResponseHeaderBuilder, int contentLength)

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreamingTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreamingTestCase.java
@@ -64,9 +64,9 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
     }
 
     @Test
-    public void stringWithTransferEncoding() throws Exception
+    public void stringWithTransferEncodingHeader() throws Exception
     {
-        final String url = getUrl("stringWithTransferEncoding");
+        final String url = getUrl("stringWithTransferEncodingHeader");
         testResponseIsChunkedEncoding(url);
     }
 
@@ -74,7 +74,21 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
     public void stringWithTransferEncodingOutboundProperty() throws Exception
     {
         final String url = getUrl("stringWithTransferEncodingOutboundProperty");
-        testResponseIsChunkedEncoding(url);
+        testResponseIsContentLengthEncoding(url);
+    }
+
+    @Test
+    public void stringWithTransferEncodingAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url);
+    }
+
+    @Test
+    public void stringWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url);
     }
 
     // AUTO  - InputStream
@@ -101,9 +115,9 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
     }
 
     @Test
-    public void inputStreamWithTransferEncoding() throws Exception
+    public void inputStreamWithTransferEncodingHeader() throws Exception
     {
-        final String url = getUrl("inputStreamWithTransferEncoding");
+        final String url = getUrl("inputStreamWithTransferEncodingHeader");
         testResponseIsChunkedEncoding(url);
     }
 
@@ -115,9 +129,16 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
     }
 
     @Test
-    public void inputStreamWithTransferEncodingAndContentLength() throws Exception
+    public void inputStreamWithTransferEncodingAndContentLengthHeader() throws Exception
     {
-        final String url = getUrl("inputStreamWithTransferEncodingAndContentLength");
+        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url);
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthOutboundProperty");
         testResponseIsContentLengthEncoding(url);
     }
 

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreamingTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreamingTestCase.java
@@ -91,6 +91,20 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
         testResponseIsContentLengthEncoding(url);
     }
 
+    @Test
+    public void stringWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingHeaderAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url);
+    }
+
+    @Test
+    public void stringWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingOutboundPropertyAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url);
+    }
+
     // AUTO  - InputStream
 
     @Test
@@ -139,6 +153,20 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
     public void inputStreamWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
     {
         final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url);
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url);
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader");
         testResponseIsContentLengthEncoding(url);
     }
 

--- a/modules/http/src/test/resources/http-listener-response-streaming-config.xml
+++ b/modules/http/src/test/resources/http-listener-response-streaming-config.xml
@@ -70,6 +70,26 @@
         <set-property propertyName="Content-Length" value="#[stringPayload.length()]"/>
     </flow>
 
+    <flow name="stringWithTransferEncodingHeaderAndContentLengthOutboundPropertyFlow">
+        <http:listener config-ref="listenerConfig" path="/stringWithTransferEncodingHeaderAndContentLengthOutboundProperty">
+            <http:response-builder>
+                <http:header headerName="Transfer-Encoding" value="chunked"/>
+            </http:response-builder>
+        </http:listener>
+        <set-payload value="#[stringPayload]"/>
+        <set-property propertyName="Content-Length" value="#[stringPayload.length()]"/>
+    </flow>
+
+    <flow name="stringWithTransferEncodingOutboundPropertyAndContentLengthHeaderFlow">
+        <http:listener config-ref="listenerConfig" path="/stringWithTransferEncodingOutboundPropertyAndContentLengthHeader">
+            <http:response-builder>
+                <http:header headerName="Transfer-Encoding" value="chunked"/>
+            </http:response-builder>
+        </http:listener>
+        <set-payload value="#[stringPayload]"/>
+        <set-property propertyName="Content-Length" value="#[stringPayload.length()]"/>
+    </flow>
+
     <flow name="inputStreamFlow">
         <http:listener config-ref="listenerConfig" path="/inputStream"/>
         <set-payload value="#[inputStreamPayload]"/>
@@ -119,6 +139,26 @@
         <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncodingAndContentLengthOutboundProperty"/>
         <set-payload value="#[inputStreamPayload]"/>
         <set-property propertyName="Content-Length" value="#[stringPayload.length()]"/>
+        <set-property propertyName="Transfer-Encoding" value="chunked"/>
+    </flow>
+
+    <flow name="inputStreamWithTransferEncodingHeaderAndContentLengthOutboundPropertyFlow">
+        <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty">
+            <http:response-builder>
+                <http:header headerName="Transfer-Encoding" value="chunked"/>
+            </http:response-builder>
+        </http:listener>
+        <set-payload value="#[inputStreamPayload]"/>
+        <set-property propertyName="Content-Length" value="#[stringPayload.length()]"/>
+    </flow>
+
+    <flow name="inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeaderFlow">
+        <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader">
+            <http:response-builder>
+                <http:header headerName="Content-Length" value="#[stringPayload.length()]"/>
+            </http:response-builder>
+        </http:listener>
+        <set-payload value="#[inputStreamPayload]"/>
         <set-property propertyName="Transfer-Encoding" value="chunked"/>
     </flow>
 

--- a/modules/http/src/test/resources/http-listener-response-streaming-config.xml
+++ b/modules/http/src/test/resources/http-listener-response-streaming-config.xml
@@ -38,7 +38,7 @@
     </flow>
 
     <flow name="stringWithTransferEncodingFlow">
-        <http:listener config-ref="listenerConfig" path="/stringWithTransferEncoding">
+        <http:listener config-ref="listenerConfig" path="/stringWithTransferEncodingHeader">
             <http:response-builder>
                 <http:header headerName="Transfer-Encoding" value="chunked"/>
             </http:response-builder>
@@ -51,6 +51,23 @@
         <http:listener config-ref="listenerConfig" path="/stringWithTransferEncodingOutboundProperty"/>
         <set-payload value="#[stringPayload]"/>
         <set-property propertyName="Transfer-Encoding" value="chunked"/>
+    </flow>
+
+    <flow name="stringWithTransferEncodingAndContentLengthFlow">
+        <http:listener config-ref="listenerConfig" path="/stringWithTransferEncodingAndContentLengthHeader">
+            <http:response-builder>
+                <http:header headerName="Transfer-Encoding" value="chunked"/>
+                <http:header headerName="Content-Length" value="#[stringPayload.length()]"/>
+            </http:response-builder>
+        </http:listener>
+        <set-payload value="#[stringPayload]"/>
+    </flow>
+
+    <flow name="stringWithTransferEncodingAndContentLengthOutboundPropertyFlow">
+        <http:listener config-ref="listenerConfig" path="/stringWithTransferEncodingAndContentLengthOutboundProperty"/>
+        <set-payload value="#[stringPayload]"/>
+        <set-property propertyName="Transfer-Encoding" value="chunked"/>
+        <set-property propertyName="Content-Length" value="#[stringPayload.length()]"/>
     </flow>
 
     <flow name="inputStreamFlow">
@@ -74,7 +91,7 @@
     </flow>
 
     <flow name="inputStreamWithTransferEncodingFlow">
-        <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncoding">
+        <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncodingHeader">
             <http:response-builder>
                 <http:header headerName="Transfer-Encoding" value="chunked"/>
             </http:response-builder>
@@ -89,13 +106,20 @@
     </flow>
 
     <flow name="inputStreamWithTransferEncodingAndContentLengthFlow">
-        <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncodingAndContentLength">
+        <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncodingAndContentLengthHeader">
             <http:response-builder>
                 <http:header headerName="Transfer-Encoding" value="chunked"/>
                 <http:header headerName="Content-Length" value="#[stringPayload.length()]"/>
             </http:response-builder>
         </http:listener>
         <set-payload value="#[inputStreamPayload]"/>
+    </flow>
+
+    <flow name="inputStreamWithTransferEncodingAndContentLengthOutboundPropertyFlow">
+        <http:listener config-ref="listenerConfig" path="/inputStreamWithTransferEncodingAndContentLengthOutboundProperty"/>
+        <set-payload value="#[inputStreamPayload]"/>
+        <set-property propertyName="Content-Length" value="#[stringPayload.length()]"/>
+        <set-property propertyName="Transfer-Encoding" value="chunked"/>
     </flow>
 
     <flow name="neverStringFlow">
@@ -110,7 +134,6 @@
             </http:response-builder>
         </http:listener>
         <set-payload value="#[stringPayload]"/>
-        <set-property propertyName="Transfer-Encoding" value="chunked"/>
     </flow>
 
     <flow name="neverStringTransferEncodingOutboundPropertyFlow" >


### PR DESCRIPTION
…s it is a hop-by-hop header