### PR TITLE
MULE-8927 - Properly encode tokens of endpoint uris

### DIFF
--- a/core/src/test/java/org/mule/endpoint/DynamicURIBuilderTestCase.java
+++ b/core/src/test/java/org/mule/endpoint/DynamicURIBuilderTestCase.java
@@ -11,6 +11,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
 import org.mule.api.endpoint.MalformedEndpointException;
@@ -37,7 +38,7 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
     {
         String uriTemplate = "http://admin%40abc:admin%40123@localhost:8080/#[expression]";
 
-        createExpressionManager(uriTemplate);
+        createExpressionManager(uriTemplate, EXPECTED_ADDRESS);
 
         URIBuilder uriBuilder = new URIBuilder(uriTemplate, muleContext);
 
@@ -49,7 +50,7 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
     {
         String templatePort = "#[expression]";
 
-        createExpressionManager("http://admin%40abc:admin%40123@localhost:#[expression]/test?foo=bar");
+        createExpressionManager(ATTRIBUTE_EXPRESSION, "8080");
 
         URIBuilder uriBuilder = createDefaultUriBuilder(muleContext);
         uriBuilder.setPort(templatePort);
@@ -60,7 +61,7 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
     @Test
     public void resolvesDynamicHost() throws Exception
     {
-        createExpressionManager("http://admin%40abc:admin%40123@#[expression]:8080/test?foo=bar");
+        createExpressionManager(ATTRIBUTE_EXPRESSION, "localhost");
 
         URIBuilder uriBuilder = createDefaultUriBuilder(muleContext);
         uriBuilder.setHost(ATTRIBUTE_EXPRESSION);
@@ -71,7 +72,7 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
     @Test
     public void resolvesDynamicPath() throws Exception
     {
-        createExpressionManager("http://admin%40abc:admin%40123@localhost:8080/#[expression]");
+        createExpressionManager(ATTRIBUTE_EXPRESSION, "test?foo=bar");
 
         URIBuilder uriBuilder = createDefaultUriBuilder(muleContext);
         uriBuilder.setPath(ATTRIBUTE_EXPRESSION);
@@ -82,7 +83,7 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
     @Test
     public void resolvesDynamicPassword() throws Exception
     {
-        createExpressionManager("http://admin%40abc:#[expression]@localhost:8080/test?foo=bar");
+        createExpressionManager(ATTRIBUTE_EXPRESSION, "admin@123");
 
         URIBuilder uriBuilder = createDefaultUriBuilder(muleContext);
         uriBuilder.setPassword(ATTRIBUTE_EXPRESSION);
@@ -93,7 +94,7 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
     @Test
     public void resolvesDynamicUser() throws Exception
     {
-        createExpressionManager("http://#[expression]:admin%40123@localhost:8080/test?foo=bar");
+        createExpressionManager(ATTRIBUTE_EXPRESSION, "admin@abc");
 
         URIBuilder uriBuilder = createDefaultUriBuilder(muleContext);
         uriBuilder.setUser(ATTRIBUTE_EXPRESSION);
@@ -110,13 +111,13 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
         dynamicURIBuilder.build(event);
     }
 
-    private void createExpressionManager(String templateUri)
+    private void createExpressionManager(String expression, final String expressionValue)
     {
         ExpressionManager expressionManager = mock(ExpressionManager.class);
 
         when(muleContext.getExpressionManager()).thenReturn(expressionManager);
-        when(expressionManager.isExpression(templateUri)).thenReturn(true);
-        when(expressionManager.parse(templateUri, event, true)).thenReturn(EXPECTED_ADDRESS);
+        when(expressionManager.isExpression(expression)).thenReturn(true);
+        when(expressionManager.parse(expression, event, true)).thenReturn(expressionValue);
     }
 
     private void doDynamicUriResolverTest(URIBuilder uriBuilder) throws URISyntaxException, UnsupportedEncodingException, MalformedEndpointException
@@ -131,8 +132,8 @@ public class DynamicURIBuilderTestCase extends AbstractMuleTestCase
     {
         URIBuilder uriBuilder = new URIBuilder(muleContext);
 
-        uriBuilder.setUser("admin%40abc");
-        uriBuilder.setPassword("admin%40123");
+        uriBuilder.setUser("admin@abc");
+        uriBuilder.setPassword("admin@123");
         uriBuilder.setHost("localhost");
         uriBuilder.setPath("test?foo=bar");
         uriBuilder.setProtocol("http");

--- a/tests/integration/src/test/resources/org/mule/test/integration/construct/http-proxy-encoded-url-config.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/construct/http-proxy-encoded-url-config.xml
@@ -17,7 +17,7 @@
 
     <pattern:http-proxy name="assembledDynamicAddress">
         <http:inbound-endpoint address="http://localhost:${port2}"/>
-        <http:outbound-endpoint user="admin" password="admin%40123" path="#[message.inboundProperties['path']]?foo=bar" host="localhost"
+        <http:outbound-endpoint user="admin" password="admin@123" path="#[message.inboundProperties['path']]?foo=bar" host="localhost"
                                 port="${serverPort}" exchange-pattern="request-response"/>
     </pattern:http-proxy>
 
@@ -29,7 +29,7 @@
 
     <pattern:http-proxy name="assembledStaticAddress">
         <http:inbound-endpoint address="http://localhost:${port4}"/>
-        <http:outbound-endpoint user="admin" password="admin%40123" path="test?foo=bar" host="localhost" port="${serverPort}"
+        <http:outbound-endpoint user="admin" password="admin@123" path="test?foo=bar" host="localhost" port="${serverPort}"
                                 exchange-pattern="request-response"/>
     </pattern:http-proxy>
 </mule>

--- a/tests/integration/src/test/resources/org/mule/test/integration/endpoints/dynamic-endpoint-encoded-url-config.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/endpoints/dynamic-endpoint-encoded-url-config.xml
@@ -16,7 +16,7 @@
 
     <flow name="assembledDynamicAddress">
         <vm:inbound-endpoint path="testAssembledDynamic" exchange-pattern="request-response"/>
-        <http:outbound-endpoint user="admin" password="admin%40123" path="#[message.inboundProperties['path']]?foo=bar" host="localhost"
+        <http:outbound-endpoint user="admin" password="admin@123" path="#[message.inboundProperties['path']]?foo=bar" host="localhost"
                                 port="${serverPort}" exchange-pattern="request-response"/>
     </flow>
 
@@ -28,7 +28,7 @@
 
     <flow name="assembledStaticAddress">
         <vm:inbound-endpoint path="testAssembledStatic" exchange-pattern="request-response"/>
-        <http:outbound-endpoint user="admin" password="admin%40123" path="test?foo=bar" host="localhost" port="${serverPort}"
+        <http:outbound-endpoint user="admin" password="admin@123" path="test?foo=bar" host="localhost" port="${serverPort}"
                                 exchange-pattern="request-response"/>
     </flow>
 </mule>


### PR DESCRIPTION
The attributes that end in and endpoint URI (for instance: smtp user and passwords) previously had to be encoded as a workaround for this issue. That workaround has to be removed when this fix is in place. 

Keep in mind that this also affects the result of MEL expressions (for instance, if an expression evaluated to a username with an @ char, it had to be encoded before using it), so a check has to be done during migration to remove all the additional encoding that was placed for workarounding this.