### PR TITLE
Extend the CXF URL hack to support SOAP over WMQ and AMQP endpoints.

### DIFF
--- a/modules/cxf/src/main/java/org/mule/module/cxf/support/CxfUtils.java
+++ b/modules/cxf/src/main/java/org/mule/module/cxf/support/CxfUtils.java
@@ -100,6 +100,8 @@ public final class CxfUtils
             url = url.replace("servlet://", "http://");
             url = url.replace("jetty://", "http://");
             url = url.replace("jetty-ssl://", "https://");
+            url = url.replace("wmq://", "http://");
+            url = url.replace("amqp://", "http://");
         }
         return url;
     }


### PR DESCRIPTION
CXF components will throw a NPE when added after WMQ or AMQP inbound endpoints.
The org.apache.cxf.binding.soap.SoapTransportFactory#getDestination() method only recognize the http and jms protocols.
Endpoint URL protocol need to be replaced with http:// to works properly.
org.mule.module.cxf.builder.AbstractInboundMessageProcessorBuilder#getAddress() method already uses http as default protocol.