### PR TITLE
MULE-8938: Connector and Endpoint message notifications not fired when

### DIFF
--- a/core/src/main/java/org/mule/execution/AsyncResponseFlowProcessingPhase.java
+++ b/core/src/main/java/org/mule/execution/AsyncResponseFlowProcessingPhase.java
@@ -79,7 +79,7 @@ public class AsyncResponseFlowProcessingPhase extends NotificationFiringProcessi
             }
             catch (final MessagingException e)
             {
-                fireNotification(null, MESSAGE_ERROR_RESPONSE);
+                fireNotification(e.getEvent(), MESSAGE_ERROR_RESPONSE);
                 template.sendFailureResponseToClient(e, createSendFailureResponseCompletationCallback(phaseResultNotifier));
             }
         }
@@ -192,7 +192,7 @@ public class AsyncResponseFlowProcessingPhase extends NotificationFiringProcessi
         {
             try
             {
-                fireNotification(null, MESSAGE_ERROR_RESPONSE);
+                fireNotification(exception.getEvent(), MESSAGE_ERROR_RESPONSE);
                 template.sendFailureResponseToClient(exception, createSendFailureResponseCompletationCallback(phaseResultNotifier));
             }
             catch (MuleException e)

--- a/core/src/main/java/org/mule/execution/FlowProcessingPhase.java
+++ b/core/src/main/java/org/mule/execution/FlowProcessingPhase.java
@@ -145,7 +145,7 @@ public class FlowProcessingPhase extends NotificationFiringProcessingPhase<FlowP
     {
         if (flowProcessingPhaseTemplate instanceof RequestResponseFlowProcessingPhaseTemplate)
         {
-            fireNotification(null, MESSAGE_ERROR_RESPONSE);
+            fireNotification(messagingException.getEvent(), MESSAGE_ERROR_RESPONSE);
             ((RequestResponseFlowProcessingPhaseTemplate) flowProcessingPhaseTemplate).sendFailureResponseToClient(messagingException);
         }
     }

--- a/core/src/test/java/org/mule/message/processing/FlowProcessingPhaseTestCase.java
+++ b/core/src/test/java/org/mule/message/processing/FlowProcessingPhaseTestCase.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 import static org.mule.context.notification.BaseConnectorMessageNotification.MESSAGE_ERROR_RESPONSE;
 import static org.mule.context.notification.BaseConnectorMessageNotification.MESSAGE_RESPONSE;
 
-import org.mule.RequestContext;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -202,15 +201,12 @@ public class FlowProcessingPhaseTestCase extends AbstractMuleTestCase
     @Test
     public void errorResponseNotificationFired() throws Exception
     {
-        MuleEvent event = mock(MuleEvent.class);
-        when(event.getMuleContext()).thenReturn(mock(MuleContext.class));
-        RequestContext.setEvent(event);
         when(mockContext.supportsAsynchronousProcessing()).thenReturn(false);
         when(mockRequestResponseTemplate.afterRouteEvent(any(MuleEvent.class))).thenThrow(mockMessagingException);
         when(mockMessagingException.handled()).thenReturn(false);
         phase.runPhase(mockRequestResponseTemplate, mockContext, mockNotifier);
         verify(notificationHelper, never()).fireNotification(any(MuleEvent.class), isNull(String.class), any(FlowConstruct.class), eq(MESSAGE_RESPONSE));
-        verify(notificationHelper).fireNotification(eq(event), isNull(String.class), any(FlowConstruct.class), eq(MESSAGE_ERROR_RESPONSE));
+        verify(notificationHelper).fireNotification(any(MuleEvent.class), isNull(String.class), any(FlowConstruct.class), eq(MESSAGE_ERROR_RESPONSE));
     }
 
     private void verifyOnlySuccessfulWasCalled()


### PR DESCRIPTION
an exception is thrown - Include event in notification