### PR TITLE
MULE-9892: Fix flaky HttpRequestExpectHeaderTestCase#handlesContinueR…

### DIFF
--- a/tests/http/src/test/java/org/mule/runtime/module/http/functional/requester/HttpRequestExpectHeaderTestCase.java
+++ b/tests/http/src/test/java/org/mule/runtime/module/http/functional/requester/HttpRequestExpectHeaderTestCase.java
@@ -17,7 +17,6 @@ import org.mule.runtime.module.http.functional.AbstractHttpExpectHeaderServerTes
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class HttpRequestExpectHeaderTestCase extends AbstractHttpExpectHeaderServerTestCase
@@ -31,7 +30,6 @@ public class HttpRequestExpectHeaderTestCase extends AbstractHttpExpectHeaderSer
         return "http-request-expect-header-config.xml";
     }
 
-    @Ignore("MULE-9892: Fix flaky")
     @Test
     public void handlesContinueResponse() throws Exception
     {

--- a/tests/http/src/test/resources/http-request-expect-header-config.xml
+++ b/tests/http/src/test/resources/http-request-expect-header-config.xml
@@ -17,7 +17,7 @@
             </httpn:response-validator>
             <httpn:request-builder>
                 <httpn:headers>
-                    <httpn:header key="Expect" value="Continue"/>
+                    <httpn:header key="Expect" value="100-continue"/>
                 </httpn:headers>
             </httpn:request-builder>
         </httpn:request>


### PR DESCRIPTION
…esponse (not flaky, just wrong)
 