### PR TITLE
MULE-8962: HTTP Connector throws a NPE when the value for a uri-param…

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/request/HttpRequesterRequestBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/HttpRequesterRequestBuilder.java
@@ -37,6 +37,11 @@ public class HttpRequesterRequestBuilder extends HttpMessageBuilder
             List<String> uriParamValues = uriParamMap.getAll(uriParamName);
             String uriParamValue = uriParamValues.get(uriParamValues.size() - 1);
 
+            if (uriParamValue == null)
+            {
+                throw new NullPointerException(String.format("Expression {%s} evaluated to null.", uriParamName));
+            }
+
             path = path.replaceAll(String.format("\\{%s\\}", uriParamName), uriParamValue);
         }
         return path;

--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestUriParamsTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestUriParamsTestCase.java
@@ -6,21 +6,30 @@
  */
 package org.mule.module.http.functional.requester;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.isA;
 import static org.junit.Assert.assertThat;
+import static org.junit.rules.ExpectedException.none;
+import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.construct.Flow;
+import org.mule.transport.NullPayload;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  *
  */
 public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase
 {
+    @Rule
+    public ExpectedException expectedException = none();
 
     @Override
     protected String getConfigFile()
@@ -79,6 +88,19 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase
         flow.process(event);
 
         assertThat(uri, equalTo("/testPath/testValueNew/testValue2"));
+    }
+
+    @Test
+    public void sendsUriParamsIfNull() throws Exception
+    {
+        Flow flow = (Flow) getFlowConstruct("uriParamNull");
+
+        MuleEvent event = getTestEvent(NullPayload.getInstance());
+
+        expectedException.expect(MessagingException.class);
+        expectedException.expectCause(isA(NullPointerException.class));
+        expectedException.expectMessage(containsString("Expression {testParam2} evaluated to null."));
+        flow.process(event);
     }
 
 }

--- a/modules/http/src/test/resources/http-request-uri-params-config.xml
+++ b/modules/http/src/test/resources/http-request-uri-params-config.xml
@@ -34,5 +34,13 @@
         </http:request>
     </flow>
 
+    <flow name="uriParamNull">
+        <http:request config-ref="config" path="testPath/{testParam1}/{testParam2}" >
+            <http:request-builder>
+                <http:uri-param paramName="testParam1" value="testValue1" />
+                <http:uri-param paramName="testParam2" value="#[payload]" />
+            </http:request-builder>
+        </http:request>
+    </flow>
 
 </mule>


### PR DESCRIPTION
… is null