### PR TITLE
MULE-8964: JMS polls for messages using XA transaction timeout

### DIFF
--- a/transports/jms/src/main/resources/META-INF/mule-jms.xsd
+++ b/transports/jms/src/main/resources/META-INF/mule-jms.xsd
@@ -524,6 +524,15 @@
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="xaPollingTimeout" type="mule:substitutableInt">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            The number of milliseconds that a transacted message receiver will wait for an incoming message inside an active XA transaction.
+                            When no polling timeout is configured, the transaction timeout will be used instead. This attribute is ignored when no XA transaction is configured.
+                            NOTE: this value must be considered when the transaction timeout is configured. This means that the transaction timeout must be large enough to cover the polling timeout and the message processing times.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/transports/jms/src/test/java/org/mule/transport/jms/XaPollingTimeoutTestCase.java
+++ b/transports/jms/src/test/java/org/mule/transport/jms/XaPollingTimeoutTestCase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.jms;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import org.mule.api.construct.FlowConstruct;
+import org.mule.api.endpoint.InboundEndpoint;
+import org.mule.api.lifecycle.CreateException;
+import org.mule.api.transport.Connector;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.probe.PollingProber;
+import org.mule.tck.probe.Probe;
+
+import javax.jms.MessageConsumer;
+
+import org.junit.Test;
+
+public class XaPollingTimeoutTestCase extends FunctionalTestCase
+{
+
+    private static MessageConsumer messageConsumer = mock(MessageConsumer.class);
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "xa-polling-timeout-config.xml";
+    }
+
+    @Test
+    public void usesConfiguredXaPollingTimeout() throws Exception
+    {
+        final PollingProber prober = new PollingProber(RECEIVE_TIMEOUT, 100);
+
+        prober.check(new Probe()
+        {
+            @Override
+            public boolean isSatisfied()
+            {
+                try
+                {
+                    verify(messageConsumer, atLeastOnce()).receive(10000);
+                    return true;
+                }
+                catch (Throwable e)
+                {
+                    return false;
+                }
+            }
+
+            @Override
+            public String describeFailure()
+            {
+                return "Message consumer was not invoked using the right timeout";
+            }
+        });
+    }
+
+    public static class TestXaTransactedJmsMessageReceiver extends XaTransactedJmsMessageReceiver
+    {
+
+        public TestXaTransactedJmsMessageReceiver(Connector connector, FlowConstruct flowConstruct, InboundEndpoint endpoint) throws CreateException
+        {
+            super(connector, flowConstruct, endpoint);
+        }
+
+        @Override
+        protected MessageConsumer createConsumer() throws Exception
+        {
+            return messageConsumer;
+        }
+    }
+}

--- a/transports/jms/src/test/resources/xa-polling-timeout-config.xml
+++ b/transports/jms/src/test/resources/xa-polling-timeout-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" 
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:jms="http://www.mulesoft.org/schema/mule/jms"
+      xmlns:jbossts="http://www.mulesoft.org/schema/mule/jbossts"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+        http://www.mulesoft.org/schema/mule/jms http://www.mulesoft.org/schema/mule/jms/current/mule-jms.xsd
+        http://www.mulesoft.org/schema/mule/jbossts http://www.mulesoft.org/schema/mule/jbossts/current/mule-jbossts.xsd">
+
+    <jbossts:transaction-manager/>
+
+    <jms:activemq-xa-connector name="jmsConnectorCustomPool" maxRedelivery="-1" specification="1.1" numberOfConsumers="1">
+        <service-overrides xaTransactedMessageReceiver="org.mule.transport.jms.XaPollingTimeoutTestCase$TestXaTransactedJmsMessageReceiver" />
+    </jms:activemq-xa-connector>
+
+    <flow name="main">
+        <jms:inbound-endpoint queue="testIn" connector-ref="jmsConnectorCustomPool" xaPollingTimeout="10000">
+            <xa-transaction action="ALWAYS_BEGIN"/>
+        </jms:inbound-endpoint>
+        
+        <echo-component/>
+    </flow>
+</mule>


### PR DESCRIPTION
_ Removing reference to un-existent endpoint property (pollingFrequency)
_ Adding transactedPollingTimeout endpotin property
_ Consuming messages using the right timeout