### PR TITLE
MULE-7680: fix for HTTP response with multiple HTTP "Set-Cookie" headers in different case

### DIFF
--- a/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
@@ -228,7 +228,7 @@ public class HttpMuleMessageFactory extends AbstractMuleMessageFactory
             {
                 putCookieHeaderInMapAsAServer(headersMap, header, uri);
             }
-            else if (HttpConstants.HEADER_COOKIE_SET.equals(header.getName()))
+            else if (HttpConstants.HEADER_COOKIE_SET.equalsIgnoreCase(header.getName()))
             {
                 putCookieHeaderInMapAsAClient(headersMap, header, uri);
             }


### PR DESCRIPTION
Without fix an exception was raised:

java.lang.IllegalArgumentException: Invalid cookiesObject. Only class org.apache.commons.httpclient.Cookie[] and interface java.util.Map are supported

with response headers like:
SET-COOKIE: header-name-is-uppercase=SET-COOKIE-UPPERCASE-1
Set-Cookie: header-name-is-camelcase=Set-Cookie-CamelCase-1

**Note:**

1. No testcase provided since Jetty (and the JDK contained com.sun.net.httpserver.HttpServer) are to rigid for this test and does not allow setting Set-Cookie headers with different case.
2. Full test available in https://github.com/skltp/patch-mule-transport-http, but it uses LitteProxy (https://github.com/adamfisk/LittleProxy) as webserver, which caused other problems (most likely due to some dependency clash) when I added it as a test-scoped dependency in mule-transport-http, so I had to remove the test.