### PR TITLE
MULE-8677: HTTP requestor should ignore 'Transfer-Encoding' property …

### DIFF
--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -8,6 +8,7 @@ Migration changes from 3.7.x to 3.8.x
 MULE-8626: The HTTP Connector will now ignore a "Connection" outbound property when responding to a request (listener) or making one (request), instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a response/request builder.
 MULE-8678: The HTTP Connector will now ignore a "Host" outbound property when making a request, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a request builder.
 MULE-8676: The HTTP Connector will now ignore a "Transfer-Encoding" outbound property when sending a response, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a response builder.
+MULE-8677: The HTTP Connector will now ignore a "Transfer-Encoding" outbound property when making a request, instead of transforming it to a header. This means that: if such property is desired, it should be explicitly added as a header using a request builder.
 
 Migration changes from 3.6.x to 3.7.x
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/request/MuleEventToHttpRequest.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/MuleEventToHttpRequest.java
@@ -43,10 +43,14 @@ import com.google.common.collect.Maps;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import javax.activation.DataHandler;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +58,7 @@ import org.slf4j.LoggerFactory;
 public class MuleEventToHttpRequest
 {
     private static final Logger logger = LoggerFactory.getLogger(MuleEventToHttpRequest.class);
+    private static final List<String> ignoredProperties = Arrays.asList(CONNECTION, HOST, TRANSFER_ENCODING);
 
     private DefaultHttpRequester requester;
     private MuleContext muleContext;
@@ -104,9 +109,20 @@ public class MuleEventToHttpRequest
 
     private boolean isNotIgnoredProperty(String outboundProperty)
     {
-        return !outboundProperty.startsWith(HTTP_PREFIX) && !outboundProperty.equalsIgnoreCase(CONNECTION) && !outboundProperty.equalsIgnoreCase(HOST);
+        return !outboundProperty.startsWith(HTTP_PREFIX) && !equalsIgnoredProperty(outboundProperty);
     }
 
+    private boolean equalsIgnoredProperty(final String outboundProperty)
+    {
+        return CollectionUtils.exists(ignoredProperties, new Predicate()
+        {
+            @Override
+            public boolean evaluate(Object propertyName)
+            {
+                return outboundProperty.equalsIgnoreCase((String) propertyName);
+            }
+        });
+    }
 
     private HttpEntity createRequestEntity(HttpRequestBuilder requestBuilder, MuleEvent muleEvent, String resolvedMethod) throws MessagingException
     {

--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestHeadersTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestHeadersTestCase.java
@@ -15,6 +15,8 @@ import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_LIST
 import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_SCHEME;
 import static org.mule.module.http.api.HttpHeaders.Names.CONNECTION;
 import static org.mule.module.http.api.HttpHeaders.Names.HOST;
+import static org.mule.module.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
+import static org.mule.module.http.api.HttpHeaders.Values.CHUNKED;
 import static org.mule.module.http.api.HttpHeaders.Values.CLOSE;
 import org.mule.api.MuleEvent;
 import org.mule.construct.Flow;
@@ -34,6 +36,8 @@ public class HttpRequestHeadersTestCase extends AbstractHttpRequestTestCase
 
     @Rule
     public SystemProperty host = new SystemProperty("host" , "localhost");
+    @Rule
+    public SystemProperty encoding = new SystemProperty("encoding" , CHUNKED);
 
     @Override
     protected String getConfigFile()
@@ -178,6 +182,24 @@ public class HttpRequestHeadersTestCase extends AbstractHttpRequestTestCase
         processEventInFlow(event, "outboundProperties");
 
         assertThat(getFirstReceivedHeader(HOST), is(not(host.getValue())));
+    }
+
+    @Test
+    public void acceptsTransferEncodingHeader() throws Exception
+    {
+        processEventInFlow(getTestEvent(TEST_MESSAGE), "transferEncodingHeader");
+
+        assertThat(getFirstReceivedHeader(TRANSFER_ENCODING), is(encoding.getValue()));
+    }
+
+    @Test
+    public void ignoresTransferEncodingOutboundProperty() throws Exception
+    {
+        MuleEvent event = getTestEvent(TEST_MESSAGE);
+        event.getMessage().setOutboundProperty(TRANSFER_ENCODING, encoding.getValue());
+        processEventInFlow(event, "outboundProperties");
+
+        assertThat(headers.asMap(), not(hasKey(TRANSFER_ENCODING)));
     }
 
     private void processEventInFlow(MuleEvent event, String flowName) throws Exception

--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestStreamingTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestStreamingTestCase.java
@@ -41,6 +41,8 @@ public class HttpRequestStreamingTestCase extends AbstractHttpRequestTestCase
         return "http-request-streaming-config.xml";
     }
 
+    //AUTO
+
     @Test
     public void streamsWhenPayloadIsInputStreamAndStreamingModeAuto() throws Exception
     {
@@ -64,21 +66,58 @@ public class HttpRequestStreamingTestCase extends AbstractHttpRequestTestCase
     }
 
     @Test
+    public void doesNotStreamStringWithContentLengthHeaderAndStreamingModeAuto() throws Exception
+    {
+        MuleEvent event = getTestEvent(TEST_MESSAGE);
+        event.getMessage().setOutboundProperty(CONTENT_LENGTH, TEST_MESSAGE.length());
+        assertNoStreaming("streamingAuto", event);
+    }
+
+    @Test
     public void doesNotStreamWithContentLengthTransferEncodingHeadersAndStreamingModeAuto() throws Exception
     {
         MuleEvent event = getTestEvent(new ByteArrayInputStream(TEST_MESSAGE.getBytes()));
         event.getMessage().setOutboundProperty(CONTENT_LENGTH, TEST_MESSAGE.length());
-        event.getMessage().setOutboundProperty(TRANSFER_ENCODING, CHUNKED);
-        assertNoStreaming("streamingAuto", event);
+        assertNoStreaming("streamingAutoHeader", event);
+    }
+
+    @Test
+    public void doesNotStreamStringWithContentLengthTransferEncodingHeadersAndStreamingModeAuto() throws Exception
+    {
+        MuleEvent event = getTestEvent(TEST_MESSAGE);
+        event.getMessage().setOutboundProperty(CONTENT_LENGTH, TEST_MESSAGE.length());
+        assertNoStreaming("streamingAutoHeader", event);
     }
 
     @Test
     public void streamsWhenPayloadIsStringTransferEncodingHeaderAndStreamingModeAuto() throws Exception
     {
+        assertStreaming("streamingAutoHeader", getTestEvent(TEST_MESSAGE));
+    }
+
+    @Test
+    public void doesNotStreamWhenPayloadIsStringTransferEncodingPropertyAndStreamingModeAuto() throws Exception
+    {
         MuleEvent event = getTestEvent(TEST_MESSAGE);
         event.getMessage().setOutboundProperty(TRANSFER_ENCODING, CHUNKED);
-        assertStreaming("streamingAuto", event);
+        assertNoStreaming("streamingAuto", event);
     }
+
+    @Test
+    public void streamsWhenPayloadIsInputStreamTransferEncodingHeaderAndStreamingModeAuto() throws Exception
+    {
+        assertStreaming("streamingAutoHeader", getTestEvent(new ByteArrayInputStream(TEST_MESSAGE.getBytes())));
+    }
+
+    @Test
+    public void streamsWhenPayloadIsInputStreamTransferEncodingPropertyAndStreamingModeAuto() throws Exception
+    {
+        MuleEvent event = getTestEvent(new ByteArrayInputStream(TEST_MESSAGE.getBytes()));
+        event.getMessage().setOutboundProperty(TRANSFER_ENCODING, CHUNKED);
+        assertStreaming("streamingAutoHeader", event);
+    }
+
+    //ALWAYS
 
     @Test
     public void streamsWhenStreamingModeAlways() throws Exception
@@ -110,6 +149,7 @@ public class HttpRequestStreamingTestCase extends AbstractHttpRequestTestCase
         assertStreaming("streamingAlways", event);
     }
 
+    //NEVER
 
     @Test
     public void doesNotStreamWhenStreamingModeNever() throws Exception

--- a/modules/http/src/test/resources/http-request-headers-config.xml
+++ b/modules/http/src/test/resources/http-request-headers-config.xml
@@ -51,13 +51,21 @@
     </flow>
 
     <flow name="outboundProperties">
-        <http:request config-ref="config" path="testPath" />
+        <http:request config-ref="config" path="testPath" method="POST"/>
     </flow>
 
     <flow name="hostHeader">
         <http:request config-ref="config" path="testPath" >
             <http:request-builder>
                 <http:header headerName="Host" value="${host}" />
+            </http:request-builder>
+        </http:request>
+    </flow>
+
+    <flow name="transferEncodingHeader">
+        <http:request config-ref="config" path="testPath" method="POST">
+            <http:request-builder>
+                <http:header headerName="Transfer-Encoding" value="${encoding}" />
             </http:request-builder>
         </http:request>
     </flow>

--- a/modules/http/src/test/resources/http-request-streaming-config.xml
+++ b/modules/http/src/test/resources/http-request-streaming-config.xml
@@ -14,6 +14,14 @@
         <http:request config-ref="requestConfig"  method="POST" path="path" />
     </flow>
 
+    <flow name="streamingAutoHeader">
+        <http:request config-ref="requestConfig"  method="POST" path="path">
+            <http:request-builder>
+                <http:header headerName="Transfer-Encoding" value="chunked" />
+            </http:request-builder>
+        </http:request>
+    </flow>
+
     <flow name="streamingAlways">
         <vm:inbound-endpoint path="streamingAlwaysIn" />
         <http:request config-ref="requestConfig"  method="POST" path="path" requestStreamingMode="ALWAYS" />


### PR DESCRIPTION
…as it is a hop-by-hop header