### PR TITLE
MULE-9432: Isolate domains from core artifact

### DIFF
--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/FilteringArtifactClassLoaderTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/FilteringArtifactClassLoaderTestCase.java
@@ -28,19 +28,23 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
 
     public static final String CLASS_NAME = "java.lang.Object";
     public static final String RESOURCE_NAME = "dummy.txt";
-    public static final String PLUGIN_NAME = "DUMMY_PLUGIN";
 
-    private FilteringArtifactClassLoader filteringArtifactClassLoader;
-    private final ClassLoaderFilter filter = mock(ClassLoaderFilter.class);
-    private final ArtifactClassLoader artifactClassLoader = mock(ArtifactClassLoader.class);
+    protected FilteringArtifactClassLoader filteringArtifactClassLoader;
+    protected final ClassLoaderFilter filter = mock(ClassLoaderFilter.class);
+    protected final ArtifactClassLoader artifactClassLoader = mock(ArtifactClassLoader.class);
 
     @Test(expected = ClassNotFoundException.class)
     public void throwClassNotFoundErrorWhenClassIsNotExported() throws ClassNotFoundException
     {
         when(filter.exportsClass(CLASS_NAME)).thenReturn(false);
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, null, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
 
         filteringArtifactClassLoader.loadClass(CLASS_NAME);
+    }
+
+    protected FilteringArtifactClassLoader doCreateClassLoader()
+    {
+        return new FilteringArtifactClassLoader(artifactClassLoader, filter);
     }
 
     @Test
@@ -53,7 +57,7 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
         when(filter.exportsClass(CLASS_NAME)).thenReturn(true);
         when(artifactClassLoader.getClassLoader()).thenReturn(classLoader);
 
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, artifactClassLoader, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
         Class<?> aClass = filteringArtifactClassLoader.loadClass(CLASS_NAME);
         assertThat(aClass, equalTo(expectedClass));
     }
@@ -62,7 +66,7 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
     public void filtersResourceWhenNotExported() throws ClassNotFoundException
     {
         when(filter.exportsClass(RESOURCE_NAME)).thenReturn(false);
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, null, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
 
         URL resource = filteringArtifactClassLoader.getResource(RESOURCE_NAME);
         assertThat(resource, equalTo(null));
@@ -76,7 +80,7 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
         when(filter.exportsResource(RESOURCE_NAME)).thenReturn(true);
         when(artifactClassLoader.findResource(RESOURCE_NAME)).thenReturn(expectedResource);
 
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, artifactClassLoader, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
 
         URL resource = filteringArtifactClassLoader.getResource(RESOURCE_NAME);
         assertThat(resource, equalTo(expectedResource));
@@ -92,7 +96,7 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
         when(filter.exportsResource(RESOURCE_NAME)).thenReturn(false);
         when(artifactClassLoader.getClassLoader()).thenReturn(classLoader);
 
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, artifactClassLoader, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
 
         Enumeration<URL> resources = filteringArtifactClassLoader.getResources(RESOURCE_NAME);
         assertThat(resources, EnumerationMatcher.equalTo(Collections.EMPTY_LIST));
@@ -106,7 +110,7 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
         when(filter.exportsResource(RESOURCE_NAME)).thenReturn(true);
         when(artifactClassLoader.findResources(RESOURCE_NAME)).thenReturn(new EnumerationAdapter<>(Collections.singleton(resource)));
 
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, artifactClassLoader, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
 
         Enumeration<URL> resources = filteringArtifactClassLoader.getResources(RESOURCE_NAME);
         assertThat(resources, EnumerationMatcher.equalTo(Collections.singletonList(resource)));
@@ -115,7 +119,7 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
     @Test
     public void returnsCorrectClassLoader() throws Exception
     {
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, artifactClassLoader, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
 
         final ClassLoader classLoader = filteringArtifactClassLoader.getClassLoader();
 
@@ -125,7 +129,7 @@ public class FilteringArtifactClassLoaderTestCase extends AbstractMuleTestCase
     @Test
     public void doesNotDisposesFilteredClassLoader() throws Exception
     {
-        filteringArtifactClassLoader = new FilteringArtifactClassLoader(PLUGIN_NAME, artifactClassLoader, filter);
+        filteringArtifactClassLoader = doCreateClassLoader();
 
         filteringArtifactClassLoader.dispose();
 

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/FilteringContainerClassLoader.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/FilteringContainerClassLoader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.launcher;
+
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderFilter;
+import org.mule.runtime.module.artifact.classloader.FilteringArtifactClassLoader;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+
+/**
+ * Filtering artifact classLoader that to use as the parent classloader for
+ * all mule tops artifact (domains, server plugins, etc).
+ * <p>
+ * Differs from the base class is that exposes all the resources available in the
+ * delegate classLoader and the delegate's parent classLoader.
+ */
+public class FilteringContainerClassLoader extends FilteringArtifactClassLoader
+{
+
+    /**
+     * Creates a new instance
+     *
+     * @param containerClassLoader delegate classLoader. Not null.
+     * @param filter filter used to determine which classes and resources are exported
+     *               on the delegate classLoader.
+     */
+    public FilteringContainerClassLoader(ArtifactClassLoader containerClassLoader, ClassLoaderFilter filter)
+    {
+        super(containerClassLoader, filter);
+    }
+
+    @Override
+    protected URL getResourceFromDelegate(ArtifactClassLoader artifactClassLoader, String name)
+    {
+        return artifactClassLoader.getClassLoader().getResource(name);
+    }
+
+    @Override
+    protected Enumeration<URL> getResourcesFromDelegate(ArtifactClassLoader artifactClassLoader, String name) throws IOException
+    {
+        return artifactClassLoader.getClassLoader().getResources(name);
+    }
+}

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/PassThroughClassLoaderFilter.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/PassThroughClassLoaderFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.launcher;
+
+import org.mule.runtime.module.artifact.classloader.ClassLoaderFilter;
+
+/**
+ * Provides a {@link ClassLoaderFilter} that does not filter any class or resource.
+ */
+public class PassThroughClassLoaderFilter implements ClassLoaderFilter
+{
+
+    @Override
+    public boolean exportsClass(String name)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean exportsResource(String name)
+    {
+        return true;
+    }
+}

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/application/DefaultApplicationFactory.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/application/DefaultApplicationFactory.java
@@ -121,7 +121,7 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application>
 
         for (ApplicationPlugin plugin : applicationPlugins)
         {
-            final FilteringArtifactClassLoader filteringPluginClassLoader = new FilteringArtifactClassLoader(plugin.getArtifactName(), plugin.getArtifactClassLoader(), plugin.getDescriptor().getClassLoaderFilter());
+            final FilteringArtifactClassLoader filteringPluginClassLoader = new FilteringArtifactClassLoader(plugin.getArtifactClassLoader(), plugin.getDescriptor().getClassLoaderFilter());
 
             classLoaders.add(filteringPluginClassLoader);
         }

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/domain/DefaultDomainFactory.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/domain/DefaultDomainFactory.java
@@ -11,6 +11,7 @@ import static org.mule.runtime.module.launcher.MuleFoldersUtil.getDomainFolder;
 import static org.mule.runtime.module.launcher.artifact.ArtifactFactoryUtils.getDeploymentFile;
 import static org.mule.runtime.module.launcher.domain.Domain.DEFAULT_DOMAIN_NAME;
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.launcher.DeploymentListener;
 import org.mule.runtime.module.launcher.descriptor.DomainDescriptor;
@@ -29,10 +30,13 @@ public class DefaultDomainFactory implements DomainFactory
     private final DomainDescriptorParser domainDescriptorParser;
 
     protected DeploymentListener deploymentListener;
+    private final ArtifactClassLoader containerClassLoader;
 
-    public DefaultDomainFactory(ArtifactClassLoaderFactory<DomainDescriptor> domainClassLoaderFactory, DomainManager domainManager)
+    public DefaultDomainFactory(ArtifactClassLoaderFactory<DomainDescriptor> domainClassLoaderFactory, DomainManager domainManager, ArtifactClassLoader containerClassLoader)
     {
         checkArgument(domainManager != null, "Domain manager cannot be null");
+        checkArgument(containerClassLoader != null, "Container classLoader cannot be null");
+        this.containerClassLoader = containerClassLoader;
         this.domainClassLoaderFactory = domainClassLoaderFactory;
         this.domainManager = domainManager;
         this.domainDescriptorParser = new DomainDescriptorParser();
@@ -56,7 +60,7 @@ public class DefaultDomainFactory implements DomainFactory
             throw new IllegalArgumentException("Mule domain name may not contain spaces: " + artifactName);
         }
         DomainDescriptor descriptor = findDomain(artifactName);
-        DefaultMuleDomain defaultMuleDomain = new DefaultMuleDomain(descriptor, domainClassLoaderFactory.create(null, descriptor));
+        DefaultMuleDomain defaultMuleDomain = new DefaultMuleDomain(descriptor, domainClassLoaderFactory.create(containerClassLoader, descriptor));
         defaultMuleDomain.setDeploymentListener(deploymentListener);
         DomainWrapper domainWrapper = new DomainWrapper(defaultMuleDomain, this);
         domainManager.addDomain(domainWrapper);

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/FilteringContainerClassLoaderTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/FilteringContainerClassLoaderTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.launcher;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import org.mule.runtime.module.artifact.classloader.EnumerationMatcher;
+import org.mule.runtime.module.artifact.classloader.FilteringArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.FilteringArtifactClassLoaderTestCase;
+import org.mule.runtime.module.artifact.classloader.TestClassLoader;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import org.junit.Test;
+
+public class FilteringContainerClassLoaderTestCase extends FilteringArtifactClassLoaderTestCase
+{
+
+    @Override
+    protected FilteringArtifactClassLoader doCreateClassLoader()
+    {
+        return new FilteringContainerClassLoader(artifactClassLoader, filter);
+    }
+
+    @Test
+    @Override
+    public void loadsExportedResource() throws ClassNotFoundException, MalformedURLException
+    {
+        TestClassLoader classLoader = new TestClassLoader();
+        URL expectedResource = new URL("file:///app.txt");
+        classLoader.addResource(RESOURCE_NAME, expectedResource);
+
+        when(filter.exportsResource(RESOURCE_NAME)).thenReturn(true);
+        when(artifactClassLoader.getClassLoader()).thenReturn(classLoader);
+
+        filteringArtifactClassLoader = doCreateClassLoader();
+
+        URL resource = filteringArtifactClassLoader.getResource(RESOURCE_NAME);
+        assertThat(resource, equalTo(expectedResource));
+    }
+
+    @Test
+    @Override
+    public void getsExportedResources() throws Exception
+    {
+        TestClassLoader classLoader = new TestClassLoader();
+        URL resource = new URL("file:/app.txt");
+        classLoader.addResource(RESOURCE_NAME, resource);
+
+        when(filter.exportsResource(RESOURCE_NAME)).thenReturn(true);
+        when(artifactClassLoader.getClassLoader()).thenReturn(classLoader);
+
+        filteringArtifactClassLoader = doCreateClassLoader();
+
+        Enumeration<URL> resources = filteringArtifactClassLoader.getResources(RESOURCE_NAME);
+        assertThat(resources, EnumerationMatcher.equalTo(Collections.singletonList(resource)));
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/AbstractDomainTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/AbstractDomainTestCase.java
@@ -11,13 +11,15 @@ import static java.util.Collections.emptySet;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import org.mule.runtime.core.api.config.MuleProperties;
-import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleClassLoaderLookupPolicy;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -30,7 +32,7 @@ public class AbstractDomainTestCase extends AbstractMuleTestCase
     @Rule
     public final SystemProperty muleHomeSystemProperty = new SystemProperty(MuleProperties.MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getCanonicalPath());
     protected final File muleHomeFolder;
-    protected final ClassLoaderLookupPolicy lookupPolicy = new MuleClassLoaderLookupPolicy(emptyMap(), emptySet());
+    protected final ArtifactClassLoader containerClassLoader = new MuleArtifactClassLoader("mule", new URL[0], getClass().getClassLoader(), new MuleClassLoaderLookupPolicy(emptyMap(), emptySet()));
 
     public AbstractDomainTestCase() throws IOException
     {

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/DefaultDomainFactoryTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/DefaultDomainFactoryTestCase.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class DefaultDomainFactoryTestCase extends AbstractDomainTestCase
 {
-    private DomainFactory domainFactory = new DefaultDomainFactory(new DomainClassLoaderFactory(lookupPolicy), new DefaultDomainManager());
+    private DomainFactory domainFactory = new DefaultDomainFactory(new DomainClassLoaderFactory(getClass().getClassLoader()), new DefaultDomainManager(), containerClassLoader);
 
     public DefaultDomainFactoryTestCase() throws IOException
     {

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/DomainClassLoaderFactoryTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/DomainClassLoaderFactoryTestCase.java
@@ -55,7 +55,7 @@ public class DomainClassLoaderFactoryTestCase extends AbstractDomainTestCase
 
         DomainDescriptor descriptor = getTestDescriptor(DEFAULT_DOMAIN_NAME);
 
-        assertThat(new DomainClassLoaderFactory(lookupPolicy).create(null, descriptor).getArtifactName(), is(DEFAULT_DOMAIN_NAME));
+        assertThat(new DomainClassLoaderFactory(getClass().getClassLoader()).create(containerClassLoader, descriptor).getArtifactName(), is(DEFAULT_DOMAIN_NAME));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class DomainClassLoaderFactoryTestCase extends AbstractDomainTestCase
         createDomainDir(MULE_DOMAIN_FOLDER, domainName);
         DomainDescriptor descriptor = getTestDescriptor(domainName);
 
-        final ArtifactClassLoader domainClassLoader = new DomainClassLoaderFactory(lookupPolicy).create(null, descriptor);
+        final ArtifactClassLoader domainClassLoader = new DomainClassLoaderFactory(getClass().getClassLoader()).create(containerClassLoader, descriptor);
 
         assertThat(domainClassLoader.getClassLoader(), instanceOf(MuleSharedDomainClassLoader.class));
         assertThat(domainClassLoader.getArtifactName(), equalTo(domainName));
@@ -76,7 +76,7 @@ public class DomainClassLoaderFactoryTestCase extends AbstractDomainTestCase
     {
         DomainDescriptor descriptor = getTestDescriptor("someDomain");
 
-        new DomainClassLoaderFactory(lookupPolicy).create(null, descriptor);
+        new DomainClassLoaderFactory(getClass().getClassLoader()).create(containerClassLoader, descriptor);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class DomainClassLoaderFactoryTestCase extends AbstractDomainTestCase
         String domainName = "descriptor-domain";
         DomainDescriptor descriptor = getTestDescriptor(domainName);
         createDomainDir(MULE_DOMAIN_FOLDER, domainName);
-        ArtifactClassLoader domainClassLoader = new DomainClassLoaderFactory(lookupPolicy).create(null, descriptor);
+        ArtifactClassLoader domainClassLoader = new DomainClassLoaderFactory(getClass().getClassLoader()).create(containerClassLoader, descriptor);
 
         assertThat(domainClassLoader.getClassLoader(), instanceOf(MuleSharedDomainClassLoader.class));
         assertThat(domainClassLoader.getArtifactName(), equalTo(domainName));

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/TestDomainFactory.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/domain/TestDomainFactory.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.launcher.domain;
 
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.launcher.descriptor.DomainDescriptor;
 
@@ -17,9 +18,9 @@ public class TestDomainFactory extends DefaultDomainFactory
     private boolean failOnStop;
     private boolean failOnDispose;
 
-    public TestDomainFactory(ArtifactClassLoaderFactory<DomainDescriptor> domainClassLoaderFactory)
+    public TestDomainFactory(ArtifactClassLoaderFactory<DomainDescriptor> domainClassLoaderFactory, ArtifactClassLoader containerClassLoader)
     {
-        super(domainClassLoaderFactory, new DefaultDomainManager());
+        super(domainClassLoaderFactory, new DefaultDomainManager(), containerClassLoader);
     }
 
     @Override


### PR DESCRIPTION
_ Defining a filtering classloader to control what is exported from the container to the domains/plugins/apps