### PR TITLE
MULE-9565: Return UnionType when static metadata is fetch on a type that declares SubTypes

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/metadata/OperationMetadataTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/metadata/OperationMetadataTestCase.java
@@ -44,8 +44,10 @@ import org.mule.runtime.core.internal.metadata.MuleMetadataManager;
 import org.mule.runtime.extension.api.introspection.metadata.NullMetadataKey;
 import org.mule.runtime.module.extension.internal.util.ExtensionsTestUtils;
 import org.mule.test.metadata.extension.LocationKey;
-import org.mule.test.metadata.extension.model.Circle;
-import org.mule.test.metadata.extension.model.Square;
+import org.mule.test.metadata.extension.model.animals.Bear;
+import org.mule.test.metadata.extension.model.shapes.Circle;
+import org.mule.test.metadata.extension.model.shapes.Rectangle;
+import org.mule.test.metadata.extension.model.shapes.Square;
 
 import java.io.IOException;
 import java.util.List;
@@ -429,7 +431,7 @@ public class OperationMetadataTestCase extends MetadataExtensionFunctionalTestCa
     }
 
     @Test
-    public void unionTypeMetadataWithSubtypes()
+    public void abstractClassWithSubtypesMetadataType()
     {
         componentId = new ProcessorId(TYPE_WITH_DECLARED_SUBTYPES_METADATA, FIRST_PROCESSOR_INDEX);
         MetadataResult<ComponentMetadataDescriptor> metadata = metadataManager.getMetadata(componentId);
@@ -441,6 +443,34 @@ public class OperationMetadataTestCase extends MetadataExtensionFunctionalTestCa
         MetadataType shapeType = shapeMetadata.getType();
         assertThat(shapeType, is(instanceOf(DefaultUnionType.class)));
         assertThat(((DefaultUnionType) shapeType).getTypes(), hasSize(2));
-        assertThat(((DefaultUnionType) shapeType).getTypes(), hasItems(toMetadataType(Circle.class), toMetadataType(Square.class)));
+        assertThat(((DefaultUnionType) shapeType).getTypes(), hasItems(toMetadataType(Circle.class), toMetadataType(Rectangle.class)));
+    }
+
+    @Test
+    public void instantiableClassWithSubtypesMetadataType()
+    {
+        componentId = new ProcessorId(TYPE_WITH_DECLARED_SUBTYPES_METADATA, FIRST_PROCESSOR_INDEX);
+        MetadataResult<ComponentMetadataDescriptor> metadata = metadataManager.getMetadata(componentId);
+        assertThat(metadata.isSuccess(), is(true));
+
+        TypeMetadataDescriptor rectangleMetadata = metadata.get().getParametersMetadata().get(1);
+        assertThat(rectangleMetadata.getName(), is("rectangle"));
+
+        MetadataType shapeType = rectangleMetadata.getType();
+        assertThat(shapeType, is(instanceOf(DefaultUnionType.class)));
+        assertThat(((DefaultUnionType) shapeType).getTypes(), hasSize(2));
+        assertThat(((DefaultUnionType) shapeType).getTypes(), hasItems(toMetadataType(Rectangle.class), toMetadataType(Square.class)));
+    }
+
+    @Test
+    public void interfaceWithSubtypesMetadataType()
+    {
+        componentId = new ProcessorId(TYPE_WITH_DECLARED_SUBTYPES_METADATA, FIRST_PROCESSOR_INDEX);
+        MetadataResult<ComponentMetadataDescriptor> metadata = metadataManager.getMetadata(componentId);
+        assertThat(metadata.isSuccess(), is(true));
+
+        TypeMetadataDescriptor animalMetadata = metadata.get().getParametersMetadata().get(2);
+        assertThat(animalMetadata.getName(), is("animal"));
+        assertThat(animalMetadata.getType(), is(toMetadataType(Bear.class)));
     }
 }

--- a/modules/extensions-spring-support/src/test/resources/metadata-tests.xml
+++ b/modules/extensions-spring-support/src/test/resources/metadata-tests.xml
@@ -125,6 +125,8 @@
     </flow>
 
     <flow name="typeWithDeclaredSubtypesMetadata">
-        <metadata:type-with-declared-subtypes-metadata config-ref="config" shape="#[new org.mule.test.metadata.extension.model.Circle()]" count="1"/>
+        <metadata:type-with-declared-subtypes-metadata config-ref="config" shape="#[new org.mule.test.metadata.extension.model.shapes.Circle()]"
+                                                       rectangle="#[new org.mule.test.metadata.extension.model.shapes.Rectangle()]"
+                                                       animal="#[new org.mule.test.metadata.extension.model.animals.Bear()"/>
     </flow>
 </mule>

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/metadata/MetadataMediator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/metadata/MetadataMediator.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.module.extension.internal.metadata;
 
 import static java.util.stream.Collectors.toList;
+import static org.mule.metadata.java.utils.JavaTypeUtils.getType;
 import static org.mule.runtime.api.metadata.descriptor.builder.MetadataDescriptorBuilder.typeDescriptor;
 import static org.mule.runtime.api.metadata.resolving.FailureCode.NO_DYNAMIC_TYPE_AVAILABLE;
 import static org.mule.runtime.api.metadata.resolving.MetadataResult.failure;
@@ -14,6 +15,7 @@ import static org.mule.runtime.api.metadata.resolving.MetadataResult.mergeResult
 import static org.mule.runtime.api.metadata.resolving.MetadataResult.success;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.getContentParameter;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.getMetadataKeyParts;
+import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.isInstantiable;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.isNullType;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.isVoid;
 import org.mule.metadata.api.builder.BaseTypeBuilder;
@@ -30,6 +32,7 @@ import org.mule.runtime.api.metadata.descriptor.OutputMetadataDescriptor;
 import org.mule.runtime.api.metadata.descriptor.TypeMetadataDescriptor;
 import org.mule.runtime.api.metadata.descriptor.builder.ComponentMetadataDescriptorBuilder;
 import org.mule.runtime.api.metadata.descriptor.builder.MetadataDescriptorBuilder;
+import org.mule.runtime.api.metadata.descriptor.builder.TypeMetadataDescriptorBuilder;
 import org.mule.runtime.api.metadata.resolving.MetadataContentResolver;
 import org.mule.runtime.api.metadata.resolving.MetadataKeysResolver;
 import org.mule.runtime.api.metadata.resolving.MetadataOutputResolver;
@@ -205,14 +208,28 @@ public class MetadataMediator
      */
     private TypeMetadataDescriptor buildParameterTypeMetadataDescriptor(ParameterModel parameterModel)
     {
-        List<MetadataType> subTypes = subTypesMappingContainer.getSubTypes(parameterModel.getType());
+        MetadataType parameterType = parameterModel.getType();
+        TypeMetadataDescriptorBuilder typeDescriptorBuilder = typeDescriptor(parameterModel.getName());
+
+        List<MetadataType> subTypes = subTypesMappingContainer.getSubTypes(parameterType);
         if (!subTypes.isEmpty())
         {
+            boolean isIntantiable = isInstantiable(getType(parameterType));
+            if (subTypes.size() == 1 && !isIntantiable)
+            {
+                return typeDescriptorBuilder.withType(subTypes.get(0)).build();
+            }
+
             UnionTypeBuilder<?> unionTypeBuilder = BaseTypeBuilder.create(MetadataFormat.JAVA).unionType();
+            if (isIntantiable)
+            {
+                unionTypeBuilder.of(parameterType);
+            }
             subTypes.forEach(unionTypeBuilder::of);
-            return typeDescriptor(parameterModel.getName()).withType(unionTypeBuilder.build()).build();
+            return typeDescriptorBuilder.withType(unionTypeBuilder.build()).build();
+
         }
-        return typeDescriptor(parameterModel.getName()).withType(parameterModel.getType()).build();
+        return typeDescriptorBuilder.withType(parameterType).build();
     }
 
     /**

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/metadata/MetadataMediator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/metadata/MetadataMediator.java
@@ -212,24 +212,24 @@ public class MetadataMediator
         TypeMetadataDescriptorBuilder typeDescriptorBuilder = typeDescriptor(parameterModel.getName());
 
         List<MetadataType> subTypes = subTypesMappingContainer.getSubTypes(parameterType);
-        if (!subTypes.isEmpty())
+        if (subTypes.isEmpty())
         {
-            boolean isIntantiable = isInstantiable(getType(parameterType));
-            if (subTypes.size() == 1 && !isIntantiable)
-            {
-                return typeDescriptorBuilder.withType(subTypes.get(0)).build();
-            }
-
-            UnionTypeBuilder<?> unionTypeBuilder = BaseTypeBuilder.create(MetadataFormat.JAVA).unionType();
-            if (isIntantiable)
-            {
-                unionTypeBuilder.of(parameterType);
-            }
-            subTypes.forEach(unionTypeBuilder::of);
-            return typeDescriptorBuilder.withType(unionTypeBuilder.build()).build();
-
+            return typeDescriptorBuilder.withType(parameterType).build();
         }
-        return typeDescriptorBuilder.withType(parameterType).build();
+
+        boolean isInstantiable = isInstantiable(getType(parameterType));
+        if (subTypes.size() == 1 && !isInstantiable)
+        {
+            return typeDescriptorBuilder.withType(subTypes.get(0)).build();
+        }
+
+        UnionTypeBuilder<?> unionTypeBuilder = BaseTypeBuilder.create(MetadataFormat.JAVA).unionType();
+        if (isInstantiable)
+        {
+            unionTypeBuilder.of(parameterType);
+        }
+        subTypes.forEach(unionTypeBuilder::of);
+        return typeDescriptorBuilder.withType(unionTypeBuilder.build()).build();
     }
 
     /**

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/MetadataExtension.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/MetadataExtension.java
@@ -13,16 +13,21 @@ import org.mule.runtime.extension.api.annotation.SubTypeMapping;
 import org.mule.runtime.extension.api.annotation.capability.Xml;
 import org.mule.runtime.extension.api.annotation.connector.Providers;
 import org.mule.runtime.extension.api.annotation.metadata.MetadataScope;
-import org.mule.test.metadata.extension.model.Circle;
-import org.mule.test.metadata.extension.model.Shape;
-import org.mule.test.metadata.extension.model.Square;
+import org.mule.test.metadata.extension.model.animals.Animal;
+import org.mule.test.metadata.extension.model.animals.Bear;
+import org.mule.test.metadata.extension.model.shapes.Circle;
+import org.mule.test.metadata.extension.model.shapes.Rectangle;
+import org.mule.test.metadata.extension.model.shapes.Shape;
+import org.mule.test.metadata.extension.model.shapes.Square;
 import org.mule.test.metadata.extension.resolver.TestContentAndOutputResolverWithKeyResolver;
 
 @Extension(name = "Metadata")
 @Operations({MetadataOperations.class, MetadataFailureOperations.class, MetadataInheritedExtensionResolversOperations.class, MetadataInheritedOperationResolversOperations.class})
 @Providers(MetadataConnectionProvider.class)
 @Sources({MetadataSource.class, MetadataSourceWithMultilevel.class})
-@SubTypeMapping(baseType = Shape.class, subTypes = {Circle.class, Square.class})
+@SubTypeMapping(baseType = Animal.class, subTypes = Bear.class)
+@SubTypeMapping(baseType = Shape.class, subTypes = {Circle.class, Rectangle.class})
+@SubTypeMapping(baseType = Rectangle.class, subTypes = {Square.class})
 @Xml(namespaceLocation = "http://www.mulesoft.org/schema/mule/metadata", namespace = "metadata")
 @MetadataScope(keysResolver = TestContentAndOutputResolverWithKeyResolver.class,
         contentResolver = TestContentAndOutputResolverWithKeyResolver.class,

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/MetadataOperations.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/MetadataOperations.java
@@ -11,7 +11,9 @@ import org.mule.runtime.extension.api.annotation.metadata.Content;
 import org.mule.runtime.extension.api.annotation.metadata.MetadataKeyId;
 import org.mule.runtime.extension.api.annotation.metadata.MetadataScope;
 import org.mule.runtime.extension.api.annotation.param.Connection;
-import org.mule.test.metadata.extension.model.Shape;
+import org.mule.test.metadata.extension.model.animals.Animal;
+import org.mule.test.metadata.extension.model.shapes.Rectangle;
+import org.mule.test.metadata.extension.model.shapes.Shape;
 import org.mule.test.metadata.extension.resolver.TestContentAndOutputResolverWithKeyResolver;
 import org.mule.test.metadata.extension.resolver.TestContentAndOutputResolverWithoutKeyResolver;
 import org.mule.test.metadata.extension.resolver.TestContentResolverWithKeyResolver;
@@ -126,8 +128,8 @@ public class MetadataOperations extends MetadataOperationsParent
         return null;
     }
 
-    public boolean typeWithDeclaredSubtypesMetadata(Shape shape, int count)
+    public boolean typeWithDeclaredSubtypesMetadata(Shape shape, Rectangle rectangle, Animal animal)
     {
-        return shape.getColor().length() > count;
+        return false;
     }
 }

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/animals/Animal.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/animals/Animal.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.metadata.extension.model.animals;
+
+public interface Animal
+{
+
+}

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/animals/Bear.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/animals/Bear.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.metadata.extension.model.animals;
+
+public class Bear implements Animal
+{
+    private String bearName;
+
+    public String getBearName()
+    {
+        return bearName;
+    }
+
+    public void setBearName(String bearName)
+    {
+        this.bearName = bearName;
+    }
+}

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Circle.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Circle.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.metadata.extension.model.shapes;
+
+public class Circle extends Shape
+{
+    private int diameter;
+
+    public int getDiameter()
+    {
+        return diameter;
+    }
+
+    public void setDiameter(int diameter)
+    {
+        this.diameter = diameter;
+    }
+}

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Rectangle.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Rectangle.java
@@ -4,9 +4,9 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.test.metadata.extension.model;
+package org.mule.test.metadata.extension.model.shapes;
 
-public class Square extends Shape
+public class Rectangle extends Shape
 {
     private int height;
     private int width;

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Shape.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Shape.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.test.metadata.extension.model;
+package org.mule.test.metadata.extension.model.shapes;
 
 public abstract class Shape
 {

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Square.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/model/shapes/Square.java
@@ -4,19 +4,8 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.test.metadata.extension.model;
+package org.mule.test.metadata.extension.model.shapes;
 
-public class Circle extends Shape
+public class Square extends Rectangle
 {
-    private int diameter;
-
-    public int getDiameter()
-    {
-        return diameter;
-    }
-
-    public void setDiameter(int diameter)
-    {
-        this.diameter = diameter;
-    }
 }


### PR DESCRIPTION
Added logic for more specific cases like Subtype(Interface, ConcreteClass) and Subtype(ConcreteClass, ChildConcreteClass) 