### PR TITLE
MULE-9630: Reintroduce HTTP transport

### DIFF
--- a/tests/integration-tranports/src/test/resources/META-INF/mule-module.properties
+++ b/tests/integration-tranports/src/test/resources/META-INF/mule-module.properties
@@ -4,5 +4,6 @@ artifact.export.classPackages=org.mule.test.integration,\
                               org.mule.test.integration.transaction.xa,\
                               org.mule.test.integration.exceptions,\
                               org.mule.test.tck,\
+                              org.mule.test.integration.transformer.response,\
                               org.mule.test.integration.transport,\
                               org.mule.test.integration.transport.file

--- a/tests/integration/src/test/resources/META-INF/mule-module.properties
+++ b/tests/integration/src/test/resources/META-INF/mule-module.properties
@@ -19,6 +19,7 @@ artifact.export.classPackages=org.mule.issues,\
                               org.mule.test.integration.exceptions,\
                               org.mule.test.integration.el,\
                               org.mule.test.integration.client,\
+                              org.mule.test.issues,\
                               org.mule.test.construct,\
                               org.mule.test.config,\
                               org.mule.test.components,\

--- a/transports/http/src/main/resources/META-INF/mule-module.properties
+++ b/transports/http/src/main/resources/META-INF/mule-module.properties
@@ -1,0 +1,18 @@
+module.name=http-transport
+
+artifact.export.classPackages=org.mule.runtime.transport.http,\
+                              org.mule.runtime.transport.http.builder,\
+                              org.mule.runtime.transport.http.components,\
+                              org.mule.runtime.transport.http.config,\
+                              org.mule.runtime.transport.http.construct.support,\
+                              org.mule.runtime.transport.http.filters,\
+                              org.mule.runtime.transport.http.i18n,\
+                              org.mule.runtime.transport.http.multipart,\
+                              org.mule.runtime.transport.http.ntlm,\
+                              org.mule.runtime.transport.http.servlet,\
+                              org.mule.runtime.transport.http.transformers
+
+artifact.export.resourcePackages=/META-INF,\
+                                 /META-INF/services/org/mule/runtime/core/config,\
+                                 /META-INF/services/org/mule/runtime/core/i18n,\
+                                 /META-INF/services/org/mule/runtime/transport

--- a/transports/http/src/test/resources/META-INF/mule-module.properties
+++ b/transports/http/src/test/resources/META-INF/mule-module.properties
@@ -1,0 +1,5 @@
+module.name=http-transport-test
+
+artifact.export.classPackages=org.mule.runtime.transport.http.functional,\
+                              org.mule.runtime.transport.http.issues,\
+                              org.mule.runtime.transport.http.reliability


### PR DESCRIPTION
- Add missing mule-module.properties