### PR TITLE
MULE-9963 - Validate that complex types are provided on a exclusive w…

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/processor/InterceptingMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/api/processor/InterceptingMessageProcessor.java
@@ -20,6 +20,13 @@ import org.mule.runtime.core.api.source.MessageSource;
  * 
  * @since 3.0
  */
-public interface InterceptingMessageProcessor extends MessageProcessor, MessageSource
+public interface InterceptingMessageProcessor extends MessageProcessor
 {
+
+    /**
+     * Set the MessageProcessor listener that will be invoked
+     * when a message is received or generated.
+     */
+    void setListener(MessageProcessor listener);
+
 }


### PR DESCRIPTION
…ay - InterceptingMessageProcessor was implementing MessageSource just for the method in the interface but it was not a message source. That causes a miss behaviour in the new DSL processing and InterceptingMessageProcessors where injected in the MessageSource instead of as a MessageProcessor