### PR TITLE
MULE-8205 Fix persistent connection and streaming for HTTP 1.0 clients

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/domain/HttpProtocol.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/domain/HttpProtocol.java
@@ -11,7 +11,7 @@ package org.mule.module.http.internal.domain;
  */
 public enum HttpProtocol
 {
-    HTTP_1_0("HTTP/1.0"), HTTP_1_1("HTTP/1.1");
+    HTTP_0_9("HTTP/0.9"), HTTP_1_0("HTTP/1.0"), HTTP_1_1("HTTP/1.1");
 
     private final String protocolName;
 

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerPersistentConnections10TestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerPersistentConnections10TestCase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.module.http.api.HttpHeaders.Values.CLOSE;
+import static org.mule.module.http.api.HttpHeaders.Values.KEEP_ALIVE;
+
+import java.io.IOException;
+
+import org.apache.http.HttpVersion;
+import org.junit.Test;
+
+public class HttpListenerPersistentConnections10TestCase extends HttpListenerPersistentConnectionsTestCase
+{
+
+    @Override
+    protected HttpVersion getHttpVersion()
+    {
+        return HttpVersion.HTTP_1_0;
+    }
+
+    @Test
+    public void nonPersistentCheckHeader() throws Exception
+    {
+        assertThat(performRequest(nonPersistentPort.getNumber(), getHttpVersion(), false), is(CLOSE));
+    }
+
+    @Test
+    public void persistentCheckHeader() throws Exception
+    {
+        // Since in 1.0 keep alive is not the default, it has to be explicit for
+        // persistent connections
+        assertThat(performRequest(persistentPort.getNumber(), getHttpVersion(), false), is(KEEP_ALIVE));
+    }
+
+    @Test
+    public void persistentCloseHeaderCheckHeader() throws Exception
+    {
+        assertThat(performRequest(persistentPortCloseHeader.getNumber(), getHttpVersion(), false), is(CLOSE));
+    }
+
+    @Test
+    public void persistentClosePropertyCheckHeader() throws Exception
+    {
+        assertThat(performRequest(persistentPortCloseProperty.getNumber(), getHttpVersion(), false), is(KEEP_ALIVE));
+    }
+
+    @Test
+    public void persistentEchoCheckHeader() throws IOException
+    {
+        // Echo sets the content-lenght at 0, so keep-alive is ok for 1.0
+        assertThat(performRequest(persistentStreamingPort.getNumber(), getHttpVersion(), true), is(KEEP_ALIVE));
+    }
+
+    /**
+     * <h1>MULE-8502</h1>
+     * 
+     * <a href="http://tools.ietf.org/html/rfc2068#section-19.7.1">rfc2068#section-19.7.1</a> states that a 1.1. server cannot send chunked content to a 1.0 client.
+     * In this case, the only way for the server to indicate that the transmission of the content has finished is to close the connection (and send the appropriate header indicating this)
+     * Although the "Transfer-encoding: Chunked" header is sent in the response, the client should ignore it since it is not part of the 1.0 spec 
+     * @throws IOException
+     */
+    @Test
+    public void persistentStreamingTransformerCheckHeader() throws IOException
+    {
+        assertThat(performRequest(persistentStreamingTransformerPort.getNumber(), getHttpVersion(), true), is(CLOSE));
+    }
+
+    @Test
+    public void persistentConnectionStreamingTransformerClosing() throws Exception
+    {
+        assertConnectionClosesAfterSend(persistentStreamingTransformerPort, getHttpVersion());
+    }
+
+}

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerPersistentConnections11TestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerPersistentConnections11TestCase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mule.module.http.api.HttpHeaders.Values.CLOSE;
+
+import java.io.IOException;
+
+import org.apache.http.HttpVersion;
+import org.junit.Test;
+
+public class HttpListenerPersistentConnections11TestCase extends HttpListenerPersistentConnectionsTestCase
+{
+
+    @Override
+    protected HttpVersion getHttpVersion()
+    {
+        return HttpVersion.HTTP_1_1;
+    }
+
+    @Test
+    public void nonPersistentCheckHeader() throws Exception
+    {
+        assertThat(performRequest(nonPersistentPort.getNumber(), getHttpVersion(), false), is(CLOSE));
+    }
+
+    @Test
+    public void persistentCheckHeader() throws Exception
+    {
+        assertThat(performRequest(persistentPort.getNumber(), getHttpVersion(), false), is(nullValue()));
+    }
+
+    @Test
+    public void persistentCloseHeaderCheckHeader() throws Exception
+    {
+        assertThat(performRequest(persistentPortCloseHeader.getNumber(), getHttpVersion(), false), is(CLOSE));
+    }
+
+    @Test
+    public void persistentClosePropertyCheckHeader() throws Exception
+    {
+        assertThat(performRequest(persistentPortCloseProperty.getNumber(), getHttpVersion(), false), is(nullValue()));
+    }
+
+    @Test
+    public void persistentEchoCheckHeader() throws IOException
+    {
+        assertThat(performRequest(persistentStreamingPort.getNumber(), getHttpVersion(), true), is(nullValue()));
+    }
+
+    @Test
+    public void persistentStreamingTransformerCheckHeader() throws IOException
+    {
+        assertThat(performRequest(persistentStreamingTransformerPort.getNumber(), getHttpVersion(), true), is(nullValue()));
+    }
+
+    @Test
+    public void nonPersistentConnectionClosing() throws Exception
+    {
+        assertConnectionClosesAfterSend(nonPersistentPort, getHttpVersion());
+    }
+
+    @Test
+    public void persistentConnectionClosing() throws Exception
+    {
+        assertConnectionClosesAfterTimeout(persistentPort, getHttpVersion());
+    }
+
+    @Test
+    public void persistentConnectionClosingWithRequestConnectionCloseHeader() throws Exception
+    {
+        assertConnectionClosesWithRequestConnectionCloseHeader(persistentPort, getHttpVersion());
+    }
+
+    @Test
+    public void persistentConnectionCloseHeaderClosing() throws Exception
+    {
+        assertConnectionClosesAfterSend(persistentPortCloseHeader, getHttpVersion());
+    }
+
+    @Test
+    public void persistentConnectionClosePropertyClosing() throws Exception
+    {
+        assertConnectionClosesAfterTimeout(persistentPortCloseProperty, getHttpVersion());
+    }
+
+}

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreaming10TestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreaming10TestCase.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import java.io.IOException;
+
+import org.apache.http.HttpVersion;
+import org.junit.Test;
+
+public class HttpListenerResponseStreaming10TestCase extends HttpListenerResponseStreamingTestCase
+{
+
+    @Override
+    protected HttpVersion getHttpVersion()
+    {
+        return HttpVersion.HTTP_1_0;
+    }
+
+    // AUTO - String
+
+    @Test
+    public void string() throws Exception
+    {
+        final String url = getUrl("string");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingHeaderAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingOutboundPropertyAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // AUTO  - InputStream
+
+    @Test
+    public void inputStream() throws Exception
+    {
+        final String url = getUrl("inputStream");
+        testResponseIsNotChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingHeader");
+        testResponseIsNotChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingOutboundProperty");
+        testResponseIsNotChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // NEVER - String
+
+    @Test
+    public void neverString() throws Exception
+    {
+        final String url = getUrl("neverString");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverStringTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("neverStringTransferEncodingHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverStringTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("neverStringTransferEncodingOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // NEVER - InputStream
+
+    @Test
+    public void neverInputStream() throws Exception
+    {
+        final String url = getUrl("neverInputStream");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverInputStreamTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("neverInputStreamTransferEncodingHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverInputStreamTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("neverInputStreamTransferEncodingOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // ALWAYS - String
+
+    /**
+     * Last paragraph of <a href="http://tools.ietf.org/html/rfc2068#section-3.6">rfc2068#section-3.6</a> states:
+     *  A server MUST NOT send transfer-codings to an HTTP/1.0 client.
+     * @throws IOException
+     */
+    @Test
+    public void alwaysString() throws Exception
+    {
+        final String url = getUrl("alwaysString");
+        testResponseIsNotChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysStringContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("alwaysStringContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysStringContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("alwaysStringContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // ALWAYS - InputStream
+
+    @Test
+    public void alwaysInputStream() throws Exception
+    {
+        final String url = getUrl("alwaysInputStream");
+        testResponseIsNotChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysInputStreamContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("alwaysInputStreamContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysInputStreamContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("alwaysInputStreamContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+}

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreaming11TestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreaming11TestCase.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import org.apache.http.HttpVersion;
+import org.junit.Test;
+
+public class HttpListenerResponseStreaming11TestCase extends HttpListenerResponseStreamingTestCase
+{
+
+    @Override
+    protected HttpVersion getHttpVersion()
+    {
+        return HttpVersion.HTTP_1_1;
+    }
+
+    // AUTO - String
+
+    @Test
+    public void string() throws Exception
+    {
+        final String url = getUrl("string");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingHeader");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingHeaderAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void stringWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("stringWithTransferEncodingOutboundPropertyAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // AUTO  - InputStream
+
+    @Test
+    public void inputStream() throws Exception
+    {
+        final String url = getUrl("inputStream");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingHeader");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingOutboundProperty");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // NEVER - String
+
+    @Test
+    public void neverString() throws Exception
+    {
+        final String url = getUrl("neverString");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverStringTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("neverStringTransferEncodingHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverStringTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("neverStringTransferEncodingOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // NEVER - InputStream
+
+    @Test
+    public void neverInputStream() throws Exception
+    {
+        final String url = getUrl("neverInputStream");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverInputStreamTransferEncodingHeader() throws Exception
+    {
+        final String url = getUrl("neverInputStreamTransferEncodingHeader");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void neverInputStreamTransferEncodingOutboundProperty() throws Exception
+    {
+        final String url = getUrl("neverInputStreamTransferEncodingOutboundProperty");
+        testResponseIsContentLengthEncoding(url, getHttpVersion());
+    }
+
+    // ALWAYS - String
+
+    @Test
+    public void alwaysString() throws Exception
+    {
+        final String url = getUrl("alwaysString");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysStringContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("alwaysStringContentLengthHeader");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysStringContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("alwaysStringContentLengthOutboundProperty");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    // ALWAYS - InputStream
+
+    @Test
+    public void alwaysInputStream() throws Exception
+    {
+        final String url = getUrl("alwaysInputStream");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysInputStreamContentLengthHeader() throws Exception
+    {
+        final String url = getUrl("alwaysInputStreamContentLengthHeader");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+    @Test
+    public void alwaysInputStreamContentLengthOutboundProperty() throws Exception
+    {
+        final String url = getUrl("alwaysInputStreamContentLengthOutboundProperty");
+        testResponseIsChunkedEncoding(url, getHttpVersion());
+    }
+
+}

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreamingTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseStreamingTestCase.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_LENGTH;
 import static org.mule.module.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
 import static org.mule.module.http.api.HttpHeaders.Values.CHUNKED;
+
 import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.util.IOUtils;
@@ -22,17 +23,19 @@ import java.io.IOException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.client.fluent.Response;
 import org.junit.Rule;
-import org.junit.Test;
 
-public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
+public abstract class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
 {
 
     public static final String TEST_BODY = RandomStringUtils.randomAlphabetic(100*1024);
     @Rule
     public DynamicPort listenPort = new DynamicPort("port");
+
+    protected abstract HttpVersion getHttpVersion();
 
     @Override
     protected String getConfigFile()
@@ -40,231 +43,9 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
         return "http-listener-response-streaming-config.xml";
     }
 
-    // AUTO - String
-
-    @Test
-    public void string() throws Exception
+    protected void testResponseIsContentLengthEncoding(String url, HttpVersion httpVersion) throws IOException
     {
-        final String url = getUrl("string");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void stringWithContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("stringWithContentLengthHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void stringWithContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("stringWithContentLengthOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void stringWithTransferEncodingHeader() throws Exception
-    {
-        final String url = getUrl("stringWithTransferEncodingHeader");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void stringWithTransferEncodingOutboundProperty() throws Exception
-    {
-        final String url = getUrl("stringWithTransferEncodingOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void stringWithTransferEncodingAndContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("stringWithTransferEncodingAndContentLengthHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void stringWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("stringWithTransferEncodingAndContentLengthOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void stringWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("stringWithTransferEncodingHeaderAndContentLengthOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void stringWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("stringWithTransferEncodingOutboundPropertyAndContentLengthHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    // AUTO  - InputStream
-
-    @Test
-    public void inputStream() throws Exception
-    {
-        final String url = getUrl("inputStream");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("inputStreamWithContentLengthHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("inputStreamWithContentLengthOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithTransferEncodingHeader() throws Exception
-    {
-        final String url = getUrl("inputStreamWithTransferEncodingHeader");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithTransferEncodingOutboundProperty() throws Exception
-    {
-        final String url = getUrl("inputStreamWithTransferEncodingOutboundProperty");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithTransferEncodingAndContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithTransferEncodingAndContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("inputStreamWithTransferEncodingAndContentLengthOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("inputStreamWithTransferEncodingHeaderAndContentLengthOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("inputStreamWithTransferEncodingOutboundPropertyAndContentLengthHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    // NEVER - String
-
-    @Test
-    public void neverString() throws Exception
-    {
-        final String url = getUrl("neverString");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void neverStringTransferEncodingHeader() throws Exception
-    {
-        final String url = getUrl("neverStringTransferEncodingHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void neverStringTransferEncodingOutboundProperty() throws Exception
-    {
-        final String url = getUrl("neverStringTransferEncodingOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    // NEVER - InputStream
-
-    @Test
-    public void neverInputStream() throws Exception
-    {
-        final String url = getUrl("neverInputStream");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void neverInputStreamTransferEncodingHeader() throws Exception
-    {
-        final String url = getUrl("neverInputStreamTransferEncodingHeader");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    @Test
-    public void neverInputStreamTransferEncodingOutboundProperty() throws Exception
-    {
-        final String url = getUrl("neverInputStreamTransferEncodingOutboundProperty");
-        testResponseIsContentLengthEncoding(url);
-    }
-
-    // ALWAYS - String
-
-    @Test
-    public void alwaysString() throws Exception
-    {
-        final String url = getUrl("alwaysString");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void alwaysStringContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("alwaysStringContentLengthHeader");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void alwaysStringContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("alwaysStringContentLengthOutboundProperty");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    // ALWAYS - InputStream
-
-    @Test
-    public void alwaysInputStream() throws Exception
-    {
-        final String url = getUrl("alwaysInputStream");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void alwaysInputStreamContentLengthHeader() throws Exception
-    {
-        final String url = getUrl("alwaysInputStreamContentLengthHeader");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    @Test
-    public void alwaysInputStreamContentLengthOutboundProperty() throws Exception
-    {
-        final String url = getUrl("alwaysInputStreamContentLengthOutboundProperty");
-        testResponseIsChunkedEncoding(url);
-    }
-
-    private void testResponseIsContentLengthEncoding(String url) throws IOException
-    {
-        final Response response = Request.Get(url).connectTimeout(1000).socketTimeout(1000).execute();
+        final Response response = Request.Get(url).version(httpVersion).connectTimeout(1000).socketTimeout(1000).execute();
         final HttpResponse httpResponse = response.returnResponse();
         final Header transferEncodingHeader = httpResponse.getFirstHeader(TRANSFER_ENCODING);
         final Header contentLengthHeader = httpResponse.getFirstHeader(CONTENT_LENGTH);
@@ -273,20 +54,31 @@ public class HttpListenerResponseStreamingTestCase extends FunctionalTestCase
         assertThat(IOUtils.toString(httpResponse.getEntity().getContent()), is(TEST_BODY));
     }
 
-    private String getUrl(String path)
+    protected String getUrl(String path)
     {
         return String.format("http://localhost:%s/%s", listenPort.getNumber(), path);
     }
 
-    private void testResponseIsChunkedEncoding(String url) throws IOException
+    protected void testResponseIsChunkedEncoding(String url, HttpVersion httpVersion) throws IOException
     {
-        final Response response = Request.Post(url).connectTimeout(1000).socketTimeout(1000).bodyByteArray(TEST_BODY.getBytes()).execute();
+        final Response response = Request.Post(url).version(httpVersion).connectTimeout(1000).socketTimeout(1000).bodyByteArray(TEST_BODY.getBytes()).execute();
         final HttpResponse httpResponse = response.returnResponse();
         final Header transferEncodingHeader = httpResponse.getFirstHeader(TRANSFER_ENCODING);
         final Header contentLengthHeader = httpResponse.getFirstHeader(CONTENT_LENGTH);
         assertThat(contentLengthHeader, nullValue());
         assertThat(transferEncodingHeader, notNullValue());
         assertThat(transferEncodingHeader.getValue(), is(CHUNKED));
+        assertThat(IOUtils.toString(httpResponse.getEntity().getContent()), is(TEST_BODY));
+    }
+
+    protected void testResponseIsNotChunkedEncoding(String url, HttpVersion httpVersion) throws IOException
+    {
+        final Response response = Request.Post(url).version(httpVersion).connectTimeout(1000).socketTimeout(1000).bodyByteArray(TEST_BODY.getBytes()).execute();
+        final HttpResponse httpResponse = response.returnResponse();
+        final Header transferEncodingHeader = httpResponse.getFirstHeader(TRANSFER_ENCODING);
+        final Header contentLengthHeader = httpResponse.getFirstHeader(CONTENT_LENGTH);
+        assertThat(contentLengthHeader, nullValue());
+        assertThat(transferEncodingHeader, is(nullValue()));
         assertThat(IOUtils.toString(httpResponse.getEntity().getContent()), is(TEST_BODY));
     }
 

--- a/modules/http/src/test/resources/http-listener-persistent-connections-config.xml
+++ b/modules/http/src/test/resources/http-listener-persistent-connections-config.xml
@@ -34,4 +34,17 @@
         <echo-component/>
     </flow>
 
+    <!-- MULE-8502 -->
+    <http:listener-config name="persistentConfigStreaming" host="localhost" port="${persistentStreamingPort}" usePersistentConnections="true" connectionIdleTimeout="1000" />
+    <flow name="persistentStreaming">
+        <http:listener path="/" config-ref="persistentConfigStreaming" responseStreamingMode="ALWAYS" />
+        <echo-component />
+    </flow>
+
+    <http:listener-config name="persistentConfigStreamingTransformer" host="localhost" port="${persistentStreamingTransformerPort}" usePersistentConnections="true" connectionIdleTimeout="1000" />
+    <flow name="persistentStreamingTransformer">
+        <http:listener path="/" config-ref="persistentConfigStreamingTransformer" responseStreamingMode="ALWAYS" />
+        <set-payload value="from_payload_transformer" />
+    </flow>
+
 </mule>


### PR DESCRIPTION
When the payload was an InputStream and the client HTTP version was 1.0, the payload stream was not being closed. Thas is also fixed now.