### PR TITLE
MULE-9689: Split Jar reactor from Distribution reactor

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -29,7 +29,11 @@ The following table lists common goals to execute for building Mule. These goals
 |Command | Description |
 |:----------|:-------------|
 | `mvn clean`	 | purges any built artifacts or intermediate files (such as .class) from the target directory |
-| `mvn install` | installs the artifact to your local repository, will run all tests but the ones that have external dependencies. |
+| `mvn install` | installs all modules but the distributions to your local repository, will run all tests but the ones that have external dependencies. |
+| `mvn install -Pdistributions` | installs all modules and distributions to your local repository. |
+| `mvn install -Prelease` | same as `mvn install` including sources, tests, javadocs and GPG signatures. |
+| `mvn install -Prelease -DskipGpg=true` | same as `mvn install -Prelease` without GPG signatures. |
+| `mvn install -Pdistributions,release` | installs all jars, distributions including sources, tests, javadocs and GPG signatures. |
 | `mvn test`    | runs any unit tests for this sub-project |
 | `mvn -DskipTests install` |	By default, Maven runs all unit tests for each project for each build which, depending on the project, can take a long time to complete. If you wish, you can skip the tests using this command.|
  

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
     <modules>
         <module>buildtools</module>
         <module>core</module>
-        <module>distributions</module>
         <module>modules</module>
         <module>patterns</module>
         <module>tools</module>
@@ -125,7 +124,6 @@
         <skipDistributions>true</skipDistributions>
         <skipVerifications>false</skipVerifications>
         <skipInstalls>false</skipInstalls>
-        <skipGpg>true</skipGpg>
 
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <coberturaVersion>2.5</coberturaVersion>
@@ -2149,20 +2147,26 @@
             </properties>
         </profile>
         <profile>
-            <id>release</id>
-            <activation>
-                <property>
-                    <name>buildDistributions</name>
-                    <value>true</value>
-                </property>
-            </activation>
+            <id>distributions</id>
             <properties>
                 <skipIntegrationTests>true</skipIntegrationTests>
                 <skipDistributions>false</skipDistributions>
-                <skipVerifications>true</skipVerifications>
+                <skipVerifications>false</skipVerifications>
+                <skipInstalls>false</skipInstalls>
+            </properties>
+            <modules>
+                <module>distributions</module>
+            </modules>
+        </profile>
+		<profile>
+            <id>release</id>
+            <properties>
+                <skipIntegrationTests>true</skipIntegrationTests>
+                <skipVerifications>false</skipVerifications>
                 <skipInstalls>false</skipInstalls>
                 <skipTests>true</skipTests>
                 <skipSystemTests>true</skipSystemTests>
+                <skipGpg>false</skipGpg>
             </properties>
             <build>
                 <defaultGoal>deploy</defaultGoal>


### PR DESCRIPTION
Removing distributions modules from default reactor.
* To build only jars use: mvn install
* To build jars + distributions use: mvn install -Pdistribution
* To build jars for release use: mvn install -Prelease
* To build jars + distribution for release use: mvn install -Prelease,distributions