### PR TITLE
MULE-6417: / by zero in ComponentStatistics

### DIFF
--- a/core/src/main/java/org/mule/management/stats/ComponentStatistics.java
+++ b/core/src/main/java/org/mule/management/stats/ComponentStatistics.java
@@ -16,7 +16,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * 
+ * ComponentStatistics is a basic metrics aggregation class that is accessible
+ * via the JMX api. This class is not thread-safe - occasional errors in 
+ * reported statistics should be expected, especially when the {@code clear()} 
+ * method is used.
  */
 public class ComponentStatistics implements Statistics
 {
@@ -43,6 +46,7 @@ public class ComponentStatistics implements Statistics
      * are measured for from the property statIntervalTime. If the property is 
      * not set or cannot be parsed, disable interval time and just compute 
      * stats from start of mule.
+     * 
      * TODO: The code to create and use an interval time for measuring average execution 
      * time could be removed once a complete solution is available in MuleHQ to
      * monitor this
@@ -70,7 +74,12 @@ public class ComponentStatistics implements Statistics
         }
     }
 
-    public void clear()
+    /**
+     * Resets the state of this component statistics collector. If called
+     * while a branch is being executed, then statistics may be slightly
+     * erroneous.
+     */
+    public synchronized void clear()
     {
         minExecutionTime = 0;
         maxExecutionTime = 0;
@@ -79,6 +88,15 @@ public class ComponentStatistics implements Statistics
         averageExecutionTime = 0;
     }
 
+    /**
+     * Returns true if this stats collector is enabled.
+     * This value does not affect statistics tabulation directly - it is
+     * up to the component to enable/disable collection based on the value
+     * of this method.
+     * 
+     * @return True if stats collection is enabled, otherwise false.
+     */
+    @Override
     public boolean isEnabled()
     {
         return enabled;
@@ -94,28 +112,55 @@ public class ComponentStatistics implements Statistics
         printer.print(this);
     }
 
+    /**
+     * Tags this stats collector as enabled or disabled. Does not affect
+     * stats calculation - it is up to the caller to check this flag.
+     * 
+     * @param b True if stats should be enabled, otherwise false.
+     */
     public void setEnabled(boolean b)
     {
         this.enabled = b;
     }
 
+    /**
+     * The maximum total event execution time seen since last cleared.
+     *  
+     * @return The maximum time, or zero if no events have been started.
+     */
     public long getMaxExecutionTime()
     {
         return maxExecutionTime;
     }
 
+    /**
+     * The minimum total event execution time seen since last cleared.
+     *  
+     * @return The maximum time, or zero if no events have been completed.
+     */
     public long getMinExecutionTime()
     {
         return minExecutionTime;
     }
 
+    /**
+     * The total cumulative execution time since statistics were last cleared.
+     * Includes the sum of all branch times plus any directly recorded execution
+     * times.
+     * 
+     * @return The total cumulative execution time, in milliseconds.
+     */
     public long getTotalExecutionTime()
     {
         return totalExecTime;
     }
 
-    /*
-     * executedEvents is since interval started
+    /**
+     * Then number of events executed since last cleared. NOTE: When branch times
+     * are recorded, an event will typically be recorded as 'executed' on the
+     * first branch event. See {@link #addExecutionBranchTime(boolean, long, long)}.
+     * 
+     * @return The number of events executed since last cleared.
      */
     public long getExecutedEvents()
     {
@@ -123,13 +168,23 @@ public class ComponentStatistics implements Statistics
     }
 
     /**
-     * Add a new execution-time measurement for one branch of processing an event
+     * Add a new execution-time measurement for one branch of processing an event.
+     * 
      * @param first true if this is the first branch for this event
      * @param branch the time to execute this branch
-     * @param total the total time (so far) for  processing this event
+     * @param total the total time (so far) for processing this event
      */
     public synchronized void addExecutionBranchTime(boolean first, long branch, long total)
     {
+        // TODO: ComponentStatistics should really create distinct Event
+        // objects that can be used to aggregate statistics and then atomically
+        // log them at completion time. 
+        //
+        // As-written, any calls made to clear() after the first call to 
+        // addExecutionBranchTime(...) but before the call to 
+        // addCompleteExecutionTime(...) will necessarily lead to the collection 
+        // of incomplete/incorrect statistics for that event.
+        
         if (statIntervalTimeEnabled)
         {
             long currentTime = System.currentTimeMillis();
@@ -150,31 +205,42 @@ public class ComponentStatistics implements Statistics
             executedEvent++;
         }
 
-        totalExecTime += ProcessingTime.getEffectiveTime(branch);
-        long effectiveTotal = ProcessingTime.getEffectiveTime(total);
-        if (maxExecutionTime == 0 || effectiveTotal > maxExecutionTime)
+        if (executedEvent > 0)
         {
-            maxExecutionTime = effectiveTotal;
+            totalExecTime += ProcessingTime.getEffectiveTime(branch);
+            long effectiveTotal = ProcessingTime.getEffectiveTime(total);
+            if (maxExecutionTime == 0 || effectiveTotal > maxExecutionTime)
+            {
+                maxExecutionTime = effectiveTotal;
+            }
+            averageExecutionTime = totalExecTime / executedEvent;
         }
-        averageExecutionTime = Math.round(totalExecTime / executedEvent);
     }
 
     /**
-     * Add the complete execution time for a flow that also reports branhc execution times
+     * Add the complete execution time for a flow that also reports branch execution times.
+     * Use in conjunction with {@link #addExecutionBranchTime(boolean, long, long)}.
+     * 
+     * @param time the total time required to process this event
      */
     public synchronized void addCompleteExecutionTime(long time)
     {
-        long effectiveTime = ProcessingTime.getEffectiveTime(time);
-        if (minExecutionTime == 0 || effectiveTime < minExecutionTime)
+        if (executedEvent > 0) 
         {
-            minExecutionTime = effectiveTime;
+            long effectiveTime = ProcessingTime.getEffectiveTime(time);
+            if (minExecutionTime == 0 || effectiveTime < minExecutionTime)
+            {
+                minExecutionTime = effectiveTime;
+            }
         }
     }
 
     /**
      * Add a new execution-time measurement for processing an event.
+     * Do not use when reporting branch execution times; instead see
+     * {@link #addCompleteExecutionTime(long)}.
      *
-     * @param time
+     * @param time The total event time to be logged/recorded.
      */
     public synchronized void addExecutionTime(long time)
     {
@@ -206,9 +272,15 @@ public class ComponentStatistics implements Statistics
         {
             maxExecutionTime = time;
         }
-        averageExecutionTime = Math.round(totalExecTime / executedEvent);
+        averageExecutionTime = totalExecTime / executedEvent;
     }
 
+    /** 
+     * Returns the average execution time, rounded downwards.
+     * 
+     * @return the total event time accumulated to this point, 
+     * divided by the total number of events recorded.
+     */
     public long getAverageExecutionTime()
     {
         return averageExecutionTime;

--- a/core/src/test/java/org/mule/management/stats/ComponentStatisticsTestCase.java
+++ b/core/src/test/java/org/mule/management/stats/ComponentStatisticsTestCase.java
@@ -6,9 +6,12 @@
  */
 package org.mule.management.stats;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 /**
@@ -39,11 +42,11 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     private void assertValues(ComponentStatistics stats,
             long numEvents, long totalTime, long avgTime, 
             long maxTime, long minTime) {
-        assertEquals("getExecutedEvents", numEvents, stats.getExecutedEvents());
-        assertEquals("getTotalExecutionTime", totalTime, stats.getTotalExecutionTime());
-        assertEquals("getAverageExecutionTime", avgTime, stats.getAverageExecutionTime());
-        assertEquals("getMaxExecutionTime", maxTime, stats.getMaxExecutionTime());
-        assertEquals("getMinExecutionTime", minTime, stats.getMinExecutionTime()); 
+        assertThat("getExecutedEvents", stats.getExecutedEvents(), equalTo(numEvents));
+        assertThat("getTotalExecutionTime", stats.getTotalExecutionTime(), equalTo(totalTime));
+        assertThat("getAverageExecutionTime", stats.getAverageExecutionTime(), equalTo(avgTime));
+        assertThat("getMaxExecutionTime", stats.getMaxExecutionTime(), equalTo(maxTime));
+        assertThat("getMinExecutionTime", stats.getMinExecutionTime(), equalTo(minTime)); 
     }
     
     @Test
@@ -51,7 +54,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
         ComponentStatistics stats = new ComponentStatistics();
         // num, total, avg, max, min
         assertValues(stats, 0L, 0L, 0L, 0L, 0L);
-        assertEquals(false, stats.isEnabled());
+        assertThat(stats.isEnabled(), equalTo(false));
     }
     
     @Test

--- a/core/src/test/java/org/mule/management/stats/ComponentStatisticsTestCase.java
+++ b/core/src/test/java/org/mule/management/stats/ComponentStatisticsTestCase.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.management.stats;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.*;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+/**
+ * Validates some basic assumptions about the ComponentStatistics class
+ * behavior.
+ */
+public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
+
+    /* This class was added to address MULE-6417 */
+    
+    private String env_statIntervalTime;
+    
+    @Before
+    public void setUp() {
+        // ComponentStatistics reads statIntervalTime from the environment.
+        // We will want to control it.
+        env_statIntervalTime = System.getProperty("statIntervalTime");
+        System.clearProperty("statIntervalTime");
+    }
+    
+    @After
+    public void tearDown() {
+        if (env_statIntervalTime != null) {
+            System.setProperty("statIntervalTime", env_statIntervalTime);
+        }
+    }
+    
+    private void assertValues(ComponentStatistics stats,
+            long numEvents, long totalTime, long avgTime, 
+            long maxTime, long minTime) {
+        assertEquals("getExecutedEvents", numEvents, stats.getExecutedEvents());
+        assertEquals("getTotalExecutionTime", totalTime, stats.getTotalExecutionTime());
+        assertEquals("getAverageExecutionTime", avgTime, stats.getAverageExecutionTime());
+        assertEquals("getMaxExecutionTime", maxTime, stats.getMaxExecutionTime());
+        assertEquals("getMinExecutionTime", minTime, stats.getMinExecutionTime()); 
+    }
+    
+    @Test
+    public void testDefaults() {
+        ComponentStatistics stats = new ComponentStatistics();
+        // num, total, avg, max, min
+        assertValues(stats, 0L, 0L, 0L, 0L, 0L);
+        assertEquals(false, stats.isEnabled());
+    }
+    
+    @Test
+    public void testSingleEvent() {
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionTime(100L);
+        // num, total, avg, max, min
+        assertValues(stats, 1L, 100L, 100L, 100L, 100L);
+    }
+    
+    @Test
+    public void testSingleBranchEvent() {
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionBranchTime(true /*first*/, 25L, 25L);
+        // num, total, avg, max, min
+        assertValues(stats, 1L, 25L, 25L, 25L, 0L);
+        stats.addExecutionBranchTime(false /*first*/, 25L, 50L);
+        assertValues(stats, 1L, 50L, 50L, 50L, 0L);
+        stats.addCompleteExecutionTime(50L);
+        assertValues(stats, 1L, 50L, 50L, 50L, 50L);
+    }
+    
+    @Test
+    public void testClear() {
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionTime(100L);
+        stats.clear();
+        // num, total, avg, max, min
+        assertValues(stats, 0L, 0L, 0L, 0L, 0L);
+    }
+    
+    /* 
+     * New behavior under the fix to MULE-6417 - no longer throws a 
+     * divide-by-zero error. Instead, the remainder of the fragmented
+     * event is ignored until a new event is started.
+     * 
+     * Note that this is a partial solution - if multiple components
+     * are active at the same time, collection can be 're-enabled' 
+     * for an already-started event. The established API does not 
+     * allow for a solution, so for now this quirk must be accepted.
+     */
+    @Test
+    public void testClearDuringBranch() {
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionBranchTime(true /*first*/, 25L, 25L);
+        stats.clear();
+        assertValues(stats, 0L, 0L, 0L, 0L, 0L);
+        stats.addExecutionBranchTime(false /*first*/, 25L, 50L);
+        assertValues(stats, 0L, 0L, 0L, 0L, 0L);
+    }
+    
+    @Test
+    public void testMaxMinAverage() {
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionTime(2L);
+        stats.addExecutionTime(3L);
+        // num, total, avg, max, min
+        assertValues(stats, 2L, 5L, 2L /*note: floor*/, 3L, 2L);
+    }
+    
+    @Test
+    public void testBranchMaxMinAverage() {
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionBranchTime(true /*first*/, 2L, 2L);
+        stats.addCompleteExecutionTime(2L);
+        stats.addExecutionBranchTime(true /*first*/, 3L, 3L);
+        stats.addCompleteExecutionTime(3L);
+        // num, total, avg, max, min
+        assertValues(stats, 2L, 5L, 2L /*note: floor*/, 3L, 2L);
+    }
+
+    @Test
+    public void testMultiBranchMaxMinAverage() {
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionBranchTime(true /*first*/, 1L, 1L);
+        stats.addExecutionBranchTime(false /*false*/, 1L, 2L);
+        stats.addCompleteExecutionTime(2L);
+        stats.addExecutionBranchTime(true /*first*/, 3L, 3L);
+        stats.addCompleteExecutionTime(3L);
+        // num, total, avg, max, min
+        assertValues(stats, 2L, 5L, 2L /*note: floor*/, 3L, 2L);
+    }
+    
+    @Test
+    public void testStatIntervalReset() {
+        // configure to reset continuously
+        // this functionality is flawed in many ways, but we'll test the basics anyways
+        System.setProperty("statIntervalTime", "-1");
+        ComponentStatistics stats = new ComponentStatistics();
+
+        // single
+        stats.addExecutionTime(100L); // reset and then collect
+        assertValues(stats, 1L, 100L, 100L, 100L, 100L);
+        stats.addExecutionTime(200L); // reset and then collect
+        assertValues(stats, 1L, 200L, 200L, 200L, 200L);
+        
+        // branch
+        stats.addExecutionBranchTime(true, 100L, 100L); // reset and then collect
+        assertValues(stats, 1L, 100L, 100L, 100L, 0L);
+        stats.addExecutionBranchTime(true, 200L, 200L); // reset and then collect
+        assertValues(stats, 1L, 200L, 200L, 200L, 0L);
+        stats.addCompleteExecutionTime(200L); // currently doesn't reset
+        assertValues(stats, 1L, 200L, 200L, 200L, 200L);  
+    }
+
+    @Test
+    public void testStatIntervalNoReset() {
+        // configure to reset far into the future
+        System.setProperty("statIntervalTime", "9999");
+        ComponentStatistics stats = new ComponentStatistics();
+        stats.addExecutionTime(100L);
+        assertValues(stats, 1L, 100L, 100L, 100L, 100L);
+        stats.addExecutionBranchTime(true, 100L, 100L); // no reset expected
+        assertValues(stats, 2L, 200L, 100L, 100L, 100L);
+    }
+}

--- a/core/src/test/java/org/mule/management/stats/ComponentStatisticsTestCase.java
+++ b/core/src/test/java/org/mule/management/stats/ComponentStatisticsTestCase.java
@@ -22,20 +22,20 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
 
     /* This class was added to address MULE-6417 */
     
-    private String env_statIntervalTime;
+    private String originalStatIntervalTime;
     
     @Before
     public void setUp() {
         // ComponentStatistics reads statIntervalTime from the environment.
         // We will want to control it.
-        env_statIntervalTime = System.getProperty("statIntervalTime");
+        originalStatIntervalTime = System.getProperty("statIntervalTime");
         System.clearProperty("statIntervalTime");
     }
     
     @After
     public void tearDown() {
-        if (env_statIntervalTime != null) {
-            System.setProperty("statIntervalTime", env_statIntervalTime);
+        if (originalStatIntervalTime != null) {
+            System.setProperty("statIntervalTime", originalStatIntervalTime);
         }
     }
     
@@ -50,7 +50,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
     
     @Test
-    public void testDefaults() {
+    public void verifyStatDefaults() {
         ComponentStatistics stats = new ComponentStatistics();
         // num, total, avg, max, min
         assertValues(stats, 0L, 0L, 0L, 0L, 0L);
@@ -58,7 +58,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
     
     @Test
-    public void testSingleEvent() {
+    public void processSingleEvent() {
         ComponentStatistics stats = new ComponentStatistics();
         stats.addExecutionTime(100L);
         // num, total, avg, max, min
@@ -66,7 +66,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
     
     @Test
-    public void testSingleBranchEvent() {
+    public void processSingleBranchEvent() {
         ComponentStatistics stats = new ComponentStatistics();
         stats.addExecutionBranchTime(true /*first*/, 25L, 25L);
         // num, total, avg, max, min
@@ -78,7 +78,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
     
     @Test
-    public void testClear() {
+    public void clearStats() {
         ComponentStatistics stats = new ComponentStatistics();
         stats.addExecutionTime(100L);
         stats.clear();
@@ -97,7 +97,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
      * allow for a solution, so for now this quirk must be accepted.
      */
     @Test
-    public void testClearDuringBranch() {
+    public void clearDuringBranch() {
         ComponentStatistics stats = new ComponentStatistics();
         stats.addExecutionBranchTime(true /*first*/, 25L, 25L);
         stats.clear();
@@ -107,7 +107,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
     
     @Test
-    public void testMaxMinAverage() {
+    public void verifyMaxMinAverage() {
         ComponentStatistics stats = new ComponentStatistics();
         stats.addExecutionTime(2L);
         stats.addExecutionTime(3L);
@@ -116,7 +116,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
     
     @Test
-    public void testBranchMaxMinAverage() {
+    public void verifyBranchMaxMinAverage() {
         ComponentStatistics stats = new ComponentStatistics();
         stats.addExecutionBranchTime(true /*first*/, 2L, 2L);
         stats.addCompleteExecutionTime(2L);
@@ -127,7 +127,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
 
     @Test
-    public void testMultiBranchMaxMinAverage() {
+    public void verifyMultiBranchMaxMinAverage() {
         ComponentStatistics stats = new ComponentStatistics();
         stats.addExecutionBranchTime(true /*first*/, 1L, 1L);
         stats.addExecutionBranchTime(false /*false*/, 1L, 2L);
@@ -139,7 +139,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
     
     @Test
-    public void testStatIntervalReset() {
+    public void verifyShortStatIntervalReset() {
         // configure to reset continuously
         // this functionality is flawed in many ways, but we'll test the basics anyways
         System.setProperty("statIntervalTime", "-1");
@@ -161,7 +161,7 @@ public class ComponentStatisticsTestCase extends AbstractMuleTestCase {
     }
 
     @Test
-    public void testStatIntervalNoReset() {
+    public void verifyLongStatIntervalNoReset() {
         // configure to reset far into the future
         System.setProperty("statIntervalTime", "9999");
         ComponentStatistics stats = new ComponentStatistics();


### PR DESCRIPTION
Eliminated '/ by zero' by skipping branch data updates while executedEvent(Count) is zero.
Added synchronization around clear() - now consistent with other usage of synchronization and fix other potential bugs/race conditions.
Added ComponentStatisticsTestCase to validate existing behavior and capture functional changes.
Added javadoc to describe current behavior and known weaknesses/limitations.

A better fix may be to introduce an explicit Event object that can accumulate branch events and then be committed as an atomic update. However, that would break existing APIs.