### PR TITLE
MULE-9958: Make DataType getters return Objects instead of Strings

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/transformer/datatype/DataTypeTransformersTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/transformer/datatype/DataTypeTransformersTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.transformer.datatype;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.mule.runtime.api.metadata.MediaType;
+import org.mule.runtime.core.api.transformer.TransformerException;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.nio.charset.UnsupportedCharsetException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@SmallTest
+public class DataTypeTransformersTestCase extends AbstractMuleTestCase
+{
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @Test
+    public void validCharset() throws TransformerException
+    {
+        final StringToCharsetTransformer transformer = new StringToCharsetTransformer();
+
+        assertThat(transformer.transform(US_ASCII.name()), is(US_ASCII));
+    }
+
+    @Test
+    public void invalidCharset() throws TransformerException
+    {
+        final StringToCharsetTransformer transformer = new StringToCharsetTransformer();
+
+        expected.expect(TransformerException.class);
+        expected.expectCause(instanceOf(UnsupportedCharsetException.class));
+        transformer.transform("invalid");
+    }
+
+    @Test
+    public void validMediaType() throws TransformerException
+    {
+        final StringToMediaTypeTransformer transformer = new StringToMediaTypeTransformer();
+
+        final MediaType transformed = (MediaType) transformer.transform("text/plain");
+        assertThat(transformed.getPrimaryType(), is("text"));
+        assertThat(transformed.getSubType(), is("plain"));
+        assertThat(transformed.getCharset().isPresent(), is(false));
+    }
+
+    @Test
+    public void validMediaTypeWithCharset() throws TransformerException
+    {
+        final StringToMediaTypeTransformer transformer = new StringToMediaTypeTransformer();
+
+        final MediaType transformed = (MediaType) transformer.transform("text/plain;charset=" + US_ASCII.name());
+        assertThat(transformed.getPrimaryType(), is("text"));
+        assertThat(transformed.getSubType(), is("plain"));
+        assertThat(transformed.getCharset().get(), is(US_ASCII));
+    }
+
+    @Test
+    public void invalidMediaType() throws TransformerException
+    {
+        final StringToMediaTypeTransformer transformer = new StringToMediaTypeTransformer();
+
+        expected.expect(TransformerException.class);
+        expected.expectCause(instanceOf(IllegalArgumentException.class));
+        transformer.transform("invalid");
+    }
+}

--- a/core/src/main/java/org/mule/runtime/core/transformer/datatype/StringToCharsetTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/transformer/datatype/StringToCharsetTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.transformer.datatype;
+
+import static org.mule.runtime.core.config.i18n.MessageFactory.createStaticMessage;
+
+import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.api.metadata.DataTypeBuilder;
+import org.mule.runtime.core.api.transformer.TransformerException;
+import org.mule.runtime.core.transformer.AbstractTransformer;
+
+import java.nio.charset.Charset;
+
+/**
+ * Converts strings to {@link Charset} instances. See {@link DataTypeBuilder#charset(String)}
+ */
+public class StringToCharsetTransformer extends AbstractTransformer
+{
+
+    public StringToCharsetTransformer()
+    {
+        this.registerSourceType(DataType.STRING);
+        this.setReturnDataType(DataType.builder().type(Charset.class).build());
+    }
+
+    @Override
+    protected Object doTransform(Object src, Charset enc) throws TransformerException
+    {
+        try
+        {
+            return DataType.builder().charset((String) src).build().getMediaType().getCharset().get();
+        }
+        catch (Exception e)
+        {
+            throw new TransformerException(createStaticMessage("Exception transforming to Charset."), e);
+        }
+    }
+
+}

--- a/core/src/main/java/org/mule/runtime/core/transformer/datatype/StringToMediaTypeTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/transformer/datatype/StringToMediaTypeTransformer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.transformer.datatype;
+
+import static org.mule.runtime.core.config.i18n.MessageFactory.createStaticMessage;
+
+import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.api.metadata.DataTypeBuilder;
+import org.mule.runtime.api.metadata.MediaType;
+import org.mule.runtime.core.api.transformer.TransformerException;
+import org.mule.runtime.core.transformer.AbstractTransformer;
+
+import java.nio.charset.Charset;
+
+/**
+ * Converts strings to {@link MediaType} instances. See {@link DataTypeBuilder#mediaType(String)}
+ */
+public class StringToMediaTypeTransformer extends AbstractTransformer
+{
+
+    public StringToMediaTypeTransformer()
+    {
+        this.registerSourceType(DataType.STRING);
+        this.setReturnDataType(DataType.builder().type(MediaType.class).build());
+    }
+
+    @Override
+    protected Object doTransform(Object src, Charset enc) throws TransformerException
+    {
+        try
+        {
+            return DataType.builder().mediaType((String) src).build().getMediaType();
+        }
+        catch (Exception e)
+        {
+            throw new TransformerException(createStaticMessage("Exception transforming to MediaType."), e);
+        }
+    }
+
+}

--- a/core/src/main/resources/META-INF/services/org/mule/runtime/core/config/registry-bootstrap.properties
+++ b/core/src/main/resources/META-INF/services/org/mule/runtime/core/config/registry-bootstrap.properties
@@ -21,3 +21,5 @@ core.transformer.16=org.mule.runtime.core.transformer.simple.NumberToString,name
 core.transformer.17=org.mule.runtime.core.transformer.simple.StringToBoolean,name=StringToBoolean
 core.transformer.18=org.mule.runtime.core.transformer.simple.DataHandlerToInputStreamTransformer
 
+core.transformer.19=org.mule.runtime.core.transformer.datatype.StringToCharsetTransformer
+core.transformer.20=org.mule.runtime.core.transformer.datatype.StringToMediaTypeTransformer


### PR DESCRIPTION
* add support for extensions to receive MeidaType and Charset as
parameters