### PR TITLE
MULE-8163: Requests randomly fail (1 in 1M) with NPE

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
@@ -206,7 +206,18 @@ public class GrizzlyHttpClient implements HttpClient
         {
             // No timeout is used to get the value of the future object, as the responseTimeout configured in the request that
             // is being sent will make the call throw a {@code TimeoutException} if this time is exceeded.
-            return createMuleResponse(future.get());
+            Response response = future.get();
+
+            // Under high load, sometimes the get() method returns null. Retrying once fixes the problem (see MULE-8163).
+            if (response == null)
+            {
+                if (logger.isDebugEnabled())
+                {
+                    logger.debug("Null response returned by async client");
+                }
+                response = future.get();
+            }
+            return createMuleResponse(response);
         }
         catch (InterruptedException e)
         {


### PR DESCRIPTION
This change was tested in the proxy scenario and fixes the problem. No test is provided as we were unable to reproduce it locally.