### PR TITLE
MULE-8936: The 'protocol' attr in an http:request-config element does…

### DIFF
--- a/modules/http/src/main/resources/META-INF/mule-httpn.xsd
+++ b/modules/http/src/main/resources/META-INF/mule-httpn.xsd
@@ -974,22 +974,29 @@
     </xsd:complexType>
 
     <xsd:simpleType name="httpProtocol">
-        <xsd:restriction base="mule:substitutableName">
-            <xsd:enumeration value="HTTP">
-                <xsd:annotation>
-                    <xsd:documentation>
-                        Plain HTTP protocol with no encryption (HTTPS / SSL/ TLS) configured
-                    </xsd:documentation>
-                </xsd:annotation>
-            </xsd:enumeration>
-            <xsd:enumeration value="HTTPS">
-                <xsd:annotation>
-                    <xsd:documentation>
-                        HTTP protocol used with encryption (HTTPS / SSL / TLS).
-                    </xsd:documentation>
-                </xsd:annotation>
-            </xsd:enumeration>
-        </xsd:restriction>
+        <xsd:union>
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="HTTP">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                Plain HTTP protocol with no encryption (HTTPS / SSL/ TLS) configured
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="HTTPS">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                HTTP protocol used with encryption (HTTPS / SSL / TLS).
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:enumeration>
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType>
+                <xsd:restriction base="mule:propertyPlaceholderType"/>
+            </xsd:simpleType>
+        </xsd:union>
     </xsd:simpleType>
 
 </xsd:schema>

--- a/modules/http/src/test/java/org/mule/module/http/functional/HttpRestrictedCiphersAndProtocolsTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/HttpRestrictedCiphersAndProtocolsTestCase.java
@@ -42,6 +42,8 @@ public class HttpRestrictedCiphersAndProtocolsTestCase extends FunctionalTestCas
     public ExpectedException expectedException = ExpectedException.none();
     @Rule
     public SystemProperty cipherSuites = new SystemProperty("cipherSuites", "TLS_DHE_DSS_WITH_AES_128_CBC_SHA");
+    @Rule
+    public SystemProperty protocol = new SystemProperty("protocol", "HTTPS");
 
     private HttpRequestOptionsBuilder optionsBuilder = HttpRequestOptionsBuilder.newOptions().method(POST.name());
     private DefaultTlsContextFactory tlsContextFactory;

--- a/modules/http/src/test/resources/http-restricted-ciphers-and-protocols-config.xml
+++ b/modules/http/src/test/resources/http-restricted-ciphers-and-protocols-config.xml
@@ -13,7 +13,7 @@
         <tls:trust-store path="trustStore" password="mulepassword"/>
     </tls:context>
 
-    <http:request-config name="requestConfig1" protocol="HTTPS" host="localhost" port="${port1}" tlsContext-ref="tlsClientContext" />
+    <http:request-config name="requestConfig1" protocol="${protocol}" host="localhost" port="${port1}" tlsContext-ref="tlsClientContext" />
     <!--Forces TLSv1 and TLSv1.2 with a cipher suite for each-->
     <http:request-config name="requestConfig2" protocol="HTTPS" host="localhost" port="${port2}">
         <tls:context enabledProtocols="TLSv1, TLSv1.2" enabledCipherSuites="TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, ${cipherSuites}">
@@ -33,7 +33,7 @@
     </tls:context>
 
     <!--Forces TLSv1-->
-    <http:listener-config name="listenerConfig1" protocol="HTTPS" host="localhost" port="${port1}">
+    <http:listener-config name="listenerConfig1" protocol="${protocol}" host="localhost" port="${port1}">
         <tls:context enabledProtocols="TLSv1">
             <tls:key-store path="serverKeystore" keyPassword="mulepassword" password="mulepassword"/>
         </tls:context>


### PR DESCRIPTION
… not support '${propertyname}' as value. There was no need for a validation since the Enum conversion already prevents values other than HTTP and HTTPS.