### PR TITLE
MULE-9753: Classloading model prone to linkage errors

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/util/PropertiesUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/util/PropertiesUtils.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.core.util;
 
+import static org.mule.runtime.core.util.ClassUtils.getResources;
+import static org.mule.runtime.core.util.Preconditions.checkArgument;
 import org.mule.runtime.core.api.MuleRuntimeException;
 import org.mule.runtime.core.config.i18n.CoreMessages;
 import org.mule.runtime.core.config.i18n.Message;
@@ -341,7 +343,7 @@ public final class PropertiesUtils
     }
 
     /**
-     * Discovers properties files available on the execution context
+     * Discovers properties files available on the classloader that loaded {@link PropertiesUtils} class
      *
      * @param resource resource to find. Not empty
      * @return a non null list of Properties
@@ -349,9 +351,25 @@ public final class PropertiesUtils
      */
     public static List<Properties> discoverProperties(String resource) throws IOException
     {
+        return discoverProperties(PropertiesUtils.class.getClassLoader(), resource);
+    }
+
+    /**
+     * Discovers properties files available on the given classloader.
+     *
+     * @param classLoader classloader used to find properties resources. Not null.
+     * @param resource resource to find. Not empty
+     * @return a non null list of Properties
+     * @throws IOException when a property file cannot be processed
+     */
+    public static List<Properties> discoverProperties(ClassLoader classLoader, String resource) throws IOException
+    {
+        checkArgument(!StringUtils.isEmpty(resource), "Resource cannot be empty");
+        checkArgument(classLoader != null, "ClassLoader cannot be null");
+
         List<Properties> result = new LinkedList<Properties>();
 
-        Enumeration<URL> allPropertiesResources = ClassUtils.getResources(resource, PropertiesUtils.class);
+        Enumeration<URL> allPropertiesResources = getResources(resource, classLoader);
         while (allPropertiesResources.hasMoreElements())
         {
             URL propertiesResource = allPropertiesResources.nextElement();

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/MuleClassLoaderLookupPolicy.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/MuleClassLoaderLookupPolicy.java
@@ -56,15 +56,21 @@ public class MuleClassLoaderLookupPolicy implements ClassLoaderLookupPolicy
 
         for (String packageName : lookupStrategies.keySet())
         {
-            ClassLoaderLookupStrategy lookupStrategy = lookupStrategies.get(packageName);
+            result.put(normalizePackageName(packageName), lookupStrategies.get(packageName));
+        }
+
+        return result;
+    }
+
+    private void validateLookupPolicies(Map<String, ClassLoaderLookupStrategy> lookupStrategies)
+    {
+        for (String packageName : lookupStrategies.keySet())
+        {
             if (isSystemPackage(packageName))
             {
                 throw new IllegalArgumentException("Attempt to override lookup strategy for system package: " + packageName);
             }
-            result.put(normalizePackageName(packageName), lookupStrategy);
         }
-
-        return result;
     }
 
     private String normalizePackageName(String packageName)
@@ -124,6 +130,7 @@ public class MuleClassLoaderLookupPolicy implements ClassLoaderLookupPolicy
     @Override
     public ClassLoaderLookupPolicy extend(Map<String, ClassLoaderLookupStrategy> lookupStrategies)
     {
+        validateLookupPolicies(lookupStrategies);
         final HashMap<String, ClassLoaderLookupStrategy> newLookupStraetgies = new HashMap<>(this.configuredlookupStrategies);
 
         for (String packageName : lookupStrategies.keySet())
@@ -134,7 +141,9 @@ public class MuleClassLoaderLookupPolicy implements ClassLoaderLookupPolicy
             }
         }
 
-        return new MuleClassLoaderLookupPolicy(newLookupStraetgies, rootSystemPackages);
+        final MuleClassLoaderLookupPolicy muleClassLoaderLookupPolicy = new MuleClassLoaderLookupPolicy(newLookupStraetgies, rootSystemPackages);
+
+        return muleClassLoaderLookupPolicy;
     }
 
     private boolean isSystemPackage(String packageName)

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/MuleClassLoaderLookupPolicyTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/MuleClassLoaderLookupPolicyTestCase.java
@@ -28,9 +28,9 @@ public class MuleClassLoaderLookupPolicyTestCase extends AbstractMuleTestCase
 {
 
     @Test(expected = IllegalArgumentException.class)
-    public void forbidsCustomLookupStrategyForSystemPackage() throws Exception
+    public void extendingCustomLookupStrategyForSystemPackage() throws Exception
     {
-        new MuleClassLoaderLookupPolicy(Collections.singletonMap(Object.class.getName(), CHILD_FIRST), singleton("java"));
+        new MuleClassLoaderLookupPolicy(Collections.emptyMap(), singleton("java")).extend(Collections.singletonMap(Object.class.getName(), CHILD_FIRST));
     }
 
     @Test

--- a/modules/container/src/main/java/org/mule/runtime/container/internal/ClasspathModuleDiscoverer.java
+++ b/modules/container/src/main/java/org/mule/runtime/container/internal/ClasspathModuleDiscoverer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.container.internal;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.core.util.PropertiesUtils.discoverProperties;
+import static org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilter.EXPORTED_CLASS_PACKAGES_PROPERTY;
+import static org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilter.EXPORTED_RESOURCE_PACKAGES_PROPERTY;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Discovers {@link MuleModule} searching for {@link #MODULE_PROPERTIES} files
+ * resources available in a given classloader.
+ */
+public class ClasspathModuleDiscoverer implements ModuleDiscoverer
+{
+    public static final String MODULE_PROPERTIES = "META-INF/mule-module.properties";
+    private final ClassLoader classLoader;
+
+    public ClasspathModuleDiscoverer(ClassLoader classLoader)
+    {
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public List<MuleModule> discover()
+    {
+        List<MuleModule> modules = new LinkedList<>();
+        Set<String> moduleNames = new HashSet<>();
+
+        try
+        {
+            for (Properties moduleProperties : discoverProperties(classLoader, MODULE_PROPERTIES))
+            {
+                final MuleModule module = createModule(moduleProperties);
+
+                if (moduleNames.contains(module.getName()))
+                {
+                    throw new IllegalStateException(String.format("Module '%s' was already defined", module.getName()));
+                }
+                moduleNames.add(module.getName());
+                modules.add(module);
+            }
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Cannot discover mule modules", e);
+        }
+
+        return modules;
+    }
+
+    private MuleModule createModule(Properties moduleProperties)
+    {
+        final String moduleName = (String) moduleProperties.get("module.name");
+        if (isEmpty(moduleName))
+        {
+            throw new IllegalStateException("Mule-module.properties must contain module.name property");
+        }
+
+        Set<String> modulePackages = new HashSet<>();
+        Set<String> modulePaths = new HashSet<>();
+
+        final String exportedPackagesProperty = (String) moduleProperties.get(EXPORTED_CLASS_PACKAGES_PROPERTY);
+        if (!isEmpty(exportedPackagesProperty))
+        {
+            for (String packageName : exportedPackagesProperty.split(","))
+            {
+                packageName = packageName.trim();
+                if (!isEmpty(packageName))
+                {
+                    modulePackages.add(packageName);
+                }
+            }
+        }
+
+        final String exportedResourcesProperty = (String) moduleProperties.get(EXPORTED_RESOURCE_PACKAGES_PROPERTY);
+        if (!isEmpty(exportedResourcesProperty))
+        {
+            for (String path : exportedResourcesProperty.split(","))
+            {
+                if (!isEmpty(path.trim()))
+                {
+                    if (path.startsWith("/"))
+                    {
+                        path = path.substring(1);
+                    }
+                    modulePaths.add(path);
+                }
+            }
+        }
+
+        return new MuleModule(moduleName, modulePackages, modulePaths);
+    }
+
+}

--- a/modules/container/src/main/java/org/mule/runtime/container/internal/ModuleDiscoverer.java
+++ b/modules/container/src/main/java/org/mule/runtime/container/internal/ModuleDiscoverer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.container.internal;
+
+import java.util.List;
+
+/**
+ * Discovers available mule modules.
+ */
+public interface ModuleDiscoverer
+{
+
+    /**
+     * Discovers available mule modules.
+     *
+     * @return a non null {@linl List} containing all {@link MuleModule} found in the container.
+     */
+    List<MuleModule> discover();
+}

--- a/modules/container/src/main/java/org/mule/runtime/container/internal/MuleModule.java
+++ b/modules/container/src/main/java/org/mule/runtime/container/internal/MuleModule.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.container.internal;
+
+import static java.util.Collections.unmodifiableSet;
+import static org.mule.runtime.core.util.Preconditions.checkArgument;
+
+import org.mule.runtime.core.util.StringUtils;
+
+import java.util.Set;
+
+/**
+ * Provides module definition information
+ */
+public class MuleModule
+{
+    private final String name;
+    private final Set<String> exportedPackages;
+    private final Set<String> exportedPaths;
+
+
+    /**
+     * Creates a new module
+     *
+     * @param name module name. Not empty.
+     * @param exportedPackages java packages exported by this module. Not null.
+     * @param exportedPaths java resources exported by this module. Not null;
+     */
+    public MuleModule(String name, Set<String> exportedPackages, Set<String> exportedPaths)
+    {
+        checkArgument(!StringUtils.isEmpty(name), "Name cannot be empty");
+        checkArgument(exportedPackages != null, "ExportedPackages cannot be null");
+        checkArgument(exportedPaths != null, "ExportedPaths cannot be null");
+        this.name = name;
+        this.exportedPackages = unmodifiableSet(exportedPackages);
+        this.exportedPaths = unmodifiableSet(exportedPaths);
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Set<String> getExportedPackages()
+    {
+        return exportedPackages;
+    }
+
+    public Set<String> getExportedPaths()
+    {
+        return exportedPaths;
+    }
+}

--- a/modules/container/src/test/java/org/mule/runtime/container/internal/ContainerClassLoaderFactoryTestCase.java
+++ b/modules/container/src/test/java/org/mule/runtime/container/internal/ContainerClassLoaderFactoryTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.container.internal;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy.CHILD_FIRST;
+import static org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy.PARENT_ONLY;
+
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class ContainerClassLoaderFactoryTestCase
+{
+
+    @Test
+    public void createsClassLoaderLookupPolicy() throws Exception
+    {
+        final ContainerClassLoaderFactory factory = new ContainerClassLoaderFactory();
+        final ModuleDiscoverer moduleDiscoverer = mock(ModuleDiscoverer.class);
+        final List<MuleModule> modules = new ArrayList<>();
+        modules.add(new TestModuleBuilder("module1").exportingPackages("org.foo1", "org.foo1.bar").build());
+        modules.add(new TestModuleBuilder("module2").exportingPackages("org.foo2").build());
+        when(moduleDiscoverer.discover()).thenReturn(modules);
+        factory.setModuleDiscoverer(moduleDiscoverer);
+
+        final ArtifactClassLoader containerClassLoader = factory.createContainerClassLoader(this.getClass().getClassLoader());
+
+        final ClassLoaderLookupPolicy classLoaderLookupPolicy = containerClassLoader.getClassLoaderLookupPolicy();
+        assertThat(classLoaderLookupPolicy.getLookupStrategy("org.foo1.Foo"), is(PARENT_ONLY));
+        assertThat(classLoaderLookupPolicy.getLookupStrategy("org.foo1.bar.Bar"), is(PARENT_ONLY));
+        assertThat(classLoaderLookupPolicy.getLookupStrategy("org.foo2.Fo"), is(PARENT_ONLY));
+        assertThat(classLoaderLookupPolicy.getLookupStrategy("org.foo2.bar.Bar"), is(CHILD_FIRST));
+    }
+}

--- a/modules/container/src/test/java/org/mule/runtime/container/internal/ContainerClassLoaderFilterFactoryTestCase.java
+++ b/modules/container/src/test/java/org/mule/runtime/container/internal/ContainerClassLoaderFilterFactoryTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.container.internal;
+
+import static java.util.Collections.singleton;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderFilter;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class ContainerClassLoaderFilterFactoryTestCase extends AbstractMuleTestCase
+{
+
+    private ContainerClassLoaderFilterFactory factory = new ContainerClassLoaderFilterFactory();
+
+
+    @Test
+    public void acceptsExportedModulePackages() throws Exception
+    {
+        final List<MuleModule> muleModules = new ArrayList<>();
+        muleModules.add(new TestModuleBuilder("module1").exportingPackages("org.foo1", "org.foo1.bar").exportingPaths("META-INF", "META-INF/docs1").build());
+        muleModules.add(new TestModuleBuilder("module2").exportingPackages("org.foo2").exportingPaths("META-INF", "META-INF/docs2").build());
+
+        final ClassLoaderFilter classLoaderFilter = factory.create(Collections.emptySet(), muleModules);
+
+        assertThat(classLoaderFilter.exportsClass("org.foo1.Foo"), is(true));
+        assertThat(classLoaderFilter.exportsClass("org.foo1.bar.Bar"), is(true));
+        assertThat(classLoaderFilter.exportsClass("org.foo2.Foo"), is(true));
+        assertThat(classLoaderFilter.exportsClass("org.bar.Bar"), is(false));
+        assertThat(classLoaderFilter.exportsClass("org.foo2.bar.Bar"), is(false));
+        assertThat(classLoaderFilter.exportsResource("META-INF/foo.txt"), is(true));
+        assertThat(classLoaderFilter.exportsResource("META-INF/docs1/foo.txt"), is(true));
+        assertThat(classLoaderFilter.exportsResource("META-INF/docs2/foo.txt"), is(true));
+        assertThat(classLoaderFilter.exportsResource("/foo.txt"), is(false));
+    }
+
+
+    @Test
+    public void acceptsExportedSystemPackages() throws Exception
+    {
+        final List<MuleModule> muleModules = new ArrayList<>();
+        final Set<String> bootPackages = singleton("org.foo1");
+
+        final ClassLoaderFilter classLoaderFilter = factory.create(bootPackages, muleModules);
+
+        assertThat(classLoaderFilter.exportsClass("org.foo1.Foo"), is(true));
+        assertThat(classLoaderFilter.exportsClass("org.foo1.bar.Bar"), is(true));
+        assertThat(classLoaderFilter.exportsClass("org.bar.Bar"), is(false));
+    }
+
+}

--- a/modules/container/src/test/java/org/mule/runtime/container/internal/TestModuleBuilder.java
+++ b/modules/container/src/test/java/org/mule/runtime/container/internal/TestModuleBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.container.internal;
+
+import static org.mule.runtime.core.util.Preconditions.checkArgument;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Builds instances of {@link MuleModule}.
+ * <p/>
+ * Builder instances are not reusable. Creaet a new one every time a module must be created.
+ */
+public class TestModuleBuilder
+{
+
+    private final String name;
+    private Set<String> packages = new HashSet<>();
+    private Set<String> paths = new HashSet<>();
+
+    /**
+     * Creates a new builder
+     *
+     * @param name name for the module. Not empty
+     */
+    public TestModuleBuilder(String name)
+    {
+        checkArgument(!StringUtils.isEmpty(name), "Name cannot be empty");
+        this.name = name;
+    }
+
+    /**
+     * Adds new java packages to be exported
+     *
+     * @param packages packages to export
+     * @return {@code this}
+     */
+    public TestModuleBuilder exportingPackages(String... packages)
+    {
+        for (String packageName : packages)
+        {
+            this.packages.add(packageName);
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds new resource paths to be exported
+     *
+     * @param paths paths to export
+     * @return {@code this}
+     */
+    public TestModuleBuilder exportingPaths(String... paths)
+    {
+        for (String path : paths)
+        {
+            this.paths.add(path);
+        }
+
+        return this;
+    }
+
+    /**
+     * Creates a module with the configured state
+     *
+     * @return a new {@link MuleModule} with the configured state.
+     */
+    public MuleModule build()
+    {
+        return new MuleModule(name, packages, paths);
+    }
+}

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/MuleContainer.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/MuleContainer.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.launcher;
 
-import org.mule.runtime.container.ContainerClassLoaderFactory;
+import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
 import org.mule.runtime.core.api.DefaultMuleException;
 import org.mule.runtime.core.api.MuleException;
 import org.mule.runtime.core.api.MuleRuntimeException;

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/DeploymentServiceTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/DeploymentServiceTestCase.java
@@ -43,7 +43,7 @@ import static org.mule.runtime.module.launcher.MuleFoldersUtil.getDomainFolder;
 import static org.mule.runtime.module.launcher.descriptor.PropertiesDescriptorParser.PROPERTY_DOMAIN;
 import static org.mule.runtime.module.launcher.domain.Domain.DEFAULT_DOMAIN_NAME;
 import static org.mule.runtime.module.launcher.domain.Domain.DOMAIN_CONFIG_FILE_LOCATION;
-import org.mule.runtime.container.ContainerClassLoaderFactory;
+import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
 import org.mule.runtime.core.DefaultMuleEvent;
 import org.mule.runtime.core.DefaultMuleMessage;
 import org.mule.runtime.core.MessageExchangePattern;

--- a/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.fail;
 import org.mule.functional.functional.FlowAssert;
 import org.mule.functional.functional.FunctionalTestComponent;
 import org.mule.runtime.config.spring.SpringXmlConfigurationBuilder;
-import org.mule.runtime.container.ContainerClassLoaderFactory;
+import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
 import org.mule.runtime.core.api.MuleEvent;
 import org.mule.runtime.core.api.MuleException;
 import org.mule.runtime.core.api.component.Component;

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/deployment/FakeMuleServer.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/deployment/FakeMuleServer.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import org.mule.runtime.container.ContainerClassLoaderFactory;
+import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
 import org.mule.runtime.container.api.MuleCoreExtension;
 import org.mule.runtime.core.api.DefaultMuleException;
 import org.mule.runtime.core.api.MuleException;


### PR DESCRIPTION
There are two problems:
1) Modules are not declaring properly exporting every API package (no transitive dependencies)
2) Container classloader is not using the exported packages to build the proper classLoaderLookupPolicy

This PR fixes the second problem. The pending one will be managed on a different issue