### PR TITLE
MULE-10180: Classloader leak when Oracle JDBC Driver is not used but …

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/AbstractArtifactClassLoader.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/AbstractArtifactClassLoader.java
@@ -98,7 +98,7 @@ public abstract class AbstractArtifactClassLoader extends FineGrainedControlClas
             classStream = this.getClass().getResourceAsStream(resourceReleaserClassLocation);
             byte[] classBytes = IOUtils.toByteArray(classStream);
             classStream.close();
-            Class clazz = defineClass(null, classBytes, 0, classBytes.length);
+            Class clazz = this.defineClass(null, classBytes, 0, classBytes.length);
             return (ResourceReleaser) clazz.newInstance();
         }
         catch (Exception e)

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/DefaultResourceReleaser.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/DefaultResourceReleaser.java
@@ -26,7 +26,7 @@ public class DefaultResourceReleaser implements ResourceReleaser
 {
 
     public static final String DIAGNOSABILITY_BEAN_NAME = "diagnosability";
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final transient Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void release()
@@ -66,7 +66,8 @@ public class DefaultResourceReleaser implements ResourceReleaser
         ClassLoader driverClassLoader = driver.getClass().getClassLoader();
         while (driverClassLoader != null)
         {
-            if (driverClassLoader.equals(getClass().getClassLoader()))
+            // It has to be the same reference not equals to
+            if (driverClassLoader == getClass().getClassLoader())
             {
                 return true;
             }
@@ -80,7 +81,10 @@ public class DefaultResourceReleaser implements ResourceReleaser
     {
         try
         {
-            logger.debug("Deregistering driver: {}", driver.getClass());
+            if (logger.isDebugEnabled())
+            {
+                logger.debug("Deregistering driver: {}", driver.getClass());
+            }
             deregisterDriver(driver);
 
             if (isOracleDriver(driver))
@@ -101,8 +105,8 @@ public class DefaultResourceReleaser implements ResourceReleaser
 
     private void deregisterOracleDiagnosabilityMBean()
     {
-        final ClassLoader cl = this.getClass().getClassLoader();
-        final MBeanServer mBeanServer = getPlatformMBeanServer();
+        ClassLoader cl = this.getClass().getClassLoader();
+        MBeanServer mBeanServer = getPlatformMBeanServer();
         final Hashtable<String, String> keys = new Hashtable<String, String>();
         keys.put("type", DIAGNOSABILITY_BEAN_NAME);
         keys.put("name", cl.getClass().getName() + "@" + toHexString(cl.hashCode()).toLowerCase());


### PR DESCRIPTION
…included in application lib folder

_URLClassLoader in Java 7 added a close method that closes any files that were opened by it, removed workaround. This fixed the locks for files in windows, files were locked by OracleDriver
_Improvements in DefaultReleaser to avoid classloader leaks
