### PR TITLE
MULE-9458: DB test failure with Oracle 12c

### DIFF
--- a/modules/db/src/test/java/org/mule/module/db/integration/model/AbstractTestDatabase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/model/AbstractTestDatabase.java
@@ -54,8 +54,10 @@ public abstract class AbstractTestDatabase
 
     public static void executeDdl(Connection connection, String ddl) throws SQLException
     {
-        QueryRunner qr = new QueryRunner();
-        qr.update(connection, ddl);
+        try (Statement statement = connection.createStatement())
+        {
+            statement.executeUpdate(ddl);
+        }
     }
 
     public void executeUpdate(Connection connection, String updateSql) throws SQLException

--- a/modules/db/src/test/java/org/mule/module/db/integration/model/OracleTestDatabase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/model/OracleTestDatabase.java
@@ -15,6 +15,9 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
+/**
+ * Defines an Oracle test database to use with ojdbc7 driver.
+ */
 public class OracleTestDatabase extends AbstractTestDatabase
 {
 
@@ -202,7 +205,7 @@ public class OracleTestDatabase extends AbstractTestDatabase
     @Override
     public DataType getIdFieldInputMetaDataType()
     {
-        return DataType.STRING;
+        return DataType.DECIMAL;
     }
 
     @Override


### PR DESCRIPTION
_ Changing DDL execution to avoid issues creating Oracle trigger
_ Updating data type expected for metadata
_ Updating QueryParamTypeResolver to use template parameter type when driver does not provide the type information