### PR TITLE
MULE-9166: Changed 'mule-core-tests' version placeholder to depend in…

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-core-tests</artifactId>
-            <version>${project.version}</version>
+            <version>${mule.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>


### PR DESCRIPTION
… the mule version instead of the project version of the extension