### PR TITLE
MULE-9616: Reintroduce transport infrastructure in Mule 4

### DIFF
--- a/modules/spring-config/src/main/resources/META-INF/mule.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule.xsd
@@ -502,6 +502,18 @@
         </xsd:choice>
     </xsd:group>
 
+    <xsd:group name="messageProcessorOrMixedContentMessageProcessor">
+        <xsd:choice>
+            <xsd:element ref="abstract-message-processor">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        A message processor
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+    </xsd:group>
+    
     <xsd:element name="processor" type="refMessageProcessorType" substitutionGroup="abstract-message-processor">
         <xsd:annotation>
             <xsd:documentation>


### PR DESCRIPTION
* Readding group in xsd as it was before bringing back the transports