### PR TITLE
MULE-9153: Add support for interfaces as parameters of an @Operation

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/ConfigParserTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/module/extension/internal/ConfigParserTestCase.java
@@ -17,11 +17,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.runners.Parameterized.Parameter;
 import static org.junit.runners.Parameterized.Parameters;
 import static org.mule.module.extension.internal.util.ExtensionsTestUtils.getConfigurationFromRegistry;
+
 import org.mule.api.MuleEvent;
 import org.mule.module.extension.HealthStatus;
 import org.mule.module.extension.HeisenbergExtension;
 import org.mule.module.extension.KnockeableDoor;
 import org.mule.module.extension.Ricin;
+import org.mule.module.extension.Weapon;
 import org.mule.tck.junit4.ExtensionsFunctionalTestCase;
 
 import java.math.BigDecimal;
@@ -70,6 +72,7 @@ public class ConfigParserTestCase extends ExtensionsFunctionalTestCase
     private static final int DEATH_YEAR = 2011;
     private static final HealthStatus INITIAL_HEALTH = HealthStatus.CANCER;
     private static final HealthStatus FINAL_HEALTH = HealthStatus.DEAD;
+    private static final Ricin WEAPON = new Ricin();
 
     @Parameters
     public static Collection<Object[]> data()
@@ -171,6 +174,8 @@ public class ConfigParserTestCase extends ExtensionsFunctionalTestCase
         event.setFlowVariable("shoppingMall", SHOPPING_MALL);
         event.setFlowVariable("initialHealth", INITIAL_HEALTH);
         event.setFlowVariable("finalHealth", FINAL_HEALTH);
+        WEAPON.setMicrogramsPerKilo(10L);
+        event.setFlowVariable("weapon", WEAPON);
 
         return event;
     }

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-config.xml
@@ -10,7 +10,7 @@
                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd
                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
-    <context:property-placeholder location="heisenberg.properties" />
+    <context:property-placeholder location="heisenberg.properties"/>
 
     <heisenberg:config name="heisenberg"
                        myName="Heisenberg"
@@ -124,7 +124,8 @@
                        ricinPacks="#[app.registry.ricinPacks]"
                        nextDoor="#[app.registry.door]"
                        firstEndevour="Gray Matter Technologies"
-                       labAddress="#['Pollos Hermanos']">
+                       labAddress="#['Pollos Hermanos']"
+                       weapon="#[weapon]">
     </heisenberg:config>
 
     <spring:beans>
@@ -147,18 +148,18 @@
         <util:set id="ricinPacks">
             <spring:ref bean="ricin"/>
         </util:set>
-        </spring:beans>
-    
+    </spring:beans>
+
     <heisenberg:door victim="Gustavo Fring" address="pollos hermanos" name="door">
-        <heisenberg:previous victim="Krazy-8" address="Jesse's" />
+        <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
     </heisenberg:door>
-    
+
     <heisenberg:ricin microgramsPerKilo="22" name="ricin">
-        <heisenberg:destination victim="Lidia" address="Stevia coffe shop" />
+        <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
     </heisenberg:ricin>
-    
-    <heisenberg:door victim="Skyler" address="308 Negra Arroyo Lane" name="skylerDoor" />
-    
-    <heisenberg:door victim="Saul" address="Shopping Mall" name="saulDoor" />
+
+    <heisenberg:door victim="Skyler" address="308 Negra Arroyo Lane" name="skylerDoor"/>
+
+    <heisenberg:door victim="Saul" address="Shopping Mall" name="saulDoor"/>
 
 </mule>

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-operation-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-operation-config.xml
@@ -39,11 +39,11 @@
     </heisenberg:config>
 
     <flow name="sayMyName">
-        <heisenberg:say-my-name />
+        <heisenberg:say-my-name/>
     </flow>
 
     <flow name="die">
-        <heisenberg:die />
+        <heisenberg:die/>
     </flow>
 
     <flow name="getFixedEnemy">
@@ -55,11 +55,11 @@
     </flow>
 
     <flow name="hideInEvent">
-        <heisenberg:hide-meth-in-event />
+        <heisenberg:hide-meth-in-event/>
     </flow>
 
     <flow name="hideInMessage">
-        <heisenberg:hide-meth-in-message />
+        <heisenberg:hide-meth-in-message/>
     </flow>
 
     <flow name="killFromPayload">
@@ -76,7 +76,7 @@
     </flow>
 
     <flow name="killMany">
-        <heisenberg:kill-many  reason="I'm the one who knocks">
+        <heisenberg:kill-many reason="I'm the one who knocks">
             <heisenberg:kill-operations>
                 <heisenberg:kill-with-custom-message victim="Gustavo Fring" goodbyeMessage="bye bye"/>
                 <heisenberg:kill-with-custom-message victim="Frank" goodbyeMessage="bye bye"/>
@@ -86,7 +86,7 @@
     </flow>
 
     <flow name="killManyButOnlyOneProvided">
-        <heisenberg:kill-many  reason="I'm the one who knocks">
+        <heisenberg:kill-many reason="I'm the one who knocks">
             <heisenberg:kill-operations>
                 <heisenberg:kill-with-custom-message victim="Gustavo Fring" goodbyeMessage="bye bye"/>
             </heisenberg:kill-operations>
@@ -94,7 +94,7 @@
     </flow>
 
     <flow name="killOne">
-        <heisenberg:kill-one  reason="I'm the one who knocks">
+        <heisenberg:kill-one reason="I'm the one who knocks">
             <heisenberg:kill-operation>
                 <heisenberg:kill-with-custom-message victim="Gustavo Fring" goodbyeMessage="bye bye"/>
             </heisenberg:kill-operation>
@@ -102,49 +102,58 @@
     </flow>
 
     <flow name="injectedExtensionManager">
-        <heisenberg:get-injected-extension-manager />
+        <heisenberg:get-injected-extension-manager/>
     </flow>
 
     <flow name="alias">
-        <heisenberg:alias greeting="Howdy!" myName="Walter White" age="52"  />
+        <heisenberg:alias greeting="Howdy!" myName="Walter White" age="52"/>
     </flow>
 
 
     <flow name="knockStaticInlineDoor">
         <heisenberg:knock>
-            <heisenberg:door victim="Inline Skyler" address="308 Negra Arroyo Lane" />
+            <heisenberg:door victim="Inline Skyler" address="308 Negra Arroyo Lane"/>
         </heisenberg:knock>
     </flow>
 
     <flow name="knockStaticTopLevelDoor">
-        <heisenberg:knock door="door" />
+        <heisenberg:knock door="door"/>
     </flow>
 
     <flow name="knockDynamicTopLevelDoor">
-        <heisenberg:knock door="dynamicDoor" />
+        <heisenberg:knock door="dynamicDoor"/>
     </flow>
 
     <flow name="knockDynamicInlineDoor">
         <heisenberg:knock>
-            <heisenberg:door victim="#[victim]" address="308 Negra Arroyo Lane" />
+            <heisenberg:door victim="#[victim]" address="308 Negra Arroyo Lane"/>
         </heisenberg:knock>
     </flow>
 
     <flow name="knockManyWithInlineList">
         <heisenberg:knock-many>
             <heisenberg:doors>
-                <heisenberg:door victim="Inline Skyler" address="308 Negra Arroyo Lane" />
-                <heisenberg:door victim="#[victim]" address="308 Negra Arroyo Lane" />
+                <heisenberg:door victim="Inline Skyler" address="308 Negra Arroyo Lane"/>
+                <heisenberg:door victim="#[victim]" address="308 Negra Arroyo Lane"/>
             </heisenberg:doors>
         </heisenberg:knock-many>
     </flow>
 
     <flow name="knockManyByExpression">
-        <heisenberg:knock-many doors="#[doors]" />
+        <heisenberg:knock-many doors="#[doors]"/>
     </flow>
 
     <flow name="callSaul">
-        <heisenberg:call-saul />
+        <heisenberg:call-saul/>
+    </flow>
+
+    <flow name="killWithWeapon">
+        <heisenberg:kill-with-weapon weapon="#[weapon]"/>
+    </flow>
+
+
+    <flow name="killWithMultipleWeapons">
+        <heisenberg:kill-with-multiples-weapons weaponList="#[weapons]"/>
     </flow>
 
 </mule>

--- a/modules/extensions-spring-support/src/test/resources/heisenberg.xsd
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg.xsd
@@ -50,6 +50,13 @@
                                 </xs:sequence>
                             </xs:complexType>
                         </xs:element>
+                        <xs:element minOccurs="0" maxOccurs="1" name="weapon">
+                            <xs:complexType>
+                                <xs:complexContent>
+                                    <xs:extension xmlns="http://www.mulesoft.org/schema/mule/heisenberg" base="org.mule.module.extension.Weapon"></xs:extension>
+                                </xs:complexContent>
+                            </xs:complexType>
+                        </xs:element>
                     </xs:choice>
                     <xs:attribute type="xs:string" use="required" name="name"></xs:attribute>
                     <xs:attribute type="mule:expressionObject" use="optional" name="nextDoor"></xs:attribute>
@@ -61,6 +68,7 @@
                     <xs:attribute type="mule:expressionString" use="optional" name="labAddress"></xs:attribute>
                     <xs:attribute xmlns="http://www.mulesoft.org/schema/mule/heisenberg" type="org.mule.module.extension.HealthStatusEnumType" use="required" name="initialHealth"></xs:attribute>
                     <xs:attribute type="mule:expressionDecimal" use="required" name="money"></xs:attribute>
+                    <xs:attribute type="mule:expressionObject" use="optional" name="weapon"></xs:attribute>
                     <xs:attribute type="mule:expressionMap" use="optional" name="candidateDoors"></xs:attribute>
                     <xs:attribute type="xs:string" use="optional" name="firstEndevour"></xs:attribute>
                     <xs:attribute type="mule:expressionString" use="optional" name="myName"></xs:attribute>
@@ -117,6 +125,22 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension xmlns="http://www.mulesoft.org/schema/mule/heisenberg" base="org.mule.module.extension.Ricin">
+                    <xs:attribute type="xs:string" use="required" name="name"></xs:attribute>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="org.mule.module.extension.Weapon">
+        <xs:complexContent>
+            <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
+                <xs:sequence></xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" substitutionGroup="mule:abstract-extension" name="weapon">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension xmlns="http://www.mulesoft.org/schema/mule/heisenberg" base="org.mule.module.extension.Weapon">
                     <xs:attribute type="xs:string" use="required" name="name"></xs:attribute>
                 </xs:extension>
             </xs:complexContent>
@@ -281,6 +305,56 @@
                 </xs:attribute>
                 <xs:attribute type="mule:expressionString" use="optional" name="victim"></xs:attribute>
                 <xs:attribute type="mule:expressionString" use="required" name="goodbyeMessage"></xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element xmlns="http://www.mulesoft.org/schema/mule/heisenberg" type="KillWithMultiplesWeaponsType" substitutionGroup="heisenberg-empire" name="kill-with-multiples-weapons"></xs:element>
+    <xs:complexType name="KillWithMultiplesWeaponsType">
+        <xs:complexContent>
+            <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractMessageProcessorType">
+                <xs:sequence>
+                    <xs:element minOccurs="0" maxOccurs="1" name="weapon-list">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element minOccurs="0" maxOccurs="unbounded" name="weapon-list">
+                                    <xs:complexType>
+                                        <xs:complexContent>
+                                            <xs:extension xmlns="http://www.mulesoft.org/schema/mule/heisenberg" base="org.mule.module.extension.Weapon"></xs:extension>
+                                        </xs:complexContent>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
+                    <xs:annotation>
+                        <xs:documentation>Specify which configuration to use for this invocation.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute type="mule:expressionList" use="optional" name="weaponList"></xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element xmlns="http://www.mulesoft.org/schema/mule/heisenberg" type="KillWithWeaponType" substitutionGroup="heisenberg-empire" name="kill-with-weapon"></xs:element>
+    <xs:complexType name="KillWithWeaponType">
+        <xs:complexContent>
+            <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractMessageProcessorType">
+                <xs:sequence>
+                    <xs:element minOccurs="0" maxOccurs="1" name="weapon">
+                        <xs:complexType>
+                            <xs:complexContent>
+                                <xs:extension xmlns="http://www.mulesoft.org/schema/mule/heisenberg" base="org.mule.module.extension.Weapon"></xs:extension>
+                            </xs:complexContent>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
+                    <xs:annotation>
+                        <xs:documentation>Specify which configuration to use for this invocation.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute type="mule:expressionObject" use="optional" name="weapon"></xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/HeisenbergExtension.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/HeisenbergExtension.java
@@ -8,6 +8,7 @@ package org.mule.module.extension;
 
 import static org.mule.extension.api.introspection.ExpressionSupport.NOT_SUPPORTED;
 import static org.mule.extension.api.introspection.ExpressionSupport.REQUIRED;
+
 import org.mule.api.MuleContext;
 import org.mule.api.MuleException;
 import org.mule.api.context.MuleContextAware;
@@ -15,6 +16,7 @@ import org.mule.api.lifecycle.InitialisationException;
 import org.mule.api.lifecycle.Lifecycle;
 import org.mule.extension.annotation.api.Extensible;
 import org.mule.extension.annotation.api.Extension;
+import org.mule.extension.annotation.api.Operation;
 import org.mule.extension.annotation.api.Operations;
 import org.mule.extension.annotation.api.Parameter;
 import org.mule.extension.annotation.api.ParameterGroup;
@@ -81,6 +83,10 @@ public class HeisenbergExtension implements Lifecycle, MuleContextAware
     @Parameter
     @Optional
     private KnockeableDoor nextDoor;
+
+    @Parameter
+    @Optional
+    private Weapon weapon;
 
     /**
      * Doors I might knock on but still haven't made up mind about

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/HeisenbergOperations.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/HeisenbergOperations.java
@@ -7,6 +7,7 @@
 package org.mule.module.extension;
 
 import static java.util.stream.Collectors.toList;
+
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleMessage;
 import org.mule.api.NestedProcessor;
@@ -24,6 +25,7 @@ import org.mule.extension.api.runtime.ContentType;
 
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -72,6 +74,18 @@ public class HeisenbergOperations
     public String killWithCustomMessage(@Optional(defaultValue = "#[payload]") String victim, String goodbyeMessage)
     {
         return String.format("%s, %s", goodbyeMessage, victim);
+    }
+
+    @Operation
+    public String killWithWeapon(Weapon weapon)
+    {
+        return weapon.kill();
+    }
+
+    @Operation
+    public List<String> killWithMultiplesWeapons(List<Weapon> weaponList)
+    {
+        return weaponList.stream().map(Weapon::kill).collect(Collectors.toList());
     }
 
     @Operation

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/Ricin.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/Ricin.java
@@ -8,8 +8,10 @@ package org.mule.module.extension;
 
 import org.mule.extension.annotation.api.Parameter;
 
-public class Ricin
+public class Ricin implements Weapon
 {
+
+    public static final String RICIN_KILL_MESSAGE = "You have been killed with Ricin";
     @Parameter
     private Long microgramsPerKilo;
 
@@ -19,6 +21,11 @@ public class Ricin
     public Long getMicrogramsPerKilo()
     {
         return microgramsPerKilo;
+    }
+
+    public void setMicrogramsPerKilo(long microgramsPerKilo)
+    {
+        this.microgramsPerKilo = microgramsPerKilo;
     }
 
     public KnockeableDoor getDestination()
@@ -41,5 +48,11 @@ public class Ricin
     public int hashCode()
     {
         return microgramsPerKilo.hashCode();
+    }
+
+    @Override
+    public String kill()
+    {
+        return RICIN_KILL_MESSAGE;
     }
 }

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/Weapon.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/Weapon.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.extension;
+
+public interface Weapon
+{
+
+    String kill();
+}

--- a/modules/extensions-support/src/test/java/org/mule/module/extension/internal/AnnotationsBasedDescriberTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/module/extension/internal/AnnotationsBasedDescriberTestCase.java
@@ -25,6 +25,7 @@ import static org.mule.module.extension.HeisenbergExtension.NAMESPACE;
 import static org.mule.module.extension.HeisenbergExtension.SCHEMA_LOCATION;
 import static org.mule.module.extension.HeisenbergExtension.SCHEMA_VERSION;
 import static org.mule.module.extension.internal.introspection.AnnotationsBasedDescriber.DEFAULT_CONNECTION_PROVIDER_NAME;
+
 import org.mule.config.MuleManifest;
 import org.mule.extension.annotation.api.Configuration;
 import org.mule.extension.annotation.api.Configurations;
@@ -50,6 +51,7 @@ import org.mule.module.extension.HeisenbergOperations;
 import org.mule.module.extension.KnockeableDoor;
 import org.mule.module.extension.MoneyLaunderingOperation;
 import org.mule.module.extension.Ricin;
+import org.mule.module.extension.Weapon;
 import org.mule.module.extension.internal.model.property.ConnectionTypeModelProperty;
 import org.mule.module.extension.internal.model.property.ImplementingTypeModelProperty;
 import org.mule.tck.size.SmallTest;
@@ -79,6 +81,8 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
     private static final String GET_ENEMY_OPERATION = "getEnemy";
     private static final String KILL_OPERATION = "kill";
     private static final String KILL_CUSTOM_OPERATION = "killWithCustomMessage";
+    private static final String KILL_WITH_WEAPON = "killWithWeapon";
+    private static final String KILL_WITH_MULTIPLES_WEAPONS = "killWithMultiplesWeapons";
     private static final String HIDE_METH_IN_EVENT_OPERATION = "hideMethInEvent";
     private static final String HIDE_METH_IN_MESSAGE_OPERATION = "hideMethInMessage";
     private static final String DIE = "die";
@@ -148,7 +152,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
         assertThat(conf.getName(), equalTo(DEFAULT_CONFIG_NAME));
 
         List<ParameterDeclaration> parameters = conf.getParameters();
-        assertThat(parameters, hasSize(15));
+        assertThat(parameters, hasSize(16));
 
         assertParameter(parameters, "myName", "", DataType.of(String.class), false, SUPPORTED, HEISENBERG);
         assertParameter(parameters, "age", "", DataType.of(Integer.class), false, SUPPORTED, AGE);
@@ -166,6 +170,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
         assertParameter(parameters, "finalHealth", "", DataType.of(HealthStatus.class), true, SUPPORTED, null);
         assertParameter(parameters, "labAddress", "", DataType.of(String.class), false, REQUIRED, null);
         assertParameter(parameters, "firstEndevour", "", DataType.of(String.class), false, NOT_SUPPORTED, null);
+        assertParameter(parameters, "weapon", "", DataType.of(Weapon.class), false, SUPPORTED, null);
     }
 
     private void assertExtensionProperties(Declaration declaration)
@@ -179,11 +184,13 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
 
     private void assertTestModuleOperations(Declaration declaration) throws Exception
     {
-        assertThat(declaration.getOperations(), hasSize(15));
+        assertThat(declaration.getOperations(), hasSize(17));
         assertOperation(declaration, SAY_MY_NAME_OPERATION, "");
         assertOperation(declaration, GET_ENEMY_OPERATION, "");
         assertOperation(declaration, KILL_OPERATION, "");
         assertOperation(declaration, KILL_CUSTOM_OPERATION, "");
+        assertOperation(declaration, KILL_WITH_WEAPON, "");
+        assertOperation(declaration, KILL_WITH_MULTIPLES_WEAPONS, "");
         assertOperation(declaration, HIDE_METH_IN_EVENT_OPERATION, "");
         assertOperation(declaration, HIDE_METH_IN_MESSAGE_OPERATION, "");
         assertOperation(declaration, DIE, "");
@@ -208,6 +215,16 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
         assertThat(operation.getParameters(), hasSize(2));
         assertParameter(operation.getParameters(), "victim", "", DataType.of(String.class), false, SUPPORTED, "#[payload]");
         assertParameter(operation.getParameters(), "goodbyeMessage", "", DataType.of(String.class), true, SUPPORTED, null);
+
+        operation = getOperation(declaration, KILL_WITH_WEAPON);
+        assertThat(operation, is(notNullValue()));
+        assertThat(operation.getParameters(), hasSize(1));
+        assertParameter(operation.getParameters(), "weapon", "", DataType.of(Weapon.class), true, SUPPORTED, null);
+
+        operation = getOperation(declaration, KILL_WITH_MULTIPLES_WEAPONS);
+        assertThat(operation, is(notNullValue()));
+        assertThat(operation.getParameters(), hasSize(1));
+        assertParameter(operation.getParameters(), "weaponList", "", DataType.of(List.class, Weapon.class), true, SUPPORTED, null);
 
         operation = getOperation(declaration, KILL_CUSTOM_OPERATION);
         assertThat(operation, is(notNullValue()));


### PR DESCRIPTION
Now when using a non instantiable class used as `@Operation` parameter or as `ConnectionProvider`/`Config` `@Parameter` child elements are not generated, these kind of classes can be only configured by reference.