### PR TITLE
MULE-9660 OAuth2 authorization-code-grant-type is always expecting a …

### DIFF
--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/TokenResponseProcessor.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/TokenResponseProcessor.java
@@ -26,7 +26,7 @@ public class TokenResponseProcessor
     protected Logger logger = LoggerFactory.getLogger(getClass());
     private final TokenResponseConfiguration tokenResponseConfiguration;
     private final ExpressionManager expressionManager;
-    private final boolean retrieveRefreshToken;
+    private final boolean retrieveRefreshTokenIfPresent;
     private String accessToken;
     private String refreshToken;
     private String expiresIn;
@@ -42,11 +42,11 @@ public class TokenResponseProcessor
         return new TokenResponseProcessor(tokenResponseConfiguration, expressionManager, false);
     }
 
-    private TokenResponseProcessor(final TokenResponseConfiguration tokenResponseConfiguration, final ExpressionManager expressionManager, boolean retrieveRefreshToken)
+    private TokenResponseProcessor(final TokenResponseConfiguration tokenResponseConfiguration, final ExpressionManager expressionManager, boolean retrieveRefreshTokenIfPresent)
     {
         this.tokenResponseConfiguration = tokenResponseConfiguration;
         this.expressionManager = expressionManager;
-        this.retrieveRefreshToken = retrieveRefreshToken;
+        this.retrieveRefreshTokenIfPresent = retrieveRefreshTokenIfPresent;
     }
 
     public void process(final MuleEvent muleEvent)
@@ -57,13 +57,13 @@ public class TokenResponseProcessor
         {
             logger.error("Could not extract access token from token URL. Expressions used to retrieve access token was " + tokenResponseConfiguration.getAccessToken());
         }
-        if (retrieveRefreshToken)
+        if (retrieveRefreshTokenIfPresent)
         {
             refreshToken = expressionManager.parse(tokenResponseConfiguration.getRefreshToken(), muleEvent);
             refreshToken = isEmpty(refreshToken) ? null : refreshToken;
             if (refreshToken == null)
             {
-                logger.error("Could not extract refresh token from token URL. Expressions used to retrieve refresh token was " + tokenResponseConfiguration.getRefreshToken());
+                logger.warn("Could not extract refresh token from token URL or not issued by the OAuth server. Expressions used to retrieve refresh token was " + tokenResponseConfiguration.getRefreshToken() + ", it will not be possible to refresh the access token once it is expired");
             }
         }
         expiresIn = expressionManager.parse(tokenResponseConfiguration.getExpiresIn(), muleEvent);

--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/authorizationcode/DefaultAuthorizationCodeGrantType.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/authorizationcode/DefaultAuthorizationCodeGrantType.java
@@ -182,7 +182,7 @@ public class DefaultAuthorizationCodeGrantType extends AbstractGrantType impleme
     }
 
     @Override
-    public boolean shouldRetry(final MuleEvent firstAttemptResponseEvent)
+    public boolean shouldRetry(final MuleEvent firstAttemptResponseEvent) throws MuleException
     {
         if (!StringUtils.isBlank(getRefreshTokenWhen()))
         {
@@ -191,16 +191,25 @@ public class DefaultAuthorizationCodeGrantType extends AbstractGrantType impleme
             {
                 throw new MuleRuntimeException(createStaticMessage("Expression %s should return a boolean but return %s", getRefreshTokenWhen(), value));
             }
-            final Boolean shouldRetryRequest = (Boolean) value;
+            Boolean shouldRetryRequest = (Boolean) value;
             if (shouldRetryRequest)
             {
-                try
+                final String resourceId = resourceOwnerIdEvaluator.resolveStringValue(firstAttemptResponseEvent);
+                final Boolean refreshTokenIssuedByServer = !StringUtils.isBlank(this.getConfigOAuthContext().getContextForResourceOwner(resourceId).getRefreshToken());
+                if (refreshTokenIssuedByServer)
                 {
-                    refreshToken(firstAttemptResponseEvent, resourceOwnerIdEvaluator.resolveStringValue(firstAttemptResponseEvent));
+                    try
+                    {
+                        refreshToken(firstAttemptResponseEvent, resourceId);
+                    }
+                    catch (MuleException e)
+                    {
+                        throw new MuleRuntimeException(e);
+                    }
                 }
-                catch (MuleException e)
+                else
                 {
-                    throw new MuleRuntimeException(e);
+                    throw new RequestAuthenticationException(createStaticMessage(String.format("Cannot do a refresh token to get a new access token for the %s user due to OAuth server did not issued a refresh_token. You would have to re-authenticate the user before trying to execute an operation to the API.", resourceId)));
                 }
             }
             return shouldRetryRequest;

--- a/modules/oauth/src/test/java/org/mule/module/oauth2/internal/authorizationcode/functional/AuthorizationCodeAuthorizationFailureTestCase.java
+++ b/modules/oauth/src/test/java/org/mule/module/oauth2/internal/authorizationcode/functional/AuthorizationCodeAuthorizationFailureTestCase.java
@@ -11,6 +11,7 @@ import static java.lang.String.valueOf;
 import static org.apache.commons.lang.StringUtils.EMPTY;
 import static org.apache.http.client.fluent.Request.Get;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mule.module.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
 import static org.mule.module.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -21,8 +22,9 @@ import static org.mule.module.oauth2.internal.authorizationcode.AutoAuthorizatio
 import static org.mule.module.oauth2.internal.authorizationcode.AutoAuthorizationCodeTokenRequestHandler.TOKEN_NOT_FOUND_STATUS;
 import static org.mule.module.oauth2.internal.authorizationcode.AutoAuthorizationCodeTokenRequestHandler.TOKEN_URL_CALL_FAILED_STATUS;
 import static org.mule.tck.MuleTestUtils.testWithSystemProperty;
-
 import org.mule.module.oauth2.internal.StateEncoder;
+import org.mule.module.oauth2.internal.authorizationcode.state.ResourceOwnerOAuthContext;
+import org.mule.module.oauth2.internal.tokenmanager.TokenManagerConfig;
 import org.mule.tck.MuleTestUtils;
 import org.mule.tck.functional.FlowAssert;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -38,6 +40,7 @@ public class AuthorizationCodeAuthorizationFailureTestCase extends AbstractAutho
 {
 
     private static final String EXPECTED_STATUS_CODE_SYSTEM_PROPERTY = "expectedStatusCode";
+    public static final String REFRESHED_ACCESS_TOKEN = "rbBQLgJXBEYo83K4Fqs4guasdfsdfa";
 
     @Rule
     public DynamicPort onCompleteUrlPort = new DynamicPort("onCompleteUrlPort");
@@ -109,7 +112,7 @@ public class AuthorizationCodeAuthorizationFailureTestCase extends AbstractAutho
     }
 
     @Test
-    public void callToTokenUrlSuccessButNoAccessTokenRetrieved() throws Exception
+    public void callToTokenUrlSuccessButNoAccessTokenRetrievedEmptyResponse() throws Exception
     {
         configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantTypeWithBody(EMPTY);
 
@@ -117,9 +120,9 @@ public class AuthorizationCodeAuthorizationFailureTestCase extends AbstractAutho
     }
 
     @Test
-    public void callToTokenUrlSuccessButNoRefreshTokenRetrieved() throws Exception
+    public void callToTokenUrlSuccessButNoAccessTokenRetrieved() throws Exception
     {
-        configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantType(ACCESS_TOKEN, null);
+        configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantType(null, null);
 
         testWithSystemProperty(EXPECTED_STATUS_CODE_SYSTEM_PROPERTY, valueOf(TOKEN_NOT_FOUND_STATUS), new MuleTestUtils.TestCallback()
         {
@@ -135,6 +138,53 @@ public class AuthorizationCodeAuthorizationFailureTestCase extends AbstractAutho
             }
         });
 
+    }
+
+    @Test
+    public void callToTokenUrlSuccessButNoRefreshTokenRetrieved() throws Exception
+    {
+        configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantType(ACCESS_TOKEN, null);
+        Get(getRedirectUrlWithOnCompleteUrlAndCodeQueryParams())
+                .connectTimeout(REQUEST_TIMEOUT)
+                .socketTimeout(REQUEST_TIMEOUT)
+                .execute();
+        final TokenManagerConfig tokenManagerConfig = muleContext.getRegistry().lookupObject(TokenManagerConfig.class);
+        final ResourceOwnerOAuthContext oauthContext = tokenManagerConfig.getConfigOAuthContext().getContextForResourceOwner(ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID);
+
+        assertThat(oauthContext.getAccessToken(), is(ACCESS_TOKEN));
+        assertThat(oauthContext.getRefreshToken(), is(nullValue()));
+    }
+
+    @Test
+    public void callToTokenUrlSuccessButNoRefreshTokenRetrievedOnSubsequentRefreshOperation() throws Exception
+    {
+        // During the initial call to token url it returns an access_token and refresh_token
+        configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantType(ACCESS_TOKEN, REFRESH_TOKEN);
+        Get(getRedirectUrlWithOnCompleteUrlAndCodeQueryParams())
+                .connectTimeout(REQUEST_TIMEOUT)
+                .socketTimeout(REQUEST_TIMEOUT)
+                .execute();
+
+        final TokenManagerConfig tokenManagerConfig = muleContext.getRegistry().lookupObject(TokenManagerConfig.class);
+        ResourceOwnerOAuthContext oauthContext = tokenManagerConfig.getConfigOAuthContext().getContextForResourceOwner(ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID);
+
+        // Validates that the oauth context has both tokens
+        assertThat(oauthContext.getAccessToken(), is(ACCESS_TOKEN));
+        assertThat(oauthContext.getRefreshToken(), is(REFRESH_TOKEN));
+
+        // In order to validate that oauth context is updated (due to it is persisted with OS) we now do another call but only returning the REFRESHED_ACCESS_TOKEN without
+        // a refresh token.
+        configureWireMockToExpectTokenPathRequestForAuthorizationCodeGrantType(REFRESHED_ACCESS_TOKEN, null);
+        Get(getRedirectUrlWithOnCompleteUrlAndCodeQueryParams())
+                .connectTimeout(REQUEST_TIMEOUT)
+                .socketTimeout(REQUEST_TIMEOUT)
+                .execute();
+
+        // We need to retrieve the oauth context again to get it updated...
+        oauthContext = tokenManagerConfig.getConfigOAuthContext().getContextForResourceOwner(ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID);
+
+        assertThat(oauthContext.getAccessToken(), is(REFRESHED_ACCESS_TOKEN));
+        assertThat(oauthContext.getRefreshToken(), is(nullValue()));
     }
 
     private void verifyCallToRedirectUrlFails() throws IOException

--- a/modules/oauth/src/test/java/org/mule/module/oauth2/internal/authorizationcode/functional/AuthorizationCodeRefreshTokenConfigTestCase.java
+++ b/modules/oauth/src/test/java/org/mule/module/oauth2/internal/authorizationcode/functional/AuthorizationCodeRefreshTokenConfigTestCase.java
@@ -6,14 +6,21 @@
  */
 package org.mule.module.oauth2.internal.authorizationcode.functional;
 
+import org.mule.api.MessagingException;
+import org.mule.module.oauth2.api.RequestAuthenticationException;
 import org.mule.module.oauth2.internal.authorizationcode.state.ResourceOwnerOAuthContext;
 
+import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class AuthorizationCodeRefreshTokenConfigTestCase extends AbstractAuthorizationCodeRefreshTokenConfigTestCase
 {
 
     public static final String SINGLE_TENANT_OAUTH_CONFIG = "oauthConfig";
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Override
     protected String getConfigFile()
@@ -27,4 +34,16 @@ public class AuthorizationCodeRefreshTokenConfigTestCase extends AbstractAuthori
         executeRefreshToken("testFlow", SINGLE_TENANT_OAUTH_CONFIG, ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID, 403);
     }
 
+    /**
+     * Refresh token is optional therefore this test will validate an scenario where if the access_token is invalid and refresh_token
+     * has not been provided in last refreshToken operation either token operation an {@link RequestAuthenticationException} should be thrown.
+     * @throws Exception
+     */
+    @Test
+    public void afterFailureWithRefreshTokenNotIssuedThrowAuthenticationException() throws Exception
+    {
+        expectedException.expect(MessagingException.class);
+        expectedException.expectCause(Matchers.<Throwable>instanceOf(RequestAuthenticationException.class));
+        executeRefreshTokenNotIssuedOnTokenCall("testFlow", SINGLE_TENANT_OAUTH_CONFIG, ResourceOwnerOAuthContext.DEFAULT_RESOURCE_OWNER_ID, 403);
+    }
 }


### PR DESCRIPTION
…refresh_token when it is optional according to the spec