### PR TITLE
MULE-8831: Cached MVEL Compiled expressions are not immutable

### DIFF
--- a/core/src/main/java/org/apache/commons/io/input/ClassLoaderObjectInputStream.java
+++ b/core/src/main/java/org/apache/commons/io/input/ClassLoaderObjectInputStream.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.io.StreamCorruptedException;
+import java.lang.reflect.Proxy;
+
+/**
+ * A special ObjectInputStream that loads a class based on a specified
+ * <code>ClassLoader</code> rather than the system default.
+ * <p>
+ * This is useful in dynamic container environments.
+ *
+ * @version $Id$
+ * @since 1.1
+ */
+public class ClassLoaderObjectInputStream extends ObjectInputStream {
+
+    /** The class loader to use. */
+    private final ClassLoader classLoader;
+
+    /**
+     * Constructs a new ClassLoaderObjectInputStream.
+     *
+     * @param classLoader  the ClassLoader from which classes should be loaded
+     * @param inputStream  the InputStream to work on
+     * @throws IOException in case of an I/O error
+     * @throws StreamCorruptedException if the stream is corrupted
+     */
+    public ClassLoaderObjectInputStream(
+            final ClassLoader classLoader, final InputStream inputStream)
+            throws IOException, StreamCorruptedException {
+        super(inputStream);
+        this.classLoader = classLoader;
+    }
+
+    /**
+     * Resolve a class specified by the descriptor using the
+     * specified ClassLoader or the super ClassLoader.
+     *
+     * @param objectStreamClass  descriptor of the class
+     * @return the Class object described by the ObjectStreamClass
+     * @throws IOException in case of an I/O error
+     * @throws ClassNotFoundException if the Class cannot be found
+     */
+    @Override
+    protected Class<?> resolveClass(final ObjectStreamClass objectStreamClass)
+            throws IOException, ClassNotFoundException {
+
+        try {
+            return Class.forName(objectStreamClass.getName(), false, classLoader);
+        } catch (ClassNotFoundException cnfe) {
+            // delegate to super class loader which can resolve primitives
+            return super.resolveClass(objectStreamClass);
+        }
+    }
+
+    /**
+     * Create a proxy class that implements the specified interfaces using
+     * the specified ClassLoader or the super ClassLoader.
+     *
+     * @param interfaces the interfaces to implement
+     * @return a proxy class implementing the interfaces
+     * @throws IOException in case of an I/O error
+     * @throws ClassNotFoundException if the Class cannot be found
+     * @see java.io.ObjectInputStream#resolveProxyClass(java.lang.String[])
+     * @since 2.1
+     */
+    @Override
+    protected Class<?> resolveProxyClass(final String[] interfaces) throws IOException,
+                                                                           ClassNotFoundException {
+        final Class<?>[] interfaceClasses = new Class[interfaces.length];
+        for (int i = 0; i < interfaces.length; i++) {
+            interfaceClasses[i] = Class.forName(interfaces[i], false, classLoader);
+        }
+        try {
+            return Proxy.getProxyClass(classLoader, interfaceClasses);
+        } catch (final IllegalArgumentException e) {
+            return super.resolveProxyClass(interfaces);
+        }
+    }
+
+}

--- a/core/src/main/java/org/mule/el/mvel/MVELExpressionExecutor.java
+++ b/core/src/main/java/org/mule/el/mvel/MVELExpressionExecutor.java
@@ -10,6 +10,7 @@ package org.mule.el.mvel;
 import org.mule.api.MuleRuntimeException;
 import org.mule.api.el.ExpressionExecutor;
 import org.mule.api.expression.InvalidExpressionException;
+import org.mule.api.serialization.ObjectSerializer;
 import org.mule.mvel2.MVEL;
 import org.mule.mvel2.ParserConfiguration;
 import org.mule.mvel2.ParserContext;
@@ -40,12 +41,14 @@ public class MVELExpressionExecutor implements ExpressionExecutor<MVELExpression
     protected static final int COMPILED_EXPRESSION_MAX_CACHE_SIZE = 1000;
 
     protected ParserConfiguration parserConfiguration;
+    protected final ObjectSerializer objectSerializer;
 
     protected LoadingCache<String, Serializable> compiledExpressionsCache;
 
-    public MVELExpressionExecutor(final ParserConfiguration parserConfiguration)
+    public MVELExpressionExecutor(final ParserConfiguration parserConfiguration, ObjectSerializer objectSerializer)
     {
         this.parserConfiguration = parserConfiguration;
+        this.objectSerializer = objectSerializer;
 
         MVEL.COMPILER_OPT_PROPERTY_ACCESS_DOESNT_FAIL = true;
         OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
@@ -69,7 +72,8 @@ public class MVELExpressionExecutor implements ExpressionExecutor<MVELExpression
         {
             log.trace("Executing MVEL expression '" + expression + "' with context: \n" + context.toString());
         }
-        return MVEL.executeExpression(getCompiledExpression(expression), context);
+        Serializable compiledExpression = getCompiledExpression(expression);
+        return MVEL.executeExpression(compiledExpression, context);
     }
 
     @Override
@@ -89,7 +93,10 @@ public class MVELExpressionExecutor implements ExpressionExecutor<MVELExpression
     {
         try
         {
-            return compiledExpressionsCache.getUnchecked(expression);
+            Serializable serializedExpression = compiledExpressionsCache.getUnchecked(expression);
+
+            byte[] serialized = objectSerializer.serialize(serializedExpression);
+            return (Serializable) objectSerializer.deserialize(serialized);
         }
         catch (UncheckedExecutionException e)
         {

--- a/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguage.java
+++ b/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguage.java
@@ -77,7 +77,7 @@ public class MVELExpressionLanguage implements ExpressionLanguage, Initialisable
     public void initialise() throws InitialisationException
     {
         parserConfiguration = createParserConfiguration(imports);
-        expressionExecutor = new MVELExpressionExecutor(parserConfiguration);
+        expressionExecutor = new MVELExpressionExecutor(parserConfiguration, muleContext.getObjectSerializer());
 
         loadGlobalFunctions();
         createStaticContext();

--- a/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguageContext.java
+++ b/core/src/main/java/org/mule/el/mvel/MVELExpressionLanguageContext.java
@@ -118,7 +118,7 @@ public class MVELExpressionLanguageContext extends MuleBaseVariableResolverFacto
     @Override
     public void addAlias(String alias, String expression)
     {
-        addResolver(alias, new MuleAliasVariableResolver(alias, expression, this, parserConfiguration));
+        addResolver(alias, new MuleAliasVariableResolver(alias, expression, this, muleContext.getObjectSerializer()));
     }
 
     @Override

--- a/core/src/main/java/org/mule/el/mvel/MuleAliasVariableResolver.java
+++ b/core/src/main/java/org/mule/el/mvel/MuleAliasVariableResolver.java
@@ -6,7 +6,7 @@
  */
 package org.mule.el.mvel;
 
-import org.mule.mvel2.ParserConfiguration;
+import org.mule.api.serialization.ObjectSerializer;
 
 class MuleAliasVariableResolver extends MuleVariableResolver<Object>
 {
@@ -18,12 +18,12 @@ class MuleAliasVariableResolver extends MuleVariableResolver<Object>
     public MuleAliasVariableResolver(String name,
                                      String expression,
                                      MVELExpressionLanguageContext context,
-                                     ParserConfiguration parserConfiguration)
+                                     ObjectSerializer objectSerializer)
     {
         super(name, null, null, null);
         this.expression = expression;
         this.context = context;
-        this.executor = new MVELExpressionExecutor(context.parserConfiguration);
+        this.executor = new MVELExpressionExecutor(context.parserConfiguration, objectSerializer);
     }
 
     public MuleAliasVariableResolver(MuleAliasVariableResolver aliasVariableResolver,

--- a/core/src/test/java/org/mule/el/ExpressionLanguageEnrichmentTestCase.java
+++ b/core/src/test/java/org/mule/el/ExpressionLanguageEnrichmentTestCase.java
@@ -20,6 +20,7 @@ import org.mule.config.DefaultMuleConfiguration;
 import org.mule.construct.Flow;
 import org.mule.el.context.AbstractELTestCase;
 import org.mule.expression.DefaultExpressionManager;
+import org.mule.serialization.internal.JavaObjectSerializer;
 import org.mule.tck.size.SmallTest;
 import org.mule.tck.testmodels.fruit.Apple;
 import org.mule.tck.testmodels.fruit.Fruit;
@@ -55,6 +56,9 @@ public class ExpressionLanguageEnrichmentTestCase extends AbstractELTestCase
         MuleRegistry muleRegistry = mock(MuleRegistry.class);
         Mockito.when(muleContext.getConfiguration()).thenReturn(new DefaultMuleConfiguration());
         Mockito.when(muleContext.getRegistry()).thenReturn(muleRegistry);
+        JavaObjectSerializer objectSerializer = new JavaObjectSerializer();
+        objectSerializer.setMuleContext(muleContext);
+        Mockito.when(muleContext.getObjectSerializer()).thenReturn(objectSerializer);
         Mockito.when(muleRegistry.lookupObjectsForLifecycle(Mockito.any(Class.class))).thenReturn(
             Collections.<Object> emptyList());
         expressionManager.setMuleContext(muleContext);

--- a/core/src/test/java/org/mule/el/function/DateTimeExpressionLanguageFunctionTestCase.java
+++ b/core/src/test/java/org/mule/el/function/DateTimeExpressionLanguageFunctionTestCase.java
@@ -38,7 +38,7 @@ public class DateTimeExpressionLanguageFunctionTestCase extends AbstractMuleTest
     public void setup() throws InitialisationException
     {
         ParserConfiguration parserConfiguration = new ParserConfiguration();
-        expressionExecutor = new MVELExpressionExecutor(parserConfiguration);
+        expressionExecutor = new MVELExpressionExecutor(parserConfiguration, null);
         context = new MVELExpressionLanguageContext(parserConfiguration, Mockito.mock(MuleContext.class));
         dateTimeFunction = new DateTimeExpressionLanguageFuntion();
         context.declareFunction("dateTime", dateTimeFunction);

--- a/core/src/test/java/org/mule/el/function/RegexExpressionLanguageFunctionTestCase.java
+++ b/core/src/test/java/org/mule/el/function/RegexExpressionLanguageFunctionTestCase.java
@@ -9,6 +9,8 @@ package org.mule.el.function;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
 
 import org.mule.api.MuleContext;
 import org.mule.api.MuleMessage;
@@ -20,6 +22,7 @@ import org.mule.el.mvel.MVELExpressionExecutor;
 import org.mule.el.mvel.MVELExpressionLanguageContext;
 import org.mule.mvel2.CompileException;
 import org.mule.mvel2.ParserConfiguration;
+import org.mule.serialization.internal.JavaObjectSerializer;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -42,8 +45,11 @@ public class RegexExpressionLanguageFunctionTestCase extends AbstractMuleTestCas
     public void setup() throws InitialisationException
     {
         ParserConfiguration parserConfiguration = new ParserConfiguration();
-        expressionExecutor = new MVELExpressionExecutor(parserConfiguration);
-        context = new MVELExpressionLanguageContext(parserConfiguration, Mockito.mock(MuleContext.class));
+        MuleContext muleContext = mock(MuleContext.class, RETURNS_DEEP_STUBS);
+        JavaObjectSerializer objectSerializer = new JavaObjectSerializer();
+        objectSerializer.setMuleContext(muleContext);
+        expressionExecutor = new MVELExpressionExecutor(parserConfiguration, objectSerializer);
+        context = new MVELExpressionLanguageContext(parserConfiguration, muleContext);
         regexFuntion = new RegexExpressionLanguageFuntion();
         context.declareFunction("regex", regexFuntion);
     }
@@ -215,7 +221,7 @@ public class RegexExpressionLanguageFunctionTestCase extends AbstractMuleTestCas
 
     protected void addMessageToContextWithPayload(String payload) throws TransformerException
     {
-        MuleMessage message = Mockito.mock(MuleMessage.class);
+        MuleMessage message = mock(MuleMessage.class);
         Mockito.when(message.getPayload(Mockito.any(Class.class))).thenReturn(payload);
         context.addFinalVariable("message", new MessageContext(message));
     }

--- a/core/src/test/java/org/mule/el/function/WildcardExpressionLanguageFunctionTestCase.java
+++ b/core/src/test/java/org/mule/el/function/WildcardExpressionLanguageFunctionTestCase.java
@@ -8,6 +8,8 @@ package org.mule.el.function;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
 
 import org.mule.api.MuleContext;
 import org.mule.api.MuleMessage;
@@ -19,6 +21,7 @@ import org.mule.el.mvel.MVELExpressionExecutor;
 import org.mule.el.mvel.MVELExpressionLanguageContext;
 import org.mule.mvel2.CompileException;
 import org.mule.mvel2.ParserConfiguration;
+import org.mule.serialization.internal.JavaObjectSerializer;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -40,8 +43,11 @@ public class WildcardExpressionLanguageFunctionTestCase extends AbstractMuleTest
     public void setup() throws InitialisationException
     {
         ParserConfiguration parserConfiguration = new ParserConfiguration();
-        expressionExecutor = new MVELExpressionExecutor(parserConfiguration);
-        context = new MVELExpressionLanguageContext(parserConfiguration, Mockito.mock(MuleContext.class));
+        MuleContext muleContext = mock(MuleContext.class, RETURNS_DEEP_STUBS);
+        JavaObjectSerializer objectSerializer = new JavaObjectSerializer();
+        objectSerializer.setMuleContext(muleContext);
+        expressionExecutor = new MVELExpressionExecutor(parserConfiguration, objectSerializer);
+        context = new MVELExpressionLanguageContext(parserConfiguration, muleContext);
         wildcardFunction = new WildcardExpressionLanguageFuntion();
         context.declareFunction("wildcard", wildcardFunction);
     }
@@ -228,7 +234,7 @@ public class WildcardExpressionLanguageFunctionTestCase extends AbstractMuleTest
     @SuppressWarnings("unchecked")
     protected void addMessageToContextWithPayload(String payload) throws TransformerException
     {
-        MuleMessage message = Mockito.mock(MuleMessage.class);
+        MuleMessage message = mock(MuleMessage.class);
         Mockito.when(message.getPayload(Mockito.any(Class.class))).thenReturn(payload);
         context.addFinalVariable("message", new MessageContext(message));
     }

--- a/core/src/test/java/org/mule/el/mvel/CachedMvelCompiledExpressionTestCase.java
+++ b/core/src/test/java/org/mule/el/mvel/CachedMvelCompiledExpressionTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.el.mvel;
+
+import static org.junit.Assert.assertThat;
+import org.mule.api.el.ExpressionLanguage;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class CachedMvelCompiledExpressionTestCase extends AbstractMuleContextTestCase
+{
+
+    public static final String VARIABLE = "VARIABLE";
+    public static final String ASSIGNMENT_EXPRESSION = "payload.details=" + VARIABLE;
+
+    @Test
+    public void createsNewCompiledExpressionInstances() throws Exception
+    {
+        ExpressionLanguage expressionLanguage = muleContext.getExpressionLanguage();
+
+        Map<String, Object> vars = new HashMap();
+        vars.put(VARIABLE, new FooDetails());
+        expressionLanguage.evaluate(ASSIGNMENT_EXPRESSION, getTestEvent(new Foo()), vars);
+
+
+        BarDetails barDetails = new BarDetails();
+        vars.put(VARIABLE, barDetails);
+        Object result = expressionLanguage.evaluate(ASSIGNMENT_EXPRESSION, getTestEvent(new Bar()), vars);
+        assertThat(result, Matchers.<Object>equalTo(barDetails));
+    }
+
+    public static class Foo
+    {
+
+        public FooDetails details;
+
+    }
+
+    public static class FooDetails
+    {
+
+    }
+
+    public static class Bar
+    {
+
+        public BarDetails details;
+
+    }
+
+    public static class BarDetails
+    {
+
+    }
+}

--- a/core/src/test/java/org/mule/el/mvel/MVELExpressionExecutorTestCase.java
+++ b/core/src/test/java/org/mule/el/mvel/MVELExpressionExecutorTestCase.java
@@ -38,7 +38,7 @@ public class MVELExpressionExecutorTestCase extends AbstractELTestCase
     @Before
     public void setupMVEL() throws InitialisationException
     {
-        mvel = new MVELExpressionExecutor(new ParserConfiguration());
+        mvel = new MVELExpressionExecutor(new ParserConfiguration(), muleContext.getObjectSerializer());
         context = Mockito.mock(MVELExpressionLanguageContext.class);
         Mockito.when(context.isResolveable(Mockito.anyString())).thenReturn(false);
     }
@@ -76,10 +76,12 @@ public class MVELExpressionExecutorTestCase extends AbstractELTestCase
     @Test
     public void useContextClassLoader() throws ClassNotFoundException
     {
+        MyClassClassLoader classLoader = new MyClassClassLoader();
+        muleContext.setExecutionClassLoader(classLoader);
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try
         {
-            Thread.currentThread().setContextClassLoader(new MyClassClassLoader());
+            Thread.currentThread().setContextClassLoader(classLoader);
             assertFalse((Boolean) mvel.execute("1 is org.MyClass", null));
         }
         catch (Exception e)

--- a/pom.xml
+++ b/pom.xml
@@ -1771,6 +1771,7 @@
                             <exclude>**/ConfigurationPatternArchetypeMojo.java</exclude>
                             <exclude>**/ModuleArchetypeMojo.java</exclude>
                             <exclude>**/MultipartConfiguration.java</exclude>
+                            <exclude>**/ClassLoaderObjectInputStream.java</exclude>
 
                             <exclude>**/ParamReader.java</exclude>
                             <exclude>**/Part.java</exclude>

--- a/tests/integration/src/test/java/org/mule/test/transformers/ExpressionTransformerTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/transformers/ExpressionTransformerTestCase.java
@@ -62,15 +62,18 @@ public class ExpressionTransformerTestCase extends AbstractMuleContextTestCase
     @Test
     public void testExpressionEvaluationClassLoaderEL() throws ClassNotFoundException, TransformerException
     {
+        MyClassClassLoader appClassLoader = new MyClassClassLoader();
+        muleContext.setExecutionClassLoader(appClassLoader);
+
         ExpressionTransformer transformer = new ExpressionTransformer();
         transformer.setMuleContext(muleContext);
         transformer.addArgument(new ExpressionArgument("test", new ExpressionConfig("payload is org.MyClass",
-            null, null), false));
+                                                                                    null, null), false));
 
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try
         {
-            Thread.currentThread().setContextClassLoader(new MyClassClassLoader());
+            Thread.currentThread().setContextClassLoader(appClassLoader);
             transformer.initialise();
         }
         catch (Exception e)


### PR DESCRIPTION
_ Using ObjectSerializer to return a new CompiledExpression instance every time.
_ Updating AbstractVariableEnricherDataTypePropagator to use regexs instead of using ASTNodes from MVEL to dependency on "executed" compiledExpressions
_ Applying patch for https://issues.apache.org/jira/browse/IO-368 as there is no newer version of commons-io included the fix