### PR TITLE
MULE-8948: CE Build fails when using JDK8 without adding the property…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2139,6 +2139,15 @@
                 <vmtype>org.eclipse.jdt.internal.launching.macosx.MacOSXType</vmtype>
             </properties>
         </profile>
+        <profile>
+            <id>jdk8+</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <xDocLint>'-Xdoclint:none'</xDocLint>
+            </properties>
+        </profile>
 
         <!-- C.I. staged build profiles -->
         <profile>


### PR DESCRIPTION
… -DxDocLint='-Xdoclint:none'