### PR TITLE
MULE-8707: Classloader leak using Oracle JDBC Driver

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/DefaultResourceReleaser.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/DefaultResourceReleaser.java
@@ -60,7 +60,7 @@ public class DefaultResourceReleaser implements ResourceReleaser
 
     private void deregisterOracleDiagnosabilityMBean()
     {
-        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        final ClassLoader cl = this.getClass().getClassLoader();
         final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
         final Hashtable<String, String> keys = new Hashtable<String, String>();
         keys.put("type", DIAGNOSABILITY_BEAN_NAME);


### PR DESCRIPTION
Need to use the same classlaoder that loaded the resource releaser instead of the one from the context, as they could be different in runtime depending on the application classloading model being used