### PR TITLE
MULE-10298: Deploy applications in parallel

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/ArchiveDeployer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/ArchiveDeployer.java
@@ -26,7 +26,7 @@ public interface ArchiveDeployer<T extends Artifact>
     T deployExplodedArtifact(String artifactDir) throws DeploymentException;
 
     /**
-     * Indicates if a previously failed artifact (zombie) was updated.
+     * Indicates if a previously failed artifact (zombie) configuration was updated on the file system.
      *
      * @param artifactName name of the artifact to check. Non empty.
      * @return true if the zombie artifact was updated, false it the artifact is not a zombie or it was not updated.

--- a/modules/launcher/src/main/java/org/mule/module/launcher/ArchiveDeployer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/ArchiveDeployer.java
@@ -6,7 +6,6 @@
  */
 package org.mule.module.launcher;
 
-import org.mule.module.launcher.application.Application;
 import org.mule.module.launcher.artifact.Artifact;
 import org.mule.module.launcher.artifact.ArtifactFactory;
 
@@ -25,6 +24,14 @@ public interface ArchiveDeployer<T extends Artifact>
     T deployPackagedArtifact(String zip) throws DeploymentException;
 
     T deployExplodedArtifact(String artifactDir) throws DeploymentException;
+
+    /**
+     * Indicates if a previously failed artifact (zombie) was updated.
+     *
+     * @param artifactName name of the artifact to check. Non empty.
+     * @return true if the zombie artifact was updated, false it the artifact is not a zombie or it was not updated.
+     */
+    boolean isUpdatedZombieArtifact(String artifactName);
 
     T deployPackagedArtifact(URL artifactAchivedUrl);
 

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DomainArchiveDeployer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DomainArchiveDeployer.java
@@ -65,7 +65,7 @@ public class DomainArchiveDeployer implements ArchiveDeployer<Domain>
     @Override
     public boolean isUpdatedZombieArtifact(String artifactName)
     {
-        //TODO(pablo.kraan): MULE-10337: need to track zombie domains, similar to how apps are managed
+        // Domains does not manage zombie artifacts
         return true;
     }
 

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DomainArchiveDeployer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DomainArchiveDeployer.java
@@ -39,7 +39,7 @@ public class DomainArchiveDeployer implements ArchiveDeployer<Domain>
     private final DeploymentService deploymentService;
     private final ArchiveDeployer<Application> applicationDeployer;
 
-    public DomainArchiveDeployer(ArchiveDeployer<Domain> domainDeployer, ArchiveDeployer<Application> applicationDeployer, ArtifactDeployer<Application> applicationArtifactDeployer, DeploymentService deploymentService)
+    public DomainArchiveDeployer(ArchiveDeployer<Domain> domainDeployer, ArchiveDeployer<Application> applicationDeployer, DeploymentService deploymentService)
     {
         this.domainDeployer = domainDeployer;
         this.applicationDeployer = applicationDeployer;
@@ -60,6 +60,13 @@ public class DomainArchiveDeployer implements ArchiveDeployer<Domain>
         Domain domain = domainDeployer.deployExplodedArtifact(artifactDir);
         deployBundledAppsIfDomainWasCreated(domain);
         return domain;
+    }
+
+    @Override
+    public boolean isUpdatedZombieArtifact(String artifactName)
+    {
+        //TODO(pablo.kraan): MULE-10337: need to track zombie domains, similar to how apps are managed
+        return true;
     }
 
     @Override

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DomainDeploymentTemplate.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DomainDeploymentTemplate.java
@@ -55,7 +55,10 @@ public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplat
             for (Application domainApplication : domainApplications)
             {
                 applicationDeployer.preTrackArtifact(domainApplication);
-                applicationDeployer.deployExplodedArtifact(domainApplication.getArtifactName());
+                if (applicationDeployer.isUpdatedZombieArtifact(domainApplication.getArtifactName()))
+                {
+                    applicationDeployer.deployExplodedArtifact(domainApplication.getArtifactName());
+                }
             }
         }
         domainApplications = Collections.emptyList();

--- a/modules/launcher/src/main/java/org/mule/module/launcher/MuleContainer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/MuleContainer.java
@@ -88,10 +88,11 @@ public class MuleContainer
 
     public MuleContainer(String[] args)
     {
+        init(args);
+
         this.deploymentService = new MuleDeploymentService(pluginClassLoaderManager);
         this.coreExtensionManager = new DefaultMuleCoreExtensionManager();
 
-        init(args);
     }
 
     public MuleContainer(DeploymentService deploymentService, MuleCoreExtensionManager coreExtensionManager)
@@ -104,11 +105,12 @@ public class MuleContainer
      */
     public MuleContainer(String[] args, DeploymentService deploymentService, MuleCoreExtensionManager coreExtensionManager) throws IllegalArgumentException
     {
+        init(args);
+
         //TODO(pablo.kraan): remove the args argument and use the already existing setters to set everything needed
         this.deploymentService = deploymentService;
         this.coreExtensionManager = coreExtensionManager;
 
-        init(args);
     }
 
     protected void init(String[] args) throws IllegalArgumentException

--- a/modules/launcher/src/main/java/org/mule/module/launcher/ParallelDeploymentDirectoryWatcher.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/ParallelDeploymentDirectoryWatcher.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher;
+
+import org.mule.module.launcher.application.Application;
+import org.mule.module.launcher.domain.Domain;
+import org.mule.module.launcher.util.ObservableList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Provides parallel deployment of Mule applications.
+ */
+public class ParallelDeploymentDirectoryWatcher extends DeploymentDirectoryWatcher
+{
+
+    private final ThreadPoolExecutor threadPoolExecutor;
+
+    public ParallelDeploymentDirectoryWatcher(ArchiveDeployer<Domain> domainArchiveDeployer, ArchiveDeployer<Application> applicationArchiveDeployer, ObservableList<Domain> domains, ObservableList<Application> applications, ReentrantLock deploymentLock)
+    {
+        super(domainArchiveDeployer, applicationArchiveDeployer, domains, applications, deploymentLock);
+        this.threadPoolExecutor = new ThreadPoolExecutor(0, 20, 5, TimeUnit.SECONDS, new SynchronousQueue(), new ThreadPoolExecutor.CallerRunsPolicy());
+    }
+
+    @Override
+    protected void deployPackedApps(String[] zips)
+    {
+        if (zips.length == 0)
+        {
+            return;
+        }
+
+        List<Callable<Object>> tasks = new ArrayList<>(zips.length);
+        for (final String zip : zips)
+        {
+            tasks.add(new Callable<Object>()
+            {
+
+                @Override
+                public Object call() throws Exception
+                {
+                    try
+                    {
+                        applicationArchiveDeployer.deployPackagedArtifact(zip);
+                    }
+                    catch (Exception e)
+                    {
+                        // Ignore and continue
+                    }
+                    return null;
+                }
+            });
+        }
+
+        waitForTasksToFinish(tasks);
+    }
+
+
+    @Override
+    protected void deployExplodedApps(String[] apps)
+    {
+        List<Callable<Object>> tasks = new ArrayList<>(apps.length);
+
+        for (final String addedApp : apps)
+        {
+            if (applicationArchiveDeployer.isUpdatedZombieArtifact(addedApp))
+            {
+                tasks.add(new Callable<Object>()
+                {
+
+                    @Override
+                    public Object call() throws Exception
+                    {
+                        try
+                        {
+                            applicationArchiveDeployer.deployExplodedArtifact(addedApp);
+                        }
+                        catch (Exception e)
+                        {
+                            // Ignore and continue
+                        }
+                        return null;
+                    }
+                });
+            }
+        }
+
+        if (!tasks.isEmpty())
+        {
+            waitForTasksToFinish(tasks);
+        }
+    }
+
+    private void waitForTasksToFinish(List<Callable<Object>> tasks)
+    {
+        try
+        {
+            final List<Future<Object>> futures = threadPoolExecutor.invokeAll(tasks);
+
+            for (Future<Object> future : futures)
+            {
+                try
+                {
+                    future.get();
+                }
+                catch (ExecutionException e)
+                {
+                    // Ignore and continue with the next one
+                }
+            }
+
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/ParallelDeploymentDirectoryWatcher.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/ParallelDeploymentDirectoryWatcher.java
@@ -23,6 +23,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Provides parallel deployment of Mule applications.
+ *
+ * @since 3.8.2
  */
 public class ParallelDeploymentDirectoryWatcher extends DeploymentDirectoryWatcher
 {

--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/ApplicationStatusMapper.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/ApplicationStatusMapper.java
@@ -22,11 +22,11 @@ import java.util.Map;
 public class ApplicationStatusMapper
 {
 
-    private static Map<String, ApplicationStatus> statusMapping;
+    private static final Map<String, ApplicationStatus> statusMapping = getStatusMapping();
 
     public static ApplicationStatus getApplicationStatus(String currentPhase)
     {
-        final ApplicationStatus applicationStatus = getStatusMapping().get(currentPhase);
+        final ApplicationStatus applicationStatus = statusMapping.get(currentPhase);
 
         if (applicationStatus == null)
         {
@@ -38,22 +38,13 @@ public class ApplicationStatusMapper
 
     private static Map<String, ApplicationStatus> getStatusMapping()
     {
-        if (statusMapping == null)
-        {
-            synchronized (ApplicationStatusMapper.class)
-            {
-                if (statusMapping == null)
-                {
-                    statusMapping = new HashMap<String, ApplicationStatus>();
+        Map<String, ApplicationStatus> statusMapping = new HashMap<>();
 
-                    statusMapping.put(NotInLifecyclePhase.PHASE_NAME, ApplicationStatus.CREATED);
-                    statusMapping.put(Disposable.PHASE_NAME, ApplicationStatus.DESTROYED);
-                    statusMapping.put(Stoppable.PHASE_NAME, ApplicationStatus.STOPPED);
-                    statusMapping.put(Startable.PHASE_NAME, ApplicationStatus.STARTED);
-                    statusMapping.put(Initialisable.PHASE_NAME, ApplicationStatus.INITIALISED);
-                }
-            }
-        }
+        statusMapping.put(NotInLifecyclePhase.PHASE_NAME, ApplicationStatus.CREATED);
+        statusMapping.put(Disposable.PHASE_NAME, ApplicationStatus.DESTROYED);
+        statusMapping.put(Stoppable.PHASE_NAME, ApplicationStatus.STOPPED);
+        statusMapping.put(Startable.PHASE_NAME, ApplicationStatus.STARTED);
+        statusMapping.put(Initialisable.PHASE_NAME, ApplicationStatus.INITIALISED);
 
         return statusMapping;
     }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactFactory.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactFactory.java
@@ -21,7 +21,7 @@ public interface ArtifactFactory<T extends Artifact>
      * @param artifactName artifact identifier
      * @return the newly created Artifact
      */
-    public T createArtifact(String artifactName) throws IOException;
+    T createArtifact(String artifactName) throws IOException;
 
     /**
      * @return the directory of the Artifact. Usually this directory contains the Artifact resources

--- a/modules/launcher/src/main/java/org/mule/module/launcher/log4j2/LoggerContextCache.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/log4j2/LoggerContextCache.java
@@ -122,7 +122,7 @@ final class LoggerContextCache implements Disposable
         }
     }
 
-    LoggerContext getLoggerContext(final ClassLoader classLoader)
+    synchronized LoggerContext getLoggerContext(final ClassLoader classLoader)
     {
         final LoggerContext ctx;
         try

--- a/modules/launcher/src/main/java/org/mule/module/launcher/util/ObservableList.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/util/ObservableList.java
@@ -51,14 +51,14 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public void add(int index, E element)
+    public synchronized void add(int index, E element)
     {
         delegate.add(index, element);
         pcs.firePropertyChange(new ElementAddedEvent(this, element, index));
     }
 
     @Override
-    public boolean addAll(Collection<? extends E> c)
+    public synchronized boolean addAll(Collection<? extends E> c)
     {
         int index = size() - 1;
         index = index < 0 ? 0 : index;
@@ -82,7 +82,7 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public boolean addAll(int index, Collection<? extends E> c)
+    public synchronized boolean addAll(int index, Collection<? extends E> c)
     {
         boolean success = delegate.addAll(index, c);
 
@@ -103,7 +103,7 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public void clear()
+    public synchronized void clear()
     {
         List<E> values = new ArrayList<E>();
         values.addAll(delegate);
@@ -115,73 +115,73 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public boolean contains(Object o)
+    public synchronized boolean contains(Object o)
     {
         return delegate.contains(o);
     }
 
     @Override
-    public boolean containsAll(Collection<?> c)
+    public synchronized boolean containsAll(Collection<?> c)
     {
         return delegate.containsAll(c);
     }
 
     @Override
-    public boolean equals(Object o)
+    public synchronized boolean equals(Object o)
     {
         return delegate.equals(o);
     }
 
     @Override
-    public E get(int index)
+    public synchronized E get(int index)
     {
         return delegate.get(index);
     }
 
     @Override
-    public int hashCode()
+    public synchronized  int hashCode()
     {
         return delegate.hashCode();
     }
 
     @Override
-    public int indexOf(Object o)
+    public synchronized int indexOf(Object o)
     {
         return delegate.indexOf(o);
     }
 
     @Override
-    public boolean isEmpty()
+    public synchronized  boolean isEmpty()
     {
         return delegate.isEmpty();
     }
 
     @Override
-    public Iterator<E> iterator()
+    public synchronized Iterator<E> iterator()
     {
-        return new ObservableIterator(delegate.iterator());
+        return new ObservableIterator(new ArrayList(delegate).iterator());
     }
 
     @Override
-    public int lastIndexOf(Object o)
+    public synchronized int lastIndexOf(Object o)
     {
         return delegate.lastIndexOf(o);
     }
 
     @Override
-    public ListIterator<E> listIterator()
+    public synchronized ListIterator<E> listIterator()
     {
-        return new ObservableListIterator(delegate.listIterator(), 0);
+        return new ObservableListIterator(new ArrayList(delegate).listIterator(), 0);
     }
 
     @Override
-    public ListIterator<E> listIterator(int index)
+    public synchronized ListIterator<E> listIterator(int index)
     {
-        return new ObservableListIterator(delegate.listIterator(index), index);
+        return new ObservableListIterator(new ArrayList<E>(delegate).listIterator(index), index);
     }
 
     @Override
-    public E remove(int index)
+    public synchronized E remove(int index)
     {
         E element = delegate.remove(index);
         pcs.firePropertyChange(new ElementRemovedEvent(this, element, index));
@@ -189,7 +189,7 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public boolean remove(Object o)
+    public synchronized boolean remove(Object o)
     {
         int index = delegate.indexOf(o);
         boolean success = delegate.remove(o);
@@ -201,7 +201,7 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public boolean removeAll(Collection<?> c)
+    public synchronized boolean removeAll(Collection<?> c)
     {
         if (c == null)
         {
@@ -227,7 +227,7 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public boolean retainAll(Collection<?> c)
+    public synchronized boolean retainAll(Collection<?> c)
     {
         if (c == null)
         {
@@ -256,7 +256,7 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public E set(int index, E element)
+    public synchronized E set(int index, E element)
     {
         E oldValue = delegate.set(index, element);
         pcs.firePropertyChange(new ElementUpdatedEvent(this, oldValue, element, index));
@@ -264,25 +264,25 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public int size()
+    public synchronized int size()
     {
         return delegate.size();
     }
 
     @Override
-    public List<E> subList(int fromIndex, int toIndex)
+    public synchronized List<E> subList(int fromIndex, int toIndex)
     {
         return delegate.subList(fromIndex, toIndex);
     }
 
     @Override
-    public Object[] toArray()
+    public synchronized  Object[] toArray()
     {
         return delegate.toArray();
     }
 
     @Override
-    public boolean add(E o)
+    public synchronized boolean add(E o)
     {
         boolean success = delegate.add(o);
         if (success)
@@ -293,7 +293,7 @@ public class ObservableList<E> implements List<E>
     }
 
     @Override
-    public Object[] toArray(Object[] a)
+    public synchronized Object[] toArray(Object[] a)
     {
         return delegate.toArray(a);
     }

--- a/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
@@ -1909,12 +1909,6 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
         doDomainUndeployAndVerifyAppsAreUndeployed(createUndeployDummyDomainAction());
     }
 
-    @Override
-    public int getTestTimeoutSecs()
-    {
-        return 120000;
-    }
-
     @Test
     public void undeployDomainDoesNotDeployAllApplications() throws Exception
     {

--- a/modules/launcher/src/test/java/org/mule/module/launcher/DomainArchiveDeployerTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/DomainArchiveDeployerTestCase.java
@@ -90,7 +90,7 @@ public class DomainArchiveDeployerTestCase extends AbstractMuleTestCase
     public void returnNullIfDeploymentReturnsNull()
     {
         when(mockDomainDeployer.deployPackagedArtifact(DOMAIN_ZIP_PATH)).thenReturn(null);
-        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockApplicationArtifactDeployer, mockDeploymentService);
+        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockDeploymentService);
         assertThat(domainArchiveDeployer.deployPackagedArtifact("someZipFile"), nullValue());
     }
 
@@ -98,7 +98,7 @@ public class DomainArchiveDeployerTestCase extends AbstractMuleTestCase
     public void doNotFailIfNoAppsFolderPresent() throws Exception
     {
         when(mockDomainDeployer.deployPackagedArtifact(DOMAIN_ZIP_PATH)).thenReturn(mockDomain);
-        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockApplicationArtifactDeployer, mockDeploymentService);
+        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockDeploymentService);
         assertThat(domainArchiveDeployer.deployPackagedArtifact(DOMAIN_ZIP_PATH), is(mockDomain));
     }
 
@@ -110,7 +110,7 @@ public class DomainArchiveDeployerTestCase extends AbstractMuleTestCase
         when(mockDomainDeployer.deployPackagedArtifact(DOMAIN_ZIP_PATH)).thenReturn(mockDomain);
         putApplicationInTestDomainAppsFolder(testAppName);
         putApplicationInTestDomainAppsFolder(testApp2Name);
-        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockApplicationArtifactDeployer, mockDeploymentService);
+        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockDeploymentService);
         domainArchiveDeployer.deployPackagedArtifact(DOMAIN_ZIP_PATH);
         verifyApplicationCopyToAppsFolder(testAppName);
         verifyApplicationCopyToAppsFolder(testApp2Name);
@@ -122,7 +122,7 @@ public class DomainArchiveDeployerTestCase extends AbstractMuleTestCase
         when(mockDeploymentService.findDomain(DOMAIN_NAME)).thenReturn(mockDomain);
         when(mockDomainDeployer.deployPackagedArtifact(DOMAIN_ZIP_PATH)).thenReturn(mockDomain);
         when(mockDeploymentService.findDomainApplications(DOMAIN_NAME)).thenReturn(Arrays.asList(new Application[0]));
-        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockApplicationArtifactDeployer, mockDeploymentService);
+        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockDeploymentService);
         domainArchiveDeployer.undeployArtifact(DOMAIN_NAME);
         verify(mockDomainDeployer, times(1)).undeployArtifact(DOMAIN_NAME);
     }
@@ -133,7 +133,7 @@ public class DomainArchiveDeployerTestCase extends AbstractMuleTestCase
         when(mockDeploymentService.findDomain(DOMAIN_NAME)).thenReturn(mockDomain);
         when(mockDomainDeployer.deployPackagedArtifact(DOMAIN_ZIP_PATH)).thenReturn(mockDomain);
         when(mockDeploymentService.findDomainApplications(DOMAIN_NAME)).thenReturn(Arrays.asList(new Application[] {mockApplication1, mockApplication2}));
-        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockApplicationArtifactDeployer, mockDeploymentService);
+        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockDeploymentService);
         domainArchiveDeployer.undeployArtifact(DOMAIN_NAME);
         verify(mockApplicationDeployer, times(1)).undeployArtifact(MOCK_APPLICATION_1_NAME);
         verify(mockApplicationDeployer, times(1)).undeployArtifact(MOCK_APPLICATION_2_NAME);
@@ -144,7 +144,7 @@ public class DomainArchiveDeployerTestCase extends AbstractMuleTestCase
     public void undeployNonExistentDomain()
     {
         when(mockDeploymentService.findDomain(NON_EXISTENT_DOMAIN_ID)).thenReturn(null);
-        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockApplicationArtifactDeployer, mockDeploymentService);
+        DomainArchiveDeployer domainArchiveDeployer = new DomainArchiveDeployer(mockDomainDeployer, mockApplicationDeployer, mockDeploymentService);
         domainArchiveDeployer.undeployArtifact(NON_EXISTENT_DOMAIN_ID);
     }
 


### PR DESCRIPTION
_ Removing lazy initialisation from ApplicationStatusMapper
_ Synchronising access to LoggerContextCache#getLoggerContext
_ Synchronising ObservableList
_ Extracting isUpdatedZombieArtifact from ArchiveDeployer#deployExplodedApp so it can be executed without having to run a new thread
_ Removing deployment lock from DefaultArchiveDeployer so locking is managed form DeploymentService
_ Moving MuleContainer#initArgs before creation of deployment service so the StartupContext can be used on the MuleDeploymentService constructor
_ Updating MuleDeploymentService to create a sequential or parallel deploymentDirectoryWatcher depending on the configuration
_ Adding ParallelDeploymentDirectoryWatcher to manage parallel deployment
_ Making DeploymentServiceTestCase parameterised to run sequential/parallel deployments
_ Adding deploysMultipleAppsZipOnStartup
_ Fixing test flakiness and bugs (MULE-10094 and a couple of non reported ones)