### PR TITLE
MULE-9546 JMSMessage-to-object-transformer doesn't propagate DataType…

### DIFF
--- a/transports/jms/src/test/java/org/mule/transport/jms/integration/JmsObjectToMessageDataTypeTransformerTestCase.java
+++ b/transports/jms/src/test/java/org/mule/transport/jms/integration/JmsObjectToMessageDataTypeTransformerTestCase.java
@@ -7,11 +7,17 @@
 
 package org.mule.transport.jms.integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 import static org.mule.tck.functional.FlowAssert.verify;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleException;
+import org.mule.api.processor.MessageProcessor;
 
 import javax.jms.JMSException;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
+import javax.jms.TextMessage;
 
 import org.junit.Test;
 
@@ -37,5 +43,16 @@ public class JmsObjectToMessageDataTypeTransformerTestCase extends AbstractJmsFu
         };
         send(sendTextMessageScenario);
         verify("message-to-string-flow");
+    }
+
+    public static class CheckTextMessageType implements MessageProcessor
+    {
+
+        @Override
+        public MuleEvent process(MuleEvent event) throws MuleException
+        {
+            assertThat(event.getMessage().getDataType().getType(), typeCompatibleWith(TextMessage.class));
+            return event;
+        }
     }
 }

--- a/transports/jms/src/test/resources/integration/jms-object-to-message-transformer-data-type-test-case.xml
+++ b/transports/jms/src/test/resources/integration/jms-object-to-message-transformer-data-type-test-case.xml
@@ -9,7 +9,7 @@
 
     <flow name="message-to-string-flow">
         <jms:inbound-endpoint ref="in"/>
-        <test:assert expression="#[message.dataType.getType().getName() == 'org.apache.activemq.command.ActiveMQTextMessage']"></test:assert>
+        <custom-processor class="org.mule.transport.jms.integration.JmsObjectToMessageDataTypeTransformerTestCase$CheckTextMessageType"/>
         <jms:jmsmessage-to-object-transformer/>
         <test:assert expression="#[message.dataType.getType().getName() == 'java.lang.Object']"></test:assert>
     </flow>


### PR DESCRIPTION
… - Fixed test to work with WMQ and ActiveMQ