### PR TITLE
MULE-9362: Update xmlsec version 1.5.3 which has vulnerabilities to 1.5.8 which is the version used in CXF 2.7.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
         <wrapperVersion>3.2.3</wrapperVersion>
         <xalanVersion>2.7.2</xalanVersion>
         <xmlPullVersion>1.1.3.4.O</xmlPullVersion>
+        <xmlSecurityVersion>1.5.8</xmlSecurityVersion>
         <xstreamVersion>1.4.7</xstreamVersion>
         <xaPoolVersion>1.5.0</xaPoolVersion>
     </properties>
@@ -1097,6 +1098,11 @@
                         <artifactId>xml-apis</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.santuario</groupId>
+                <artifactId>xmlsec</artifactId>
+                <version>${xmlSecurityVersion}</version>
             </dependency>
             <dependency>
                 <groupId>mx4j</groupId>


### PR DESCRIPTION
Adding explicit xmlsec dependency to root pom since that dependency is used in CXF, OpenSAML, WSSF4 with different 2.7.x versions. Not declaring it explicitly would mean that we need to exclude the dependency in each of those.