### PR TITLE
MULE-9389: Mule Context's getTransactionManager randomly returns null if

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/config/spring/factories/TransactionManagerFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/config/spring/factories/TransactionManagerFactoryBean.java
@@ -45,7 +45,14 @@ public class TransactionManagerFactoryBean implements FactoryBean<TransactionMan
     @Override
     public TransactionManager getObject() throws Exception
     {
-        if (txManagerFactory != null)
+        if (muleContext.isDisposing())
+        {
+            // The txManager might be declared, but if it isn't used by the application it won't be created until the
+            // muleContext is disposed.
+            // At that point, there is no need to create the txManager.
+            return null;
+        }
+        else if (txManagerFactory != null)
         {
             try
             {


### PR DESCRIPTION
called during context start - Fix CI