### PR TITLE
MULE-9958: Make DataType getters return Objects instead of Strings

### DIFF
--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/AbstractXStreamTransformer.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/AbstractXStreamTransformer.java
@@ -10,15 +10,17 @@ import org.mule.runtime.core.api.lifecycle.InitialisationException;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.config.i18n.MessageFactory;
 import org.mule.runtime.core.transformer.AbstractMessageTransformer;
-
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.converters.Converter;
+import org.mule.runtime.module.xml.transformer.datatype.CollectionDataTypeXStreamConverter;
+import org.mule.runtime.module.xml.transformer.datatype.SimpleDataTypeXStreamConverter;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
 
 /**
  * <code>AbstractXStreamTransformer</code> is a base class for all XStream based
@@ -27,10 +29,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class AbstractXStreamTransformer extends AbstractMessageTransformer
 {
-    private final AtomicReference<XStream> xstream = new AtomicReference<XStream>();
+    private final AtomicReference<XStream> xstream = new AtomicReference<>();
     private volatile String driverClass = XStreamFactory.XSTREAM_XPP_DRIVER;
-    private volatile Map<String, Class<?>> aliases = new HashMap<String, Class<?>>();
-    private volatile Set<Class <? extends Converter>> converters = new HashSet<Class <? extends Converter>>();
+    private volatile Map<String, Class<?>> aliases = new HashMap<>();
+    private volatile Set<Class <? extends Converter>> converters = new HashSet<>();
 
     @Override
     public void initialise() throws InitialisationException
@@ -38,6 +40,9 @@ public abstract class AbstractXStreamTransformer extends AbstractMessageTransfor
         super.initialise();
         try
         {
+            addConverter(SimpleDataTypeXStreamConverter.class);
+            addConverter(CollectionDataTypeXStreamConverter.class);
+
             // Create XStream instance as part of initialization so that we can set
             // the context classloader that will be required to load classes.
             XStream xStreamInstance = getXStream();
@@ -80,12 +85,12 @@ public abstract class AbstractXStreamTransformer extends AbstractMessageTransfor
 
         if (aliases != null)
         {
-            clone.setAliases(new HashMap<String, Class<?>>(aliases));
+            clone.setAliases(new HashMap<>(aliases));
         }
 
         if (converters != null)
         {
-            clone.setConverters(new HashSet<Class <? extends Converter>>(converters));
+            clone.setConverters(new HashSet<>(converters));
         }
 
         return clone;

--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/datatype/CollectionDataTypeXStreamConverter.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/datatype/CollectionDataTypeXStreamConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.xml.transformer.datatype;
+
+import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.core.api.MuleRuntimeException;
+import org.mule.runtime.core.metadata.CollectionDataType;
+import org.mule.runtime.core.util.ClassUtils;
+
+import java.util.Collection;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * A serializer to handle instances of {@link CollectionDataType}.
+ *
+ * @since 4.0
+ */
+
+public class CollectionDataTypeXStreamConverter implements Converter
+{
+
+    @Override
+    public boolean canConvert(Class type)
+    {
+        return CollectionDataType.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context)
+    {
+        final CollectionDataType dataType = (CollectionDataType) source;
+        writer.addAttribute("type", dataType.getType().getName());
+        writer.addAttribute("mediaType", dataType.getMediaType().toString());
+        writer.addAttribute("itemType", dataType.getType().getName());
+        writer.addAttribute("itemMediaType", dataType.getMediaType().toString());
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context)
+    {
+        Class<? extends Collection> type;
+        Class<?> itemType;
+        try
+        {
+            type = ClassUtils.getClass(reader.getAttribute("type"));
+            itemType = ClassUtils.getClass(reader.getAttribute("itemType"));
+        }
+        catch (ClassNotFoundException e)
+        {
+            throw new MuleRuntimeException(e);
+        }
+        final String mediaType = reader.getAttribute("mediaType");
+        final String itemMediaType = reader.getAttribute("itemMediaType");
+        return createDataType(type, mediaType, itemType, itemMediaType);
+    }
+
+
+    protected CollectionDataType createDataType(Class<? extends Collection> type, String mimeType, Class<?> itemType, String itemMediaType)
+    {
+        return (CollectionDataType) DataType.builder().collectionType(type).itemType(itemType).itemMediaType(itemMediaType).mediaType(mimeType).build();
+    }
+
+}

--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/datatype/SimpleDataTypeXStreamConverter.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/datatype/SimpleDataTypeXStreamConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.xml.transformer.datatype;
+
+import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.core.api.MuleRuntimeException;
+import org.mule.runtime.core.metadata.SimpleDataType;
+import org.mule.runtime.core.util.ClassUtils;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * A serializer to handle instances of {@link SimpleDataType}.
+ *
+ * @since 4.0
+ */
+public class SimpleDataTypeXStreamConverter implements Converter
+{
+
+    @Override
+    public boolean canConvert(Class type)
+    {
+        return SimpleDataType.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void marshal(Object source, HierarchicalStreamWriter writer, MarshallingContext context)
+    {
+        final SimpleDataType dataType = (SimpleDataType) source;
+        writer.addAttribute("type", dataType.getType().getName());
+        writer.addAttribute("mediaType", dataType.getMediaType().toString());
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context)
+    {
+        Class<?> type;
+        try
+        {
+            type = ClassUtils.getClass(reader.getAttribute("type"));
+        }
+        catch (ClassNotFoundException e)
+        {
+            throw new MuleRuntimeException(e);
+        }
+        final String mediaType = reader.getAttribute("mediaType");
+        return createDataType(type, mediaType);
+    }
+
+    protected SimpleDataType createDataType(Class<?> type, String mimeType)
+    {
+        return (SimpleDataType) DataType.builder().type(type).mediaType(mimeType).build();
+    }
+
+}


### PR DESCRIPTION
* Fix for XML serialization of dataTypes with the new model.