### PR TITLE
MULE-9497 Until-successful synchronous processing strategy leaves the…

### DIFF
--- a/core/src/test/java/org/mule/routing/SynchronousUntilSuccessfulProcessingStrategyTestCase.java
+++ b/core/src/test/java/org/mule/routing/SynchronousUntilSuccessfulProcessingStrategyTestCase.java
@@ -7,17 +7,16 @@
 package org.mule.routing;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
-
 import org.mule.RequestContext;
 import org.mule.VoidMuleEvent;
 import org.mule.api.MessagingException;
@@ -32,8 +31,6 @@ import org.mule.api.store.ListableObjectStore;
 import org.mule.routing.filters.ExpressionFilter;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -103,7 +100,7 @@ public class SynchronousUntilSuccessfulProcessingStrategyTestCase extends Abstra
         {
             assertThat(e, instanceOf(RoutingException.class));
             verify(mockRoute, times(DEFAULT_RETRIES + 1)).process(event);
-            assertThat(RequestContext.getEvent(), is(e.getEvent()));
+            assertThat(RequestContext.getEvent(), sameInstance(e.getEvent()));
         }
     }
 
@@ -129,9 +126,19 @@ public class SynchronousUntilSuccessfulProcessingStrategyTestCase extends Abstra
     public void successfulExecution() throws Exception
     {
         SynchronousUntilSuccessfulProcessingStrategy processingStrategy = createProcessingStrategy();
-        when(mockRoute.process(event)).thenReturn(event);
-        assertThat(processingStrategy.route(event), is(event));
+        when(mockRoute.process(event)).thenAnswer(new Answer<MuleEvent>()
+        {
+
+            @Override
+            public MuleEvent answer(InvocationOnMock invocation) throws Throwable
+            {
+                return (MuleEvent) invocation.getArguments()[0];
+            }
+        });
+        MuleEvent response = processingStrategy.route(event);
+        assertThat(response, is(event));
         verify(mockRoute).process(event);
+        assertThat(RequestContext.getEvent(), sameInstance(response));
     }
 
     @Test
@@ -168,28 +175,22 @@ public class SynchronousUntilSuccessfulProcessingStrategyTestCase extends Abstra
     {
         String ackExpression = "some-expression";
         String expressionEvalutaionResult = "new payload";
-        event.setMessage(spy(event.getMessage()));
         when(mockUntilSuccessfulConfiguration.getAckExpression()).thenReturn(ackExpression);
         when(mockUntilSuccessfulConfiguration.getMuleContext().getExpressionManager().evaluate(ackExpression, event)).thenReturn(expressionEvalutaionResult);
         SynchronousUntilSuccessfulProcessingStrategy processingStrategy = createProcessingStrategy();
-        when(mockRoute.process(event)).thenReturn(event);
-        assertThat(processingStrategy.route(event), is(event));
-        verify(mockRoute).process(argThat(new BaseMatcher<MuleEvent>() {
-            @Override
-            public void describeTo(Description description)
-            {
-                description.appendText("MuleEvent matcher and asserter");
-            }
+        when(mockRoute.process(any(MuleEvent.class))).thenAnswer(new Answer<MuleEvent>()
+        {
 
             @Override
-            public boolean matches(Object item)
+            public MuleEvent answer(InvocationOnMock invocation) throws Throwable
             {
-                return event.getId().equals(((MuleEvent) item).getId());
+                return (MuleEvent) invocation.getArguments()[0];
             }
-        }));
+        });
+        MuleEvent response = processingStrategy.route(event);
+        assertThat(response.getMessage().getPayloadAsString(), equalTo(expressionEvalutaionResult));
+        verify(mockRoute).process(any(MuleEvent.class));
         verify(mockUntilSuccessfulConfiguration.getMuleContext().getExpressionManager()).evaluate(ackExpression, event);
-        verify(event.getMessage()).setPayload(expressionEvalutaionResult);
-        assertThat(RequestContext.getEvent(), is(event));
     }
 
     @Test


### PR DESCRIPTION
… RequestContext inconsistent

Fixes test on 3.5.x and also the assertion.