### PR TITLE
MULE-9145: modifying CheckRequiredAttributesWhenNoChildren pre-processor to take the NS into account.

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/config/spring/handlers/MuleNamespaceHandler.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/handlers/MuleNamespaceHandler.java
@@ -357,7 +357,7 @@ public class MuleNamespaceHandler extends AbstractMuleNamespaceHandler
                 new CheckExclusiveAttributesAndChildren(new String[]{"source", "target"},
                     new String[]{"enrich"}))
             .registerPreProcessor(
-                new CheckRequiredAttributesWhenNoChildren(new String[][]{new String[]{"target"}}, "enrich"))
+                new CheckRequiredAttributesWhenNoChildren(new String[][]{new String[]{"target"}}, "enrich", "http://www.mulesoft.org/schema/mule/core"))
             .addCollection("enrichExpressionPairs");
         registerMuleBeanDefinitionParser("enrich", new ChildDefinitionParser("enrichExpressionPair",
             EnrichExpressionPair.class));

--- a/modules/spring-config/src/main/java/org/mule/config/spring/parsers/processors/CheckRequiredAttributesWhenNoChildren.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/parsers/processors/CheckRequiredAttributesWhenNoChildren.java
@@ -17,6 +17,14 @@ import org.w3c.dom.Element;
 public class CheckRequiredAttributesWhenNoChildren extends CheckRequiredAttributes
 {
     private String elementName;
+    private String elementNamespaceUrl;
+
+    public CheckRequiredAttributesWhenNoChildren(String[][] attributeNames, String elementName, String elementNamespaceUrl)
+    {
+        super(attributeNames);
+        this.elementName = elementName;
+        this.elementNamespaceUrl = elementNamespaceUrl;
+    }
 
     public CheckRequiredAttributesWhenNoChildren(String[][] attributeNames, String elementName)
     {
@@ -27,7 +35,7 @@ public class CheckRequiredAttributesWhenNoChildren extends CheckRequiredAttribut
     public void preProcess(PropertyConfiguration config, Element element)
     {
         // If there are child elements we skip this check
-        if (element.getElementsByTagName(elementName).getLength() > 0)
+        if (element.getElementsByTagNameNS(elementNamespaceUrl, elementName).getLength() > 0)
         {
             return;
         }

--- a/modules/spring-config/src/main/java/org/mule/config/spring/parsers/specific/ExpressionTransformerDefinitionParser.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/parsers/specific/ExpressionTransformerDefinitionParser.java
@@ -34,7 +34,7 @@ public class ExpressionTransformerDefinitionParser extends ParentContextDefiniti
         otherwise(new ExpressionTransformerChildDefinitionParser("messageProcessor", messageProcessor));
 
         registerPreProcessor(new CheckRequiredAttributesWhenNoChildren(new String[][]{{"expression"}},
-                "return-argument")).registerPreProcessor(
+                "return-argument", "http://www.mulesoft.org/schema/mule/core")).registerPreProcessor(
             new CheckExclusiveAttributesAndChildren(new String[]{"expression"},
                 new String[]{"return-argument"}))
             .addIgnored("evaluator")

--- a/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/AbstractPreProcessorTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/AbstractPreProcessorTestCase.java
@@ -40,20 +40,34 @@ public abstract class AbstractPreProcessorTestCase extends AbstractMuleTestCase
 
     protected void assertOk(String[][] constraint, String attributes) throws ParserConfigurationException
     {
-        createCheck(constraint).preProcess(null, createElement(attributes));
+        createCheck(constraint, null, null).preProcess(null, createElement(attributes));
     }
 
-    protected abstract PreProcessor createCheck(String[][] constraint);
+    protected void assertOk(String[][] constraint, String attributes, String elementName, String namespaceUri) throws ParserConfigurationException
+    {
+        createCheck(constraint, elementName, namespaceUri).preProcess(null, createElement(attributes, elementName, namespaceUri));
+    }
+
+    protected abstract PreProcessor createCheck(String[][] constraint, String elementName, String namespaceUri);
 
     protected Element createElement(String attributes) throws ParserConfigurationException
     {
+        return createElement(attributes, null, null);
+    }
+
+    protected Element createElement(String attributes, String child, String namespaceUri) throws ParserConfigurationException
+    {
         DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document document = builder.newDocument();
-        Element element = document.createElement("element");
+        Element element = document.createElementNS(namespaceUri, "element");
         StringTokenizer tokens = new StringTokenizer(attributes);
         while (tokens.hasMoreTokens())
         {
             element.setAttribute(tokens.nextToken(), "value");
+        }
+        if (child != null)
+        {
+            element.appendChild(document.createElementNS(namespaceUri, child));
         }
         return element;
     }

--- a/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/CheckExclusiveAttributesTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/CheckExclusiveAttributesTestCase.java
@@ -128,7 +128,7 @@ public class CheckExclusiveAttributesTestCase extends AbstractPreProcessorTestCa
     }
     
     @Override
-    protected PreProcessor createCheck(String[][] constraint)
+    protected PreProcessor createCheck(String[][] constraint, String elementName, String elementNamespaceUrl)
     {
         return new CheckExclusiveAttributes(constraint);
     }

--- a/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/CheckRequiredAttributesTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/CheckRequiredAttributesTestCase.java
@@ -223,7 +223,8 @@ public class CheckRequiredAttributesTestCase extends AbstractPreProcessorTestCas
         assertOk(groups, "from id name type");
     }
 
-    protected PreProcessor createCheck(String[][] constraint)
+    @Override
+    protected PreProcessor createCheck(String[][] constraint, String elementName, String elementNamespaceUrl)
     {
         return new CheckRequiredAttributes(constraint);
     }

--- a/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/CheckRequiredAttributesWhenNoChildrenTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/config/spring/parsers/processors/CheckRequiredAttributesWhenNoChildrenTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.config.spring.parsers.processors;
+
+import org.mule.config.spring.parsers.PreProcessor;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Test;
+
+public class CheckRequiredAttributesWhenNoChildrenTestCase extends AbstractPreProcessorTestCase
+{
+
+    private static final String MULE_NAMESPACE_URL = "http://www.mulesoft.org/schema/mule/core";
+
+    @Test
+    public void testChildWithoutNamespace() throws ParserConfigurationException
+    {
+        assertOk(new String[][]{new String[] {"constraintAttribute"}}, "", "aChild", null);
+    }
+
+    @Test
+    public void testChildWithNamespace() throws ParserConfigurationException
+    {
+        assertOk(new String[][]{new String[] {"constraintAttribute"}}, "", "aChild", MULE_NAMESPACE_URL);
+    }
+
+    @Test(expected = CheckRequiredAttributes.CheckRequiredAttributesException.class)
+    public void testAttributeNotPresentAndNoChildren() throws CheckRequiredAttributes.CheckRequiredAttributesException, ParserConfigurationException
+    {
+        assertOk(new String[][]{new String[] {"constraintAttribute"}}, "", null, MULE_NAMESPACE_URL);
+    }
+
+    @Test
+    public void testAttributePresentAndNoChildren() throws ParserConfigurationException
+    {
+        assertOk(new String[][]{new String[] {"constraintAttribute"}}, "constraintAttribute", null, MULE_NAMESPACE_URL);
+    }
+
+    @Override
+    protected PreProcessor createCheck(String[][] constraint, String elementName, String elementNamespaceUrl)
+    {
+        return new CheckRequiredAttributesWhenNoChildren(constraint, elementName, elementNamespaceUrl);
+    }
+}


### PR DESCRIPTION
Changed all usages of this pre-processor and added test.