### PR TITLE
MULE-9268: Allow studio to discover and instantiate ExtensionModels

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/module/extension/internal/manager/DefaultExtensionDiscoverer.java
+++ b/modules/extensions-support/src/main/java/org/mule/module/extension/internal/manager/DefaultExtensionDiscoverer.java
@@ -28,7 +28,7 @@ import java.util.List;
  *
  * @since 4.0.0
  */
-final class DefaultExtensionDiscoverer implements ExtensionDiscoverer
+public final class DefaultExtensionDiscoverer implements ExtensionDiscoverer
 {
 
     private final ExtensionFactory extensionFactory;


### PR DESCRIPTION
The default contructor needs to be public in order to use it via SPI