### PR TITLE
MULE-6575: There is no way to turn off logging in exception strategy

### DIFF
--- a/core/src/main/java/org/mule/exception/AbstractExceptionListener.java
+++ b/core/src/main/java/org/mule/exception/AbstractExceptionListener.java
@@ -65,7 +65,7 @@ public abstract class AbstractExceptionListener extends AbstractMessageProcessor
     protected WildcardFilter commitTxFilter;
 
     protected boolean enableNotifications = true;
-    protected String logException;
+    protected String logException = "true";
 
     protected String globalName;
 


### PR DESCRIPTION
Fix tests