### PR TITLE
MULE-9776: Fix the http-ext to include it as a zip in the distribution

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -166,7 +166,7 @@
 /mule-standalone-${productVersion}/app-plugins/mule-module-ftp-${productVersion}.zip
 /mule-standalone-${productVersion}/app-plugins/mule-module-sockets-${productVersion}.zip
 /mule-standalone-${productVersion}/app-plugins/mule-module-validation-${productVersion}.zip
-/mule-standalone-${productVersion}/app-plugins/mule-module-http-ext-4.0-SNAPSHOT.zip
+/mule-standalone-${productVersion}/app-plugins/mule-module-http-ext-${productVersion}.zip
 
 #
 # /lib/opt


### PR DESCRIPTION
Fix version of the http extension line in the assembly-whitelist.txt