### PR TITLE
MULE-10452: Memory leak caused by DefaultDataTypeBuilder's cache

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/metadata/DefaultDataTypeBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/metadata/DefaultDataTypeBuilder.java
@@ -327,7 +327,8 @@ public class DefaultDataTypeBuilder implements DataTypeBuilder, DataTypeBuilder.
     }
 
     built = true;
-    return dataTypeCache.getUnchecked(this);
+    //TODO(pablo.kraan): MULE-10452 - re-add the dataType cache but avoiding the memory-leak
+    return this.doBuild();
   }
 
   protected DataType doBuild() {


### PR DESCRIPTION
_ Creating the datatype instance every time instead of using the cache to avoid the memory leak (temporal solution for M3)