### PR TITLE
MULE-9738: Improve functional test case to work with extensions - Mig…

### DIFF
--- a/extensions/sockets/src/main/java/org/mule/extension/socket/api/ConnectionSettings.java
+++ b/extensions/sockets/src/main/java/org/mule/extension/socket/api/ConnectionSettings.java
@@ -7,8 +7,8 @@
 package org.mule.extension.socket.api;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.mule.runtime.core.util.StringUtils.EMPTY;
+import static org.mule.runtime.core.util.StringUtils.isBlank;
 import org.mule.runtime.extension.api.annotation.Parameter;
 
 import java.net.InetSocketAddress;

--- a/extensions/sockets/src/main/java/org/mule/extension/socket/api/SocketsExtension.java
+++ b/extensions/sockets/src/main/java/org/mule/extension/socket/api/SocketsExtension.java
@@ -6,18 +6,21 @@
  */
 package org.mule.extension.socket.api;
 
-import org.mule.extension.socket.api.connection.tcp.protocol.XmlMessageEOFProtocol;
 import org.mule.extension.socket.api.config.ListenerConfig;
 import org.mule.extension.socket.api.config.RequesterConfig;
+import org.mule.extension.socket.api.connection.tcp.protocol.AbstractByteProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.CustomProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.DirectProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.EOFProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.LengthProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.SafeProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.StreamingProtocol;
-import org.mule.extension.socket.api.socket.tcp.TcpProtocol;
+import org.mule.extension.socket.api.connection.tcp.protocol.XmlMessageEOFProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.XmlMessageProtocol;
+import org.mule.extension.socket.api.exceptions.LengthExceededException;
+import org.mule.extension.socket.api.exceptions.ReadingTimeoutException;
 import org.mule.extension.socket.api.socket.tcp.TcpClientSocketProperties;
+import org.mule.extension.socket.api.socket.tcp.TcpProtocol;
 import org.mule.extension.socket.api.socket.tcp.TcpServerSocketProperties;
 import org.mule.extension.socket.api.socket.udp.UdpSocketProperties;
 import org.mule.runtime.extension.api.annotation.Configurations;
@@ -34,7 +37,8 @@ import org.mule.runtime.extension.api.annotation.SubTypeMapping;
 @Configurations({ListenerConfig.class, RequesterConfig.class})
 @SubTypeMapping(baseType = TcpProtocol.class, subTypes = {SafeProtocol.class, DirectProtocol.class, LengthProtocol.class,
         StreamingProtocol.class, XmlMessageProtocol.class, XmlMessageEOFProtocol.class, CustomProtocol.class, EOFProtocol.class})
-@Export(classes = {TcpClientSocketProperties.class, TcpServerSocketProperties.class, UdpSocketProperties.class})
+@Export(classes = {TcpClientSocketProperties.class, TcpServerSocketProperties.class, UdpSocketProperties.class, ReadingTimeoutException.class, LengthExceededException.class,
+        LengthProtocol.class, AbstractByteProtocol.class})
 public class SocketsExtension
 {
 

--- a/extensions/sockets/src/test/java/org/mule/extension/socket/CustomProtocolTestCase.java
+++ b/extensions/sockets/src/test/java/org/mule/extension/socket/CustomProtocolTestCase.java
@@ -9,8 +9,10 @@ package org.mule.extension.socket;
 import static org.hamcrest.Matchers.instanceOf;
 import org.mule.runtime.core.api.MessagingException;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore("MULE-9738: It is not supported yet to application access classes from extensions")
 public class CustomProtocolTestCase extends SocketExtensionTestCase
 {
     @Override

--- a/extensions/sockets/src/test/java/org/mule/extension/socket/ParameterizedProtocolTestCase.java
+++ b/extensions/sockets/src/test/java/org/mule/extension/socket/ParameterizedProtocolTestCase.java
@@ -10,17 +10,17 @@ import org.mule.extension.socket.api.connection.tcp.protocol.DirectProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.LengthProtocol;
 import org.mule.extension.socket.api.connection.tcp.protocol.SafeProtocol;
 import org.mule.extension.socket.api.socket.tcp.TcpProtocol;
+import org.mule.functional.junit4.runners.RunnerDelegateTo;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 /**
  * Base clase for common tests across all the {@link TcpProtocol} implementations
  */
-@RunWith(Parameterized.class)
+@RunnerDelegateTo(Parameterized.class)
 public abstract class ParameterizedProtocolTestCase extends SocketExtensionTestCase
 {
 

--- a/extensions/sockets/src/test/java/org/mule/extension/socket/TcpMultipleSendTestCase.java
+++ b/extensions/sockets/src/test/java/org/mule/extension/socket/TcpMultipleSendTestCase.java
@@ -7,15 +7,15 @@
 package org.mule.extension.socket;
 
 import static org.junit.Assert.assertEquals;
+import org.mule.functional.junit4.runners.RunnerDelegateTo;
 import org.mule.runtime.core.util.IOUtils;
 
 import java.io.InputStream;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunnerDelegateTo(Parameterized.class)
 public class TcpMultipleSendTestCase extends ParameterizedProtocolTestCase
 {
 

--- a/extensions/sockets/src/test/java/org/mule/extension/socket/TcpReconnectionTestCase.java
+++ b/extensions/sockets/src/test/java/org/mule/extension/socket/TcpReconnectionTestCase.java
@@ -10,15 +10,14 @@ import static java.lang.String.format;
 import static org.mockito.Mockito.when;
 import static org.mule.extension.socket.SocketExtensionTestCase.POLL_DELAY_MILLIS;
 import static org.mule.extension.socket.SocketExtensionTestCase.TIMEOUT_MILLIS;
-
 import org.mule.extension.socket.api.ConnectionSettings;
 import org.mule.extension.socket.api.connection.tcp.TcpListenerConnection;
 import org.mule.extension.socket.api.connection.tcp.TcpRequesterConnection;
 import org.mule.extension.socket.api.connection.tcp.protocol.SafeProtocol;
-import org.mule.extension.socket.api.socket.tcp.TcpClientSocketProperties;
-import org.mule.extension.socket.api.socket.tcp.TcpServerSocketProperties;
 import org.mule.extension.socket.api.socket.factory.TcpServerSocketFactory;
 import org.mule.extension.socket.api.socket.factory.TcpSocketFactory;
+import org.mule.extension.socket.api.socket.tcp.TcpClientSocketProperties;
+import org.mule.extension.socket.api.socket.tcp.TcpServerSocketProperties;
 import org.mule.extension.socket.api.worker.SocketWorker;
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.core.api.MuleContext;

--- a/extensions/sockets/src/test/java/org/mule/extension/socket/TcpSendTestCase.java
+++ b/extensions/sockets/src/test/java/org/mule/extension/socket/TcpSendTestCase.java
@@ -6,11 +6,12 @@
  */
 package org.mule.extension.socket;
 
+import org.mule.functional.junit4.runners.RunnerDelegateTo;
+
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunnerDelegateTo(Parameterized.class)
 public class TcpSendTestCase extends ParameterizedProtocolTestCase
 {
 

--- a/extensions/sockets/src/test/resources/custom-protocol-config.xml
+++ b/extensions/sockets/src/test/resources/custom-protocol-config.xml
@@ -2,8 +2,10 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
+      xmlns:spring="http://www.springframework.org/schema/beans"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/sockets http://www.mulesoft.org/schema/mule/sockets/current/mule-sockets.xsd">
+
 
     <sockets:request-config name="tcp-requester">
         <sockets:tcp-requester-connection host="localhost" port="${port}" failOnUnresolvedHost="true" sendTcpNoDelay="true">
@@ -32,9 +34,15 @@
         <set-payload value="Consumed"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/custom-protocol-ref-config.xml
+++ b/extensions/sockets/src/test/resources/custom-protocol-ref-config.xml
@@ -30,9 +30,15 @@
         <set-payload value="Consumed"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/length-protocol-config.xml
+++ b/extensions/sockets/src/test/resources/length-protocol-config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/sockets http://www.mulesoft.org/schema/mule/sockets/current/mule-sockets.xsd">
@@ -32,9 +33,15 @@
         <set-payload value="Consumed"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/mixed-protocols-config.xml
+++ b/extensions/sockets/src/test/resources/mixed-protocols-config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/sockets http://www.mulesoft.org/schema/mule/sockets/current/mule-sockets.xsd">
@@ -32,9 +33,15 @@
         <set-payload value="Consumed"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/send-encoded-string-config.xml
+++ b/extensions/sockets/src/test/resources/send-encoded-string-config.xml
@@ -2,6 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
+      xmlns:spring="http://www.springframework.org/schema/beans"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/sockets http://www.mulesoft.org/schema/mule/sockets/current/mule-sockets.xsd">
 
@@ -28,9 +29,15 @@
         <set-payload value="Consumed"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/tcp-connection-timeout-config.xml
+++ b/extensions/sockets/src/test/resources/tcp-connection-timeout-config.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
-
+      xmlns:spring="http://www.springframework.org/schema/beans"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
 
        http://www.mulesoft.org/schema/mule/sockets http://www.mulesoft.org/schema/mule/sockets/current/mule-sockets.xsd">
@@ -21,9 +21,15 @@
         <set-payload value="Response"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/tcp-reading-timeout-config.xml
+++ b/extensions/sockets/src/test/resources/tcp-reading-timeout-config.xml
@@ -3,6 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
       xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:spring="http://www.springframework.org/schema/beans"
 
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
@@ -33,9 +34,15 @@
         <test:component waitTime="200"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/tcp-send-config.xml
+++ b/extensions/sockets/src/test/resources/tcp-send-config.xml
@@ -37,9 +37,15 @@
         <set-payload value="Consumed"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/udp-send-config.xml
+++ b/extensions/sockets/src/test/resources/udp-send-config.xml
@@ -2,6 +2,8 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/sockets http://www.mulesoft.org/schema/mule/sockets/current/mule-sockets.xsd">
 
@@ -25,9 +27,15 @@
         <set-payload value="Consumed"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>

--- a/extensions/sockets/src/test/resources/xml-protocol-config.xml
+++ b/extensions/sockets/src/test/resources/xml-protocol-config.xml
@@ -2,6 +2,8 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:sockets="http://www.mulesoft.org/schema/mule/sockets"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/sockets http://www.mulesoft.org/schema/mule/sockets/current/mule-sockets.xsd">
 
@@ -31,9 +33,15 @@
         <flow-ref name="onIncomingConnection"/>
     </flow>
 
+    <!--TODO(gfernandes) MULE-10117 remove this when support for accessing resources is added to runner -->
+    <spring:beans>
+        <spring:bean id="onIncomingConnectionBean" scope="prototype" class="org.mule.extension.socket.SocketExtensionTestCase$OnIncomingConnectionBean"/>
+    </spring:beans>
+
     <sub-flow name="onIncomingConnection">
-        <expression-component>org.mule.extension.socket.SocketExtensionTestCase.onIncomingConnection(message)
-        </expression-component>
+        <component>
+            <spring-object bean="onIncomingConnectionBean"/>
+        </component>
     </sub-flow>
 
 </mule>


### PR DESCRIPTION
…rate sockets extension to use isolated test runner

_Had to use spring-beans to workaround not supported access for test classes from isolated test runner
_Did not remove mule-module.properties due to it is used from http integration tests and also in standalone mode the sockets ext jar goes to the container (yet)