### PR TITLE
MULE-9274: Troubleshooting: When the doc:name property is not present,

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/config/spring/MuleDocumentLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/MuleDocumentLoader.java
@@ -45,12 +45,15 @@ import org.xml.sax.helpers.DefaultHandler;
 final class MuleDocumentLoader implements DocumentLoader
 {
 
-    private static final UserDataHandler NULL_DATA_HANDLER = new UserDataHandler()
+    private static final UserDataHandler COPY_METADATA_ANNOTATIONS_DATA_HANDLER = new UserDataHandler()
     {
         @Override
         public void handle(short operation, String key, Object data, Node src, Node dst)
         {
-            // Nothing to do.
+            if (operation == NODE_IMPORTED || operation == NODE_CLONED)
+            {
+                dst.setUserData(METADATA_ANNOTATIONS_KEY, src.getUserData(METADATA_ANNOTATIONS_KEY), this);
+            }
         }
     };
 
@@ -162,7 +165,7 @@ final class MuleDocumentLoader implements DocumentLoader
                 annotationsStack.peek().appendElementBody(SystemUtils.LINE_SEPARATOR + metadataAnnotations.getElementString() + SystemUtils.LINE_SEPARATOR);
             }
 
-            walker.getParentNode().setUserData(METADATA_ANNOTATIONS_KEY, metadataAnnotations, NULL_DATA_HANDLER);
+            walker.getParentNode().setUserData(METADATA_ANNOTATIONS_KEY, metadataAnnotations, COPY_METADATA_ANNOTATIONS_DATA_HANDLER);
             walker = walker.walkOut();
         }
     }

--- a/modules/spring-config/src/main/java/org/mule/config/spring/parsers/generic/ParentDefinitionParser.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/parsers/generic/ParentDefinitionParser.java
@@ -30,6 +30,7 @@ public class ParentDefinitionParser extends AbstractHierarchicalDefinitionParser
         addBeanFlag(MuleHierarchicalBeanDefinitionParserDelegate.MULE_NO_REGISTRATION);
     }
 
+    @Override
     protected Class getBeanClass(Element element)
     {
         try
@@ -44,6 +45,7 @@ public class ParentDefinitionParser extends AbstractHierarchicalDefinitionParser
         }
     }
 
+    @Override
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext)
     {
         preProcess(element);
@@ -65,6 +67,14 @@ public class ParentDefinitionParser extends AbstractHierarchicalDefinitionParser
         return (AbstractBeanDefinition) beanAssembler.getTarget();
     }
 
+    @Override
+    protected void processMetadataAnnotations(Element element, ParserContext context, BeanDefinitionBuilder builder)
+    {
+        // Nothing to do
+        // We don't want annotations from inner elements to override the annotations from its parent element.
+    }
+
+    @Override
     protected void postProcess(ParserContext context, BeanAssembler assembler, Element element)
     {
         // by default the name matches the "real" bean

--- a/tests/integration/src/test/java/org/mule/test/config/ConfigurationAnnotationsTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/config/ConfigurationAnnotationsTestCase.java
@@ -99,6 +99,21 @@ public class ConfigurationAnnotationsTestCase extends FunctionalTestCase
     }
 
     @Test
+    public void testDefaultAnnotationsInNotAnnotatedObject()
+    {
+        FlowConstruct flow = muleContext.getRegistry().lookupFlowConstruct("NotAnnotatedBridge");
+        assertThat(flow, not(nullValue()));
+        assertThat(getDocName(flow), is(nullValue()));
+        assertThat(getDocDescription(flow), is(nullValue()));
+        assertThat(getSourceFile(flow), is("annotations.xml"));
+        assertThat(getSourceFileLine(flow), is(23));
+        assertThat(getSourceElement(flow), is("<flow name=\"NotAnnotatedBridge\">" + SystemUtils.LINE_SEPARATOR +
+                                              "<inbound-endpoint ref=\"notAnnotatedIn\"></inbound-endpoint>" + SystemUtils.LINE_SEPARATOR +
+                                              "<echo-component></echo-component>" + SystemUtils.LINE_SEPARATOR +
+                                              "</flow>"));
+    }
+
+    @Test
     public void testJavaComponentAnnotations()
     {
         DefaultJavaComponent echo = muleContext.getRegistry().lookupByType(DefaultJavaComponent.class).values().iterator().next();
@@ -130,15 +145,22 @@ public class ConfigurationAnnotationsTestCase extends FunctionalTestCase
     {
         OutboundEndpoint out = muleContext.getRegistry().lookupByType(OutboundEndpoint.class).values().iterator().next();
         assertThat(out, not(nullValue()));
-        assertThat(getDocName(out), is("outbound vm endpoint"));
-        assertThat(getDocDescription(out), is("Accepts outbound messages"));
-        assertThat(getSourceFile(out), is("annotations-config.xml"));
-        assertThat(getSourceFileLine(out), is(22));
-        assertThat(getSourceElement(out), is("<endpoint name=\"out\" address=\"vm://out\" exchange-pattern=\"request-response\" doc:name=\"outbound vm endpoint\">" + SystemUtils.LINE_SEPARATOR +
-                                             "<annotations>" + SystemUtils.LINE_SEPARATOR +
-                                             "<doc:description>Accepts outbound messages</doc:description>" + SystemUtils.LINE_SEPARATOR +
-                                             "</annotations>" + SystemUtils.LINE_SEPARATOR +
-                                             "</endpoint>"));
+        assertThat(getDocName(out), is(nullValue()));
+        assertThat(getDocDescription(out), is(nullValue()));
+        assertThat(getSourceFile(out), is("annotations.xml"));
+        assertThat(getSourceFileLine(out), is(18));
+        assertThat(getSourceElement(out), is("<outbound-endpoint ref=\"out\"></outbound-endpoint>"));
+    }
+
+    @Test
+    public void testInsideSpringBeansAnnotations()
+    {
+        Transformer stb = muleContext.getRegistry().lookupTransformer("ManziTransformer");
+        assertThat(stb, not(nullValue()));
+        assertThat(getDocName(stb), is("manzi-transformer"));
+        assertThat(getSourceFile(stb), is("annotations-config.xml"));
+        assertThat(getSourceFileLine(stb), is(30));
+        assertThat(getSourceElement(stb), is("<append-string-transformer message=\"Manzi\" name=\"ManziTransformer\" doc:name=\"manzi-transformer\"></append-string-transformer>"));
     }
 
     protected String getDocName(Object obj)

--- a/tests/integration/src/test/resources/org/mule/config/spring/annotations-config.xml
+++ b/tests/integration/src/test/resources/org/mule/config/spring/annotations-config.xml
@@ -25,4 +25,10 @@
         </annotations>
     </endpoint>
 
+    <spring:beans>
+        <mule>
+            <append-string-transformer message="Manzi" name="ManziTransformer" doc:name="manzi-transformer"/>
+        </mule>
+    </spring:beans>
+
 </mule>

--- a/tests/integration/src/test/resources/org/mule/config/spring/annotations.xml
+++ b/tests/integration/src/test/resources/org/mule/config/spring/annotations.xml
@@ -18,4 +18,11 @@
         <outbound-endpoint ref="out"/>
     </flow>
 
+    <endpoint name="notAnnotatedIn" address="vm://notAnnotatedIn" exchange-pattern="request-response"/>
+
+    <flow name="NotAnnotatedBridge">
+        <inbound-endpoint ref="notAnnotatedIn"/>
+        <echo-component/>
+    </flow>
+
 </mule>


### PR DESCRIPTION
the xml file name and the line number appear with null in the exception
logging