### PR TITLE
MULE-9444 Upgrade Saxon to 9.7.0.3-HE

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -368,8 +368,8 @@
 /mule-standalone-${productVersion}/lib/opt/relaxngDatatype-20020414.jar
 /mule-standalone-${productVersion}/lib/opt/rhino-1.7R4.jar
 /mule-standalone-${productVersion}/lib/opt/rome-0.9.jar
-/mule-standalone-${productVersion}/lib/opt/Saxon-HE-9.7.0-3.jar
-/mule-standalone-${productVersion}/lib/opt/Saxon-HE-9.7.0-3-xqj.jar
+/mule-standalone-${productVersion}/lib/opt/Saxon-HE-9.6.0-7.jar
+/mule-standalone-${productVersion}/lib/opt/Saxon-HE-9.6.0-7-xqj.jar
 /mule-standalone-${productVersion}/lib/opt/signpost-core-1.2.1.2.jar
 /mule-standalone-${productVersion}/lib/opt/smack-3.4.1.jar
 /mule-standalone-${productVersion}/lib/opt/smackx-3.4.1.jar

--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -31,7 +31,6 @@ MULE-9306: Losing flow and session variables when using MuleClient to dispatch/s
 MULE-9383: HTTP Connector will allow invalid Content-Type header values. In order to strictly validate them as before, use the mule.strictContentType=true system property.
 MULE-9405: MuleException instead of NPE is now thrown when setting a null value for a context-property in an XstlTransformation.
 MULE-9160: Log4J was upgraded from 2.1 to 2.5.
-MULE-9444: Saxon was upgraded from 9.6.0-1-HE to 9.7.0.3-HE (for more information visit http://saxon.sourceforge.net/#F9.7HE) and XMLUnit from 1.5 to 1.6. When using JAXP the implementation of javax.xml.namespace.NamespaceContext would have to also implement net.sf.saxon.om.NamespaceResolver.
 
 Migration changes from 3.6.x to 3.7.x
 

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
         <rhinoVersion>1.7R4</rhinoVersion>
         <rhinoJsr223Version>1.1</rhinoJsr223Version>
         <saajVersion>1.3</saajVersion>
-        <saxonVersion>9.7.0-3</saxonVersion>
+        <saxonVersion>9.6.0-7</saxonVersion>
         <slf4jVersion>1.7.7</slf4jVersion>
         <smackVersion>3.4.1</smackVersion>
         <springOsgiVersion>1.0.2</springOsgiVersion>


### PR DESCRIPTION
Due to performance and stability issues found in Saxon 9.7 latest release this PR does a downgrade to the latest available 9.6 version of Saxon.
`org.mule.module.xml.xpath.PathNamespaceContext` was not reverted so it will allow later to change Saxon libraries to 9.7.x whenever that release is stable and has fixed performance issues without having to patch Mule XML module.