### PR TITLE
MULE-8770: Memory leak caused by per-app logging

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
@@ -100,7 +100,8 @@ public class DefaultMuleApplication implements Application
                 throw new InstallException(MessageFactory.createStaticMessage(message));
             }
         }
-        deploymentClassLoader = applicationClassLoaderFactory.create(descriptor);
+
+        initDeploymentClassLoader();
     }
 
     @Override
@@ -299,6 +300,7 @@ public class DefaultMuleApplication implements Application
         {
             // kill any refs to the old classloader to avoid leaks
             Thread.currentThread().setContextClassLoader(null);
+            deploymentClassLoader = null;
         }
     }
 
@@ -317,7 +319,20 @@ public class DefaultMuleApplication implements Application
     @Override
     public ArtifactClassLoader getArtifactClassLoader()
     {
+        if (deploymentClassLoader == null)
+        {
+            initDeploymentClassLoader();
+        }
+
         return deploymentClassLoader;
+    }
+
+    private synchronized void initDeploymentClassLoader()
+    {
+        if (deploymentClassLoader == null)
+        {
+            deploymentClassLoader = applicationClassLoaderFactory.create(descriptor);
+        }
     }
 
     @Override

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/AbstractArtifactClassLoader.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/AbstractArtifactClassLoader.java
@@ -56,6 +56,15 @@ public abstract class AbstractArtifactClassLoader extends FineGrainedControlClas
     @Override
     public void dispose()
     {
+        try
+        {
+            createResourceReleaserInstance().release();
+        }
+        catch (Exception e)
+        {
+            logger.error(e);
+        }
+
         for (ShutdownListener listener : shutdownListeners)
         {
             try
@@ -66,15 +75,6 @@ public abstract class AbstractArtifactClassLoader extends FineGrainedControlClas
             {
                 logger.error(e);
             }
-        }
-
-        try
-        {
-            createResourceReleaserInstance().release();
-        }
-        catch (Exception e)
-        {
-            logger.error(e);
         }
 
         super.dispose();


### PR DESCRIPTION
_ Executing ResourceReleaser before executing shutdownListeners
_ Cleaning application classloader when app is disposed