### PR TITLE
MULE-9514: Wrong key used to cache static endpoints in DynamicOutboun…

### DIFF
--- a/core/src/main/java/org/mule/endpoint/DynamicOutboundEndpoint.java
+++ b/core/src/main/java/org/mule/endpoint/DynamicOutboundEndpoint.java
@@ -108,7 +108,7 @@ public class DynamicOutboundEndpoint implements OutboundEndpoint
         {
             final EndpointURI endpointURIForMessage = createEndpointUri(uri);
             outboundEndpoint = createStaticEndpoint(endpointURIForMessage);
-            staticEndpoints.put(endpointURIForMessage.getAddress(), outboundEndpoint);
+            staticEndpoints.put(uri, outboundEndpoint);
         }
 
         return outboundEndpoint;

--- a/core/src/test/java/org/mule/endpoint/outbound/DynamicOutboundEndpointTestCase.java
+++ b/core/src/test/java/org/mule/endpoint/outbound/DynamicOutboundEndpointTestCase.java
@@ -309,7 +309,7 @@ public class DynamicOutboundEndpointTestCase extends AbstractMessageProcessorTes
         dynamicOutboundEndpoint.process(testOutboundEvent);
         dynamicOutboundEndpoint.process(testOutboundEvent);
 
-        verify(endpointBuilder, times(1)).buildOutboundEndpoint();
+        verify(endpointBuilder, times(1)).clone();
     }
 
     protected void assertMessageSentEqual(MuleEvent event) throws MuleException


### PR DESCRIPTION
…dEndpoint