### PR TITLE
MULE-8965: Configured XA transaction timeout is ignored

### DIFF
--- a/core/src/main/java/org/mule/transaction/XaTransaction.java
+++ b/core/src/main/java/org/mule/transaction/XaTransaction.java
@@ -59,6 +59,7 @@ public class XaTransaction extends AbstractTransaction
 
         try
         {
+            txManager.setTransactionTimeout(getTimeoutInSeconds());
             txManager.begin();
             synchronized (this)
             {

--- a/core/src/main/java/org/mule/transaction/XaTransactionFactory.java
+++ b/core/src/main/java/org/mule/transaction/XaTransactionFactory.java
@@ -20,11 +20,15 @@ import javax.transaction.TransactionManager;
  */
 public class XaTransactionFactory implements ExternalTransactionAwareTransactionFactory
 {
+
+    private int timeout;
+
     public Transaction beginTransaction(MuleContext muleContext) throws TransactionException
     {
         try
         {
             XaTransaction xat = new XaTransaction(muleContext);
+            xat.setTimeout(timeout);
             xat.begin();
             return xat;
         }
@@ -64,5 +68,15 @@ public class XaTransactionFactory implements ExternalTransactionAwareTransaction
     public boolean isTransacted()
     {
         return true;
+    }
+
+    public int getTimeout()
+    {
+        return timeout;
+    }
+
+    public void setTimeout(int timeout)
+    {
+        this.timeout = timeout;
     }
 }

--- a/core/src/test/java/org/mule/transaction/XaTransactionFactoryTestCase.java
+++ b/core/src/test/java/org/mule/transaction/XaTransactionFactoryTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transaction;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mule.api.MuleContext;
+import org.mule.api.transaction.Transaction;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import javax.transaction.TransactionManager;
+
+import org.junit.Test;
+
+public class XaTransactionFactoryTestCase extends AbstractMuleTestCase
+{
+
+    @Test
+    public void setsTransactionTimeout() throws Exception
+    {
+        final int timeout = 1000;
+        final XaTransactionFactory transactionFactory = new XaTransactionFactory();
+        transactionFactory.setTimeout(timeout);
+
+        final MuleContext muleContext = mock(MuleContext.class, RETURNS_DEEP_STUBS);
+
+        final TransactionManager transactionManager = mock(TransactionManager.class);
+        when(muleContext.getTransactionManager()).thenReturn(transactionManager);
+
+        final Transaction transaction = transactionFactory.beginTransaction(muleContext);
+
+        assertThat(transaction.getTimeout(), equalTo(timeout));
+    }
+}

--- a/core/src/test/java/org/mule/transaction/XaTransactionTestCase.java
+++ b/core/src/test/java/org/mule/transaction/XaTransactionTestCase.java
@@ -10,6 +10,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -114,6 +116,21 @@ public class XaTransactionTestCase extends AbstractMuleTestCase
         xaTransaction.begin();
         xaTransaction.enlistResource(mockXaResource);
         verify(mockXaResource).setTransactionTimeout(timeoutValueInSeconds);
+    }
+
+    @Test
+    public void setsTransactionTimeoutOnBegin() throws Exception
+    {
+        final int timeoutMillis = 5000;
+        final int timeoutSecs = timeoutMillis / 1000;
+
+        XaTransaction xaTransaction = new XaTransaction(mockMuleContext);
+        xaTransaction.setTimeout(timeoutMillis);
+        xaTransaction.begin();
+
+        final InOrder inOrder = inOrder(mockTransactionManager);
+        inOrder.verify(mockTransactionManager).setTransactionTimeout(timeoutSecs);
+        inOrder.verify(mockTransactionManager).begin();
     }
 
     private class BadHashCodeImplementation

--- a/modules/spring-config/src/main/java/org/mule/config/spring/handlers/MuleNamespaceHandler.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/handlers/MuleNamespaceHandler.java
@@ -335,7 +335,7 @@ public class MuleNamespaceHandler extends AbstractMuleNamespaceHandler
         registerBeanDefinitionParser("inbound-endpoint", new ChildEndpointDefinitionParser(InboundEndpointFactoryBean.class));
         registerBeanDefinitionParser("outbound-endpoint", new ChildEndpointDefinitionParser(OutboundEndpointFactoryBean.class));
         registerBeanDefinitionParser("custom-transaction", new TransactionDefinitionParser());
-        registerBeanDefinitionParser("xa-transaction", new TransactionDefinitionParser(XaTransactionFactory.class));
+        registerBeanDefinitionParser("xa-transaction", new XaTransactionDefinitionParser(XaTransactionFactory.class));
         registerBeanDefinitionParser("idempotent-redelivery-policy", new ChildDefinitionParser("redeliveryPolicy", IdempotentRedeliveryPolicy.class));
 
         // Message Processors

--- a/modules/spring-config/src/main/java/org/mule/config/spring/parsers/specific/XaTransactionDefinitionParser.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/parsers/specific/XaTransactionDefinitionParser.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.config.spring.parsers.specific;
+
+public class XaTransactionDefinitionParser extends TransactionDefinitionParser
+{
+
+    private static String[] ignoredAttributes = new String[] {FACTORY_REF, ACTION, INTERACT_WTH_EXTERNAL};
+
+    public XaTransactionDefinitionParser(Class factoryClass)
+    {
+        super(factoryClass);
+    }
+
+    @Override
+    protected String[] getIgnoredAttributes()
+    {
+        return ignoredAttributes;
+    }
+}

--- a/tests/integration/src/test/java/org/mule/test/integration/transaction/XaTransactionTimeoutTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/transaction/XaTransactionTimeoutTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.test.integration.transaction;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import org.mule.api.endpoint.InboundEndpoint;
+import org.mule.api.transaction.TransactionConfig;
+import org.mule.construct.Flow;
+import org.mule.tck.junit4.FunctionalTestCase;
+
+import org.junit.Test;
+
+public class XaTransactionTimeoutTestCase extends FunctionalTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/integration/transaction/xa-transaction-timeout-config.xml";
+    }
+
+    @Test
+    public void configuresTransactionTimeout() throws Exception
+    {
+        final Flow flow = (Flow) muleContext.getRegistry().lookupFlowConstruct("main");
+        final InboundEndpoint inboundEndpoint = (InboundEndpoint) flow.getMessageSource();
+        final TransactionConfig transactionConfig = inboundEndpoint.getTransactionConfig();
+
+        assertThat(transactionConfig.getTimeout(), equalTo(5000));
+    }
+}

--- a/tests/integration/src/test/resources/org/mule/test/integration/transaction/xa-transaction-timeout-config.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/transaction/xa-transaction-timeout-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <flow name="main">
+        <vm:inbound-endpoint path="testIn" exchange-pattern="request-response">
+            <xa-transaction action="ALWAYS_BEGIN" timeout="5000"/>
+        </vm:inbound-endpoint>
+
+        <echo-component/>
+    </flow>
+</mule>


### PR DESCRIPTION
_ Refactoring TransactionDefinitionParser to let subclasses to use different set of ignored attributes
_ Adding XaTransactionDefinitionParser for xa-transaction element
_ Updating XaTransactionFactory to set the timeout on the created transactions
_ Setting timeout on transaction manager before beginning a transaction