### PR TITLE
MULE-8982: Add debug information on HTTP requester

### DIFF
--- a/core/src/test/java/org/mule/tck/junit4/matcher/FieldDebugInfoMatcher.java
+++ b/core/src/test/java/org/mule/tck/junit4/matcher/FieldDebugInfoMatcher.java
@@ -8,7 +8,9 @@
 package org.mule.tck.junit4.matcher;
 
 import static java.lang.String.format;
+import static org.hamcrest.Matchers.equalTo;
 import org.mule.api.debug.FieldDebugInfo;
+import org.mule.api.debug.SimpleFieldDebugInfo;
 
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
@@ -20,31 +22,50 @@ public class FieldDebugInfoMatcher extends TypeSafeMatcher<FieldDebugInfo>
 
     private final String name;
     private final Class type;
-    private final Object value;
+    private final Matcher matcher;
 
     public FieldDebugInfoMatcher(String name, Class type, Object value)
     {
         this.name = name;
         this.type = type;
-        this.value = value;
+        this.matcher = equalTo(value);
+    }
+
+    public FieldDebugInfoMatcher(String name, Class type, Matcher matcher)
+    {
+        this.name = name;
+        this.type = type;
+        this.matcher = matcher;
     }
 
     @Override
     public boolean matchesSafely(FieldDebugInfo item)
     {
-        boolean sameValue = value != null && value.equals(item.getValue()) || value == null && item.getValue() == null;
+        boolean sameValue = matcher.matches(item.getValue());
 
         return name.equals(item.getName()) && sameValue && type == item.getType();
     }
 
     public void describeTo(Description description)
     {
-        description.appendText(format("a field debug info with name: '%s' type: '%s' value: '%s'", name, type, value));
+        description.appendText(format("a %s with name: '%s' type: '%s' and value that is ", SimpleFieldDebugInfo.class.getSimpleName(), name, type));
+        matcher.describeTo(description);
     }
 
     @Factory
     public static Matcher<FieldDebugInfo> fieldLike(String name, Class type, Object value)
     {
         return new FieldDebugInfoMatcher(name, type, value);
+    }
+
+    @Factory
+    public static Matcher<FieldDebugInfo> fieldLike(String name, Class type, Matcher matcher)
+    {
+        if (matcher == null)
+        {
+            throw new IllegalArgumentException("Matcher cannot be null");
+        }
+
+        return new FieldDebugInfoMatcher(name, type, matcher);
     }
 }

--- a/modules/db/src/test/java/org/mule/module/db/integration/bulkexecute/BulkExecuteDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/bulkexecute/BulkExecuteDebugInfoTestCase.java
@@ -13,8 +13,8 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mule.module.db.internal.debug.DbDebugInfoTestUtils.createQueryFieldDebugInfoMatcher;
 import static org.mule.module.db.internal.domain.query.QueryType.UPDATE;
-import static org.mule.module.db.internal.processor.DbDebugInfoUtils.createQueryFieldDebugInfo;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.QUERIES_DEBUG_FIELD;
 import static org.mule.tck.junit4.matcher.ObjectDebugInfoMatcher.objectLike;
 import org.mule.api.MuleEvent;
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -76,10 +77,11 @@ public class BulkExecuteDebugInfoTestCase extends AbstractDbIntegrationTestCase
         assertThat(debugInfo, is(not(nullValue())));
         assertThat(debugInfo.size(), equalTo(1));
 
-        final List<FieldDebugInfo> queriesDebugInfo = new ArrayList<>();
-        queriesDebugInfo.add(createQueryFieldDebugInfo(QUERY1, QUERY_TEMPLATE1));
-        queriesDebugInfo.add(createQueryFieldDebugInfo(QUERY2, QUERY_TEMPLATE2));
+        final List<Matcher<FieldDebugInfo>> queryMatchers = new ArrayList<>();
+        queryMatchers.add(createQueryFieldDebugInfoMatcher(QUERY1, QUERY_TEMPLATE1));
+        queryMatchers.add(createQueryFieldDebugInfoMatcher(QUERY2, QUERY_TEMPLATE2));
 
-        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, queriesDebugInfo)));
+        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, queryMatchers)));
     }
+
 }

--- a/modules/db/src/test/java/org/mule/module/db/integration/select/SelectDynamicQueryDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/select/SelectDynamicQueryDebugInfoTestCase.java
@@ -8,6 +8,7 @@
 package org.mule.module.db.integration.select;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -17,7 +18,6 @@ import static org.mule.module.db.internal.processor.DbDebugInfoUtils.INPUT_PARAM
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.SQL_TEXT_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.TYPE_DEBUG_FIELD;
 import static org.mule.tck.junit4.matcher.FieldDebugInfoMatcher.fieldLike;
-import static org.mule.tck.junit4.matcher.ObjectDebugInfoMatcher.objectLike;
 import org.mule.api.MuleEvent;
 import org.mule.api.debug.FieldDebugInfo;
 import org.mule.api.processor.MessageProcessor;
@@ -27,7 +27,6 @@ import org.mule.module.db.integration.TestDbConfig;
 import org.mule.module.db.integration.model.AbstractTestDatabase;
 import org.mule.module.db.internal.processor.AbstractSingleQueryDbMessageProcessor;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -69,6 +68,6 @@ public class SelectDynamicQueryDebugInfoTestCase extends AbstractDbIntegrationTe
         assertThat(debugInfo.size(), equalTo(3));
         assertThat(debugInfo, hasItem(fieldLike(SQL_TEXT_DEBUG_FIELD, String.class, "select * from PLANET order by ID")));
         assertThat(debugInfo, hasItem(fieldLike(TYPE_DEBUG_FIELD, String.class, "SELECT")));
-        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, Collections.<FieldDebugInfo>emptyList())));
+        assertThat(debugInfo, hasItem(fieldLike(INPUT_PARAMS_DEBUG_FIELD, List.class, empty())));
     }
 }

--- a/modules/db/src/test/java/org/mule/module/db/integration/select/SelectParameterizedQueryDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/select/SelectParameterizedQueryDebugInfoTestCase.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mule.api.debug.FieldDebugInfoFactory.createFieldDebugInfo;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.INPUT_PARAMS_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.SQL_TEXT_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.TYPE_DEBUG_FIELD;
@@ -32,6 +31,7 @@ import org.mule.module.db.internal.processor.DbDebugInfoUtils;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -75,8 +75,8 @@ public class SelectParameterizedQueryDebugInfoTestCase extends AbstractDbIntegra
         assertThat(debugInfo, hasItem(fieldLike(SQL_TEXT_DEBUG_FIELD, String.class, "SELECT * FROM PLANET WHERE POSITION = ? AND NAME = 'Earth'")));
         assertThat(debugInfo, hasItem(fieldLike(TYPE_DEBUG_FIELD, String.class, "SELECT")));
 
-        final List<FieldDebugInfo> paramFields = new ArrayList<>();
-        paramFields.add(createFieldDebugInfo(PARAM1, String.class, expectedPosition));
-        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, paramFields)));
+        final List<Matcher<FieldDebugInfo>> paramMatchers = new ArrayList<>();
+        paramMatchers.add(fieldLike(PARAM1, String.class, expectedPosition));
+        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, paramMatchers)));
     }
 }

--- a/modules/db/src/test/java/org/mule/module/db/integration/update/UpdateBulkParameterizedDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/update/UpdateBulkParameterizedDebugInfoTestCase.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mule.api.debug.FieldDebugInfoFactory.createFieldDebugInfo;
 import static org.mule.module.db.integration.model.Planet.EARTH;
 import static org.mule.module.db.integration.model.Planet.MARS;
 import static org.mule.module.db.internal.domain.query.QueryType.UPDATE;
@@ -23,6 +22,7 @@ import static org.mule.module.db.internal.processor.DbDebugInfoUtils.PARAM_SET_D
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.QUERY_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.SQL_TEXT_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.TYPE_DEBUG_FIELD;
+import static org.mule.tck.junit4.matcher.FieldDebugInfoMatcher.fieldLike;
 import static org.mule.tck.junit4.matcher.ObjectDebugInfoMatcher.objectLike;
 import org.mule.api.MuleEvent;
 import org.mule.api.debug.FieldDebugInfo;
@@ -37,6 +37,7 @@ import org.mule.module.db.internal.processor.AbstractDbMessageProcessor;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -83,24 +84,25 @@ public class UpdateBulkParameterizedDebugInfoTestCase extends AbstractDbIntegrat
         assertThat(debugInfo, is(not(nullValue())));
         assertThat(debugInfo.size(), equalTo(2));
 
-        List<FieldDebugInfo> queryFields = new ArrayList<>();
-        queryFields.add(createFieldDebugInfo(SQL_TEXT_DEBUG_FIELD, String.class, "update PLANET set NAME='Mercury' where NAME=?"));
-        queryFields.add(createFieldDebugInfo(TYPE_DEBUG_FIELD, String.class, UPDATE.toString()));
-        assertThat(debugInfo, hasItem(objectLike(QUERY_DEBUG_FIELD, Query.class, queryFields)));
-        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, createExpectedParamSets())));
+        List<Matcher<FieldDebugInfo>> queryMatcher = new ArrayList<>();
+        queryMatcher.add(fieldLike(SQL_TEXT_DEBUG_FIELD, String.class, "update PLANET set NAME='Mercury' where NAME=?"));
+        queryMatcher.add(fieldLike(TYPE_DEBUG_FIELD, String.class, UPDATE.toString()));
+
+        assertThat(debugInfo, hasItem(objectLike(QUERY_DEBUG_FIELD, Query.class, queryMatcher)));
+        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, createExpectedParamSetMatchers())));
     }
 
-    private List<FieldDebugInfo> createExpectedParamSets()
+    private List<Matcher<FieldDebugInfo>> createExpectedParamSetMatchers()
     {
-        final List<FieldDebugInfo> paramSets = new ArrayList<>();
+        final List<Matcher<FieldDebugInfo>> paramSetMatchers = new ArrayList<>();
 
-        final List<FieldDebugInfo> paramSet1 = new ArrayList<>();
-        paramSet1.add(createFieldDebugInfo(PARAM1, String.class, EARTH.getName()));
-        paramSets.add(createFieldDebugInfo(PARAM_SET1, List.class, paramSet1));
+        final List<Matcher<FieldDebugInfo>> paramSet1 = new ArrayList<>();
+        paramSet1.add(fieldLike(PARAM1, String.class, EARTH.getName()));
+        paramSetMatchers.add(objectLike(PARAM_SET1, List.class, paramSet1));
 
-        final List<FieldDebugInfo> paramSet2 = new ArrayList<>();
-        paramSet2.add(createFieldDebugInfo(PARAM1, String.class, MARS.getName()));
-        paramSets.add(createFieldDebugInfo(PARAM_SET2, List.class, paramSet2));
-        return paramSets;
+        final List<Matcher<FieldDebugInfo>> paramSet2 = new ArrayList<>();
+        paramSet2.add(fieldLike(PARAM1, String.class, MARS.getName()));
+        paramSetMatchers.add(objectLike(PARAM_SET2, List.class, paramSet2));
+        return paramSetMatchers;
     }
 }

--- a/modules/db/src/test/java/org/mule/module/db/integration/update/UpdateDynamicBulkDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/update/UpdateDynamicBulkDebugInfoTestCase.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mule.module.db.internal.debug.DbDebugInfoTestUtils.createQueryFieldDebugInfoMatcher;
 import static org.mule.module.db.internal.domain.query.QueryType.UPDATE;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.QUERIES_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.QUERY_DEBUG_FIELD;
@@ -25,12 +26,12 @@ import org.mule.module.db.integration.model.AbstractTestDatabase;
 import org.mule.module.db.internal.domain.param.QueryParam;
 import org.mule.module.db.internal.domain.query.QueryTemplate;
 import org.mule.module.db.internal.processor.AbstractDbMessageProcessor;
-import org.mule.module.db.internal.processor.DbDebugInfoUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 public class UpdateDynamicBulkDebugInfoTestCase extends UpdateBulkTestCase
@@ -68,14 +69,14 @@ public class UpdateDynamicBulkDebugInfoTestCase extends UpdateBulkTestCase
 
         assertThat(debugInfo, is(not(nullValue())));
         assertThat(debugInfo.size(), equalTo(1));
-        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, createExpectedQueries())));
+        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, createExpectedQueryMatchers())));
     }
 
-    private List<FieldDebugInfo> createExpectedQueries()
+    private List<Matcher<FieldDebugInfo>> createExpectedQueryMatchers()
     {
-        final List<FieldDebugInfo> queriesDebugInfo = new ArrayList<>();
-        queriesDebugInfo.add(DbDebugInfoUtils.createQueryFieldDebugInfo(QUERY1, new QueryTemplate("update PLANET set NAME='Mercury' where NAME='EARTH'", UPDATE, Collections.<QueryParam>emptyList())));
-        queriesDebugInfo.add(DbDebugInfoUtils.createQueryFieldDebugInfo(QUERY2, new QueryTemplate("update PLANET set NAME='Mercury' where NAME='MARS'", UPDATE, Collections.<QueryParam>emptyList())));
+        final List<Matcher<FieldDebugInfo>> queriesDebugInfo = new ArrayList<>();
+        queriesDebugInfo.add(createQueryFieldDebugInfoMatcher(QUERY1, new QueryTemplate("update PLANET set NAME='Mercury' where NAME='EARTH'", UPDATE, Collections.<QueryParam>emptyList())));
+        queriesDebugInfo.add(createQueryFieldDebugInfoMatcher(QUERY2, new QueryTemplate("update PLANET set NAME='Mercury' where NAME='MARS'", UPDATE, Collections.<QueryParam>emptyList())));
 
         return queriesDebugInfo;
     }

--- a/modules/db/src/test/java/org/mule/module/db/internal/debug/DbDebugInfoTestUtils.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/debug/DbDebugInfoTestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.db.internal.debug;
+
+import static org.mule.module.db.internal.processor.DbDebugInfoUtils.SQL_TEXT_DEBUG_FIELD;
+import static org.mule.module.db.internal.processor.DbDebugInfoUtils.TYPE_DEBUG_FIELD;
+import static org.mule.tck.junit4.matcher.FieldDebugInfoMatcher.fieldLike;
+import static org.mule.tck.junit4.matcher.ObjectDebugInfoMatcher.objectLike;
+import org.mule.api.debug.FieldDebugInfo;
+import org.mule.module.db.internal.domain.query.Query;
+import org.mule.module.db.internal.domain.query.QueryTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matcher;
+
+/**
+ * Provides utility methods for testing {@link FieldDebugInfo} on DB module
+ */
+public class DbDebugInfoTestUtils
+{
+
+    private DbDebugInfoTestUtils()
+    {
+    }
+
+    /**
+     * Creates a matcher to assert the debug info generated for a query
+     *
+     * @param name expected query name
+     * @param queryTemplate query to compare with the debug info
+     * @return a non null matcher
+     */
+    public static Matcher<FieldDebugInfo> createQueryFieldDebugInfoMatcher(String name, QueryTemplate queryTemplate)
+    {
+        final List<Matcher<FieldDebugInfo>> queryMatcher = new ArrayList<>();
+        queryMatcher.add(fieldLike(SQL_TEXT_DEBUG_FIELD, String.class, queryTemplate.getSqlText()));
+        queryMatcher.add(fieldLike(TYPE_DEBUG_FIELD, String.class, queryTemplate.getType().toString()));
+
+        return objectLike(name, Query.class, queryMatcher);
+    }
+}

--- a/modules/db/src/test/java/org/mule/module/db/internal/processor/AbstractParameterizedSingleQueryMessageProcessorDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/processor/AbstractParameterizedSingleQueryMessageProcessorDebugInfoTestCase.java
@@ -11,7 +11,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.Mockito.when;
-import static org.mule.api.debug.FieldDebugInfoFactory.createFieldDebugInfo;
 import static org.mule.module.db.integration.model.Planet.EARTH;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.INPUT_PARAMS_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.PARAM_DEBUG_FIELD_PREFIX;
@@ -29,6 +28,7 @@ import org.mule.module.db.internal.domain.transaction.TransactionalAction;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 public abstract class AbstractParameterizedSingleQueryMessageProcessorDebugInfoTestCase extends AbstractSingleQueryMessageProcessorDebugInfoTestCase
@@ -79,10 +79,10 @@ public abstract class AbstractParameterizedSingleQueryMessageProcessorDebugInfoT
         assertThat(debugInfo, hasItem(fieldLike(SQL_TEXT_DEBUG_FIELD, String.class, getSqlText())));
         assertThat(debugInfo, hasItem(fieldLike(TYPE_DEBUG_FIELD, String.class, getQueryType().toString())));
 
-        final List<FieldDebugInfo> paramFields = new ArrayList<>();
-        paramFields.add(createFieldDebugInfo(paramName1, String.class, EARTH.getName()));
-        paramFields.add(createFieldDebugInfo(paramName2, String.class, EARTH.getPosition()));
-        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, paramFields)));
+        final List<Matcher<FieldDebugInfo>> paramMatchers = new ArrayList<>();
+        paramMatchers.add(fieldLike(paramName1, String.class, EARTH.getName()));
+        paramMatchers.add(fieldLike(paramName2, String.class, EARTH.getPosition()));
+        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, paramMatchers)));
     }
 
     protected Query createQueryWithNamedParameters()

--- a/modules/db/src/test/java/org/mule/module/db/internal/processor/BulkExecuteMessageProcessorDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/processor/BulkExecuteMessageProcessorDebugInfoTestCase.java
@@ -13,10 +13,10 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.module.db.internal.debug.DbDebugInfoTestUtils.createQueryFieldDebugInfoMatcher;
 import static org.mule.module.db.internal.domain.query.QueryType.DELETE;
 import static org.mule.module.db.internal.domain.query.QueryType.INSERT;
 import static org.mule.module.db.internal.domain.transaction.TransactionalAction.NOT_SUPPORTED;
-import static org.mule.module.db.internal.processor.DbDebugInfoUtils.createQueryFieldDebugInfo;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.QUERIES_DEBUG_FIELD;
 import static org.mule.tck.junit4.matcher.FieldDebugInfoMatcher.fieldLike;
 import static org.mule.tck.junit4.matcher.ObjectDebugInfoMatcher.objectLike;
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -79,7 +80,7 @@ public class BulkExecuteMessageProcessorDebugInfoTestCase extends AbstractMuleTe
         final List<FieldDebugInfo> debugInfo = bulkExecuteMessageProcessor.getDebugInfo(event);
 
         assertThat(debugInfo.size(), equalTo(1));
-        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, createExpectedQueries())));
+        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, createExpectedQueryMatchers())));
     }
 
     @Test
@@ -125,11 +126,11 @@ public class BulkExecuteMessageProcessorDebugInfoTestCase extends AbstractMuleTe
         assertThat(fieldDebugInfo.getValue(), instanceOf(IllegalArgumentException.class));
     }
 
-    private List<FieldDebugInfo> createExpectedQueries()
+    private List<Matcher<FieldDebugInfo>> createExpectedQueryMatchers()
     {
-        final List<FieldDebugInfo> queriesDebugInfo = new ArrayList<>();
-        queriesDebugInfo.add(createQueryFieldDebugInfo(QUERY1, QUERY_TEMPLATE1));
-        queriesDebugInfo.add(createQueryFieldDebugInfo(QUERY2, QUERY_TEMPLATE2));
+        final List<Matcher<FieldDebugInfo>> queriesDebugInfo = new ArrayList<>();
+        queriesDebugInfo.add(createQueryFieldDebugInfoMatcher(QUERY1, QUERY_TEMPLATE1));
+        queriesDebugInfo.add(createQueryFieldDebugInfoMatcher(QUERY2, QUERY_TEMPLATE2));
 
         return queriesDebugInfo;
     }

--- a/modules/db/src/test/java/org/mule/module/db/internal/processor/DynamicBulkUpdateMessageProcessorTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/processor/DynamicBulkUpdateMessageProcessorTestCase.java
@@ -17,9 +17,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.module.db.internal.debug.DbDebugInfoTestUtils.createQueryFieldDebugInfoMatcher;
 import static org.mule.module.db.internal.domain.query.QueryType.UPDATE;
 import static org.mule.module.db.internal.domain.transaction.TransactionalAction.NOT_SUPPORTED;
-import static org.mule.module.db.internal.processor.DbDebugInfoUtils.createQueryFieldDebugInfo;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.QUERIES_DEBUG_FIELD;
 import static org.mule.tck.junit4.matcher.FieldDebugInfoMatcher.fieldLike;
 import static org.mule.tck.junit4.matcher.ObjectDebugInfoMatcher.objectLike;
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 @SmallTest
@@ -86,7 +87,7 @@ public class DynamicBulkUpdateMessageProcessorTestCase extends AbstractMuleTestC
         assertThat(debugInfo, is(not(nullValue())));
         assertThat(debugInfo.size(), equalTo(1));
 
-        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, createExpectedQueries())));
+        assertThat(debugInfo, hasItem(objectLike(QUERIES_DEBUG_FIELD, List.class, createExpectedQueryMatchers())));
     }
 
     @Test
@@ -112,13 +113,13 @@ public class DynamicBulkUpdateMessageProcessorTestCase extends AbstractMuleTestC
         assertThat(debugInfo, hasItem(fieldLike(QUERIES_DEBUG_FIELD, List.class, queryResolutionException)));
     }
 
-    private List<FieldDebugInfo> createExpectedQueries()
+    private List<Matcher<FieldDebugInfo>> createExpectedQueryMatchers()
     {
-        final List<FieldDebugInfo> queriesDebugInfo = new ArrayList<>();
-        queriesDebugInfo.add(createQueryFieldDebugInfo(QUERY1, QUERY_TEMPLATE1));
-        queriesDebugInfo.add(createQueryFieldDebugInfo(QUERY2, QUERY_TEMPLATE2));
+        final List<Matcher<FieldDebugInfo>> queryMatchers = new ArrayList<>();
+        queryMatchers.add(createQueryFieldDebugInfoMatcher(QUERY1, QUERY_TEMPLATE1));
+        queryMatchers.add(createQueryFieldDebugInfoMatcher(QUERY2, QUERY_TEMPLATE2));
 
-        return queriesDebugInfo;
+        return queryMatchers;
     }
 
     private static List<String> getPlanetNames()

--- a/modules/db/src/test/java/org/mule/module/db/internal/processor/PreparedBulkUpdateMessageProcessorDebugInfoTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/processor/PreparedBulkUpdateMessageProcessorDebugInfoTestCase.java
@@ -15,7 +15,6 @@ import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mule.api.debug.FieldDebugInfoFactory.createFieldDebugInfo;
 import static org.mule.module.db.integration.model.Planet.EARTH;
 import static org.mule.module.db.integration.model.Planet.MARS;
 import static org.mule.module.db.internal.domain.query.QueryType.UPDATE;
@@ -26,6 +25,7 @@ import static org.mule.module.db.internal.processor.DbDebugInfoUtils.PARAM_SET_D
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.QUERY_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.SQL_TEXT_DEBUG_FIELD;
 import static org.mule.module.db.internal.processor.DbDebugInfoUtils.TYPE_DEBUG_FIELD;
+import static org.mule.tck.junit4.matcher.FieldDebugInfoMatcher.fieldLike;
 import static org.mule.tck.junit4.matcher.ObjectDebugInfoMatcher.objectLike;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 @SmallTest
@@ -99,24 +100,24 @@ public class PreparedBulkUpdateMessageProcessorDebugInfoTestCase extends Abstrac
         assertThat(debugInfo.size(), equalTo(2));
 
 
-        List<FieldDebugInfo> queryFields = new ArrayList<>();
-        queryFields.add(createFieldDebugInfo(SQL_TEXT_DEBUG_FIELD, String.class, QUERY_SQL));
-        queryFields.add(createFieldDebugInfo(TYPE_DEBUG_FIELD, String.class, UPDATE.toString()));
-        assertThat(debugInfo, hasItem(objectLike(QUERY_DEBUG_FIELD, Query.class, queryFields)));
-        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, createExpectedParamSets())));
+        List<Matcher<FieldDebugInfo>> fieldMatchers = new ArrayList<>();
+        fieldMatchers.add(fieldLike(SQL_TEXT_DEBUG_FIELD, String.class, QUERY_SQL));
+        fieldMatchers.add(fieldLike(TYPE_DEBUG_FIELD, String.class, UPDATE.toString()));
+        assertThat(debugInfo, hasItem(objectLike(QUERY_DEBUG_FIELD, Query.class, fieldMatchers)));
+        assertThat(debugInfo, hasItem(objectLike(INPUT_PARAMS_DEBUG_FIELD, List.class, createExpectedParamSetMatchers())));
     }
 
-    private List<FieldDebugInfo> createExpectedParamSets()
+    private List<Matcher<FieldDebugInfo>> createExpectedParamSetMatchers()
     {
-        final List<FieldDebugInfo> paramSets = new ArrayList<>();
+        final List<Matcher<FieldDebugInfo>> paramSets = new ArrayList<>();
 
-        final List<FieldDebugInfo> paramSet1 = new ArrayList<>();
-        paramSet1.add(createFieldDebugInfo(PARAM1, String.class, EARTH.getName()));
-        paramSets.add(createFieldDebugInfo(PARAM_SET1, List.class, paramSet1));
+        final List<Matcher<FieldDebugInfo>> paramSet1 = new ArrayList<>();
+        paramSet1.add(fieldLike(PARAM1, String.class, EARTH.getName()));
+        paramSets.add(objectLike(PARAM_SET1, List.class, paramSet1));
 
-        final List<FieldDebugInfo> paramSet2 = new ArrayList<>();
-        paramSet2.add(createFieldDebugInfo(PARAM1, String.class, MARS.getName()));
-        paramSets.add(createFieldDebugInfo(PARAM_SET2, List.class, paramSet2));
+        final List<Matcher<FieldDebugInfo>> paramSet2 = new ArrayList<>();
+        paramSet2.add(fieldLike(PARAM1, String.class, MARS.getName()));
+        paramSets.add(objectLike(PARAM_SET2, List.class, paramSet2));
         return paramSets;
     }
 }

--- a/modules/http/src/main/java/org/mule/module/http/internal/request/DefaultHttpRequester.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/DefaultHttpRequester.java
@@ -34,6 +34,7 @@ import org.mule.context.notification.NotificationHelper;
 import org.mule.module.http.api.HttpAuthentication;
 import org.mule.module.http.api.requester.HttpSendBodyMode;
 import org.mule.module.http.internal.HttpParser;
+import org.mule.module.http.internal.ParameterMap;
 import org.mule.module.http.internal.domain.request.HttpRequest;
 import org.mule.module.http.internal.domain.request.HttpRequestAuthentication;
 import org.mule.module.http.internal.domain.request.HttpRequestBuilder;
@@ -69,6 +70,7 @@ public class DefaultHttpRequester extends AbstractNonBlockingMessageProcessor im
     static final String PASSWORD_DEBUG = "Password";
     static final String WORKSTATION_DEBUG = "Workstation";
     static final String AUTHENTICATION_TYPE_DEBUG = "Authentication Type";
+    static final String QUERY_PARAMS_DEBUG = "Query Params";
 
     private DefaultHttpRequesterConfig requestConfig;
     private HttpRequesterRequestBuilder requestBuilder;
@@ -613,9 +615,30 @@ public class DefaultHttpRequester extends AbstractNonBlockingMessageProcessor im
                 return resolveResponseTimeout(event);
             }
         }));
+        fields.add(createFieldDebugInfo(QUERY_PARAMS_DEBUG, List.class, getQueryParamsDebugInfo(event)));
         fields.add(getSecurityFieldDebugInfo(event));
 
         return fields;
+    }
+
+    private List<FieldDebugInfo> getQueryParamsDebugInfo(MuleEvent event)
+    {
+        final ParameterMap queryParams = requestBuilder.getQueryParams(event);
+        List<FieldDebugInfo> params = new ArrayList<>();
+        for (String paramName : queryParams.keySet())
+        {
+            final List<String> values = queryParams.getAll(paramName);
+            if (values.size() == 1)
+            {
+                params.add(createFieldDebugInfo(paramName, String.class, values.get(0)));
+            }
+            else
+            {
+                params.add(createFieldDebugInfo(paramName, List.class, values));
+            }
+
+        }
+        return params;
     }
 
     private FieldDebugInfo getSecurityFieldDebugInfo(MuleEvent event)


### PR DESCRIPTION
_ Adding debug info for query params
_ Improving debug info field matchers to compare using matchers instead of simple values