### PR TITLE
MULE-9306 Usage of MuleClient for dispatching or sending an event to …

### DIFF
--- a/core/src/main/java/org/mule/component/DefaultComponentLifecycleAdapter.java
+++ b/core/src/main/java/org/mule/component/DefaultComponentLifecycleAdapter.java
@@ -7,7 +7,6 @@
 package org.mule.component;
 
 import org.mule.DefaultMuleEventContext;
-import org.mule.RequestContext;
 import org.mule.api.DefaultMuleException;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -331,7 +330,7 @@ public class DefaultComponentLifecycleAdapter implements LifecycleAdapter
         {
             if (componentObject == null)
             {
-                throw new ComponentException(MessageFactory.createStaticMessage("componentObject is null"), RequestContext.getEvent(), component);
+                throw new ComponentException(MessageFactory.createStaticMessage("componentObject is null"), event, component);
             }
             // Use the overriding entrypoint resolver if one is set
             if (component.getEntryPointResolverSet() != null)
@@ -345,7 +344,7 @@ public class DefaultComponentLifecycleAdapter implements LifecycleAdapter
         }
         catch (Exception e)
         {
-            throw new ComponentException(RequestContext.getEvent(), component, e);
+            throw new ComponentException(event, component, e);
         }
 
         return result;

--- a/core/src/main/java/org/mule/execution/MessageProcessorNotificationExecutionInterceptor.java
+++ b/core/src/main/java/org/mule/execution/MessageProcessorNotificationExecutionInterceptor.java
@@ -6,6 +6,7 @@
  */
 package org.mule.execution;
 
+import org.mule.OptimizedRequestContext;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -44,6 +45,9 @@ class MessageProcessorNotificationExecutionInterceptor implements MessageProcess
             fireNotification(notificationManager, event.getFlowConstruct(), event, messageProcessor,
                              null, MessageProcessorNotification.MESSAGE_PROCESSOR_PRE_INVOKE);
         }
+
+        // Update RequestContext ThreadLocal in case if previous processor modified it
+        OptimizedRequestContext.unsafeSetEvent(event);
 
         MuleEvent result = null;
         MessagingException exceptionThrown = null;

--- a/core/src/main/java/org/mule/transport/AbstractMessageReceiver.java
+++ b/core/src/main/java/org/mule/transport/AbstractMessageReceiver.java
@@ -421,7 +421,8 @@ public abstract class AbstractMessageReceiver extends AbstractTransportMessageHa
 
     protected ExecutionTemplate<MuleEvent> createExecutionTemplate()
     {
-        return TransactionalErrorHandlingExecutionTemplate.createMainExecutionTemplate(endpoint.getMuleContext(), endpoint.getTransactionConfig());
+        return TransactionalErrorHandlingExecutionTemplate.createMainExecutionTemplate(endpoint.getMuleContext(), endpoint.getTransactionConfig(),
+                                                                                       flowConstruct.getExceptionListener());
     }
 
     /**

--- a/core/src/test/java/org/mule/construct/FlowTestCase.java
+++ b/core/src/test/java/org/mule/construct/FlowTestCase.java
@@ -6,18 +6,14 @@
  */
 package org.mule.construct;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mule.MessageExchangePattern.REQUEST_RESPONSE;
 
 import org.mule.MessageExchangePattern;
-import org.mule.RequestContext;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
 import org.mule.api.processor.MessageProcessor;
@@ -79,10 +75,8 @@ public class FlowTestCase extends AbstractFlowConstuctTestCase
     {
         flow.initialise();
         flow.start();
-        assertThat(RequestContext.getEvent(), is(nullValue()));
         MuleEvent response = directInboundMessageSource.process(MuleTestUtils.getTestEvent("hello",
             MessageExchangePattern.ONE_WAY, muleContext));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
         Thread.sleep(50);
 
         assertNull(response);
@@ -98,10 +92,8 @@ public class FlowTestCase extends AbstractFlowConstuctTestCase
         flow.initialise();
         flow.start();
         
-        assertThat(RequestContext.getEvent(), is(nullValue()));
         MuleEvent response = directInboundMessageSource.process(MuleTestUtils.getTestEvent("hello",
             REQUEST_RESPONSE, muleContext));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
 
         assertEquals("helloabcdef", response.getMessageAsString());
         assertEquals(Thread.currentThread(), response.getMessage().getOutboundProperty("thread"));

--- a/core/src/test/java/org/mule/processor/chain/DefaultMessageProcessorChainTestCase.java
+++ b/core/src/test/java/org/mule/processor/chain/DefaultMessageProcessorChainTestCase.java
@@ -10,6 +10,7 @@ package org.mule.processor.chain;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -48,7 +49,7 @@ import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 import org.mule.transformer.simple.StringAppendTransformer;
 import org.mule.util.ObjectUtils;
-import org.junit.After;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,7 +77,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
         builder.chain(new AppendingMP("1"), new AppendingMP("2"), new AppendingMP("3"));
         assertEquals("0123", builder.build().process(getTestEventUsingFlow("0")).getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     /*
@@ -112,7 +112,7 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
 
         // mp3
         assertNull(mp3.event);
-        assertThat(RequestContext.getEvent(), is(nullValue()));
+        assertThat(RequestContext.getEvent(), equalTo(nullmp.event));
     }
 
     /*
@@ -147,16 +147,17 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         assertNotSame(mp3.event, mp2.resultEvent);
         assertEquals(mp2.resultEvent.getMessage().getPayload(), mp3.event.getMessage().getPayload());
         assertEquals(mp3.event.getMessage().getPayload(), "012");
-        assertThat(RequestContext.getEvent(), not(nullValue()));
+        assertThat(RequestContext.getEvent(), equalTo(mp3.event));
     }
 
     @Test
     public void testMPChainWithNullReturnAtEnd() throws MuleException, Exception
     {
         DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
-        builder.chain(new AppendingMP("1"), new AppendingMP("2"), new AppendingMP("3"), new ReturnNullMP());
+        ReturnNullMP returnNullMP = new ReturnNullMP();
+        builder.chain(new AppendingMP("1"), new AppendingMP("2"), new AppendingMP("3"), returnNullMP);
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
+        assertThat(RequestContext.getEvent(), equalTo(returnNullMP.event));
     }
 
     @Test
@@ -182,7 +183,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         });
         builder.chain(new AppendingMP("3"));
         assertEquals("0123", builder.build().process(getTestEventUsingFlow("0")).getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -193,7 +193,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             new AppendingInterceptingMP("3"));
         assertEquals("0before1before2before3after3after2after1",
             builder.build().process(getTestEventUsingFlow("0")).getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -207,7 +206,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             new ReturnNullInterceptongMP(), lastMP);
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
         assertFalse(lastMP.invoked);
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -221,7 +219,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             new ReturnNullInterceptongMP(), lastMP);
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
         assertFalse(lastMP.invoked);
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -234,7 +231,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -245,7 +241,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         builder.chain(new AppendingInterceptingMP("1"), new ReturnNullInterceptongMP(), new AppendingMP("2"),
             new AppendingMP("3"), new AppendingInterceptingMP("4"), new AppendingMP("5"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -268,7 +263,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         builder.chain(new AppendingInterceptingMP("1"), new AppendingMP("2"), new ReturnNullInterceptongMP(),
             new AppendingMP("3"), new AppendingInterceptingMP("4"), new AppendingMP("5"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -295,7 +289,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         builder.chain(new AppendingInterceptingMP("1"), new ReturnNullMP(), new AppendingMP("2"),
             new AppendingMP("3"), new AppendingInterceptingMP("4"), new AppendingMP("5"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -322,7 +315,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         builder.chain(new AppendingInterceptingMP("1"), new AppendingMP("2"), new ReturnNullMP(),
             new AppendingMP("3"), new AppendingInterceptingMP("4"), new AppendingMP("5"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -337,7 +329,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        assertThat(RequestContext.getEvent(), not(nullValue()));
     }
 
     @Test
@@ -349,7 +340,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         builder.chain(new AppendingInterceptingMP("1"), new AppendingMP("2"), new AppendingMP("3"),
             new ReturnNullMP(), new AppendingInterceptingMP("4"), new AppendingMP("5"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -364,7 +354,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        assertThat(RequestContext.getEvent(), not(nullValue()));
     }
 
     @Test
@@ -375,7 +364,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         builder.chain(new AppendingInterceptingMP("1"), new AppendingMP("2"), new AppendingMP("3"),
             new AppendingInterceptingMP("4"), new AppendingMP("5"), new ReturnNullMP());
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -389,8 +377,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        
-        assertThat(RequestContext.getEvent(), not(nullValue()));
     }
 
     @Test
@@ -401,7 +387,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             new DefaultMessageProcessorChainBuilder().chain(new AppendingMP("a"), new AppendingMP("b"))
                 .build(), new AppendingMP("2"));
         assertEquals("01ab2", builder.build().process(getTestEventUsingFlow("0")).getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -413,7 +398,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             new DefaultMessageProcessorChainBuilder().chain(new AppendingMP("a"), new ReturnNullMP(),
                 new AppendingMP("b")).build(), new ReturnNullMP(), new AppendingMP("2"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -425,7 +409,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             new DefaultMessageProcessorChainBuilder().chain(new AppendingMP("a"), new ReturnVoidMP(),
                 new AppendingMP("b")).build(), new ReturnVoidMP(), new AppendingMP("2"));
         assertEquals("01ab2", builder.build().process(getTestEventUsingFlow("0")).getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), not(nullValue()));
     }
 
     @Test
@@ -437,7 +420,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             new DefaultMessageProcessorChainBuilder().chain(new AppendingMP("a"), new AppendingMP("b"),
                 new ReturnNullMP()).build(), new AppendingMP("2"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -467,7 +449,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             }
         }, new AppendingMP("2"));
         assertNull("012", builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -498,7 +479,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
                 new AppendingInterceptingMP("b")).build(), new AppendingInterceptingMP("2"));
         assertEquals("0before1beforeabeforebafterbafterabefore2after2after1",
             builder.build().process(getTestEventUsingFlow("0")).getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -511,7 +491,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
                 new ReturnNullInterceptongMP(), new AppendingInterceptingMP("b")).build(),
             new AppendingInterceptingMP("2"));
         assertNull(builder.build().process(getTestEventUsingFlow("0")));
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -527,7 +506,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        assertThat(RequestContext.getEvent(), not(nullValue()));
     }
 
     @Test
@@ -542,7 +520,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -555,7 +532,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     /**
@@ -574,7 +550,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
             .process(getTestEventUsingFlow("0"))
             .getMessage()
             .getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -592,7 +567,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         ((Lifecycle) chain).dispose();
         assertLifecycle(mp1);
         assertLifecycle(mp2);
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -615,7 +589,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         assertLifecycle(mp2);
         assertLifecycle(mpa);
         assertLifecycle(mpb);
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -623,9 +596,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
     {
         DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
         builder.chain(new TestNonIntercepting(), new TestNonIntercepting(), new TestNonIntercepting());
-        MuleEvent restul = builder.build().process(getTestEventUsingFlow(""));
+        MuleEvent event = getTestEventUsingFlow("");
+        MuleEvent restul = builder.build().process(event);
         assertEquals("MessageProcessorMessageProcessorMessageProcessor", restul.getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -636,7 +609,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         MuleEvent restul = builder.build().process(getTestEventUsingFlow(""));
         assertEquals("InterceptingMessageProcessorInterceptingMessageProcessorInterceptingMessageProcessor",
             restul.getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -649,7 +621,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         assertEquals(
             "InterceptingMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessor",
             restul.getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -662,7 +633,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         assertEquals(
             "InterceptingMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessor",
             restul.getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -675,7 +645,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         assertEquals(
             "MessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessor",
             restul.getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -688,7 +657,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         assertEquals(
             "MessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessor",
             restul.getMessage().getPayload());
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -705,7 +673,6 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         MessageProcessorChain chain = new DefaultMessageProcessorChainBuilder().chain(mp).build();
         MuleEvent response = chain.process(event);
         assertNull(response);
-        assertThat(RequestContext.getEvent(), is(nullValue()));
     }
 
     @Test
@@ -722,7 +689,7 @@ public class DefaultMessageProcessorChainTestCase extends AbstractMuleTestCase
         MessageProcessorChain chain = new DefaultMessageProcessorChainBuilder().chain(mp).build();
         MuleEvent response = chain.process(event);
         assertSame(event, response);
-        assertThat(RequestContext.getEvent(), not(nullValue()));
+        assertThat(RequestContext.getEvent(), equalTo(response));
     }
 
     static class TestNonIntercepting implements MessageProcessor

--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -75,3 +75,4 @@ MULE-8430: in previous versions of Mule, domain home folders where created relat
 MULE-8645: jasper-jdt-6.0.29 is not included anymore on Mule distributions because of some detected vulnerabilities. In case this artifact is needed, when using drools for example, then manually add it on <MULE_HOME>/lib/opt
 MULE-9020: BouncyCastle was upgraded to version 1.50.
      Note: DESede algorithm now requires keys of 16 or 24 bytes unlike the prior version which required 16 or 22 bytes.
+MULE-9306: Losing flow and session variables when using MuleClient to dispatch/send an event. Exception strategy not caching exceptions after using MuleClient on a JavaComponent.

--- a/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchExceptionHandlingTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchExceptionHandlingTestCase.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.integration.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+import org.mule.DefaultMuleMessage;
+import org.mule.RequestContext;
+import org.mule.api.DefaultMuleException;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleEventContext;
+import org.mule.api.MuleException;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.LocalMuleClient;
+import org.mule.api.lifecycle.Callable;
+import org.mule.api.processor.MessageProcessor;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.util.concurrent.Latch;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests to validate that MuleClient can be used from JavaComponent/MessageProcessor in order to dispatch an event to
+ * a sub-flow and if the component/processor throws an exception afterwards the main-flow exception strategy handles
+ * it.
+ */
+public class MuleClientDispatchExceptionHandlingTestCase extends FunctionalTestCase
+{
+    private static final Log logger = LogFactory.getLog(MuleClientDispatchExceptionHandlingTestCase.class);
+
+    @Rule
+    public DynamicPort dynamicPort1 = new DynamicPort("port1");
+
+    // These attributes need to be accessed from JavaComponent and MessageProcessor static classes therefore
+    // they are declared as static
+    private static Latch innerFlowLatch;
+    private static Latch exceptionLatch;
+    private static MuleEvent eventFromMainFlow;
+    private static MuleMessage messageFromMainFlow;
+    private static boolean eventPropagated;
+    private static boolean isSameMessage;
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/integration/client/client-dispatch-catch-exception-flow.xml";
+    }
+
+    /**
+     * Validates that a JavaComponent after doing a dispatch to a sub-flow using MuleClient
+     * throws an exception and the catch-exception-strategy defined in main-flow is called.
+     * It also validates that original event passed to JavaComponent is later propagated
+     * to the JavaComponent defined in catch-exception-strategy block.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCatchExceptionThrowFromJavaComponentToJavaComponent() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionJavaComponentToJavaComponent");
+    }
+
+    @Test
+    public void tesCatchExceptionThrowFromJavaComponentToMessageProcessor() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionJavaComponentToMessageProcessor");
+    }
+
+    @Test
+    public void testCatchExceptionThrowFromMessageProcessorToJavaComponent() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionMessageProcessorToJavaComponent");
+    }
+
+    @Test
+    public void tesCatchExceptionThrowFromMessageProcessorToMessageProcessor() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionMessageProcessorToMessageProcessor");
+    }
+
+    @Test
+    public void testCatchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow() throws Exception
+    {
+        doSendMessageToEndpoint("vm://catchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow");
+    }
+
+    private void doSendMessageToEndpoint(String endpoint) throws Exception
+    {
+        innerFlowLatch = new Latch();
+        exceptionLatch = new Latch();
+        eventPropagated = true;
+        isSameMessage = true;
+
+        LocalMuleClient client = muleContext.getClient();
+        MuleMessage result = client.send(endpoint, getTestMuleMessage("Original Message"));
+
+        boolean innerFlowCalled = innerFlowLatch.await(3, TimeUnit.SECONDS);
+        assertThat(innerFlowCalled, is(true));
+        boolean exceptionHandled = exceptionLatch.await(3, TimeUnit.SECONDS);
+        assertThat(exceptionHandled, is(true));
+
+        assertThat(isSameMessage, is(true));
+        assertThat(eventPropagated, is(true));
+
+        assertThat(result, notNullValue(MuleMessage.class));
+    }
+
+    // Just a simple JavaComponent used in catch-exception-strategy block
+    // in order to check that RequestContext has the correct event and message references
+    public static class AssertEventComponent implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            // Validates that if another Component access to the RequestContext.getEvent() the one returned
+            // is the correct, in this case it should be the same that it was set before doing the
+            // eventContext.dispatchEvent() on main-flow java component where the exception happened right after
+            // that invocatioeventPropagated = RequestContext.getEvent().equals(eventFromMainFlow);
+            // Checking if message is still the same on catch-exception-strategy
+            isSameMessage = RequestContext.getEvent().getMessage().equals(messageFromMainFlow);
+            return eventContext.getMessage();
+        }
+    }
+
+    public static class AssertEventProcessor implements MessageProcessor
+    {
+        @Override
+        public MuleEvent process(MuleEvent event) throws MuleException
+        {
+            // Validates that if another Component access to the RequestContext.getEvent() the one returned
+            // is the correct, in this case it should be the same that it was set before doing the
+            // eventContext.dispatchEvent() on main-flow java component where the exception happened right after
+            // that invocatioeventPropagated = RequestContext.getEvent().equals(eventFromMainFlow);
+            // Checking if message is still the same on catch-exception-strategy
+            isSameMessage = RequestContext.getEvent().getMessage().equals(messageFromMainFlow);
+            return event;
+        }
+    }
+
+    public static class DispatchInnerFlowThrowExceptionJavaComponent implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventFromMainFlow = RequestContext.getEvent();
+            messageFromMainFlow = eventFromMainFlow.getMessage();
+
+            eventContext.dispatchEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()),
+                                       "vm://vminnertest");
+
+            throw new Exception("expected exception!");
+        }
+    }
+
+    public static class SendInnerFlowThrowExceptionJavaComponent implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventFromMainFlow = RequestContext.getEvent();
+            messageFromMainFlow = eventFromMainFlow.getMessage();
+
+            eventContext.sendEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()),
+                                   "vm://vminnerrequestresponsetest");
+
+            throw new Exception("expected exception!");
+        }
+    }
+
+    public static class DispatchInnerFlowThrowExceptionMessageProcessor implements MessageProcessor
+    {
+        @Override
+        public MuleEvent process(MuleEvent event) throws MuleException
+        {
+            eventFromMainFlow = RequestContext.getEvent();
+            messageFromMainFlow = eventFromMainFlow.getMessage();
+
+            event.getMuleContext().getClient().dispatch("vm://vminnertest",
+                                                        new DefaultMuleMessage("payload", event.getMuleContext()));
+
+            throw new DefaultMuleException("expected exception!");
+        }
+    }
+
+    public static class ExecutionCountDownProcessor implements MessageProcessor
+    {
+        @Override
+        public synchronized MuleEvent process(MuleEvent event) throws MuleException
+        {
+            exceptionLatch.countDown();
+            return event;
+        }
+    }
+
+    public static class InnerFlowCountDownProcessor implements MessageProcessor
+    {
+        @Override
+        public synchronized MuleEvent process(MuleEvent event) throws MuleException
+        {
+            innerFlowLatch.countDown();
+            return event;
+        }
+    }
+}

--- a/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchWithoutLosingVariablesTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchWithoutLosingVariablesTestCase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.integration.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.mule.DefaultMuleMessage;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleEventContext;
+import org.mule.api.MuleException;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.LocalMuleClient;
+import org.mule.api.lifecycle.Callable;
+import org.mule.api.processor.MessageProcessor;
+import org.mule.tck.functional.FlowAssert;
+import org.mule.tck.junit4.FunctionalTestCase;
+
+import org.junit.Test;
+
+/**
+ * Tests to validate that MuleClient can be used from MessageProcessor and JavaComponent in order to dispatch an event to
+ * a sub-flow, without losing the Flow variables.
+ */
+public class MuleClientDispatchWithoutLosingVariablesTestCase extends FunctionalTestCase
+{
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/integration/client/client-flow-session-vars-when-dispatch-flow.xml";
+    }
+
+    private void doSendMessageToVMEndpoint(String flowName) throws Exception
+    {
+        LocalMuleClient client = muleContext.getClient();
+        MuleMessage result = client.send("vm://" + flowName, "TEST1", null);
+        assertThat(result, notNullValue(MuleMessage.class));
+        FlowAssert.verify(flowName);
+    }
+
+    /**
+     * When doing a dispatch from a MessageProcessor the event was overwritten in ThreadLocal by
+     * OptimizedRequestContext while processing it and before dispatching it to a different thread so
+     * the original event that is the one that has to continue the execution of the main flow
+     * was losing the Flow variables.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFlowVarsAfterDispatchFromMessageProcessor() throws Exception
+    {
+        doSendMessageToVMEndpoint("flowVarsFlowUsingProcessor");
+    }
+
+    @Test
+    public void testSessionVarsAfterDispatchFromMessageProcessor() throws Exception
+    {
+        doSendMessageToVMEndpoint("sessionVarsFlowUsingProcessor");
+    }
+
+    /**
+     * When doing a dispatch from a JavaComponent the event was overwritten in ThreadLocal by
+     * OptimizedRequestContext while processing it and before dispatching it to a different thread so
+     * the original event that is the one that has to continue the execution of the main flow
+     * was losing the Flow variables.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFlowVarsAfterDispatchFromJavaComponent() throws Exception
+    {
+        doSendMessageToVMEndpoint("flowVarsFlowUsingJavaComponent");
+    }
+
+    @Test
+    public void testSessionVarsAfterDispatchFromJavaComponent() throws Exception
+    {
+        doSendMessageToVMEndpoint("sessionVarsFlowUsingJavaComponent");
+    }
+
+    @Test
+    public void testSessionVarsFlowUsingJavaComponentRequestResponse() throws Exception
+    {
+        doSendMessageToVMEndpoint("sessionVarsFlowUsingJavaComponentRequestResponse");
+    }
+
+    public static class MessageProcessorDispatchFlowUsingNewMuleClient implements MessageProcessor
+    {
+        @Override
+        public MuleEvent process(MuleEvent event) throws MuleException
+        {
+            event.getMuleContext().getClient().dispatch("vm://vminnertest", new DefaultMuleMessage("payload", event.getMuleContext()));
+            return event;
+
+        }
+    }
+
+    public static class JavaComponentDispatchFlowUsingNewMuleClient implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventContext.dispatchEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()), "vm://vminnertest");
+            return eventContext.getMessage();
+        }
+    }
+
+    public static class JavaComponentSendFlowUsingNewMuleClient implements Callable
+    {
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            eventContext.sendEvent(new DefaultMuleMessage("payload", eventContext.getMuleContext()), "vm://vminnerrequestresponsetest");
+            return eventContext.getMessage();
+        }
+    }
+
+}

--- a/tests/integration/src/test/resources/org/mule/test/integration/client/client-dispatch-catch-exception-flow.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/client/client-dispatch-catch-exception-flow.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+           http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <vm:connector name="vmQueues"/>
+
+    <flow name="innerFlow">
+        <vm:inbound-endpoint exchange-pattern="one-way" path="vminnertest"/>
+        <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$InnerFlowCountDownProcessor"/>
+    </flow>
+
+    <flow name="innerFlowRequestResponse">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="vminnerrequestresponsetest"/>
+        <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$InnerFlowCountDownProcessor"/>
+    </flow>
+
+    <flow name="catchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionJavaComponentToJavaComponentRequestResponseInnerFlow"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$SendInnerFlowThrowExceptionJavaComponent"/>
+        <catch-exception-strategy>
+            <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventComponent"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <flow name="catchExceptionJavaComponentToJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionJavaComponentToJavaComponent"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$DispatchInnerFlowThrowExceptionJavaComponent"/>
+        <catch-exception-strategy>
+            <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventComponent"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <flow name="catchExceptionJavaComponentToMessageProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionJavaComponentToMessageProcessor"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$DispatchInnerFlowThrowExceptionJavaComponent"/>
+        <catch-exception-strategy>
+            <processor ref="assertEventProcessor"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <spring:beans>
+        <spring:bean id="myProcessor"
+                     class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$DispatchInnerFlowThrowExceptionMessageProcessor"/>
+        <spring:bean id="assertEventProcessor"
+                     class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventProcessor"/>
+    </spring:beans>
+
+    <flow name="catchExceptionMessageProcessorToJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionMessageProcessorToJavaComponent"/>
+        <processor ref="myProcessor"/>
+        <catch-exception-strategy>
+            <component class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$AssertEventComponent"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+
+    <flow name="catchExceptionMessageProcessorToMessageProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="catchExceptionMessageProcessorToMessageProcessor"/>
+        <processor ref="myProcessor"/>
+        <catch-exception-strategy>
+            <processor ref="assertEventProcessor"/>
+            <custom-processor class="org.mule.test.integration.client.MuleClientDispatchExceptionHandlingTestCase$ExecutionCountDownProcessor"/>
+        </catch-exception-strategy>
+    </flow>
+</mule>

--- a/tests/integration/src/test/resources/org/mule/test/integration/client/client-flow-session-vars-when-dispatch-flow.xml
+++ b/tests/integration/src/test/resources/org/mule/test/integration/client/client-flow-session-vars-when-dispatch-flow.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+           http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+           http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <vm:connector name="vmQueues"/>
+
+    <flow name="innerFlow">
+        <vm:inbound-endpoint exchange-pattern="one-way" path="vminnertest"/>
+        <logger level="INFO"/>
+    </flow>
+
+    <flow name="innerFlowRequestResponse">
+        <vm:inbound-endpoint exchange-pattern="one-way" path="vminnerrequestresponsetest"/>
+        <logger level="INFO"/>
+    </flow>
+
+    <spring:beans>
+        <spring:bean id="myProcessor"
+                     class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$MessageProcessorDispatchFlowUsingNewMuleClient"/>
+    </spring:beans>
+
+    <flow name="flowVarsFlowUsingProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="flowVarsFlowUsingProcessor"/>
+        <set-variable variableName="team" value="Sales"/>
+        <processor ref="myProcessor"/>
+        <set-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[flowVars['team'] == 'Sales']" />
+        <test:assert expression="#[flowVars['ammount'] == '100']" />
+    </flow>
+
+    <flow name="sessionVarsFlowUsingProcessor">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="sessionVarsFlowUsingProcessor"/>
+        <set-session-variable variableName="team" value="Sales"/>
+        <processor ref="myProcessor"/>
+        <set-session-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[sessionVars.team == 'Sales']" />
+        <test:assert expression="#[sessionVars.ammount == '100']" />
+    </flow>
+
+    <flow name="flowVarsFlowUsingJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="flowVarsFlowUsingJavaComponent"/>
+        <set-variable variableName="team" value="Sales"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$JavaComponentDispatchFlowUsingNewMuleClient"/>
+        <set-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[flowVars['team'] == 'Sales']" />
+        <test:assert expression="#[flowVars['ammount'] == '100']" />
+    </flow>
+
+    <flow name="sessionVarsFlowUsingJavaComponent">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="sessionVarsFlowUsingJavaComponent"/>
+        <set-session-variable variableName="team" value="Sales"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$JavaComponentDispatchFlowUsingNewMuleClient"/>
+        <set-session-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[sessionVars.team == 'Sales']" />
+        <test:assert expression="#[sessionVars.ammount == '100']" />
+    </flow>
+
+    <flow name="sessionVarsFlowUsingJavaComponentRequestResponse">
+        <vm:inbound-endpoint exchange-pattern="request-response" path="sessionVarsFlowUsingJavaComponentRequestResponse"/>
+        <set-session-variable variableName="team" value="Sales"/>
+        <component class="org.mule.test.integration.client.MuleClientDispatchWithoutLosingVariablesTestCase$JavaComponentSendFlowUsingNewMuleClient"/>
+        <set-session-variable variableName="ammount" value="100"/>
+        <test:assert expression="#[sessionVars.team == 'Sales']" />
+        <test:assert expression="#[sessionVars.ammount == '100']" />
+    </flow>
+</mule>


### PR DESCRIPTION
…a sub-flow from  JavaComponent or MessageProcessor leaves the RequestContext inconsistent with the event dispatched/sent by MuleClient instead of the one being processed. This generated two issues related with losing flow, session variables and strategy listener defined in main flow. Even the event later passed later to the exception strategy listener was incorrect.

Created a different PR due to 3.6.x has a different code.
@dfeist @elrodro83 please take a look to this.