### PR TITLE
MULE-9023: Scatter-gather generates wrong data type when Content-Type…

### DIFF
--- a/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
@@ -296,6 +296,11 @@ public class HttpMuleMessageFactory extends AbstractMuleMessageFactory
         }
     }
 
+    private String getContentType(Map<String, Object> headers)
+    {
+        return (String) headers.get(HttpConstants.HEADER_CONTENT_TYPE);
+    }
+
     private String getEncoding(Map<String, Object> headers)
     {
         String encoding = DEFAULT_ENCODING;


### PR DESCRIPTION
… header is present

_ Re-adding accidentally deleted method