### PR TITLE
MULE-9512: Refactor deployment service tests to avoid using pre-packa…

### DIFF
--- a/core/src/test/java/org/mule/tck/ZipUtils.java
+++ b/core/src/test/java/org/mule/tck/ZipUtils.java
@@ -7,12 +7,13 @@
 
 package org.mule.tck;
 
-import org.mule.util.StringUtils;
+import org.mule.util.ClassUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URL;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -32,28 +33,13 @@ public class ZipUtils
     public static class ZipResource
     {
 
-        private final File file;
+        private final String file;
         private final String alias;
 
-        public ZipResource(File file)
-        {
-            this(file, null);
-        }
-
-        public ZipResource(File file, String alias)
+        public ZipResource(String file, String alias)
         {
             this.file = file;
             this.alias = alias;
-        }
-
-        public String getName()
-        {
-            return StringUtils.isEmpty(alias) ? file.getName() : alias;
-        }
-
-        public File getFile()
-        {
-            return file;
         }
     }
 
@@ -70,9 +56,15 @@ public class ZipUtils
         {
             for (ZipResource zipResource : resources)
             {
-                try (FileInputStream in = new FileInputStream(zipResource.getFile()))
+                URL resourceUrl = ClassUtils.getResource(zipResource.file, ZipUtils.class);
+                if (resourceUrl == null)
                 {
-                    out.putNextEntry(new ZipEntry(zipResource.getName()));
+                    resourceUrl = new File(zipResource.file).toURI().toURL();
+                }
+
+                try (FileInputStream in = new FileInputStream(resourceUrl.getFile()))
+                {
+                    out.putNextEntry(new ZipEntry(zipResource.alias == null ? zipResource.file : zipResource.alias));
 
                     byte[] buffer = new byte[1024];
 

--- a/core/src/test/java/org/mule/util/FileUtilsTestCase.java
+++ b/core/src/test/java/org/mule/util/FileUtilsTestCase.java
@@ -12,7 +12,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import org.mule.tck.ZipUtils;
+import static org.mule.tck.ZipUtils.compress;
+import static org.mule.util.FileUtils.unzip;
+import org.mule.tck.ZipUtils.ZipResource;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import java.io.File;
@@ -368,7 +370,7 @@ public class FileUtilsTestCase extends AbstractMuleTestCase
 
         for (int i = 0; i < 2; i++)
         {
-            FileUtils.unzip(zipFile, outputDir);
+            unzip(zipFile, outputDir);
             File testFile = new File(UNZIPPED_FILE_PATH);
             assertTrue(testFile.exists());
         }
@@ -379,12 +381,10 @@ public class FileUtilsTestCase extends AbstractMuleTestCase
     {
         final String resourceName = "dummy.xml";
         final String resourceAlias = "folder" + File.separator + resourceName;
-        final File resourceFile = new File(IOUtils.getResourceAsUrl(resourceName, getClass()).getFile());
-
         final File compressedFile = new File(toDir, "test.zip");
-        ZipUtils.compress(compressedFile, new ZipUtils.ZipResource[] {new ZipUtils.ZipResource(resourceFile, resourceAlias)});
+        compress(compressedFile, new ZipResource[] {new ZipResource(resourceName, resourceAlias)});
 
-        FileUtils.unzip(compressedFile, toDir);
+        unzip(compressedFile, toDir);
 
         assertThat(new File(new File(toDir, "folder"), resourceName).exists(), is(true));
     }

--- a/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
@@ -104,35 +104,35 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
     private static final String EMPTY_DOMAIN_CONFIG_XML = "/empty-domain-config.xml";
 
     // Application plugin file builders
-    private final static ApplicationPluginFileBuilder echoPlugin = new ApplicationPluginFileBuilder("echoPlugin").usingLibrary("lib/echo-test.jar");
-    private final static ApplicationPluginFileBuilder echoPluginWithoutLib1 = new ApplicationPluginFileBuilder("echoPlugin1").containingClass("org/foo/Plugin1Echo.clazz");
+    private final ApplicationPluginFileBuilder echoPlugin = new ApplicationPluginFileBuilder("echoPlugin").usingLibrary("lib/echo-test.jar");
+    private final ApplicationPluginFileBuilder echoPluginWithoutLib1 = new ApplicationPluginFileBuilder("echoPlugin1").containingClass("org/foo/Plugin1Echo.clazz");
 
     // Application file builders
-    private final static ApplicationFileBuilder emptyAppFileBuilder = new ApplicationFileBuilder("empty-app").definedBy("empty-config.xml");
-    private final static ApplicationFileBuilder springPropertyAppFileBuilder = new ApplicationFileBuilder("property-app").definedBy("app-properties-config.xml");
-    private final static ApplicationFileBuilder dummyAppDescriptorFileBuilder = new ApplicationFileBuilder("dummy-app").definedBy("dummy-app-config.xml").configuredWith("myCustomProp", "someValue").containingClass("org/mule/module/launcher/EchoTest.clazz");
-    private final static ApplicationFileBuilder waitAppFileBuilder = new ApplicationFileBuilder("wait-app").definedBy("wait-app-config.xml");
-    private final static ApplicationFileBuilder brokenAppFileBuilder = new ApplicationFileBuilder("broken-app").corrupted();
-    private final static ApplicationFileBuilder incompleteAppFileBuilder = new ApplicationFileBuilder("incomplete-app").definedBy("incomplete-app-config.xml");
-    private final static ApplicationFileBuilder echoPluginAppFileBuilder = new ApplicationFileBuilder("dummyWithEchoPlugin").definedBy("app-with-echo-plugin-config.xml").containingPlugin(echoPlugin);
-    private final static ApplicationFileBuilder sharedLibPluginAppFileBuilder = new ApplicationFileBuilder("shared-plugin-lib-app").definedBy("app-with-echo1-plugin-config.xml").containingPlugin(echoPluginWithoutLib1).sharingLibrary("lib/bar-1.0.jar");
-    private static final ApplicationFileBuilder brokenAppWithFunkyNameAppFileBuilder = new ApplicationFileBuilder("broken-app+", brokenAppFileBuilder);
-    private static final ApplicationFileBuilder dummyDomainApp1FileBuilder = new ApplicationFileBuilder("dummy-domain-app1").definedBy("empty-config.xml").deployedWith("domain", "dummy-domain");
-    private static final ApplicationFileBuilder dummyDomainApp2FileBuilder = new ApplicationFileBuilder("dummy-domain-app2").definedBy("empty-config.xml").deployedWith("domain", "dummy-domain");
-    private static final ApplicationFileBuilder dummyDomainApp3FileBuilder = new ApplicationFileBuilder("dummy-domain-app3").definedBy("bad-app-config.xml").deployedWith("domain", "dummy-domain");
-    private static final ApplicationFileBuilder httpAAppFileBuilder = new ApplicationFileBuilder("shared-http-app-a").definedBy("shared-http-a-app-config.xml").deployedWith("domain", "shared-http-domain");
-    private static final ApplicationFileBuilder httpBAppFileBuilder = new ApplicationFileBuilder("shared-http-app-b").definedBy("shared-http-b-app-config.xml").deployedWith("domain", "shared-http-domain");
+    private final ApplicationFileBuilder emptyAppFileBuilder = new ApplicationFileBuilder("empty-app").definedBy("empty-config.xml");
+    private final ApplicationFileBuilder springPropertyAppFileBuilder = new ApplicationFileBuilder("property-app").definedBy("app-properties-config.xml");
+    private final ApplicationFileBuilder dummyAppDescriptorFileBuilder = new ApplicationFileBuilder("dummy-app").definedBy("dummy-app-config.xml").configuredWith("myCustomProp", "someValue").containingClass("org/mule/module/launcher/EchoTest.clazz");
+    private final ApplicationFileBuilder waitAppFileBuilder = new ApplicationFileBuilder("wait-app").definedBy("wait-app-config.xml");
+    private final ApplicationFileBuilder brokenAppFileBuilder = new ApplicationFileBuilder("broken-app").corrupted();
+    private final ApplicationFileBuilder incompleteAppFileBuilder = new ApplicationFileBuilder("incomplete-app").definedBy("incomplete-app-config.xml");
+    private final ApplicationFileBuilder echoPluginAppFileBuilder = new ApplicationFileBuilder("dummyWithEchoPlugin").definedBy("app-with-echo-plugin-config.xml").containingPlugin(echoPlugin);
+    private final ApplicationFileBuilder sharedLibPluginAppFileBuilder = new ApplicationFileBuilder("shared-plugin-lib-app").definedBy("app-with-echo1-plugin-config.xml").containingPlugin(echoPluginWithoutLib1).sharingLibrary("lib/bar-1.0.jar");
+    private final ApplicationFileBuilder brokenAppWithFunkyNameAppFileBuilder = new ApplicationFileBuilder("broken-app+", brokenAppFileBuilder);
+    private final ApplicationFileBuilder dummyDomainApp1FileBuilder = new ApplicationFileBuilder("dummy-domain-app1").definedBy("empty-config.xml").deployedWith("domain", "dummy-domain");
+    private final ApplicationFileBuilder dummyDomainApp2FileBuilder = new ApplicationFileBuilder("dummy-domain-app2").definedBy("empty-config.xml").deployedWith("domain", "dummy-domain");
+    private final ApplicationFileBuilder dummyDomainApp3FileBuilder = new ApplicationFileBuilder("dummy-domain-app3").definedBy("bad-app-config.xml").deployedWith("domain", "dummy-domain");
+    private final ApplicationFileBuilder httpAAppFileBuilder = new ApplicationFileBuilder("shared-http-app-a").definedBy("shared-http-a-app-config.xml").deployedWith("domain", "shared-http-domain");
+    private final ApplicationFileBuilder httpBAppFileBuilder = new ApplicationFileBuilder("shared-http-app-b").definedBy("shared-http-b-app-config.xml").deployedWith("domain", "shared-http-domain");
 
     // Domain file builders
-    private static final DomainFileBuilder brokenDomainFileBuilder = new DomainFileBuilder("brokenDomain").corrupted();
-    private static final DomainFileBuilder emptyDomainFileBuilder = new DomainFileBuilder("empty-domain").definedBy("empty-domain-config.xml");
-    private static final DomainFileBuilder waitDomainFileBuilder = new DomainFileBuilder("wait-domain").definedBy("wait-domain-config.xml");
-    private static final DomainFileBuilder incompleteDomainFileBuilder = new DomainFileBuilder("incompleteDomain").definedBy("incomplete-domain-config.xml");
-    private static final DomainFileBuilder invalidDomainBundleFileBuilder = new DomainFileBuilder("invalid-domain-bundle").definedBy("incomplete-domain-config.xml").containing(emptyAppFileBuilder);
-    private static final DomainFileBuilder dummyDomainBundleFileBuilder = new DomainFileBuilder("dummy-domain-bundle").containing(new ApplicationFileBuilder(dummyAppDescriptorFileBuilder).deployedWith("domain", "dummy-domain-bundle"));
-    private static final DomainFileBuilder dummyDomainFileBuilder = new DomainFileBuilder("dummy-domain").definedBy("empty-domain-config.xml");
-    private static final DomainFileBuilder sharedHttpDomainFileBuilder = new DomainFileBuilder("shared-http-domain").definedBy("shared-http-domain-config.xml");
-    private static final DomainFileBuilder sharedHttpBundleDomainFileBuilder = new DomainFileBuilder("shared-http-domain").definedBy("shared-http-domain-config.xml").containing(httpAAppFileBuilder).containing(httpBAppFileBuilder);
+    private final DomainFileBuilder brokenDomainFileBuilder = new DomainFileBuilder("brokenDomain").corrupted();
+    private final DomainFileBuilder emptyDomainFileBuilder = new DomainFileBuilder("empty-domain").definedBy("empty-domain-config.xml");
+    private final DomainFileBuilder waitDomainFileBuilder = new DomainFileBuilder("wait-domain").definedBy("wait-domain-config.xml");
+    private final DomainFileBuilder incompleteDomainFileBuilder = new DomainFileBuilder("incompleteDomain").definedBy("incomplete-domain-config.xml");
+    private final DomainFileBuilder invalidDomainBundleFileBuilder = new DomainFileBuilder("invalid-domain-bundle").definedBy("incomplete-domain-config.xml").containing(emptyAppFileBuilder);
+    private final DomainFileBuilder dummyDomainBundleFileBuilder = new DomainFileBuilder("dummy-domain-bundle").containing(new ApplicationFileBuilder(dummyAppDescriptorFileBuilder).deployedWith("domain", "dummy-domain-bundle"));
+    private final DomainFileBuilder dummyDomainFileBuilder = new DomainFileBuilder("dummy-domain").definedBy("empty-domain-config.xml");
+    private final DomainFileBuilder sharedHttpDomainFileBuilder = new DomainFileBuilder("shared-http-domain").definedBy("shared-http-domain-config.xml");
+    private final DomainFileBuilder sharedHttpBundleDomainFileBuilder = new DomainFileBuilder("shared-http-domain").definedBy("shared-http-domain-config.xml").containing(httpAAppFileBuilder).containing(httpBAppFileBuilder);
 
     protected File muleHome;
     protected File appsDir;
@@ -1539,7 +1539,7 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
         deploymentService.start();
 
         addPackedDomainFromBuilder(emptyAppFileBuilder);
-        File dummyDomainFile = new File(DeploymentServiceTestCase.emptyAppFileBuilder.getZipPath());
+        File dummyDomainFile = new File(emptyAppFileBuilder.getZipPath());
         long firstFileTimestamp = dummyDomainFile.lastModified();
 
         assertDeploymentSuccess(domainDeploymentListener, emptyAppFileBuilder.getId());
@@ -1564,7 +1564,7 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
         deploymentService.start();
 
         addPackedDomainFromBuilder(emptyAppFileBuilder);
-        File dummyDomainFile = new File(DeploymentServiceTestCase.emptyAppFileBuilder.getZipPath());
+        File dummyDomainFile = new File(emptyAppFileBuilder.getZipPath());
         long firstFileTimestamp = dummyDomainFile.lastModified();
 
         assertDeploymentSuccess(domainDeploymentListener, emptyAppFileBuilder.getId());

--- a/modules/launcher/src/test/java/org/mule/module/launcher/builder/ApplicationFileBuilder.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/builder/ApplicationFileBuilder.java
@@ -11,13 +11,13 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.mule.module.launcher.descriptor.ApplicationDescriptor.DEFAULT_APP_PROPERTIES_RESOURCE;
 import static org.mule.module.launcher.descriptor.ApplicationDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
 import static org.mule.module.launcher.descriptor.ApplicationDescriptor.DEFAULT_DEPLOY_PROPERTIES_RESOURCE;
+import org.mule.tck.ZipUtils.ZipResource;
 import org.mule.util.FilenameUtils;
 import org.mule.util.StringUtils;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
-import java.util.zip.ZipOutputStream;
 
 /**
  * Creates Mule Application files.
@@ -168,14 +168,27 @@ public class ApplicationFileBuilder extends AbstractArtifactFileBuilder<Applicat
     }
 
     @Override
-    protected void addCustomFileContent(ZipOutputStream out) throws Exception
+    protected List<ZipResource> getCustomResources() throws Exception
     {
+        final List<ZipResource> customResources = new LinkedList<>();
+
         for (ApplicationPluginFileBuilder plugin : plugins)
         {
-            addZipResource(out, new ZipResource(plugin.getArtifactFile().getAbsolutePath(), "plugins/" + plugin.getArtifactFile().getName()));
+            customResources.add(new ZipResource(plugin.getArtifactFile().getAbsolutePath(), "plugins/" + plugin.getArtifactFile().getName()));
         }
 
-        createPropertiesFile(out, this.properties, DEFAULT_APP_PROPERTIES_RESOURCE);
-        createPropertiesFile(out, this.deployProperties, DEFAULT_DEPLOY_PROPERTIES_RESOURCE);
+        final ZipResource appProperties = createPropertiesFile(this.properties, DEFAULT_APP_PROPERTIES_RESOURCE);
+        if (appProperties != null)
+        {
+            customResources.add(appProperties);
+        }
+
+        final ZipResource deployProperties = createPropertiesFile(this.deployProperties, DEFAULT_DEPLOY_PROPERTIES_RESOURCE);
+        if (deployProperties != null)
+        {
+            customResources.add(deployProperties);
+        }
+
+        return customResources;
     }
 }

--- a/modules/launcher/src/test/java/org/mule/module/launcher/builder/ApplicationPluginFileBuilder.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/builder/ApplicationPluginFileBuilder.java
@@ -9,12 +9,13 @@ package org.mule.module.launcher.builder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.mule.module.launcher.plugin.PluginDescriptor.PLUGIN_PROPERTIES;
+import org.mule.tck.ZipUtils.ZipResource;
 import org.mule.util.StringUtils;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Properties;
-import java.util.zip.ZipOutputStream;
 
 /**
  * Creates Mule Application Plugin files.
@@ -108,16 +109,20 @@ public class ApplicationPluginFileBuilder extends AbstractArtifactFileBuilder<Ap
     }
 
     @Override
-    protected void addCustomFileContent(ZipOutputStream out) throws IOException
+    protected List<ZipResource> getCustomResources() throws Exception
     {
+        final List<ZipResource> customResources = new LinkedList<>();
+
         if (!properties.isEmpty())
         {
             final File applicationPropertiesFile = new File(getTempFolder(), PLUGIN_PROPERTIES);
             applicationPropertiesFile.deleteOnExit();
             createPropertiesFile(applicationPropertiesFile, properties);
 
-            addZipResource(out, new ZipResource(applicationPropertiesFile.getAbsolutePath(), PLUGIN_PROPERTIES));
+            customResources.add(new ZipResource(applicationPropertiesFile.getAbsolutePath(), PLUGIN_PROPERTIES));
         }
+
+        return customResources;
     }
 
     @Override

--- a/modules/launcher/src/test/java/org/mule/module/launcher/builder/DomainFileBuilder.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/builder/DomainFileBuilder.java
@@ -9,12 +9,12 @@ package org.mule.module.launcher.builder;
 
 import static org.mule.module.launcher.domain.Domain.DOMAIN_CONFIG_FILE_LOCATION;
 import static org.mule.util.Preconditions.checkArgument;
+import org.mule.tck.ZipUtils.ZipResource;
 import org.mule.util.StringUtils;
 
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.zip.ZipOutputStream;
 
 /**
  * Creates Mule Domain files.
@@ -94,13 +94,17 @@ public class DomainFileBuilder extends AbstractArtifactFileBuilder<DomainFileBui
     }
 
     @Override
-    protected void addCustomFileContent(ZipOutputStream out) throws Exception
+    protected List<ZipResource> getCustomResources() throws Exception
     {
+        final List<ZipResource> customResources = new LinkedList<>();
+
         for (ApplicationFileBuilder application : applications)
         {
             final File applicationFile = application.getArtifactFile();
-            addZipResource(out, new ZipResource(applicationFile.getAbsolutePath(), "apps/" + applicationFile.getName()));
+            customResources.add(new ZipResource(applicationFile.getAbsolutePath(), "apps/" + applicationFile.getName()));
         }
+
+        return customResources;
     }
 
     @Override


### PR DESCRIPTION
…ged artifacts

_ Removing duplication from AbstractFileBuilder and ZipUtils
_ Making static artifact file builders on DeploymentServiceTestCase non static to avoid issues when different builders write to the same file