### PR TITLE
MULE-9023: Scatter-gather generates wrong data type when Content-Type…

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleMessage.java
+++ b/core/src/main/java/org/mule/DefaultMuleMessage.java
@@ -7,6 +7,7 @@
 package org.mule;
 
 import static org.mule.util.SystemUtils.LINE_SEPARATOR;
+
 import org.mule.api.ExceptionPayload;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -60,6 +61,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.activation.DataHandler;
 import javax.activation.FileDataSource;
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -126,7 +129,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
         {
             DataType<?> dataType = DataTypeFactory.create(payload.getClass(), previous.getDataType().getMimeType());
             dataType.setEncoding(previous.getDataType().getEncoding());
-            
+
             return dataType;
         }
     }
@@ -208,7 +211,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
         id = previous.getUniqueId();
         rootId = previous.getMessageRootId();
         setMuleContext(muleContext);
-        
+
         DataType newDataType  = dataType.cloneDataType();
 
         if (message instanceof MuleMessage)
@@ -251,10 +254,9 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
         else
         {
             copyMessageProperties(muleMessage);
-        }        
+        }
     }
 
-    
     protected void copyMessageProperties(MuleMessage muleMessage)
     {
         for (PropertyScope scope : new PropertyScope[]{PropertyScope.INBOUND, PropertyScope.OUTBOUND})
@@ -266,7 +268,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
                     Object value = muleMessage.getProperty(name, scope);
                     if (value != null)
                     {
-                        setProperty(name, value, scope);
+                        setPropertyInternal(name, value, scope, DataTypeFactory.createFromObject(value));
                     }
                 }
             }
@@ -488,6 +490,13 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
     @Override
     public void setProperty(String key, Object value, PropertyScope scope, DataType<?> dataType)
     {
+        setPropertyInternal(key, value, scope, dataType);
+
+        updateDataTypeWithProperty(key, value);
+    }
+
+    private void setPropertyInternal(String key, Object value, PropertyScope scope, DataType<?> dataType)
+    {
         assertAccess(WRITE);
         if (key != null)
         {
@@ -509,6 +518,32 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
             if (logger.isDebugEnabled())
             {
                 logger.debug("setProperty(key, value) invoked with null key. Ignoring this entry");
+            }
+        }
+    }
+
+    private void updateDataTypeWithProperty(String key, Object value)
+    {
+        // updates dataType when encoding is updated using a property instead of using #setEncoding
+        if (MuleProperties.MULE_ENCODING_PROPERTY.equals(key))
+        {
+            dataType.setEncoding((String) value);
+        }
+        else if (MuleProperties.CONTENT_TYPE_PROPERTY.equalsIgnoreCase(key))
+        {
+            try
+            {
+                MimeType mimeType = new MimeType((String) value);
+                dataType.setMimeType(mimeType.getPrimaryType() + "/" + mimeType.getSubType());
+                String encoding = mimeType.getParameter("charset");
+                if (!StringUtils.isEmpty(encoding))
+                {
+                    dataType.setEncoding(encoding);
+                }
+            }
+            catch (MimeTypeParseException e)
+            {
+                throw new IllegalArgumentException("Invalid Content-Type property value", e);
             }
         }
     }
@@ -575,6 +610,8 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
                         new Throwable());
                 properties.removeProperty(key);
             }
+
+            updateDataTypeWithProperty(key, value);
         }
         else
         {

--- a/core/src/main/java/org/mule/transformer/simple/AbstractAddVariablePropertyTransformer.java
+++ b/core/src/main/java/org/mule/transformer/simple/AbstractAddVariablePropertyTransformer.java
@@ -6,16 +6,13 @@
  */
 package org.mule.transformer.simple;
 
-import org.mule.DefaultMuleMessage;
 import org.mule.api.MuleMessage;
-import org.mule.api.config.MuleProperties;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.api.transformer.DataType;
 import org.mule.api.transformer.TransformerException;
 import org.mule.api.transport.PropertyScope;
 import org.mule.transformer.AbstractMessageTransformer;
 import org.mule.transformer.types.DataTypeFactory;
-import org.mule.transformer.types.MimeTypes;
 import org.mule.transformer.types.TypedValue;
 import org.mule.transport.NullPayload;
 import org.mule.util.AttributeEvaluator;
@@ -67,36 +64,19 @@ public abstract class AbstractAddVariablePropertyTransformer extends AbstractMes
             }
             else
             {
-                if (!MimeTypes.ANY.equals(mimeType) || !StringUtils.isEmpty(encoding))
+                if (!StringUtils.isEmpty(mimeType) || !StringUtils.isEmpty(encoding))
                 {
-                    DataType<?> dataType = DataTypeFactory.create(typedValue.getValue().getClass(), mimeType);
+                    DataType<?> dataType = DataTypeFactory.create(typedValue.getValue().getClass(), getMimeType());
                     dataType.setEncoding(getEncoding());
                     message.setProperty(key, typedValue.getValue(), getScope(), dataType);
                 }
                 else
                 {
                     message.setProperty(key, typedValue.getValue(), getScope(), typedValue.getDataType());
-
-                    updateMessageDataTypeFromProperty(message, key, typedValue.getValue());
                 }
             }
         }
         return message;
-    }
-
-    private void updateMessageDataTypeFromProperty(MuleMessage message, String key, Object value)
-    {
-        if (value instanceof String)
-        {
-            if (key.equalsIgnoreCase(MuleProperties.CONTENT_TYPE_PROPERTY) && message instanceof DefaultMuleMessage)
-            {
-                ((DefaultMuleMessage) message).setMimeType((String) value);
-            }
-            if (key.equalsIgnoreCase(MuleProperties.MULE_ENCODING_PROPERTY))
-            {
-                message.setEncoding((String) value);
-            }
-        }
     }
 
     @Override

--- a/core/src/test/java/org/mule/MuleMessageDataTypePropagationTestCase.java
+++ b/core/src/test/java/org/mule/MuleMessageDataTypePropagationTestCase.java
@@ -83,6 +83,28 @@ public class MuleMessageDataTypePropagationTestCase extends AbstractMuleTestCase
     }
 
     @Test
+    public void updatesEncodingWithPropertyAndScope() throws Exception
+    {
+        DefaultMuleMessage muleMessage = new DefaultMuleMessage(TEST, muleContext);
+        muleMessage.setProperty(MuleProperties.MULE_ENCODING_PROPERTY, CUSTOM_ENCODING, PropertyScope.OUTBOUND);
+
+        assertThat(muleMessage.getEncoding(), equalTo(CUSTOM_ENCODING));
+        assertThat(muleMessage.getPropertyNames(), hasItem(MuleProperties.MULE_ENCODING_PROPERTY));
+        assertThat(muleMessage.getProperty(MuleProperties.MULE_ENCODING_PROPERTY), Matchers.<Object>equalTo(CUSTOM_ENCODING));
+    }
+
+    @Test
+    public void updatesEncodingWithProperty() throws Exception
+    {
+        DefaultMuleMessage muleMessage = new DefaultMuleMessage(TEST, muleContext);
+        muleMessage.setProperty(MuleProperties.MULE_ENCODING_PROPERTY, CUSTOM_ENCODING);
+
+        assertThat(muleMessage.getEncoding(), equalTo(CUSTOM_ENCODING));
+        assertThat(muleMessage.getPropertyNames(), hasItem(MuleProperties.MULE_ENCODING_PROPERTY));
+        assertThat(muleMessage.getProperty(MuleProperties.MULE_ENCODING_PROPERTY), Matchers.<Object>equalTo(CUSTOM_ENCODING));
+    }
+
+    @Test
     public void setsDefaultDataTypeOnCreation() throws Exception
     {
         assertDefaultDataType(new DefaultMuleMessage(TEST, muleContext));
@@ -403,6 +425,42 @@ public class MuleMessageDataTypePropagationTestCase extends AbstractMuleTestCase
         muleMessage.setProperty(TEST_PROPERTY, TEST, PropertyScope.OUTBOUND, dataType);
 
         assertPropertyDataType(muleMessage, PropertyScope.OUTBOUND, dataType);
+    }
+
+    @Test
+    public void updatesDataTypeWithContentTypeProperty() throws Exception
+    {
+        DefaultMuleMessage muleMessage = new DefaultMuleMessage(TEST, muleContext);
+        muleMessage.setProperty(MuleProperties.CONTENT_TYPE_PROPERTY, CUSTOM_CONTENT_TYPE);
+
+        assertDataType(muleMessage, String.class, CUSTOM_MIME_TYPE, CUSTOM_ENCODING);
+    }
+
+    @Test
+    public void updatesDataTypeWithContentTypePropertyAndScope() throws Exception
+    {
+        DefaultMuleMessage muleMessage = new DefaultMuleMessage(TEST, muleContext);
+        muleMessage.setProperty(MuleProperties.CONTENT_TYPE_PROPERTY, CUSTOM_CONTENT_TYPE, PropertyScope.OUTBOUND);
+
+        assertDataType(muleMessage, String.class, CUSTOM_MIME_TYPE, CUSTOM_ENCODING);
+    }
+
+    @Test
+    public void updatesDataTypeWithContentTypeInProperties() throws Exception
+    {
+        DefaultMuleMessage muleMessage = new DefaultMuleMessage(TEST, muleContext);
+        muleMessage.addProperties(Collections.<String, Object>singletonMap(MuleProperties.CONTENT_TYPE_PROPERTY, CUSTOM_CONTENT_TYPE));
+
+        assertDataType(muleMessage, String.class, CUSTOM_MIME_TYPE, CUSTOM_ENCODING);
+    }
+
+    @Test
+    public void updatesDataTypeWithContentTypeInInboundProperties() throws Exception
+    {
+        DefaultMuleMessage muleMessage = new DefaultMuleMessage(TEST, muleContext);
+        muleMessage.addInboundProperties(Collections.<String, Object>singletonMap(MuleProperties.CONTENT_TYPE_PROPERTY, CUSTOM_CONTENT_TYPE));
+
+        assertDataType(muleMessage, String.class, CUSTOM_MIME_TYPE, CUSTOM_ENCODING);
     }
 
     private void assertDefaultDataType(MuleMessage muleMessage)

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
@@ -72,8 +72,6 @@ public class HttpRequestToMuleEvent
 
         final Map<String, DataHandler> inboundAttachments = new HashMap<>();
         Object payload = NullPayload.getInstance();
-        final String contentTypeValue = request.getHeaderValue(HttpHeaders.Names.CONTENT_TYPE);
-
         if (parseRequest)
         {
             final HttpEntity entity = request.getEntity();
@@ -85,6 +83,7 @@ public class HttpRequestToMuleEvent
                 }
                 else
                 {
+                    final String contentTypeValue = request.getHeaderValue(HttpHeaders.Names.CONTENT_TYPE);
                     if (contentTypeValue != null)
                     {
                         final MediaType mediaType = MediaType.parse(contentTypeValue);
@@ -123,8 +122,6 @@ public class HttpRequestToMuleEvent
         }
 
         final DefaultMuleMessage defaultMuleMessage = new DefaultMuleMessage(payload, inboundProperties, outboundProperties, inboundAttachments, muleContext);
-        defaultMuleMessage.setMimeType(contentTypeValue);
-
         return new DefaultMuleEvent(
                 defaultMuleMessage,
                 resolveUri(requestContext),

--- a/modules/http/src/main/java/org/mule/module/http/internal/request/HttpResponseToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/HttpResponseToMuleEvent.java
@@ -17,6 +17,7 @@ import org.mule.DefaultMuleMessage;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
+import org.mule.api.MuleMessage;
 import org.mule.api.transformer.DataType;
 import org.mule.module.http.internal.HttpParser;
 import org.mule.module.http.internal.domain.InputStreamHttpEntity;
@@ -107,9 +108,14 @@ public class HttpResponseToMuleEvent
         }
 
 
-        DefaultMuleMessage message = new DefaultMuleMessage(muleEvent.getMessage().getPayload(), inboundProperties,
+        MuleMessage message = new DefaultMuleMessage(muleEvent.getMessage().getPayload(), inboundProperties,
                                                      null, inboundAttachments, muleContext, muleEvent.getMessage().getDataType());
-        message.setMimeType(responseContentType);
+
+        if (encoding != null)
+        {
+            message.setEncoding(encoding);
+        }
+
         muleEvent.setMessage(message);
         setResponsePayload(payload, muleEvent);
 

--- a/tests/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/routing/ScatterGatherRouterTestCase.java
@@ -284,7 +284,7 @@ public class ScatterGatherRouterTestCase extends FunctionalTestCase
     public void returnsCorrectDataType() throws Exception
     {
         DefaultMuleMessage message = new DefaultMuleMessage(TEST_PAYLOAD, muleContext);
-        message.setMimeType("application/json");
+        message.setOutboundProperty("Content-Type", "application/json");
 
         MuleEvent event = new DefaultMuleEvent(message, MessageExchangePattern.REQUEST_RESPONSE, mock(Flow.class));
         MuleMessage response = runFlow("dataType", event).getMessage();

--- a/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
@@ -165,8 +165,7 @@ public class HttpMuleMessageFactory extends AbstractMuleMessageFactory
         httpHeaders.put(HttpConnector.HTTP_HEADERS, new HashMap<String, Object>(headers));
 
         String encoding = getEncoding(headers);
-        String contentType = getContentType(headers);
-
+        
         queryParameters.put(HttpConnector.HTTP_QUERY_PARAMS, processQueryParams(uri, encoding));
 
         //Make any URI params available ans inbound message headers
@@ -192,12 +191,6 @@ public class HttpMuleMessageFactory extends AbstractMuleMessageFactory
         // The encoding is stored as message property. To avoid overriding it from the message
         // properties, it must be initialized last
         initEncoding(message, encoding);
-        initMimeType(message, contentType);
-    }
-
-    private void initMimeType(DefaultMuleMessage message, String mimeType)
-    {
-        message.setMimeType(mimeType);
     }
 
     protected Map<String, Object> processIncomingHeaders(Map<String, Object> headers) throws Exception

--- a/transports/http/src/test/java/org/mule/transport/http/functional/HttpOutboundDataTypeTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/functional/HttpOutboundDataTypeTestCase.java
@@ -42,7 +42,7 @@ public class HttpOutboundDataTypeTestCase extends FunctionalTestCase
         LocalMuleClient client = muleContext.getClient();
 
         DefaultMuleMessage muleMessage = new DefaultMuleMessage(TEST_MESSAGE, muleContext);
-        muleMessage.setMimeType(MimeTypes.TEXT + "; charset=" + StandardCharsets.UTF_16.name());
+        muleMessage.setOutboundProperty("Content-Type", MimeTypes.TEXT + "; charset=" + StandardCharsets.UTF_16.name());
 
         client.dispatch("vm://testInput", muleMessage);
 

--- a/transports/jetty/src/main/java/org/mule/transport/servlet/jetty/JettyMuleMessageFactory.java
+++ b/transports/jetty/src/main/java/org/mule/transport/servlet/jetty/JettyMuleMessageFactory.java
@@ -36,11 +36,4 @@ public class JettyMuleMessageFactory extends ServletMuleMessageFactory
         message.setProperty(HttpConnector.HTTP_METHOD_PROPERTY, request.getMethod(), PropertyScope.INBOUND);
     }
 
-    @Override
-    protected String getMimeType(Object transportMessage)
-    {
-        HttpServletRequest request = (HttpServletRequest) transportMessage;
-
-        return request.getContentType();
-    }
 }


### PR DESCRIPTION
… header is present

_ Reverting previous fix
_ Changing how properties are set internally on the message to avoid overwriting the datatype