### PR TITLE
MULE-8426: Flow and session variables null after WS Consumer timeout

### DIFF
--- a/modules/ws/src/test/java/org/mule/module/ws/functional/TimeoutFunctionalTestCase.java
+++ b/modules/ws/src/test/java/org/mule/module/ws/functional/TimeoutFunctionalTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.ws.functional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleEventContext;
+import org.mule.api.MuleMessage;
+import org.mule.construct.Flow;
+import org.mule.tck.functional.EventCallback;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.util.concurrent.Latch;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TimeoutFunctionalTestCase extends FunctionalTestCase
+{
+
+    @Rule
+    public DynamicPort dynamicPort = new DynamicPort("port");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "timeout-config.xml";
+    }
+
+    @Test
+    public void flowAndSessionVarsAreNotRemovedAfterTimeout() throws Exception
+    {
+        final Latch serverLatch = new Latch();
+
+        getFunctionalTestComponent("server").setEventCallback(new EventCallback()
+        {
+            @Override
+            public void eventReceived(MuleEventContext context, Object component) throws Exception
+            {
+                serverLatch.await();
+            }
+        });
+
+        Flow flow = (Flow) getFlowConstruct("client");
+
+        MuleEvent event = getTestEvent("<echo/>");
+        event.setTimeout(1);
+
+        flow.process(event);
+        serverLatch.release();
+
+        MuleMessage message = muleContext.getClient().request("vm://out", RECEIVE_TIMEOUT);
+
+        assertThat(message.<String>getInboundProperty("flowVar"), equalTo("testFlowVar"));
+        assertThat(message.<String>getInboundProperty("sessionVar"), equalTo("testSessionVar"));
+    }
+}

--- a/modules/ws/src/test/resources/timeout-config.xml
+++ b/modules/ws/src/test/resources/timeout-config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:ws="http://www.mulesoft.org/schema/mule/ws"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+               http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+               http://www.mulesoft.org/schema/mule/ws http://www.mulesoft.org/schema/mule/ws/current/mule-ws.xsd">
+
+    <flow name="server">
+        <inbound-endpoint address="http://localhost:${port}/services/Test"/>
+        <test:component />
+    </flow>
+
+    <ws:consumer-config serviceAddress="http://localhost:${port}/services/Test" wsdlLocation="Test.wsdl"
+                        service="TestService" port="TestPort" name="globalConfig" />
+
+    <flow name="client" processingStrategy="synchronous">
+
+        <set-variable variableName="flowVarName" value="testFlowVar" />
+        <set-session-variable variableName="sessionVarName" value="testSessionVar" />
+
+        <ws:consumer operation="echo"/>
+
+        <catch-exception-strategy>
+            <set-property propertyName="flowVar" value="#[flowVars['flowVarName']]" />
+            <set-property propertyName="sessionVar" value="#[sessionVars['sessionVarName']]" />
+            <vm:outbound-endpoint address="vm://out" />
+        </catch-exception-strategy>
+    </flow>
+
+</mule>


### PR DESCRIPTION
Added test case. This problem was fixed for 3.6.3 and 3.7.0 in MULE-8318.