### PR TITLE
Jira Issue Mule-9562 mule udp connector is creating new socket object for same address

### DIFF
--- a/transports/udp/src/main/java/org/mule/transport/udp/UdpConnector.java
+++ b/transports/udp/src/main/java/org/mule/transport/udp/UdpConnector.java
@@ -172,7 +172,8 @@ public class UdpConnector extends AbstractConnector
 
     DatagramSocket getServerSocket(ImmutableEndpoint endpoint) throws Exception
     {
-        return (DatagramSocket) socketFactory.makeObject(endpoint);
+    	UdpSocketKey socketKey = new UdpSocketKey(endpoint);
+        return (DatagramSocket) socketFactory.makeObject(socketKey);
     }
 
     void releaseSocket(DatagramSocket socket, ImmutableEndpoint endpoint) throws Exception

--- a/transports/udp/src/main/java/org/mule/transport/udp/UdpConnector.java
+++ b/transports/udp/src/main/java/org/mule/transport/udp/UdpConnector.java
@@ -6,6 +6,9 @@
  */
 package org.mule.transport.udp;
 
+import java.net.DatagramSocket;
+
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleException;
 import org.mule.api.construct.FlowConstruct;
@@ -13,10 +16,6 @@ import org.mule.api.endpoint.ImmutableEndpoint;
 import org.mule.api.endpoint.InboundEndpoint;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.transport.AbstractConnector;
-
-import java.net.DatagramSocket;
-
-import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 
 /**
  * <code>UdpConnector</code> can send and receive Mule events as Datagram packets.
@@ -167,7 +166,8 @@ public class UdpConnector extends AbstractConnector
      */
     DatagramSocket getSocket(ImmutableEndpoint endpoint) throws Exception
     {
-        return (DatagramSocket) dispatcherSocketsPool.borrowObject(endpoint);
+    	UdpSocketKey socketKey = new UdpSocketKey(endpoint);
+        return (DatagramSocket) dispatcherSocketsPool.borrowObject(socketKey);
     }
 
     DatagramSocket getServerSocket(ImmutableEndpoint endpoint) throws Exception
@@ -177,14 +177,15 @@ public class UdpConnector extends AbstractConnector
 
     void releaseSocket(DatagramSocket socket, ImmutableEndpoint endpoint) throws Exception
     {
+    	UdpSocketKey socketKey = new UdpSocketKey(endpoint);
         // Sockets can't be recycled if we close them at the end...
         if (!keepSendSocketOpen)
         {
-            dispatcherSocketsPool.clear(endpoint);
+            dispatcherSocketsPool.clear(socketKey);
         }
         else
         {
-            dispatcherSocketsPool.returnObject(endpoint, socket);
+            dispatcherSocketsPool.returnObject(socketKey, socket);
         }
     }
 

--- a/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketFactory.java
+++ b/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketFactory.java
@@ -35,7 +35,6 @@ public class UdpSocketFactory implements KeyedPoolableObjectFactory
     {
         UdpSocketKey socketKey = (UdpSocketKey)key;
         DatagramSocket socket;
-
         ImmutableEndpoint ep = socketKey.getEndpoint();
         if(ep instanceof InboundEndpoint)
         {

--- a/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketFactory.java
+++ b/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketFactory.java
@@ -33,9 +33,10 @@ public class UdpSocketFactory implements KeyedPoolableObjectFactory
 
     public Object makeObject(Object key) throws Exception
     {
-        ImmutableEndpoint ep = (ImmutableEndpoint)key;
+        UdpSocketKey socketKey = (UdpSocketKey)key;
         DatagramSocket socket;
 
+        ImmutableEndpoint ep = socketKey.getEndpoint();
         if(ep instanceof InboundEndpoint)
         {
             int port = ep.getEndpointURI().getPort();
@@ -106,7 +107,8 @@ public class UdpSocketFactory implements KeyedPoolableObjectFactory
 
     public void passivateObject(Object key, Object object) throws Exception
     {
-        ImmutableEndpoint ep = (ImmutableEndpoint)key;
+    	UdpSocketKey socketKey = (UdpSocketKey)key;
+        ImmutableEndpoint ep = socketKey.getEndpoint();
 
         boolean keepSocketOpen = MapUtils.getBooleanValue(ep.getProperties(),
             UdpConnector.KEEP_SEND_SOCKET_OPEN_PROPERTY, ((UdpConnector)ep.getConnector()).isKeepSendSocketOpen());

--- a/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketFactory.java
+++ b/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketFactory.java
@@ -35,6 +35,7 @@ public class UdpSocketFactory implements KeyedPoolableObjectFactory
     {
         UdpSocketKey socketKey = (UdpSocketKey)key;
         DatagramSocket socket;
+        
         ImmutableEndpoint ep = socketKey.getEndpoint();
         if(ep instanceof InboundEndpoint)
         {

--- a/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketKey.java
+++ b/transports/udp/src/main/java/org/mule/transport/udp/UdpSocketKey.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.udp;
+
+import org.mule.api.endpoint.ImmutableEndpoint;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+/**
+ * This is used to adapt an endpoint so that it can be used as a key for sockets.  It must
+ * meet two requirements: (1) implement hash and equals in a way that reflects socket identity
+ * (ie using address and port); (2) allow access to the endpoint for use in the socket factory.
+ * For simplicity we also expose the connector, address and port directly.
+ */
+public class UdpSocketKey
+{
+
+    private InetSocketAddress address;
+    private ImmutableEndpoint endpoint;
+
+    public UdpSocketKey(ImmutableEndpoint endpoint)
+    {
+        if (!(endpoint.getConnector() instanceof UdpConnector))
+        {
+            throw new IllegalArgumentException("Sockets must be keyed via a TCP endpoint");
+        }
+        this.endpoint = endpoint;
+        address = new InetSocketAddress(
+                endpoint.getEndpointURI().getHost(),
+                endpoint.getEndpointURI().getPort());
+        if (address.isUnresolved())
+        {
+            throw new IllegalArgumentException("Unable to resolve address: " + address.getHostName());
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj instanceof UdpSocketKey && address.equals(((UdpSocketKey) obj).address);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return address.hashCode();
+    }
+
+    public ImmutableEndpoint getEndpoint()
+    {
+        return endpoint;
+    }
+
+    public UdpConnector getConnector()
+    {
+        return (UdpConnector) endpoint.getConnector();
+    }
+
+    public InetAddress getInetAddress()
+    {
+        return address.getAddress();
+    }
+
+    public int getPort()
+    {
+        return address.getPort();
+    }
+
+    @Override
+    public String toString()
+    {
+        return getInetAddress() + ":" + getPort();
+    }
+
+}


### PR DESCRIPTION
mule udp connector is  creating new socket object for same address. Currently it passing endpoint. I have create UdpSocketKey class  & now passing UdpSocketKey class object.

I have tested. It is working fine.
