### PR TITLE
MULE-10193: HttpListener - MuleMessage cast exception when sending du…

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleMessage.java
+++ b/core/src/main/java/org/mule/DefaultMuleMessage.java
@@ -6,6 +6,7 @@
  */
 package org.mule;
 
+import static java.lang.String.format;
 import static org.mule.api.config.MuleProperties.CONTENT_TYPE_PROPERTY;
 import static org.mule.api.config.MuleProperties.MULE_ENCODING_PROPERTY;
 import static org.mule.api.config.MuleProperties.SYSTEM_PROPERTY_PREFIX;
@@ -556,8 +557,8 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
                 else
                 {
                     String encoding = Charset.defaultCharset().name();
-                    logger.warn(String.format("%s when parsing Content-Type '%s': %s", e.getClass().getName(), value, e.getMessage()));
-                    logger.warn(String.format("Using defualt encoding: %s", encoding));
+                    logger.warn(format("%s when parsing Content-Type '%s': %s", e.getClass().getName(), value, e.getMessage()));
+                    logger.warn(format("Using defualt encoding: %s", encoding));
                     dataType.setEncoding(encoding);
                 }
             }
@@ -585,7 +586,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
         {
             if (((Collection) value).isEmpty())
             {
-                throw new IllegalArgumentException(String.format("Unsupported value for '%s' property. Expected 'java.lang.String' but was an empty collection", propertyName));
+                throw new IllegalArgumentException(format("Unsupported value for '%s' property. Expected 'java.lang.String' but was an empty collection", propertyName));
             }
             final Object collectionItem = ((Collection) value).iterator().next();
             if (collectionItem instanceof String)
@@ -598,7 +599,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
             }
             else
             {
-                throw new IllegalArgumentException(String.format("Unsupported type for '%s' property. Expected 'java.lang.String' but was '%s'", propertyName, value.getClass().getName()));
+                throw new IllegalArgumentException(format("Unsupported type for '%s' property. Expected 'java.lang.String' but was '%s'", propertyName, value.getClass().getName()));
             }
         }
         else if (value == null)
@@ -607,7 +608,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
         }
         else
         {
-            throw new IllegalArgumentException(String.format("Unsupported type for '%s' property. Expected 'java.lang.String' but was '%s'", propertyName, value.getClass().getName()));
+            throw new IllegalArgumentException(format("Unsupported type for '%s' property. Expected 'java.lang.String' but was '%s'", propertyName, value.getClass().getName()));
         }
 
         return propertyValue;
@@ -1866,7 +1867,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
                     }
                     catch(TransformerException ex)
                     {
-                        String message = String.format(
+                        String message = format(
                                 "Unable to serialize the attachment %s, which is of type %s with contents of type %s",
                                 name, handler.getClass(), theContent.getClass());
                         logger.error(message);

--- a/core/src/main/java/org/mule/DefaultMuleMessage.java
+++ b/core/src/main/java/org/mule/DefaultMuleMessage.java
@@ -6,9 +6,11 @@
  */
 package org.mule;
 
-import static org.mule.util.SystemUtils.LINE_SEPARATOR;
+import static org.mule.api.config.MuleProperties.CONTENT_TYPE_PROPERTY;
+import static org.mule.api.config.MuleProperties.MULE_ENCODING_PROPERTY;
 import static org.mule.api.config.MuleProperties.SYSTEM_PROPERTY_PREFIX;
-
+import static org.mule.transformer.types.SimpleDataType.CHARSET_PARAM;
+import static org.mule.util.SystemUtils.LINE_SEPARATOR;
 import org.mule.api.ExceptionPayload;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -53,6 +55,7 @@ import java.io.Serializable;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -527,17 +530,18 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
     private void updateDataTypeWithProperty(String key, Object value)
     {
         // updates dataType when encoding is updated using a property instead of using #setEncoding
-        if (MuleProperties.MULE_ENCODING_PROPERTY.equals(key))
+        if (MULE_ENCODING_PROPERTY.equals(key))
         {
-            dataType.setEncoding((String) value);
+            dataType.setEncoding(getStringPropertyValue(MULE_ENCODING_PROPERTY, value));
         }
-        else if (MuleProperties.CONTENT_TYPE_PROPERTY.equalsIgnoreCase(key))
+        else if (CONTENT_TYPE_PROPERTY.equalsIgnoreCase(key))
         {
             try
             {
-                MimeType mimeType = new MimeType((String) value);
+                final String contentType = getStringPropertyValue(CONTENT_TYPE_PROPERTY, value);
+                MimeType mimeType = new MimeType(contentType);
                 dataType.setMimeType(mimeType.getPrimaryType() + "/" + mimeType.getSubType());
-                String encoding = mimeType.getParameter("charset");
+                String encoding = mimeType.getParameter(CHARSET_PARAM);
                 if (!StringUtils.isEmpty(encoding))
                 {
                     dataType.setEncoding(encoding);
@@ -558,6 +562,55 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
                 }
             }
         }
+    }
+
+    /*
+       There are properties, like encoding and content-type, that are used to update the message datatype.
+       Those properties are supposed to be Strings, and in general, they are.
+       But, there are cases, like HTTP requests, where content-type can be present more than once, so the
+       request will contain a list containing all the content-type values.
+       This method manages this situation by checking the type of the property value and attempts to get a
+       unique String value from it. In case of having multiple String values, the first one will be used.
+       If the value is not a String or collection of Strings, an error will be thrown.
+     */
+    private String getStringPropertyValue(String propertyName, Object value)
+    {
+        String propertyValue;
+
+        if (value instanceof String)
+        {
+           propertyValue = (String) value;
+        }
+        else if (value instanceof Collection)
+        {
+            if (((Collection) value).isEmpty())
+            {
+                throw new IllegalArgumentException(String.format("Unsupported value for '%s' property. Expected 'java.lang.String' but was an empty collection", propertyName));
+            }
+            final Object collectionItem = ((Collection) value).iterator().next();
+            if (collectionItem instanceof String)
+            {
+                propertyValue = (String) collectionItem;
+            }
+            else if (collectionItem == null)
+            {
+                propertyValue = null;
+            }
+            else
+            {
+                throw new IllegalArgumentException(String.format("Unsupported type for '%s' property. Expected 'java.lang.String' but was '%s'", propertyName, value.getClass().getName()));
+            }
+        }
+        else if (value == null)
+        {
+           propertyValue = null;
+        }
+        else
+        {
+            throw new IllegalArgumentException(String.format("Unsupported type for '%s' property. Expected 'java.lang.String' but was '%s'", propertyName, value.getClass().getName()));
+        }
+
+        return propertyValue;
     }
 
     /**
@@ -1285,7 +1338,7 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
                 return encoding;
             }
         }
-        encoding = getOutboundProperty(MuleProperties.MULE_ENCODING_PROPERTY);
+        encoding = getOutboundProperty(MULE_ENCODING_PROPERTY);
         if (encoding != null)
         {
             return encoding;

--- a/core/src/main/java/org/mule/transformer/types/SimpleDataType.java
+++ b/core/src/main/java/org/mule/transformer/types/SimpleDataType.java
@@ -25,7 +25,7 @@ import org.apache.commons.beanutils.MethodUtils;
 public class SimpleDataType<T> implements DataType<T>, Cloneable
 {
 
-    private static final String CHARSET_PARAM = "charset";
+    public static final String CHARSET_PARAM = "charset";
 
     protected final Class<?> type;
     protected String mimeType = ANY_MIME_TYPE;

--- a/core/src/test/java/org/mule/DefaultMuleMessageTestCase.java
+++ b/core/src/test/java/org/mule/DefaultMuleMessageTestCase.java
@@ -7,6 +7,7 @@
 package org.mule;
 
 import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_16BE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -474,7 +475,7 @@ public class DefaultMuleMessageTestCase extends AbstractMuleContextTestCase
         MuleMessage message = createMuleMessage();
         List<String> encodings = new ArrayList<>();
         encodings.add(UTF_16.name());
-        encodings.add(UTF_16.name());
+        encodings.add(UTF_16BE.name());
         message.setProperty(MULE_ENCODING_PROPERTY, encodings);
 
         assertThat(message.getEncoding(), equalTo(UTF_16.name()));
@@ -509,7 +510,7 @@ public class DefaultMuleMessageTestCase extends AbstractMuleContextTestCase
         MuleMessage message = createMuleMessage();
         List<String> contentTypes = new ArrayList<>();
         contentTypes.add("application/json; charset=UTF-8");
-        contentTypes.add("application/json; charset=UTF-8");
+        contentTypes.add("application/xml; charset=UTF-16");
         message.setProperty(CONTENT_TYPE_PROPERTY, contentTypes);
 
         assertThat(message.getDataType().getMimeType(), equalTo("application/json"));

--- a/core/src/test/java/org/mule/DefaultMuleMessageTestCase.java
+++ b/core/src/test/java/org/mule/DefaultMuleMessageTestCase.java
@@ -6,13 +6,17 @@
  */
 package org.mule;
 
+import static java.nio.charset.StandardCharsets.UTF_16;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mule.api.config.MuleProperties.CONTENT_TYPE_PROPERTY;
+import static org.mule.api.config.MuleProperties.MULE_ENCODING_PROPERTY;
 import org.mule.api.MuleMessage;
 import org.mule.api.transport.PropertyScope;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
@@ -26,7 +30,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.activation.DataHandler;
@@ -459,5 +466,76 @@ public class DefaultMuleMessageTestCase extends AbstractMuleContextTestCase
         message.setProperty(FOO_PROPERTY, NullPayload.getInstance(), PropertyScope.OUTBOUND);
 
         assertThat(message.getProperty(FOO_PROPERTY, PropertyScope.OUTBOUND), is(nullValue()));
+    }
+
+    @Test
+    public void updatesEncodingPropertyWithStringCollection() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        List<String> encodings = new ArrayList<>();
+        encodings.add(UTF_16.name());
+        encodings.add(UTF_16.name());
+        message.setProperty(MULE_ENCODING_PROPERTY, encodings);
+
+        assertThat(message.getEncoding(), equalTo(UTF_16.name()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsToUpdateEncodingPropertyWithEmptyCollection() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        List<String> encodings = new ArrayList<>();
+        message.setProperty(MULE_ENCODING_PROPERTY, encodings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsToUpdateEncodingPropertyWithObjectCollection() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        List<Object> encodings = Collections.singletonList(new Object());
+        message.setProperty(MULE_ENCODING_PROPERTY, encodings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsToUpdateEncodingPropertyWithObjectValue() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        message.setProperty(MULE_ENCODING_PROPERTY, new Object());
+    }
+
+    @Test
+    public void updatesContentTypePropertyWithStringCollection() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        List<String> contentTypes = new ArrayList<>();
+        contentTypes.add("application/json; charset=UTF-8");
+        contentTypes.add("application/json; charset=UTF-8");
+        message.setProperty(CONTENT_TYPE_PROPERTY, contentTypes);
+
+        assertThat(message.getDataType().getMimeType(), equalTo("application/json"));
+        assertThat(message.getDataType().getEncoding(), equalTo("UTF-8"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsToUpdateContentTypePropertyWithEmptyCollection() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        List<String> contentTypes = new ArrayList<>();
+        message.setProperty(CONTENT_TYPE_PROPERTY, contentTypes);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsToUpdateContentTypePropertyWithObjectCollection() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        List<Object> contentTypes = Collections.singletonList(new Object());
+        message.setProperty(CONTENT_TYPE_PROPERTY, contentTypes);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsToUpdateContentTypePropertyWithObjectValue() throws Exception
+    {
+        MuleMessage message = createMuleMessage();
+        message.setProperty(CONTENT_TYPE_PROPERTY, new Object());
     }
 }


### PR DESCRIPTION
…plicate Content-Type header

_ DefaultMuleMessage expects to receive a String value for the content-type and enconding properties. When HTTP connector is used and there are multiple content-type headers in the request, the property value is a list of Strings. As we don't want to loose any value from the original request, in these cases, the content-type will be  obtained from the list, taking the first element.