### PR TITLE
MULE-8798: Message mime type/encoding must be reset when payload is s…

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleMessage.java
+++ b/core/src/main/java/org/mule/DefaultMuleMessage.java
@@ -434,7 +434,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
         // message. This is the only time this method will alter the payload on the message
         if (isPayloadConsumed(source.getType()))
         {
-            setPayload(result);
+            setPayload(result, dataType);
         }
 
         return (T) result;


### PR DESCRIPTION
…et without a datatype

_ Keeping datatype when message is transformed when getPayloadAsX is used and original payload is consumable