### PR TITLE
MULE-9029 100-Continue response is sent as two packets instead of one…

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/BaseResponseCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/BaseResponseCompletionHandler.java
@@ -41,6 +41,13 @@ public abstract class BaseResponseCompletionHandler extends EmptyCompletionHandl
         {
             httpResponsePacket.setChunked(true);
         }
+        else
+        {
+            // Workaround GRIZZLY-1811 by explicity setting chunking 'false' so that chunking isn't incorrectly used for
+            // sending a response with content-length when 'Expect: Continue' is used.
+            httpResponsePacket.setChunked(false);
+        }
+
         if (CLOSE.equalsIgnoreCase(httpResponsePacket.getHeader(CONNECTION)))
         {
             httpResponsePacket.getProcessingState().setKeepAlive(false);

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerExpectHeaderStreamingAlwaysTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerExpectHeaderStreamingAlwaysTestCase.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class HttpListenerExpectHeaderStreamingAlwaysTestCase extends HttpListenerExpectHeaderStreamingNeverTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-listener-expect-header-streaming-always-config.xml";
+    }
+
+    public HttpListenerExpectHeaderStreamingAlwaysTestCase(String persistentConnections)
+    {
+        super(persistentConnections);
+    }
+
+    @Override
+    protected String getExpectedResponseBody()
+    {
+        return "c\r\n" + TEST_MESSAGE + "\r\n0\r\n\r";
+    }
+}
+

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerExpectHeaderStreamingAutoStreamTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerExpectHeaderStreamingAutoStreamTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class HttpListenerExpectHeaderStreamingAutoStreamTestCase extends HttpListenerExpectHeaderStreamingAlwaysTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-listener-expect-header-streaming-auto-stream-config.xml";
+    }
+
+    public HttpListenerExpectHeaderStreamingAutoStreamTestCase(String persistentConnections)
+    {
+        super(persistentConnections);
+    }
+
+}
+

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerExpectHeaderStreamingAutoStringTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerExpectHeaderStreamingAutoStringTestCase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class HttpListenerExpectHeaderStreamingAutoStringTestCase extends HttpListenerExpectHeaderStreamingNeverTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-listener-expect-header-streaming-auto-string-config.xml";
+    }
+
+    public HttpListenerExpectHeaderStreamingAutoStringTestCase(String persistentConnections)
+    {
+        super(persistentConnections);
+    }
+
+}
+

--- a/modules/http/src/test/resources/http-listener-expect-header-streaming-always-config.xml
+++ b/modules/http/src/test/resources/http-listener-expect-header-streaming-always-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <http:listener-config name="listenerConfig" host="localhost" port="${port}" usePersistentConnections="${persistentConnections}"/>
+
+    <flow name="defaultFlow">
+        <http:listener config-ref="listenerConfig"  path="/" responseStreamingMode="ALWAYS"/>
+        <echo-component />
+    </flow>
+
+</mule>

--- a/modules/http/src/test/resources/http-listener-expect-header-streaming-auto-stream-config.xml
+++ b/modules/http/src/test/resources/http-listener-expect-header-streaming-auto-stream-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <http:listener-config name="listenerConfig" host="localhost" port="${port}" usePersistentConnections="${persistentConnections}"/>
+
+    <flow name="defaultFlow">
+        <http:listener config-ref="listenerConfig"  path="/" responseStreamingMode="AUTO"/>
+        <expression-transformer expression="new StringBufferInputStream(message.payloadAs(String))"/>
+    </flow>
+
+</mule>

--- a/modules/http/src/test/resources/http-listener-expect-header-streaming-auto-string-config.xml
+++ b/modules/http/src/test/resources/http-listener-expect-header-streaming-auto-string-config.xml
@@ -6,11 +6,11 @@
                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
                http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
 
-    <http:listener-config name="listenerConfig" host="localhost" port="${port}" usePersistentConnections="false"/>
+    <http:listener-config name="listenerConfig" host="localhost" port="${port}" usePersistentConnections="${persistentConnections}"/>
 
     <flow name="defaultFlow">
-        <http:listener config-ref="listenerConfig"  path="/" responseStreamingMode="NEVER"/>
-        <echo-component />
+        <http:listener config-ref="listenerConfig"  path="/" responseStreamingMode="AUTO"/>
+        <echo-component/>
     </flow>
 
 </mule>

--- a/modules/http/src/test/resources/http-listener-expect-header-streaming-never-config.xml
+++ b/modules/http/src/test/resources/http-listener-expect-header-streaming-never-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <http:listener-config name="listenerConfig" host="localhost" port="${port}" usePersistentConnections="${persistentConnections}"/>
+
+    <flow name="defaultFlow">
+        <http:listener config-ref="listenerConfig"  path="/" responseStreamingMode="NEVER"/>
+        <echo-component />
+    </flow>
+
+</mule>


### PR DESCRIPTION
… when chunked transfer encoding is disabled.