### PR TITLE
MULE-8476: Initial idea. The version is taken at runtime form the cla…

### DIFF
--- a/core/src/test/resources/META-INF/MANIFEST.MF
+++ b/core/src/test/resources/META-INF/MANIFEST.MF
@@ -1,17 +1,17 @@
 Manifest-Version: 1.0
 Archiver-Version: Plexus Archiver
 Created-By: Apache Maven
-Built-By: chrismordue
-Build-Jdk: 1.6.0_31
-Specification-Title: Core Configuration Patterns
-Specification-Version: 3.3.0-RC3-SNAPSHOT
+Built-By: anafelisatti
+Build-Jdk: 1.8.0_40
+Specification-Title: Mule Core
+Specification-Version: 4.0-SNAPSHOT
 Specification-Vendor: MuleSoft, Inc.
-Implementation-Title: Core Configuration Patterns
-Implementation-Version: 3.3.0-RC3-SNAPSHOT
-Implementation-Vendor-Id: org.mule.patterns
+Implementation-Title: Mule Core
+Implementation-Version: 4.0-SNAPSHOT
+Implementation-Vendor-Id: org.mule
 Implementation-Vendor: MuleSoft, Inc.
-Build-Date: 2012-Apr-13 16:46:57
-Build-Revision: 24242
+Build-Date: 2015-Aug-12 16:04:17
+Build-Revision: f019180d
 Description: Mule ESB and Integration Platform
 Dev-List-Email: mule-esb@mulesoft.com
 License: CPAL v1.0 http://www.mulesoft.com/CPAL/

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -81,6 +81,9 @@
                             <processors>
                                 <processor>org.mule.module.extension.internal.resources.ExtensionResourcesGeneratorAnnotationProcessor</processor>
                             </processors>
+                            <options>
+                                <extension.version>${project.version}</extension.version>
+                            </options>
                         </configuration>
                     </execution>
                 </executions>

--- a/extensions/validation/src/main/java/org/mule/extension/validation/internal/ValidationExtension.java
+++ b/extensions/validation/src/main/java/org/mule/extension/validation/internal/ValidationExtension.java
@@ -42,7 +42,7 @@ import java.util.Locale;
  *
  * @since 3.7.0
  */
-@Extension(name = "validation", description = "Mule Validation Extension", version = "3.7")
+@Extension(name = "validation", description = "Mule Validation Extension")
 @Operations({CommonValidationOperations.class, CustomValidatorOperation.class, ValidationStrategies.class, NumberValidationOperation.class})
 @Xml(schemaLocation = "http://www.mulesoft.org/schema/mule/validation", namespace = "validation", schemaVersion = "3.7")
 @Extensible(alias = "validator-message-processor")

--- a/modules/extensions-spring-support/src/main/java/org/mule/module/extension/internal/resources/ExtensionResourcesGeneratorAnnotationProcessor.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/module/extension/internal/resources/ExtensionResourcesGeneratorAnnotationProcessor.java
@@ -16,6 +16,7 @@ import org.mule.module.extension.internal.DefaultDescribingContext;
 import org.mule.module.extension.internal.capability.xml.schema.AnnotationProcessorUtils;
 import org.mule.module.extension.internal.introspection.AnnotationsBasedDescriber;
 import org.mule.module.extension.internal.introspection.DefaultExtensionFactory;
+import org.mule.module.extension.internal.introspection.VersionResolver;
 import org.mule.registry.SpiServiceRegistry;
 import org.mule.util.ExceptionUtils;
 
@@ -85,7 +86,7 @@ public class ExtensionResourcesGeneratorAnnotationProcessor extends AbstractProc
     private Extension parseExtension(TypeElement extensionElement, RoundEnvironment roundEnvironment)
     {
         Class<?> extensionClass = AnnotationProcessorUtils.classFor(extensionElement, processingEnv);
-        Describer describer = new AnnotationsBasedDescriber(extensionClass);
+        Describer describer = new AnnotationsBasedDescriber(extensionClass, new FixedVersionResolver());
 
         DescribingContext context = new DefaultDescribingContext(describer.describe().getRootDeclaration());
         context.getCustomParameters().put(EXTENSION_ELEMENT, extensionElement);
@@ -103,5 +104,19 @@ public class ExtensionResourcesGeneratorAnnotationProcessor extends AbstractProc
     private void log(String message)
     {
         processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, message);
+    }
+
+    private class FixedVersionResolver implements VersionResolver
+    {
+        @Override
+        public String resolveVersion(org.mule.extension.annotations.Extension extension)
+        {
+            String extensionVersion = processingEnv.getOptions().get("extension.version");
+            if (extensionVersion == null)
+            {
+                throw new RuntimeException(String.format("Cannot resolve version for extension %s: option extension.version is missing.", extension.name()));
+            }
+            return extensionVersion;
+        }
     }
 }

--- a/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/ImplicitConfigTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/ImplicitConfigTestCase.java
@@ -60,7 +60,7 @@ public class ImplicitConfigTestCase extends ExtensionsFunctionalTestCase
         assertThat(config.getOptionalWithDefault(), is(defaultValue));
     }
 
-    @Extension(name = "implicit", version = "1.0")
+    @Extension(name = "implicit")
     @Operations({ImplicitOperations.class})
     @Xml(schemaLocation = "http://www.mulesoft.org/schema/mule/implicit", namespace = "implicit", schemaVersion = "1.0")
     public static class ImplicitConfigExtension implements Initialisable, Startable, MuleContextAware

--- a/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/capability/xml/ExtensionResourcesGeneratorAnnotationProcessorTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/capability/xml/ExtensionResourcesGeneratorAnnotationProcessorTestCase.java
@@ -70,6 +70,7 @@ public class ExtensionResourcesGeneratorAnnotationProcessorTestCase extends Abst
 
         assert_().about(javaSources())
                 .that(testSourceFiles())
+                .withCompilerOptions("-Aextension.version=1.0.0-dev")
                 .processedWith(new ExtensionResourcesGeneratorAnnotationProcessor())
                 .compilesWithoutError()
                 .and().generatesFileNamed(StandardLocation.SOURCE_OUTPUT, "", "mule-documentation.xsd")

--- a/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/capability/xml/TestExtensionWithDocumentation.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/capability/xml/TestExtensionWithDocumentation.java
@@ -12,7 +12,7 @@ import org.mule.extension.annotations.Parameter;
 import org.mule.extension.annotations.ParameterGroup;
 import org.mule.extension.annotations.capability.Xml;
 
-@Extension(name = "documentation", version = "1.0")
+@Extension(name = "documentation")
 @Operations({TestDocumentedExtensionOperations.class})
 @Xml(schemaLocation = "schemaLocation", namespace = "documentation", schemaVersion = "1.0")
 public class TestExtensionWithDocumentation

--- a/modules/extensions-support/src/main/java/org/mule/module/extension/internal/introspection/AnnotationsBasedDescriber.java
+++ b/modules/extensions-support/src/main/java/org/mule/module/extension/internal/introspection/AnnotationsBasedDescriber.java
@@ -62,12 +62,20 @@ public final class AnnotationsBasedDescriber implements Describer
 
     private CapabilitiesResolver capabilitiesResolver = new DefaultCapabilitiesResolver(new SpiServiceRegistry());
     private final Class<?> extensionType;
+    private final VersionResolver versionResolver;
 
     public AnnotationsBasedDescriber(Class<?> extensionType)
     {
+        this(extensionType, new ManifestBasedVersionResolver(extensionType));
+    }
+
+    public AnnotationsBasedDescriber(Class<?> extensionType, VersionResolver versionResolver)
+    {
         checkArgument(extensionType != null, String.format("describer %s does not specify an extension type", getClass().getName()));
         this.extensionType = extensionType;
+        this.versionResolver = versionResolver;
     }
+
 
     /**
      * {@inheritDoc}
@@ -88,7 +96,12 @@ public final class AnnotationsBasedDescriber implements Describer
 
     private DeclarationDescriptor newDeclarationDescriptor(Extension extension)
     {
-        return new DeclarationDescriptor(extension.name(), extension.version()).describedAs(extension.description());
+        return new DeclarationDescriptor(extension.name(), getVersion(extension)).describedAs(extension.description());
+    }
+
+    private String getVersion(Extension extension)
+    {
+        return versionResolver.resolveVersion(extension);
     }
 
     private void declareConfigurations(DeclarationDescriptor declaration, Class<?> extensionType)

--- a/modules/extensions-support/src/main/java/org/mule/module/extension/internal/introspection/ManifestBasedVersionResolver.java
+++ b/modules/extensions-support/src/main/java/org/mule/module/extension/internal/introspection/ManifestBasedVersionResolver.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.extension.internal.introspection;
+
+import static org.mule.config.i18n.MessageFactory.createStaticMessage;
+import org.mule.api.MuleRuntimeException;
+import org.mule.extension.annotations.Extension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * Implementation of {@link VersionResolver} that infers an extension's version based on the MANIFEST.MF file contained
+ * on it's JAR. If that attempt fails, it fallbacks to searching for the file under target/test-classes.
+ *
+ * @since 4.0
+ */
+final class ManifestBasedVersionResolver implements VersionResolver
+{
+
+    private final Class extensionType;
+
+    public ManifestBasedVersionResolver(Class extensionType)
+    {
+        this.extensionType = extensionType;
+    }
+
+    @Override
+    public String resolveVersion(Extension extension)
+    {
+        String version = extensionType.getPackage().getImplementationVersion();
+        if (version == null)
+        {
+            version = fallback();
+        }
+        if (version == null)
+        {
+            throw new MuleRuntimeException(createStaticMessage(String.format("Cannot resolve version for extension %s: MANIFEST.MF could not be found.", extension.name())));
+        }
+        return version;
+    }
+
+    private String fallback()
+    {
+        //look for the location of this class
+        String packageName = extensionType.getPackage().getName();
+        String classFileName = extensionType.getName().substring(packageName.length() + 1) + ".class";
+        String classFilePath = extensionType.getResource(classFileName).toString();
+        //get rid of the package part of the path to avoid conflicts with user-defined directories
+        String packagePath = packageName.replace(".", "/");
+        classFilePath = classFilePath.substring(0, classFilePath.lastIndexOf(packagePath));
+        //get the target index since the class could be in /classes too
+        int pathIndex = classFilePath.lastIndexOf("/target/");
+        //find and load manifest
+        String manifestUrl = String.format("%s/target/test-classes/META-INF/MANIFEST.MF", classFilePath.substring(0, pathIndex + 1));
+        try (InputStream manifestInputStream = new URL(manifestUrl).openStream())
+        {
+            Manifest manifest = new Manifest(manifestInputStream);
+            return manifest.getMainAttributes().getValue(new Attributes.Name("Implementation-Version"));
+        }
+        catch (IOException e)
+        {
+            return null;
+        }
+    }
+}

--- a/modules/extensions-support/src/main/java/org/mule/module/extension/internal/introspection/VersionResolver.java
+++ b/modules/extensions-support/src/main/java/org/mule/module/extension/internal/introspection/VersionResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.extension.internal.introspection;
+
+import org.mule.extension.annotations.Extension;
+
+/**
+ * Component that resolves an extension's version.
+ *
+ * @since 4.0
+ */
+public interface VersionResolver
+{
+
+    /**
+     * Resolves the version of a given {@link Extension}
+     *
+     * @param extension the {@link Extension} for which the version will be resolved
+     * @return a {@link String} representing the version
+     */
+    String resolveVersion(Extension extension);
+}

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/HeisenbergExtension.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/HeisenbergExtension.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-@Extension(name = HeisenbergExtension.EXTENSION_NAME, description = HeisenbergExtension.EXTENSION_DESCRIPTION, version = HeisenbergExtension.EXTENSION_VERSION)
+@Extension(name = HeisenbergExtension.EXTENSION_NAME, description = HeisenbergExtension.EXTENSION_DESCRIPTION)
 @Operations({HeisenbergOperations.class, MoneyLaunderingOperation.class})
 @Xml(schemaLocation = HeisenbergExtension.SCHEMA_LOCATION, namespace = HeisenbergExtension.NAMESPACE, schemaVersion = HeisenbergExtension.SCHEMA_VERSION)
 @Extensible(alias = "heisenberg-empire")
@@ -43,7 +43,6 @@ public class HeisenbergExtension implements Lifecycle, MuleContextAware
     public static final String AGE = "50";
     public static final String EXTENSION_NAME = "heisenberg";
     public static final String EXTENSION_DESCRIPTION = "My Test Extension just to unit test";
-    public static final String EXTENSION_VERSION = "1.0";
 
     private int initialise = 0;
     private int start = 0;

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/internal/AbstractAnnotationsBasedDescriberTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/internal/AbstractAnnotationsBasedDescriberTestCase.java
@@ -6,18 +6,45 @@
  */
 package org.mule.module.extension.internal;
 
+import static org.mule.module.extension.internal.util.ExtensionsTestUtils.createManifestFileIfNecessary;
 import org.mule.extension.introspection.declaration.Describer;
 import org.mule.extension.introspection.declaration.fluent.Declaration;
 import org.mule.extension.introspection.declaration.fluent.OperationDeclaration;
 import org.mule.module.extension.internal.introspection.AnnotationsBasedDescriber;
+import org.mule.module.extension.internal.util.ExtensionsTestUtils;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.util.CollectionUtils;
+import org.mule.util.FileUtils;
 
-import org.apache.commons.collections.Predicate;
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
 
 public abstract class AbstractAnnotationsBasedDescriberTestCase extends AbstractMuleTestCase
 {
     private Describer describer;
+    private File manifest;
+
+    @Before
+    public void createResources() throws IOException
+    {
+        File metaInfDirectory = ExtensionsTestUtils.getMetaInfDirectory(getClass().getSuperclass());
+        if (metaInfDirectory != null)
+        {
+            manifest = createManifestFileIfNecessary(metaInfDirectory);
+        }
+    }
+
+    @After
+    public void deleteResources()
+    {
+        if (manifest != null && manifest.exists())
+        {
+            FileUtils.deleteQuietly(manifest);
+        }
+    }
 
     protected Describer getDescriber()
     {
@@ -36,13 +63,6 @@ public abstract class AbstractAnnotationsBasedDescriberTestCase extends Abstract
 
     protected OperationDeclaration getOperation(Declaration declaration, final String operationName)
     {
-        return (OperationDeclaration) CollectionUtils.find(declaration.getOperations(), new Predicate()
-        {
-            @Override
-            public boolean evaluate(Object object)
-            {
-                return ((OperationDeclaration) object).getName().equals(operationName);
-            }
-        });
+        return (OperationDeclaration) CollectionUtils.find(declaration.getOperations(), object -> ((OperationDeclaration) object).getName().equals(operationName));
     }
 }

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/internal/AnnotationsBasedDescriberTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/internal/AnnotationsBasedDescriberTestCase.java
@@ -15,11 +15,11 @@ import static org.mule.extension.annotations.Extension.DEFAULT_CONFIG_NAME;
 import static org.mule.module.extension.HeisenbergExtension.AGE;
 import static org.mule.module.extension.HeisenbergExtension.EXTENSION_DESCRIPTION;
 import static org.mule.module.extension.HeisenbergExtension.EXTENSION_NAME;
-import static org.mule.module.extension.HeisenbergExtension.EXTENSION_VERSION;
 import static org.mule.module.extension.HeisenbergExtension.HEISENBERG;
 import static org.mule.module.extension.HeisenbergExtension.NAMESPACE;
 import static org.mule.module.extension.HeisenbergExtension.SCHEMA_LOCATION;
 import static org.mule.module.extension.HeisenbergExtension.SCHEMA_VERSION;
+import org.mule.config.MuleManifest;
 import org.mule.extension.annotations.Configurations;
 import org.mule.extension.annotations.Operations;
 import org.mule.extension.annotations.Parameter;
@@ -72,6 +72,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
     private static final String LAUNDER_MONEY = "launder";
     private static final String INJECTED_EXTENSION_MANAGER = "getInjectedExtensionManager";
     private static final String ALIAS = "alias";
+    private static final String EXTENSION_VERSION = MuleManifest.getProductVersion();
 
     @Before
     public void setUp()
@@ -261,7 +262,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
         // template method for asserting custom capabilities in modules that define them
     }
 
-    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION, version = EXTENSION_VERSION)
+    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION)
     @Xml(schemaLocation = SCHEMA_LOCATION, namespace = NAMESPACE, schemaVersion = SCHEMA_VERSION)
     @Configurations(HeisenbergExtension.class)
     @Operations({HeisenbergOperations.class, MoneyLaunderingOperation.class})
@@ -270,7 +271,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
 
     }
 
-    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION, version = EXTENSION_VERSION)
+    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION)
     @Xml(schemaLocation = SCHEMA_LOCATION, namespace = NAMESPACE, schemaVersion = SCHEMA_VERSION)
     @Configurations({HeisenbergExtension.class, NamedHeisenbergAlternateConfig.class})
     @Operations({HeisenbergOperations.class, MoneyLaunderingOperation.class})
@@ -286,7 +287,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
 
     }
 
-    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION, version = EXTENSION_VERSION)
+    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION)
     public static class HeisenbergWithOperations extends HeisenbergExtension
     {
 

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/internal/ExtensibleExtensionOperationsTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/internal/ExtensibleExtensionOperationsTestCase.java
@@ -14,7 +14,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mule.module.extension.HeisenbergExtension.EXTENSION_DESCRIPTION;
 import static org.mule.module.extension.HeisenbergExtension.EXTENSION_NAME;
-import static org.mule.module.extension.HeisenbergExtension.EXTENSION_VERSION;
 import org.mule.extension.annotations.Extensible;
 import org.mule.extension.annotations.ExtensionOf;
 import org.mule.extension.annotations.Operation;
@@ -67,7 +66,7 @@ public class ExtensibleExtensionOperationsTestCase extends AbstractAnnotationsBa
         assertThat(capability.getType(), is(sameInstance(capabilityType)));
     }
 
-    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION, version = EXTENSION_VERSION)
+    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION)
     @Operations(ExtensibleExtensionOperation.class)
     @Extensible
     public static class ExtensibleExtension
@@ -75,14 +74,14 @@ public class ExtensibleExtensionOperationsTestCase extends AbstractAnnotationsBa
 
     }
 
-    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION, version = EXTENSION_VERSION)
+    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION)
     @Operations({ClassLevelExtensionOfOperation.class, MethodLevelExtensionOfOperation.class})
     public static class ExtendingExtension
     {
 
     }
 
-    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION, version = EXTENSION_VERSION)
+    @org.mule.extension.annotations.Extension(name = EXTENSION_NAME, description = EXTENSION_DESCRIPTION)
     @Operations({MethodLevelExtensionOfOperation.class, ExtensibleExtensionOperation.class})
     @Extensible
     public static class ExtensibleExtendingExtension

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/internal/introspection/ManifestBasedVersionResolverTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/internal/introspection/ManifestBasedVersionResolverTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.extension.internal.introspection;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.module.extension.internal.util.ExtensionsTestUtils.createManifestFileIfNecessary;
+import static org.mule.module.extension.internal.util.ExtensionsTestUtils.getMetaInfDirectory;
+import org.mule.config.MuleManifest;
+import org.mule.extension.annotations.Extension;
+import org.mule.module.extension.HeisenbergExtension;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.util.FileUtils;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ManifestBasedVersionResolverTestCase extends AbstractMuleTestCase
+{
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Class<?> clazz = HeisenbergExtension.class;
+    private VersionResolver versionResolver = new ManifestBasedVersionResolver(clazz);
+
+    @Test
+    public void failsWithOutManifest()
+    {
+        thrown.expectMessage(is("Cannot resolve version for extension heisenberg: MANIFEST.MF could not be found."));
+        testResolution();
+    }
+
+    @Test
+    public void worksWithManifest() throws Exception
+    {
+        File metaInfDirectory = getMetaInfDirectory(getClass());
+        File manifest = createManifestFileIfNecessary(metaInfDirectory);
+        try
+        {
+            assertThat(testResolution(), is(MuleManifest.getProductVersion()));
+        }
+        finally
+        {
+            if (manifest.exists())
+            {
+                FileUtils.deleteQuietly(manifest);
+            }
+        }
+
+    }
+
+    private String testResolution()
+    {
+        return versionResolver.resolveVersion(clazz.getAnnotation(Extension.class));
+    }
+}

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/internal/util/ExtensionsTestUtils.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/internal/util/ExtensionsTestUtils.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
+import org.mule.config.MuleManifest;
 import org.mule.extension.introspection.DataType;
 import org.mule.extension.introspection.Extension;
 import org.mule.extension.introspection.Operation;
@@ -28,6 +29,12 @@ import org.mule.module.extension.internal.manager.ExtensionManagerAdapter;
 import org.mule.module.extension.internal.runtime.DefaultOperationContext;
 import org.mule.module.extension.internal.runtime.resolver.ResolverSetResult;
 import org.mule.module.extension.internal.runtime.resolver.ValueResolver;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.jar.Manifest;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.mockito.ArgumentCaptor;
@@ -126,5 +133,31 @@ public abstract class ExtensionsTestUtils
                                            mock(ResolverSetResult.class),
                                            event,
                                            extractExtensionManager(event));
+    }
+
+    public static File getMetaInfDirectory(Class clazz)
+    {
+        URL classUrl = clazz.getResource(clazz.getSimpleName() + ".class");
+        if (classUrl.toString().startsWith("jar"))
+        {
+            //we are dealing with a jar file, no need to modify test-classes resources
+            return null;
+        }
+        String classPath = classUrl.getPath();
+        return new File(String.format("%starget/test-classes/META-INF", classPath.substring(0, classPath.indexOf("target"))));
+    }
+
+    public static File createManifestFileIfNecessary(File targetDirectory) throws IOException
+    {
+        File manifestFile = new File(targetDirectory.getPath(), "MANIFEST.MF");
+        if (!manifestFile.exists())
+        {
+            Manifest manifest = new Manifest(MuleManifest.getManifest());
+            try (FileOutputStream fileOutputStream = new FileOutputStream(manifestFile))
+            {
+                manifest.write(fileOutputStream);
+            }
+        }
+        return manifestFile;
     }
 }

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -175,6 +175,12 @@
             <version>${project.version}</version>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.mule.modules</groupId>
+            <artifactId>mule-module-extensions-support</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
         <!-- required for ConfigurationBuilders at runtime -->
         <dependency>
             <groupId>org.mule.modules</groupId>

--- a/tests/functional/src/main/java/org/mule/tck/junit4/ExtensionsFunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/tck/junit4/ExtensionsFunctionalTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.tck.junit4;
 
 import static org.mule.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.module.extension.internal.util.ExtensionsTestUtils.createManifestFileIfNecessary;
 import static org.mule.util.IOUtils.getResourceAsUrl;
 import static org.springframework.util.ReflectionUtils.findMethod;
 import org.mule.DefaultMuleContext;
@@ -151,6 +152,8 @@ public abstract class ExtensionsFunctionalTestCase extends FunctionalTestCase
     private void createExtensionsManager() throws Exception
     {
         extensionManager = new DefaultExtensionManager();
+        generatedResourcesDirectory = getGenerationTargetDirectory();
+        createManifestFileIfNecessary(generatedResourcesDirectory);
 
         Describer[] describers = getDescribers();
         if (ArrayUtils.isEmpty(describers))
@@ -175,8 +178,6 @@ public abstract class ExtensionsFunctionalTestCase extends FunctionalTestCase
         {
             loadExtensionsFromDescribers(extensionManager, describers);
         }
-
-        generatedResourcesDirectory = getGenerationTargetDirectory();
 
         ResourcesGenerator generator = new ExtensionsTestInfrastructureResourcesGenerator(serviceRegistry, generatedResourcesDirectory);
 


### PR DESCRIPTION
…ss package. When testing this is not possible, so we take it from a manifest file in target/test-classes. This file is generated by ExtensionsFunctionalTestCase if missing.