### PR TITLE
MULE-8734: Locks are not being destroyed

### DIFF
--- a/core/src/main/java/org/mule/util/lock/InstanceLockGroup.java
+++ b/core/src/main/java/org/mule/util/lock/InstanceLockGroup.java
@@ -56,12 +56,12 @@ public class InstanceLockGroup implements LockGroup
             if (lockEntry != null)
             {
                 lockEntry.decrementLockCount();
+                lockEntry.getLock().unlock();
                 if (!lockEntry.hasPendingLocks())
                 {
                     locks.remove(key);
+                    lockProvider.destroyLock(lockEntry.getLock());
                 }
-                lockEntry.getLock().unlock();
-                lockProvider.destroyLock(lockEntry.getLock());
             }
             lockAccessMonitor.notifyAll();
         }

--- a/core/src/main/java/org/mule/util/lock/InstanceLockGroup.java
+++ b/core/src/main/java/org/mule/util/lock/InstanceLockGroup.java
@@ -61,6 +61,7 @@ public class InstanceLockGroup implements LockGroup
                     locks.remove(key);
                 }
                 lockEntry.getLock().unlock();
+                lockProvider.destroyLock(lockEntry.getLock());
             }
             lockAccessMonitor.notifyAll();
         }
@@ -92,6 +93,7 @@ public class InstanceLockGroup implements LockGroup
                 if (!lockEntry.hasPendingLocks())
                 {
                     locks.remove(lockId);
+                    lockProvider.destroyLock(lockEntry.getLock());
                 }
             }
         }
@@ -125,6 +127,7 @@ public class InstanceLockGroup implements LockGroup
                 if (!lockEntry.hasPendingLocks())
                 {
                     locks.remove(lockId);
+                    lockProvider.destroyLock(lockEntry.getLock());
                 }
             }
         }
@@ -188,6 +191,10 @@ public class InstanceLockGroup implements LockGroup
     {
         synchronized (lockAccessMonitor)
         {
+            for (LockEntry lockEntry : locks.values())
+            {
+                lockProvider.destroyLock(lockEntry.getLock());
+            }
             locks.clear();
         }
     }

--- a/core/src/main/java/org/mule/util/lock/LockProvider.java
+++ b/core/src/main/java/org/mule/util/lock/LockProvider.java
@@ -25,4 +25,10 @@ public interface LockProvider
      */
     Lock createLock(String lockId);
 
+    /**
+     * Destroys a previously created {@link Lock} using {@link #createLock}
+     * 
+     * @param lock {@link Lock} instance previously created
+     */
+    void destroyLock(Lock lock);
 }

--- a/core/src/main/java/org/mule/util/lock/SingleServerLockProvider.java
+++ b/core/src/main/java/org/mule/util/lock/SingleServerLockProvider.java
@@ -20,4 +20,9 @@ public class SingleServerLockProvider implements LockProvider
         return new ReentrantLock(true);
     }
 
+    @Override
+    public void destroyLock(Lock lock)
+    {
+        //Nothing to do.
+    }
 }

--- a/core/src/test/java/org/mule/util/lock/InstanceLockGroupTestCase.java
+++ b/core/src/test/java/org/mule/util/lock/InstanceLockGroupTestCase.java
@@ -79,6 +79,7 @@ public class InstanceLockGroupTestCase extends AbstractMuleTestCase
         }
         instanceLockGroup.unlock("lockId");
         Mockito.verify(mockLockProvider, VerificationModeFactory.times(1)).createLock("lockId");
+        Mockito.verify(mockLockProvider,VerificationModeFactory.times(1)).destroyLock(Mockito.any(Lock.class));
     }
 
 

--- a/core/src/test/java/org/mule/util/lock/InstanceLockGroupTestCase.java
+++ b/core/src/test/java/org/mule/util/lock/InstanceLockGroupTestCase.java
@@ -9,6 +9,8 @@ package org.mule.util.lock;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 import org.mule.api.store.ObjectAlreadyExistsException;
 import org.mule.api.store.ObjectStore;
 import org.mule.api.store.ObjectStoreException;
@@ -28,7 +30,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.Mockito;
-import org.mockito.internal.verification.VerificationModeFactory;
 
 public class InstanceLockGroupTestCase extends AbstractMuleTestCase
 {
@@ -56,14 +57,12 @@ public class InstanceLockGroupTestCase extends AbstractMuleTestCase
     }
     
     @Test
-    @Ignore("MULE-6926: Flaky Test")
     public void testWhenUnlockThenDestroy() throws Exception
     {
         lockUnlockThenDestroy(1);
     }
 
     @Test
-    @Ignore("MULE-6926: Flaky Test")
     public void testWhenSeveralLockOneUnlockThenDestroy() throws Exception
     {
         lockUnlockThenDestroy(5);
@@ -77,9 +76,14 @@ public class InstanceLockGroupTestCase extends AbstractMuleTestCase
         {
             instanceLockGroup.lock("lockId");
         }
+        for (int i = 0; i < lockTimes - 1; i++)
+        {
+            instanceLockGroup.unlock("lockId");
+        }
+        verify(mockLockProvider, times(1)).createLock("lockId");
+        verify(mockLockProvider, times(0)).destroyLock(Mockito.any(Lock.class));
         instanceLockGroup.unlock("lockId");
-        Mockito.verify(mockLockProvider, VerificationModeFactory.times(1)).createLock("lockId");
-        Mockito.verify(mockLockProvider,VerificationModeFactory.times(1)).destroyLock(Mockito.any(Lock.class));
+        verify(mockLockProvider, times(1)).destroyLock(Mockito.any(Lock.class));
     }
 
 


### PR DESCRIPTION
This PR contains two commits: a revert of a change where the destroyLock method was removed, and the changes needed to destroy the locks correctly (only after they are not used anymore, not after every unlock).