### PR TITLE
MULE-9702 - Migrate HTTP tests to use extension - the current empty h…

### DIFF
--- a/tests/http/src/test/resources/http-listener-response-builder-config.xml
+++ b/tests/http/src/test/resources/http-listener-response-builder-config.xml
@@ -14,7 +14,9 @@
 
     <flow name="emptyResponseBuilderFlow">
         <httpn:listener config-ref="listenerConfig" path="${emptyResponseBuilderPath}">
-            <httpn:response-builder/>
+            <httpn:response-builder>
+                <httpn:simple-response-builder/>
+            </httpn:response-builder>
         </httpn:listener>
         <echo-component/>
     </flow>
@@ -85,7 +87,9 @@
 
     <flow name="errorEmptyResponseBuilderFlow">
         <httpn:listener config-ref="listenerConfig" path="${errorEmptyResponseBuilderPath}">
-            <httpn:error-response-builder/>
+            <httpn:error-response-builder>
+                <httpn:simple-response-builder/>
+            </httpn:error-response-builder>
         </httpn:listener>
         <test:component throwException="true"/>
     </flow>


### PR DESCRIPTION
…ttp:response-builder is not accurate. The way it is defined in the test case should not be valid. The wrapper element cannot be empty, there is an issue with how ext api generates the xsd schema