### PR TITLE
MULE-7030: Need to support XPATH 3.0 in the xpath filter

### DIFF
--- a/modules/xml/pom.xml
+++ b/modules/xml/pom.xml
@@ -161,11 +161,4 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>xqj</id>
-            <name>XQJ Maven Repository</name>
-            <url>http://xqj.net/maven</url>
-        </repository>
-    </repositories>
 </project>


### PR DESCRIPTION
The XQJ Maven Repository was removed from the XML Module pom because we already uploaded the xqj-api to our nexus repository.