### PR TITLE
MULE-9399: Mule throws a LifecycleException when disposing an Extension

### DIFF
--- a/core-tests/src/test/java/org/mule/registry/TransientRegistryTestCase.java
+++ b/core-tests/src/test/java/org/mule/registry/TransientRegistryTestCase.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+
 import org.mule.api.MuleContext;
 import org.mule.api.context.MuleContextAware;
 import org.mule.api.lifecycle.Disposable;
@@ -258,6 +259,7 @@ public class TransientRegistryTestCase extends AbstractMuleContextTestCase
             return tracker;
         }
 
+        @Override
         public void setMuleContext(MuleContext context)
         {
             tracker.add("setMuleContext");

--- a/core/src/main/java/org/mule/lifecycle/phases/MuleContextDisposePhase.java
+++ b/core/src/main/java/org/mule/lifecycle/phases/MuleContextDisposePhase.java
@@ -15,7 +15,6 @@ import org.mule.api.lifecycle.Disposable;
 import org.mule.api.lifecycle.Initialisable;
 import org.mule.api.lifecycle.LifecycleException;
 import org.mule.api.lifecycle.LifecyclePhase;
-import org.mule.api.lifecycle.Stoppable;
 import org.mule.api.routing.OutboundRouter;
 import org.mule.api.source.MessageSource;
 import org.mule.api.transformer.Transformer;
@@ -65,7 +64,7 @@ public class MuleContextDisposePhase extends DefaultLifecyclePhase
         orderedObjects.add(new NotificationLifecycleObject(Agent.class));
         orderedObjects.add(new NotificationLifecycleObject(ConfigurationProvider.class));
         orderedObjects.add(new NotificationLifecycleObject(Config.class));
-        orderedObjects.add(new NotificationLifecycleObject(Stoppable.class));
+        orderedObjects.add(new NotificationLifecycleObject(Disposable.class));
         orderedObjects.add(new NotificationLifecycleObject(Object.class));
 
         //Can call dispose from all lifecycle Phases


### PR DESCRIPTION
Source - partial fix, ensure correct fetching of disposable objects