### PR TITLE
MULE-9306 When using MuleClient from JavaComponent or from a MessageP…

### DIFF
--- a/core/src/main/java/org/mule/component/DefaultComponentLifecycleAdapter.java
+++ b/core/src/main/java/org/mule/component/DefaultComponentLifecycleAdapter.java
@@ -9,7 +9,6 @@ package org.mule.component;
 import static org.mule.config.i18n.MessageFactory.createStaticMessage;
 
 import org.mule.DefaultMuleEventContext;
-import org.mule.RequestContext;
 import org.mule.api.DefaultMuleException;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -339,7 +338,7 @@ public class DefaultComponentLifecycleAdapter implements LifecycleAdapter
         {
             if (componentObject == null)
             {
-                throw new ComponentException(createStaticMessage("componentObject is null"), RequestContext.getEvent(), component);
+                throw new ComponentException(createStaticMessage("componentObject is null"), event, component);
             }
             // Use the overriding entrypoint resolver if one is set
             if (component.getEntryPointResolverSet() != null)
@@ -353,7 +352,7 @@ public class DefaultComponentLifecycleAdapter implements LifecycleAdapter
         }
         catch (Exception e)
         {
-            throw new ComponentException(createStaticMessage("%s: %s", e.getClass().getName(), e.getMessage()), RequestContext.getEvent(), component, e);
+            throw new ComponentException(createStaticMessage("%s: %s", e.getClass().getName(), e.getMessage()), event, component, e);
         }
 
         return result;

--- a/core/src/main/java/org/mule/execution/MessageProcessorNotificationExecutionInterceptor.java
+++ b/core/src/main/java/org/mule/execution/MessageProcessorNotificationExecutionInterceptor.java
@@ -92,10 +92,11 @@ class MessageProcessorNotificationExecutionInterceptor implements MessageProcess
                     originalReplyToHandler.processExceptionReplyTo(exception, replyTo);
                 }
             });
-            // Update RequestContext ThreadLocal for backwards compatibility
-            OptimizedRequestContext.unsafeSetEvent(eventToProcess);
-
         }
+        // Update RequestContext ThreadLocal in case if previous processor modified it
+        // also for backwards compatibility
+        OptimizedRequestContext.unsafeSetEvent(eventToProcess);
+
         try
         {
             if (next == null)

--- a/core/src/main/java/org/mule/execution/TransactionalErrorHandlingExecutionTemplate.java
+++ b/core/src/main/java/org/mule/execution/TransactionalErrorHandlingExecutionTemplate.java
@@ -85,6 +85,8 @@ public class TransactionalErrorHandlingExecutionTemplate implements ExecutionTem
      *
      * @param muleContext MuleContext for this application
      * @param transactionConfig Transaction configuration
+     *
+     * @deprecated 
      */
     public static TransactionalErrorHandlingExecutionTemplate createMainExecutionTemplate(MuleContext muleContext, TransactionConfig transactionConfig)
     {

--- a/core/src/main/java/org/mule/transport/AbstractMessageReceiver.java
+++ b/core/src/main/java/org/mule/transport/AbstractMessageReceiver.java
@@ -421,7 +421,8 @@ public abstract class AbstractMessageReceiver extends AbstractTransportMessageHa
 
     protected ExecutionTemplate<MuleEvent> createExecutionTemplate()
     {
-        return TransactionalErrorHandlingExecutionTemplate.createMainExecutionTemplate(endpoint.getMuleContext(), endpoint.getTransactionConfig());
+        return TransactionalErrorHandlingExecutionTemplate.createMainExecutionTemplate(endpoint.getMuleContext(), endpoint.getTransactionConfig(),
+                                                                                       flowConstruct.getExceptionListener());
     }
 
     /**

--- a/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchExceptionHandlingTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchExceptionHandlingTestCase.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.integration.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+import org.mule.DefaultMuleMessage;
+import org.mule.RequestContext;
+import org.mule.api.DefaultMuleException;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleEventContext;
+import org.mule.api.MuleException;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.LocalMuleClient;
+import org.mule.api.lifecycle.Callable;
+import org.mule.api.processor.MessageProcessor;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.util.concurrent.Latch;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests to validate that MuleClient can be used from JavaComponent/MessageProcessor in order to dispatch an event to
+ * a sub-flow and if the component/processor throws an exception afterwards the main-flow exception strategy handles
+ * it.
+ */
+public class MuleClientDispatchExceptionHandlingTestCase extends FunctionalTestCase
+{
+    private static final Log logger = LogFactory.getLog(MuleClientDispatchExceptionHandlingTestCase.class);
+
+    @Rule
+    public DynamicPort dynamicPort1 = new DynamicPort("port1");
+
+    // These attributes need to be accessed from JavaComponent and MessageProcessor static classes therefore
+    // they are declared as static
+    private static Latch innerFlowLatch;
+    private static Latch exceptionLatch;
+    private static MuleEvent eventFromMainFlow;
+    private static MuleMessage messageFromMainFlow;
+    private static boolean eventPropagated;
+    private static boolean isSameMessage;
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/integration/client/client-dispatch-catch-exception-flow.xml";
+    }
+
+    /**
+     * Validates that a JavaComponent after doing a dispatch to a sub-flow using MuleClient
+     * throws an exception and the catch-exception-strategy defined in main-flow is called.
+     * It also validates that original event passed to JavaComponent is later propagated
+     * to the JavaComponent defined in catch-exception-strategy block.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCatchExceptionThrowFromJavaComponentToJavaComponent() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionJavaComponentToJavaComponent");
+    }
+
+    @Test
+    public void tesCatchExceptionThrowFromJavaComponentToMessageProcessor() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionJavaComponentToMessageProcessor");
+    }
+
+    @Test
+    public void testCatchExceptionThrowFromMessageProcessorToJavaComponent() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionMessageProcessorToJavaComponent");
+    }
+
+    @Test
+    public void tesCatchExceptionThrowFromMessageProcessorToMessageProcessor() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionMessageProcessorToMessageProcessor");
+    }
+
+    @Test
+    public void testCatchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow");
+    }
+
+    private void doSendMessageToEndpoint(String endpoint) throws Exception
+    {
+        innerFlowLatch = new Latch();
+        exceptionLatch = new Latch();
+        eventPropagated = true;
+        isSameMessage = true;
+
+        LocalMuleClient client = muleContext.getClient();
+        MuleMessage result = client.send(endpoint, getTestMuleMessage("Original Message"));
+
+        boolean innerFlowCalled = innerFlowLatch.await(3, TimeUnit.SECONDS);
+        assertThat(innerFlowCalled, is(true));
+        boolean exceptionHandled = exceptionLatch.await(3, TimeUnit.SECONDS);
+        assertThat(exceptionHandled, is(true));
+
+        assertThat(isSameMessage, is(true));
+        assertThat(eventPropagated, is(true));
+
+        assertThat(result, notNullValue(MuleMessage.class));
+    }
+
+    // Just a simple JavaComponent used in catch-exception-strategy block
+    // in order to check that RequestContext has the correct event and message references
+    public static class AssertEventComponent implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            // Validates that if another Component access to the RequestContext.getEvent() the one returned
+            // is the correct, in this case it should be the same that it was set before doing the
+            // eventContext.dispatchEvent() on main-flow java component where the exception happened right after
+            // that invocatioeventPropagated = RequestContext.getEvent().equals(eventFromMainFlow);
+            // Checking if message is still the same on catch-exception-strategy
+            isSameMessage = RequestContext.getEvent().getMessage().equals(messageFromMainFlow);
+            return eventContext.getMessage();
+        }
+    }
+
+    public static class AssertEventProcessor implements MessageProcessor
+    {
+        @Override
+        public MuleEvent process(MuleEvent event) throws MuleException
+        {
+            // Validates that if another Component access to the RequestContext.getEvent() the one returned
+            // is the correct, in this case it should be the same that it was set before doing the
+            // eventContext.dispatchEvent() on main-flow java component where the exception happened right after
+            // that invocatioeventPropagated = RequestContext.getEvent().equals(eventFromMainFlow);
+            // Checking if message is still the same on catch-exception-strategy
+            isSameMessage = RequestContext.getEvent().getMessage().equals(messageFromMainFlow);
+            return event;
+        }
+    }
+
+    public static class DispatchInnerFlowThrowExceptionJavaComponent implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventFromMainFlow = RequestContext.getEvent();
+            messageFromMainFlow = eventFromMainFlow.getMessage();
+
+            eventContext.dispatchEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()),
+                                       "vm://vminnertest");
+
+            throw new Exception("expected exception!");
+        }
+    }
+
+    public static class SendInnerFlowThrowExceptionJavaComponent implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventFromMainFlow = RequestContext.getEvent();
+            messageFromMainFlow = eventFromMainFlow.getMessage();
+
+            eventContext.sendEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()),
+                                   "vm://vminnerrequestresponsetest");
+
+            throw new Exception("expected exception!");
+        }
+    }
+
+    public static class DispatchInnerFlowThrowExceptionMessageProcessor implements MessageProcessor
+    {
+        @Override
+        public MuleEvent process(MuleEvent event) throws MuleException
+        {
+            eventFromMainFlow = RequestContext.getEvent();
+            messageFromMainFlow = eventFromMainFlow.getMessage();
+
+            event.getMuleContext().getClient().dispatch("vm://vminnertest",
+                                                        new DefaultMuleMessage("payload", event.getMuleContext()));
+
+            throw new DefaultMuleException("expected exception!");
+        }
+    }
+
+    public static class ExecutionCountDownProcessor implements MessageProcessor
+    {
+        @Override
+        public synchronized MuleEvent process(MuleEvent event) throws MuleException
+        {
+            exceptionLatch.countDown();
+            return event;
+        }
+    }
+
+    public static class InnerFlowCountDownProcessor implements MessageProcessor
+    {
+        @Override
+        public synchronized MuleEvent process(MuleEvent event) throws MuleException
+        {
+            innerFlowLatch.countDown();
+            return event;
+        }
+    }
+}

--- a/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchWithoutLosingVariablesTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchWithoutLosingVariablesTestCase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.integration.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.mule.DefaultMuleMessage;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleEventContext;
+import org.mule.api.MuleException;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.LocalMuleClient;
+import org.mule.api.lifecycle.Callable;
+import org.mule.api.processor.MessageProcessor;
+import org.mule.tck.functional.FlowAssert;
+import org.mule.tck.junit4.FunctionalTestCase;
+
+import org.junit.Test;
+
+/**
+ * Tests to validate that MuleClient can be used from MessageProcessor and JavaComponent in order to dispatch an event to
+ * a sub-flow, without losing the Flow variables.
+ */
+public class MuleClientDispatchWithoutLosingVariablesTestCase extends FunctionalTestCase
+{
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/integration/client/client-flow-session-vars-when-dispatch-flow.xml";
+    }
+
+    private void doSendMessageToVMEndpoint(String flowName) throws Exception
+    {
+        LocalMuleClient client = muleContext.getClient();
+        MuleMessage result = client.send("vm://" + flowName, "TEST1", null);
+        assertThat(result, notNullValue(MuleMessage.class));
+        FlowAssert.verify(flowName);
+    }
+
+    /**
+     * When doing a dispatch from a MessageProcessor the event was overwritten in ThreadLocal by
+     * OptimizedRequestContext while processing it and before dispatching it to a different thread so
+     * the original event that is the one that has to continue the execution of the main flow
+     * was losing the Flow variables.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFlowVarsAfterDispatchFromMessageProcessor() throws Exception
+    {
+        doSendMessageToVMEndpoint("flowVarsFlowUsingProcessor");
+    }
+
+    @Test
+    public void testSessionVarsAfterDispatchFromMessageProcessor() throws Exception
+    {
+        doSendMessageToVMEndpoint("sessionVarsFlowUsingProcessor");
+    }
+
+    /**
+     * When doing a dispatch from a JavaComponent the event was overwritten in ThreadLocal by
+     * OptimizedRequestContext while processing it and before dispatching it to a different thread so
+     * the original event that is the one that has to continue the execution of the main flow
+     * was losing the Flow variables.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFlowVarsAfterDispatchFromJavaComponent() throws Exception
+    {
+        doSendMessageToVMEndpoint("flowVarsFlowUsingJavaComponent");
+    }
+
+    @Test
+    public void testSessionVarsAfterDispatchFromJavaComponent() throws Exception
+    {
+        doSendMessageToVMEndpoint("sessionVarsFlowUsingJavaComponent");
+    }
+
+    @Test
+    public void testSessionVarsFlowUsingJavaComponentRequestResponse() throws Exception
+    {
+        doSendMessageToVMEndpoint("sessionVarsFlowUsingJavaComponentRequestResponse");
+    }
+
+    public static class MessageProcessorDispatchFlowUsingNewMuleClient implements MessageProcessor
+    {
+        @Override
+        public MuleEvent process(MuleEvent event) throws MuleException
+        {
+            event.getMuleContext().getClient().dispatch("vm://vminnertest", new DefaultMuleMessage("payload", event.getMuleContext()));
+            return event;
+
+        }
+    }
+
+    public static class JavaComponentDispatchFlowUsingNewMuleClient implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventContext.dispatchEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()), "vm://vminnertest");
+            return eventContext.getMessage();
+        }
+    }
+
+    public static class JavaComponentSendFlowUsingNewMuleClient implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventContext.sendEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()), "vm://vminnerrequestresponsetest");
+            return eventContext.getMessage();
+        }
+    }
+
+}

--- a/tests/integration/src/test/resources/org/mule/test/integration/client/client-dispatch-catch-exception-flow.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/client/client-dispatch-catch-exception-flow.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+           http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <vm:connector name="vmQueues"/>
+
+    <flow name="innerFlow">
+        <vm:inbound-endpoint exchange-pattern="one-way" path="vminnertest"/>
+        <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$InnerFlowCountDownProcessor"/>
+    </flow>
+
+    <flow name="innerFlowRequestResponse">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="vminnerrequestresponsetest"/>
+        <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$InnerFlowCountDownProcessor"/>
+    </flow>
+
+    <flow name="catchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$SendInnerFlowThrowExceptionJavaComponent"/>
+        <catch-exception-strategy>
+            <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventComponent"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <flow name="catchExceptionJavaComponentToJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionJavaComponentToJavaComponent"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$DispatchInnerFlowThrowExceptionJavaComponent"/>
+        <catch-exception-strategy>
+            <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventComponent"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <flow name="catchExceptionJavaComponentToMessageProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionJavaComponentToMessageProcessor"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$DispatchInnerFlowThrowExceptionJavaComponent"/>
+        <catch-exception-strategy>
+            <processor ref="assertEventProcessor"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <spring:beans>
+        <spring:bean id="myProcessor"
+                     class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$DispatchInnerFlowThrowExceptionMessageProcessor"/>
+        <spring:bean id="assertEventProcessor"
+                     class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventProcessor"/>
+    </spring:beans>
+
+    <flow name="catchExceptionMessageProcessorToJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionMessageProcessorToJavaComponent"/>
+        <processor ref="myProcessor"/>
+        <catch-exception-strategy>
+            <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventComponent"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <flow name="catchExceptionMessageProcessorToMessageProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionMessageProcessorToMessageProcessor"/>
+        <processor ref="myProcessor"/>
+        <catch-exception-strategy>
+            <processor ref="assertEventProcessor"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+</mule>

--- a/tests/integration/src/test/resources/org/mule/test/integration/client/client-flow-session-vars-when-dispatch-flow.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/client/client-flow-session-vars-when-dispatch-flow.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+           http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+           http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <vm:connector name="vmQueues"/>
+
+    <flow name="innerFlow">
+        <vm:inbound-endpoint exchange-pattern="one-way" path="vminnertest"/>
+        <logger level="INFO"/>
+    </flow>
+
+    <flow name="innerFlowRequestResponse">
+        <vm:inbound-endpoint exchange-pattern="one-way" path="vminnerrequestresponsetest"/>
+        <logger level="INFO"/>
+    </flow>
+
+    <spring:beans>
+        <spring:bean id="myProcessor"
+                     class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$MessageProcessorDispatchFlowUsingNewMuleClient"/>
+    </spring:beans>
+
+    <flow name="flowVarsFlowUsingProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="flowVarsFlowUsingProcessor"/>
+        <set-variable variableName="team" value="Sales"/>
+        <processor ref="myProcessor"/>
+        <set-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[flowVars['team'] == 'Sales']" />
+        <test:assert expression="#[flowVars['ammount'] == '100']" />
+    </flow>
+
+    <flow name="sessionVarsFlowUsingProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="sessionVarsFlowUsingProcessor"/>
+        <set-session-variable variableName="team" value="Sales"/>
+        <processor ref="myProcessor"/>
+        <set-session-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[sessionVars.team == 'Sales']" />
+        <test:assert expression="#[sessionVars.ammount == '100']" />
+    </flow>
+
+    <flow name="flowVarsFlowUsingJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="flowVarsFlowUsingJavaComponent"/>
+        <set-variable variableName="team" value="Sales"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$JavaComponentDispatchFlowUsingNewMuleClient"/>
+        <set-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[flowVars['team'] == 'Sales']" />
+        <test:assert expression="#[flowVars['ammount'] == '100']" />
+    </flow>
+
+    <flow name="sessionVarsFlowUsingJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="sessionVarsFlowUsingJavaComponent"/>
+        <set-session-variable variableName="team" value="Sales"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$JavaComponentDispatchFlowUsingNewMuleClient"/>
+        <set-session-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[sessionVars.team == 'Sales']" />
+        <test:assert expression="#[sessionVars.ammount == '100']" />
+    </flow>
+
+    <flow name="sessionVarsFlowUsingJavaComponentRequestResponse">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="sessionVarsFlowUsingJavaComponentRequestResponse"/>
+        <set-session-variable variableName="team" value="Sales"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$JavaComponentSendFlowUsingNewMuleClient"/>
+        <set-session-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[sessionVars.team == 'Sales']" />
+        <test:assert expression="#[sessionVars.ammount == '100']" />
+    </flow>
+</mule>


### PR DESCRIPTION
…rocessor the RequestContext is left inconsistent so Flow and Session variables were lost, also exception handling was not using the event being processed to handle errors when the component and processor is invoked.