### PR TITLE
MULE-9006: XmlToDomDocument transformer conflicts with ObjectToByteArray transformer

### DIFF
--- a/core/src/main/java/org/mule/transformer/simple/SerializableToByteArray.java
+++ b/core/src/main/java/org/mule/transformer/simple/SerializableToByteArray.java
@@ -22,7 +22,10 @@ import java.io.Serializable;
  */
 public class SerializableToByteArray extends AbstractTransformer implements DiscoverableTransformer
 {
-    private int priorityWeighting = DiscoverableTransformer.DEFAULT_PRIORITY_WEIGHTING;
+    /**
+     * Give core transformers a slightly higher priority
+     */
+    private int priorityWeighting = DiscoverableTransformer.DEFAULT_PRIORITY_WEIGHTING + 1;
 
     public SerializableToByteArray()
     {

--- a/core/src/test/java/org/mule/transformer/simple/ObjectToByteArrayTestCase.java
+++ b/core/src/test/java/org/mule/transformer/simple/ObjectToByteArrayTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transformer.simple;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mule.api.transformer.Converter.DEFAULT_PRIORITY_WEIGHTING;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import org.junit.Test;
+
+/**
+ * This unit test only tests the default priority of the {@link org.mule.transformer.simple.ObjectToByteArray} transformer.
+ * Actual transformation logic is tested in the {@link org.mule.transformer.simple.ObjectByteArrayTransformersWithObjectsTestCase}
+ * test and its subclasses.
+ */
+public class ObjectToByteArrayTestCase extends AbstractMuleTestCase
+{
+
+    @Test
+    public void transformerHasHigherDefaultPriority() throws Exception
+    {
+        ObjectToByteArray transformer = new ObjectToByteArray();
+        assertThat(transformer.getPriorityWeighting(), equalTo(DEFAULT_PRIORITY_WEIGHTING + 1));
+    }
+}

--- a/modules/ws/src/test/java/org/mule/module/ws/functional/WSConsumerWithXMLTransformerTestCase.java
+++ b/modules/ws/src/test/java/org/mule/module/ws/functional/WSConsumerWithXMLTransformerTestCase.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.ws.functional;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import org.mule.api.MuleEvent;
+import org.mule.construct.Flow;
+
+import org.junit.Test;
+
+public class WSConsumerWithXMLTransformerTestCase extends AbstractWSConsumerFunctionalTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "ws-consumer-with-xml-transformer-config.xml";
+    }
+
+    @Test
+    public void consumerWorksWithXMLTransformer() throws Exception
+    {
+        Flow client = (Flow) getFlowConstruct("client");
+        MuleEvent response = client.process(getTestEvent(ECHO_REQUEST));
+        assertXMLEqual(EXPECTED_ECHO_RESPONSE, response.getMessage().getPayloadAsString());
+    }
+}

--- a/modules/ws/src/test/resources/ws-consumer-with-xml-transformer-config.xml
+++ b/modules/ws/src/test/resources/ws-consumer-with-xml-transformer-config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:cxf="http://www.mulesoft.org/schema/mule/cxf"
+      xmlns:ws="http://www.mulesoft.org/schema/mule/ws"
+      xmlns:mulexml="http://www.mulesoft.org/schema/mule/xml"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/cxf http://www.mulesoft.org/schema/mule/cxf/current/mule-cxf.xsd
+               http://www.mulesoft.org/schema/mule/xml http://www.mulesoft.org/schema/mule/xml/current/mule-xml.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+               http://www.mulesoft.org/schema/mule/ws http://www.mulesoft.org/schema/mule/ws/current/mule-ws.xsd">
+
+    <configuration>
+        <http:config useTransportForUris="${useTransportForUris}"/>
+    </configuration>
+
+    <ws:consumer-config serviceAddress="http://localhost:${port}/services/Test" wsdlLocation="Test.wsdl"
+                        service="TestService" port="TestPort" name="globalConfig"/>
+
+    <flow name="client">
+        <mulexml:dom-to-xml-transformer/>
+        <mulexml:xml-to-dom-transformer/>
+        <ws:consumer operation="echo"/>
+    </flow>
+
+    <flow name="server">
+        <inbound-endpoint address="http://localhost:${port}/services/Test" exchange-pattern="request-response">
+            <cxf:jaxws-service serviceClass="org.mule.module.ws.consumer.TestService"/>
+        </inbound-endpoint>
+        <component class="org.mule.module.ws.consumer.TestService"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
Changed default priorityWeighting of the SerializableToByteArray transformer (and ObjectToByteArray that extends it) to be consistent with the rest of the core transformers.