### PR TITLE
MULE-8940: Remove trailing '/' when present in basePath

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/HttpParser.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/HttpParser.java
@@ -129,6 +129,15 @@ public class HttpParser
         return path.startsWith("/") ? path : "/" + path;
     }
 
+    public static String sanitizePathWithEndSlash(String path)
+    {
+        if (path == null || (path.equals("/")))
+        {
+            return null;
+        }
+        return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+    }
+
     public static ParameterMap decodeQueryString(String queryString)
     {
         return decodeUrlEncodedBody(queryString, Charsets.UTF_8.name());

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
@@ -139,6 +139,7 @@ public class DefaultHttpListenerConfig extends AbstractAnnotatedObject implement
             return;
         }
         basePath = HttpParser.sanitizePathWithStartSlash(this.basePath);
+        basePath = HttpParser.sanitizePathWithEndSlash(this.basePath);
         if (workerThreadingProfile == null)
         {
             workerThreadingProfile = new MutableThreadingProfile(ThreadingProfile.DEFAULT_THREADING_PROFILE);

--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfigTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfigTestCase.java
@@ -31,6 +31,7 @@ public class DefaultHttpListenerConfigTestCase extends AbstractMuleTestCase
 {
 
     private static final String LOCALHOST = "localhost";
+    private static final String RESOURCE = "/resource";
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -70,6 +71,26 @@ public class DefaultHttpListenerConfigTestCase extends AbstractMuleTestCase
         listenerConfig.setTlsContext(mockTlsContextFactory);
         listenerConfig.initialise();
         assertThat(listenerConfig.getPort(), is(HTTPS.getDefaultPort()));
+    }
+
+    @Test
+    public void validPathWhenBasePathIsForwardSlash() throws Exception
+    {
+        listenerConfig.setProtocol(HTTP);
+        listenerConfig.setBasePath("/");
+        listenerConfig.initialise();
+        assertThat(listenerConfig.getFullListenerPath(RESOURCE).getResolvedPath(), is(RESOURCE));
+    }
+
+    @Test
+    public void validPathWhenBasePathHasTrailingForwardSlash() throws Exception
+    {
+        String basePath = "/base/";
+        listenerConfig.setProtocol(HTTP);
+        listenerConfig.setBasePath(basePath);
+        listenerConfig.initialise();
+        assertThat(listenerConfig.getFullListenerPath(RESOURCE).getResolvedPath(),
+                is(basePath.substring(0, basePath.length() - 1) + RESOURCE));
     }
 
     @Test


### PR DESCRIPTION
When the http listener config is initialized, cleanse the `basePath` of
trailing forward slashes by removing them when present. Note that due to
`sanatizePathWithStartSlash`, the http path ALWAYS starts with a `/`.

- Create two test cases describing behavior.

- Create sanitize method to remove end slash.

- Call the sanitize method when initializing the config.