### PR TITLE
MULE-9689: Split Jar reactor from Distribution reactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
     <modules>
         <module>buildtools</module>
         <module>core</module>
-        <module>distributions</module>
         <module>modules</module>
         <module>patterns</module>
         <module>tools</module>
@@ -125,7 +124,6 @@
         <skipDistributions>true</skipDistributions>
         <skipVerifications>false</skipVerifications>
         <skipInstalls>false</skipInstalls>
-        <skipGpg>true</skipGpg>
 
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <coberturaVersion>2.5</coberturaVersion>
@@ -2149,20 +2147,26 @@
             </properties>
         </profile>
         <profile>
-            <id>release</id>
-            <activation>
-                <property>
-                    <name>buildDistributions</name>
-                    <value>true</value>
-                </property>
-            </activation>
+            <id>distributions</id>
             <properties>
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>false</skipDistributions>
-                <skipVerifications>true</skipVerifications>
+                <skipVerifications>false</skipVerifications>
+                <skipInstalls>false</skipInstalls>
+            </properties>
+            <modules>
+                <module>distributions</module>
+            </modules>
+        </profile>
+		<profile>
+            <id>release</id>
+            <properties>
+                <skipIntegrationTests>true</skipIntegrationTests>
+                <skipVerifications>false</skipVerifications>
                 <skipInstalls>false</skipInstalls>
                 <skipTests>true</skipTests>
                 <skipSystemTests>true</skipSystemTests>
+				<skipGpg>false</skipGpg>
             </properties>
             <build>
                 <defaultGoal>deploy</defaultGoal>


### PR DESCRIPTION
Removing distributions modules from default reactor.
* To build only jars use: mvn install
* To build jars + distributions use: mvn install -Pdistribution
* To build jars for release use: mvn install -Prelease
* To build jars + distribution for release use: mvn install -Prelease,distributions