### PR TITLE
MULE-10196: When AbstractConnector fails to connect receivers, it leaves

### DIFF
--- a/core/src/main/java/org/mule/transport/AbstractConnector.java
+++ b/core/src/main/java/org/mule/transport/AbstractConnector.java
@@ -1663,39 +1663,49 @@ public abstract class AbstractConnector extends AbstractAnnotatedObject implemen
     {
         doConnect();
 
-        if (receivers != null)
+        try
         {
-            for (MessageReceiver receiver : receivers.values())
+            if (receivers != null)
             {
-                final List<MuleException> errors = new ArrayList<>();
-                try
+                for (MessageReceiver receiver : receivers.values())
                 {
-                    if (logger.isDebugEnabled())
+                    final List<MuleException> errors = new ArrayList<>();
+                    try
                     {
-                        logger.debug("Connecting receiver on endpoint: " + receiver.getEndpoint().getEndpointURI());
+                        if (logger.isDebugEnabled())
+                        {
+                            logger.debug("Connecting receiver on endpoint: " + receiver.getEndpoint().getEndpointURI());
+                        }
+                        receiver.connect();
+                        if (isStarted())
+                        {
+                            receiver.start();
+                        }
                     }
-                    receiver.connect();
-                    if (isStarted())
+                    catch (MuleException e)
                     {
-                        receiver.start();
+                        logger.error(e);
+                        errors.add(e);
                     }
-                }
-                catch (MuleException e)
-                {
-                    logger.error(e);
-                    errors.add(e);
-                }
 
-                if (!errors.isEmpty())
-                {
-                    // throw the first one in order not to break the reconnection
-                    // strategy logic,
-                    // every exception has been logged above already
-                    // api needs refactoring to support the multi-cause exception
-                    // here
-                    throw errors.get(0);
+                    if (!errors.isEmpty())
+                    {
+                        // throw the first one in order not to break the reconnection
+                        // strategy logic,
+                        // every exception has been logged above already
+                        // api needs refactoring to support the multi-cause exception
+                        // here
+                        throw errors.get(0);
+                    }
                 }
             }
+        }
+        catch (Exception e)
+        {
+            // If an exception occurs while connection the receivers, disconnect the connector to
+            // keep a consistent state.
+            doDisconnect();
+            throw e;
         }
 
         setConnected(true);

--- a/core/src/main/java/org/mule/transport/AbstractConnector.java
+++ b/core/src/main/java/org/mule/transport/AbstractConnector.java
@@ -1693,7 +1693,7 @@ public abstract class AbstractConnector extends AbstractAnnotatedObject implemen
                         // throw the first one in order not to break the reconnection
                         // strategy logic,
                         // every exception has been logged above already
-                        // api needs refactoring to support the multi-cause exception
+                        // API needs refactoring to support the multi-cause exception
                         // here
                         throw errors.get(0);
                     }
@@ -1702,7 +1702,7 @@ public abstract class AbstractConnector extends AbstractAnnotatedObject implemen
         }
         catch (Exception e)
         {
-            // If an exception occurs while connection the receivers, disconnect the connector to
+            // If an exception occurs while connecting the receivers, disconnect the connector to
             // keep a consistent state.
             doDisconnect();
             throw e;


### PR DESCRIPTION
the connector connection active