### PR TITLE
MULE-10453: Memory leak caused by per-app logging

### DIFF
--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/ArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/ArtifactClassLoader.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.module.artifact.classloader;
 
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
@@ -16,6 +18,12 @@ public interface ArtifactClassLoader extends DisposableClassLoader, LocalResourc
    * @return the artifact unique identifier
    */
   String getArtifactName();
+
+  /**
+   * @param <T> the generic type of the artifact descriptor.
+   * @return the artifact descriptor corresponding to this classloader instance. Non null.
+   */
+  <T extends ArtifactDescriptor> T getArtifactDescriptor();
 
   /**
    * @param resource name of the resource to find.

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/FilteringArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/FilteringArtifactClassLoader.java
@@ -17,6 +17,7 @@ import static org.mule.runtime.core.api.config.MuleProperties.MULE_LOG_VERBOSE_C
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
 
 import org.mule.runtime.module.artifact.classloader.exception.NotExportedClassException;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 
 import java.io.IOException;
 import java.net.URL;
@@ -127,6 +128,11 @@ public class FilteringArtifactClassLoader extends ClassLoader implements Artifac
   @Override
   public String getArtifactName() {
     return artifactClassLoader.getArtifactName();
+  }
+
+  @Override
+  public <T extends ArtifactDescriptor> T getArtifactDescriptor() {
+    return artifactClassLoader.getArtifactDescriptor();
   }
 
   @Override

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/MuleDeployableArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/MuleDeployableArtifactClassLoader.java
@@ -8,6 +8,8 @@ package org.mule.runtime.module.artifact.classloader;
 
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
 
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+
 import java.net.URL;
 import java.util.List;
 
@@ -23,15 +25,16 @@ public class MuleDeployableArtifactClassLoader extends MuleArtifactClassLoader {
   /**
    * Creates a {@link MuleDeployableArtifactClassLoader} with the provided configuration.
    *
-   * @param name artifact name
+   * @param artifactDescriptor descriptor for the artifact owning the created class loader instance.
    * @param urls the URLs from which to load classes and resources
    * @param parent parent class loader in the hierarchy
    * @param lookupPolicy policy for resolving classes and resources
    * @param artifactPluginClassLoaders class loaders for the plugin artifacts contained by this artifact. Must be not null.
    */
-  public MuleDeployableArtifactClassLoader(String name, URL[] urls, ClassLoader parent, ClassLoaderLookupPolicy lookupPolicy,
+  public MuleDeployableArtifactClassLoader(ArtifactDescriptor artifactDescriptor, URL[] urls, ClassLoader parent,
+                                           ClassLoaderLookupPolicy lookupPolicy,
                                            List<ArtifactClassLoader> artifactPluginClassLoaders) {
-    super(name, urls, parent, lookupPolicy);
+    super(artifactDescriptor, urls, parent, lookupPolicy);
     checkArgument(artifactPluginClassLoaders != null, "artifact plugin class loaders cannot be null");
     this.artifactPluginClassLoaders = artifactPluginClassLoaders;
   }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/RegionClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/RegionClassLoader.java
@@ -7,8 +7,10 @@
 
 package org.mule.runtime.module.artifact.classloader;
 
+import static java.util.Collections.emptyList;
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
 import org.mule.runtime.core.util.ClassUtils;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 
 import java.io.IOException;
 import java.net.URL;
@@ -36,25 +38,37 @@ import sun.misc.CompoundEnumeration;
  * Only a region member can export a given package, but same resources can be exported by many members. The order in which the
  * resources are found will depend on the order in which the class loaders were added to the region.
  */
-public class RegionClassLoader extends MuleArtifactClassLoader {
+public class RegionClassLoader extends MuleDeployableArtifactClassLoader {
 
   static {
     registerAsParallelCapable();
   }
 
-  private final List<ArtifactClassLoader> classLoaders = new ArrayList<>();
+  private final List<ArtifactClassLoader> filteredClassLoaders = new ArrayList<>();
+  private final List<ArtifactClassLoader> unfilteredClassLoaders = new ArrayList<>();
   private final Map<String, ArtifactClassLoader> packageMapping = new HashMap<>();
   private final Map<String, List<ArtifactClassLoader>> resourceMapping = new HashMap<>();
 
   /**
    * Creates a new region.
-   * 
-   * @param name name of the region. Non empty
+   *
+   * @param artifactDescriptor descriptor for the artifact owning the created class loader instance.
    * @param parent parent classloader for the region. Non null
    * @param lookupPolicy lookup policy to use on the region
    */
-  public RegionClassLoader(String name, ClassLoader parent, ClassLoaderLookupPolicy lookupPolicy) {
-    super(name, new URL[0], parent, lookupPolicy);
+  public RegionClassLoader(ArtifactDescriptor artifactDescriptor, ClassLoader parent, ClassLoaderLookupPolicy lookupPolicy) {
+    super(artifactDescriptor, new URL[0], parent, lookupPolicy, emptyList());
+  }
+
+  @Override
+  public List<ArtifactClassLoader> getArtifactPluginClassLoaders() {
+
+    List<ArtifactClassLoader> result = emptyList();
+    if (unfilteredClassLoaders.size() > 1) {
+      result = unfilteredClassLoaders.subList(1, unfilteredClassLoaders.size());
+    }
+
+    return result;
   }
 
   /**
@@ -67,10 +81,11 @@ public class RegionClassLoader extends MuleArtifactClassLoader {
   public void addClassLoader(ArtifactClassLoader artifactClassLoader, ArtifactClassLoaderFilter filter) {
     checkArgument(artifactClassLoader != null, "artifactClassLoader cannot be null");
     checkArgument(filter != null, "filter cannot be null");
-    if (classLoaders.contains(artifactClassLoader)) {
+    if (filteredClassLoaders.contains(artifactClassLoader)) {
       throw new IllegalArgumentException("Region already contains classloader " + artifactClassLoader);
     }
-    classLoaders.add(artifactClassLoader);
+    filteredClassLoaders.add(new FilteringArtifactClassLoader(artifactClassLoader, filter));
+    unfilteredClassLoaders.add(artifactClassLoader);
 
     filter.getExportedClassPackages().forEach(p -> packageMapping.put(p, artifactClassLoader));
 
@@ -119,7 +134,7 @@ public class RegionClassLoader extends MuleArtifactClassLoader {
   @Override
   public final Enumeration<URL> findResources(final String name) throws IOException {
     final List<ArtifactClassLoader> artifactClassLoaders = resourceMapping.get(name);
-    List<Enumeration<URL>> enumerations = new ArrayList<>(classLoaders.size());
+    List<Enumeration<URL>> enumerations = new ArrayList<>(filteredClassLoaders.size());
 
     if (artifactClassLoaders != null) {
       for (ArtifactClassLoader artifactClassLoader : artifactClassLoaders) {
@@ -132,5 +147,35 @@ public class RegionClassLoader extends MuleArtifactClassLoader {
     }
 
     return new CompoundEnumeration<>(enumerations.toArray(new Enumeration[0]));
+  }
+
+  @Override
+  public void dispose() {
+    for (ArtifactClassLoader classLoader : unfilteredClassLoaders) {
+      try {
+        classLoader.dispose();
+      } catch (Exception e) {
+        // Ignore and continue
+      }
+    }
+
+    unfilteredClassLoaders.clear();
+    filteredClassLoaders.clear();
+
+    super.dispose();
+  }
+
+  @Override
+  public URL findLocalResource(String resourceName) {
+    URL resource = getOwnerClassLoader().findLocalResource(resourceName);
+
+    if (resource == null && getParent() instanceof LocalResourceLocator) {
+      resource = ((LocalResourceLocator) getParent()).findLocalResource(resourceName);
+    }
+    return resource;
+  }
+
+  private ArtifactClassLoader getOwnerClassLoader() {
+    return filteredClassLoaders.get(0);
   }
 }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/RegionClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/RegionClassLoader.java
@@ -155,7 +155,12 @@ public class RegionClassLoader extends MuleDeployableArtifactClassLoader {
       try {
         classLoader.dispose();
       } catch (Exception e) {
-        // Ignore and continue
+        final String message = "Error disposing classloader for '{}'. This can cause a memory leak";
+        if (logger.isDebugEnabled()) {
+          logger.debug(message, getArtifactDescriptor().getName(), e);
+        } else {
+          logger.error(message, getArtifactDescriptor().getName());
+        }
       }
     }
 

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ArtifactDescriptor.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ArtifactDescriptor.java
@@ -8,6 +8,8 @@
 package org.mule.runtime.module.artifact.descriptor;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.core.util.Preconditions.checkArgument;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilter;
 import org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter;
 
@@ -15,16 +17,22 @@ import java.io.File;
 
 public class ArtifactDescriptor {
 
-  private String name;
+  private final String name;
   private File rootFolder;
   private ArtifactClassLoaderFilter classLoaderFilter = DefaultArtifactClassLoaderFilter.NULL_CLASSLOADER_FILTER;
 
-  public String getName() {
-    return name;
+  /**
+   * Creates a new descriptor for a named artifact
+   *
+   * @param name artifact name. Non empty.
+   */
+  public ArtifactDescriptor(String name) {
+    checkArgument(!isEmpty(name), "Artifact name cannot be empty");
+    this.name = name;
   }
 
-  public void setName(String name) {
-    this.name = name;
+  public String getName() {
+    return name;
   }
 
   public File getRootFolder() {

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/ResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/ResourceReleaserTestCase.java
@@ -15,6 +15,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -94,7 +95,7 @@ public class ResourceReleaserTestCase extends AbstractMuleTestCase {
     private ResourceReleaser resourceReleaserInstance;
 
     public TestArtifactClassLoader(ClassLoader parentCl) {
-      super("testArtifact", new URL[0], parentCl, new ClassLoaderLookupPolicy() {
+      super(new ArtifactDescriptor("test"), new URL[0], parentCl, new ClassLoaderLookupPolicy() {
 
         @Override
         public ClassLoaderLookupStrategy getLookupStrategy(String className) {

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/TestArtifactClassLoader.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/TestArtifactClassLoader.java
@@ -7,6 +7,8 @@
 
 package org.mule.runtime.module.artifact.classloader;
 
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
@@ -15,6 +17,11 @@ public class TestArtifactClassLoader extends TestClassLoader implements Artifact
 
   @Override
   public String getArtifactName() {
+    return null;
+  }
+
+  @Override
+  public <T extends ArtifactDescriptor> T getArtifactDescriptor() {
     return null;
   }
 

--- a/modules/container/src/main/java/org/mule/runtime/container/internal/ContainerClassLoaderFactory.java
+++ b/modules/container/src/main/java/org/mule/runtime/container/internal/ContainerClassLoaderFactory.java
@@ -16,6 +16,7 @@ import org.mule.runtime.module.artifact.classloader.EnumerationAdapter;
 import org.mule.runtime.module.artifact.classloader.FilteringArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -42,8 +43,9 @@ public class ContainerClassLoaderFactory {
       registerAsParallelCapable();
     }
 
-    private MuleContainerClassLoader(String name, URL[] urls, ClassLoader parent, ClassLoaderLookupPolicy lookupPolicy) {
-      super(name, urls, parent, lookupPolicy);
+    private MuleContainerClassLoader(ArtifactDescriptor artifactDescriptor, URL[] urls, ClassLoader parent,
+                                     ClassLoaderLookupPolicy lookupPolicy) {
+      super(artifactDescriptor, urls, parent, lookupPolicy);
     }
 
     @Override
@@ -93,7 +95,8 @@ public class ContainerClassLoaderFactory {
   public ArtifactClassLoader createContainerClassLoader(final ClassLoader parentClassLoader) {
     final List<MuleModule> muleModules = moduleDiscoverer.discover();
     final ClassLoaderLookupPolicy containerLookupPolicy = getContainerClassLoaderLookupPolicy(muleModules);
-    return createArtifactClassLoader(parentClassLoader, muleModules, containerLookupPolicy);
+
+    return createArtifactClassLoader(parentClassLoader, muleModules, containerLookupPolicy, new ArtifactDescriptor("mule"));
   }
 
   /**
@@ -116,12 +119,15 @@ public class ContainerClassLoaderFactory {
    * @param parentClassLoader the parent {@link ClassLoader} for the container
    * @param muleModules the list of {@link MuleModule}s to be used for defining the filter
    * @param containerLookupPolicy the {@link ClassLoaderLookupPolicy} to be used by the container
+   * @param artifactDescriptor descriptor for the artifact owning the created class loader instance.
    * @return a {@link ArtifactClassLoader} to be used in a {@link FilteringContainerClassLoader}
    */
   protected ArtifactClassLoader createArtifactClassLoader(final ClassLoader parentClassLoader, List<MuleModule> muleModules,
-                                                          final ClassLoaderLookupPolicy containerLookupPolicy) {
-    return createContainerFilteringClassLoader(muleModules, new MuleContainerClassLoader("mule", new URL[0], parentClassLoader,
-                                                                                         containerLookupPolicy));
+                                                          final ClassLoaderLookupPolicy containerLookupPolicy,
+                                                          ArtifactDescriptor artifactDescriptor) {
+    return createContainerFilteringClassLoader(muleModules,
+                                               new MuleContainerClassLoader(artifactDescriptor, new URL[0], parentClassLoader,
+                                                                            containerLookupPolicy));
   }
 
   public void setModuleDiscoverer(ModuleDiscoverer moduleDiscoverer) {

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/AbstractArtifactClassLoaderBuilder.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/AbstractArtifactClassLoaderBuilder.java
@@ -19,7 +19,6 @@ import org.mule.runtime.module.deployment.internal.application.ArtifactPluginFac
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilter;
 import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
-import org.mule.runtime.module.artifact.classloader.FilteringArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptor;
@@ -118,7 +117,7 @@ public abstract class AbstractArtifactClassLoaderBuilder<T extends AbstractArtif
     checkState(artifactDescriptor != null, "artifact descriptor cannot be null");
     parentClassLoader = getParentClassLoader();
     checkState(parentClassLoader != null, "parent class loader cannot be null");
-    RegionClassLoader regionClassLoader = new RegionClassLoader("Region" + artifactId, parentClassLoader.getClassLoader(),
+    RegionClassLoader regionClassLoader = new RegionClassLoader(artifactDescriptor, parentClassLoader.getClassLoader(),
                                                                 parentClassLoader.getClassLoaderLookupPolicy());
 
     List<ArtifactPluginDescriptor> effectiveArtifactPluginDescriptors = createContainerApplicationPlugins();
@@ -136,6 +135,7 @@ public abstract class AbstractArtifactClassLoaderBuilder<T extends AbstractArtif
       final ArtifactClassLoaderFilter classLoaderFilter = effectiveArtifactPluginDescriptors.get(i).getClassLoaderFilter();
       regionClassLoader.addClassLoader(pluginClassLoaders.get(i), classLoaderFilter);
     }
+
     return artifactClassLoader;
   }
 
@@ -172,11 +172,7 @@ public abstract class AbstractArtifactClassLoaderBuilder<T extends AbstractArtif
 
       ArtifactPlugin artifactPlugin = artifactPluginFactory.create(artifactPluginDescriptor, parent);
       artifactPluginClassLoaders.add(artifactPlugin.getArtifactClassLoader());
-
-      final FilteringArtifactClassLoader filteringPluginClassLoader =
-          new FilteringArtifactClassLoader(artifactPlugin.getArtifactClassLoader(),
-                                           artifactPlugin.getDescriptor().getClassLoaderFilter());
-      classLoaders.add(filteringPluginClassLoader);
+      classLoaders.add(artifactPlugin.getArtifactClassLoader());
     }
     return classLoaders;
   }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ApplicationClassLoaderBuilder.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ApplicationClassLoaderBuilder.java
@@ -7,12 +7,12 @@
 package org.mule.runtime.module.deployment.internal;
 
 import static org.mule.runtime.core.util.Preconditions.checkState;
-
-import org.mule.runtime.module.deployment.api.domain.Domain;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.deployment.api.application.Application;
+import org.mule.runtime.module.deployment.api.domain.Domain;
 import org.mule.runtime.module.deployment.internal.application.ArtifactPluginFactory;
 import org.mule.runtime.module.deployment.internal.application.MuleApplicationClassLoaderFactory;
-import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginRepository;
 
 import java.io.IOException;
@@ -47,12 +47,13 @@ public class ApplicationClassLoaderBuilder extends AbstractArtifactClassLoaderBu
    * Creates a new {@code ArtifactClassLoader} using the provided configuration. It will create the proper class loader hierarchy
    * and filters so application classes, resources, plugins and it's domain resources are resolve correctly.
    *
-   * @return a {@code ArtifactClassLoader} created from the provided configuration.
+   * @return a {@code MuleDeployableArtifactClassLoader} created from the provided configuration.
    * @throws IOException exception cause when it was not possible to access the file provided as dependencies
    */
-  public MuleApplicationClassLoader build() throws IOException {
+  public MuleDeployableArtifactClassLoader build() throws IOException {
     checkState(domain != null, "Domain cannot be null");
-    return (MuleApplicationClassLoader) super.build();
+
+    return (MuleDeployableArtifactClassLoader) super.build();
   }
 
   /**

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DeploymentDirectoryWatcher.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DeploymentDirectoryWatcher.java
@@ -389,7 +389,7 @@ public class DeploymentDirectoryWatcher implements Runnable {
           domainArchiveDeployer.deployExplodedArtifact(addedDomain);
         }
       } catch (DeploymentException e) {
-        // Ignore and continue
+        logger.error("Error deploying domain '{}'", addedDomain, e);
       }
     }
   }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleApplicationClassLoader.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleApplicationClassLoader.java
@@ -7,11 +7,12 @@
 package org.mule.runtime.module.deployment.internal;
 
 import org.mule.runtime.container.api.MuleFoldersUtil;
-import org.mule.runtime.module.deployment.internal.application.ApplicationClassLoader;
-import org.mule.runtime.module.deployment.internal.nativelib.NativeLibraryFinder;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+import org.mule.runtime.module.deployment.internal.application.ApplicationClassLoader;
+import org.mule.runtime.module.deployment.internal.nativelib.NativeLibraryFinder;
 
 import java.net.URL;
 import java.util.List;
@@ -24,9 +25,10 @@ public class MuleApplicationClassLoader extends MuleDeployableArtifactClassLoade
 
   private NativeLibraryFinder nativeLibraryFinder;
 
-  public MuleApplicationClassLoader(String appName, ClassLoader parentCl, NativeLibraryFinder nativeLibraryFinder, List<URL> urls,
+  public MuleApplicationClassLoader(ArtifactDescriptor artifactDescriptor, ClassLoader parentCl,
+                                    NativeLibraryFinder nativeLibraryFinder, List<URL> urls,
                                     ClassLoaderLookupPolicy lookupPolicy, List<ArtifactClassLoader> artifactPluginClassLoaders) {
-    super(appName, urls.toArray(new URL[0]), parentCl, lookupPolicy, artifactPluginClassLoaders);
+    super(artifactDescriptor, urls.toArray(new URL[0]), parentCl, lookupPolicy, artifactPluginClassLoaders);
 
     this.nativeLibraryFinder = nativeLibraryFinder;
   }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleSharedDomainClassLoader.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleSharedDomainClassLoader.java
@@ -8,10 +8,10 @@ package org.mule.runtime.module.deployment.internal;
 
 import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainFolder;
 
-import org.mule.runtime.container.api.MuleFoldersUtil;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
 
 import java.io.File;
@@ -28,8 +28,9 @@ public class MuleSharedDomainClassLoader extends MuleArtifactClassLoader impleme
     registerAsParallelCapable();
   }
 
-  public MuleSharedDomainClassLoader(String domain, ClassLoader parent, ClassLoaderLookupPolicy lookupPolicy, List<URL> urls) {
-    super(domain, urls.toArray(new URL[0]), parent, lookupPolicy);
+  public MuleSharedDomainClassLoader(ArtifactDescriptor artifactDescriptor, ClassLoader parent,
+                                     ClassLoaderLookupPolicy lookupPolicy, List<URL> urls) {
+    super(artifactDescriptor, urls.toArray(new URL[0]), parent, lookupPolicy);
   }
 
   @Override

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/TemporaryArtifactClassLoaderBuilder.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/TemporaryArtifactClassLoaderBuilder.java
@@ -51,7 +51,7 @@ public class TemporaryArtifactClassLoaderBuilder extends AbstractArtifactClassLo
    */
   @Override
   public MuleDeployableArtifactClassLoader build() throws IOException {
-    setArtifactDescriptor(new ArtifactDescriptor());
+    setArtifactDescriptor(new ArtifactDescriptor("temp"));
     return (MuleDeployableArtifactClassLoader) super.build();
   }
 

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/TemporaryArtifactClassLoaderFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/TemporaryArtifactClassLoaderFactory.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.module.deployment.internal;
 
-import static org.mule.runtime.core.util.UUID.getUUID;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
@@ -28,7 +27,7 @@ public class TemporaryArtifactClassLoaderFactory implements DeployableArtifactCl
   @Override
   public ArtifactClassLoader create(ArtifactClassLoader parent, ArtifactDescriptor descriptor,
                                     List<ArtifactClassLoader> artifactPluginClassLoaders) {
-    return new MuleDeployableArtifactClassLoader(getUUID(), new URL[0], parent.getClassLoader(),
+    return new MuleDeployableArtifactClassLoader(descriptor, new URL[0], parent.getClassLoader(),
                                                  parent.getClassLoaderLookupPolicy(), artifactPluginClassLoaders);
   }
 

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/ArtifactPluginClassLoaderFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/ArtifactPluginClassLoaderFactory.java
@@ -52,7 +52,7 @@ public class ArtifactPluginClassLoaderFactory implements ArtifactClassLoaderFact
 
     final ClassLoaderLookupPolicy lookupPolicy = parent.getClassLoaderLookupPolicy().extend(pluginsLookupPolicies);
 
-    return new MuleArtifactClassLoader(descriptor.getName(), urls, parent.getClassLoader(), lookupPolicy);
+    return new MuleArtifactClassLoader(descriptor, urls, parent.getClassLoader(), lookupPolicy);
   }
 
   private ClassLoaderLookupStrategy getClassLoaderLookupStrategy(ArtifactPluginDescriptor descriptor,

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactory.java
@@ -11,16 +11,15 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 import static org.mule.runtime.core.config.i18n.MessageFactory.createStaticMessage;
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
-
+import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.deployment.api.DeploymentException;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.module.deployment.api.application.Application;
+import org.mule.runtime.module.deployment.api.domain.Domain;
 import org.mule.runtime.module.deployment.internal.ApplicationClassLoaderBuilderFactory;
 import org.mule.runtime.module.deployment.internal.ApplicationDescriptorFactory;
-import org.mule.runtime.module.deployment.internal.MuleApplicationClassLoader;
 import org.mule.runtime.module.deployment.internal.artifact.ArtifactFactory;
 import org.mule.runtime.module.deployment.internal.descriptor.ApplicationDescriptor;
-import org.mule.runtime.module.deployment.api.domain.Domain;
 import org.mule.runtime.module.deployment.internal.domain.DomainRepository;
 import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginRepository;
@@ -88,9 +87,10 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
                                                                descriptor.getDomain(), descriptor.getName())));
     }
 
-    MuleApplicationClassLoader applicationClassLoader = applicationClassLoaderBuilderFactory.createArtifactClassLoaderBuilder()
-        .setDomain(domain).addArtifactPluginDescriptors(descriptor.getPlugins().toArray(new ArtifactPluginDescriptor[0]))
-        .setArtifactId(descriptor.getName()).setArtifactDescriptor(descriptor).build();
+    MuleDeployableArtifactClassLoader applicationClassLoader =
+        applicationClassLoaderBuilderFactory.createArtifactClassLoaderBuilder()
+            .setDomain(domain).addArtifactPluginDescriptors(descriptor.getPlugins().toArray(new ArtifactPluginDescriptor[0]))
+            .setArtifactId(descriptor.getName()).setArtifactDescriptor(descriptor).build();
 
     List<ArtifactPluginDescriptor> applicationPluginDescriptors =
         concat(artifactPluginRepository.getContainerArtifactPluginDescriptors().stream(), descriptor.getPlugins().stream())
@@ -108,7 +108,7 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
     return new ApplicationWrapper(delegate);
   }
 
-  private List<ArtifactPlugin> createArtifactPluginList(MuleApplicationClassLoader applicationClassLoader,
+  private List<ArtifactPlugin> createArtifactPluginList(MuleDeployableArtifactClassLoader applicationClassLoader,
                                                         List<ArtifactPluginDescriptor> plugins) {
     return plugins.stream()
         .map(artifactPluginDescriptor -> new DefaultArtifactPlugin(artifactPluginDescriptor, applicationClassLoader

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultMuleApplication.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultMuleApplication.java
@@ -255,8 +255,8 @@ public class DefaultMuleApplication implements Application {
     }
   }
 
-  private static boolean isRegionClassLoaderMember(ClassLoader loggerClassLoader) {
-    return !(loggerClassLoader instanceof RegionClassLoader) && loggerClassLoader.getParent() instanceof RegionClassLoader;
+  private static boolean isRegionClassLoaderMember(ClassLoader classLoader) {
+    return !(classLoader instanceof RegionClassLoader) && classLoader.getParent() instanceof RegionClassLoader;
   }
 
   @Override

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/MuleApplicationClassLoaderFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/MuleApplicationClassLoaderFactory.java
@@ -6,14 +6,17 @@
  */
 package org.mule.runtime.module.deployment.internal.application;
 
-import org.mule.runtime.module.deployment.internal.MuleApplicationClassLoader;
-import org.mule.runtime.module.deployment.internal.nativelib.NativeLibraryFinderFactory;
-import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptor;
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getAppClassesFolder;
+import static org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy.PARENT_FIRST;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy;
 import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
+import org.mule.runtime.module.deployment.internal.MuleApplicationClassLoader;
 import org.mule.runtime.module.deployment.internal.descriptor.ApplicationDescriptor;
+import org.mule.runtime.module.deployment.internal.nativelib.NativeLibraryFinderFactory;
+import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptor;
 
 import java.io.IOException;
 import java.net.URL;
@@ -24,10 +27,6 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
-import static org.mule.runtime.container.api.MuleFoldersUtil.getAppClassesFolder;
-import static org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy.*;
 
 /**
  * Creates {@link MuleApplicationClassLoader} instances based on the application descriptor.
@@ -48,7 +47,7 @@ public class MuleApplicationClassLoaderFactory implements DeployableArtifactClas
 
     final ClassLoaderLookupPolicy classLoaderLookupPolicy = getApplicationClassLoaderLookupPolicy(parent, descriptor);
 
-    return new MuleApplicationClassLoader(descriptor.getName(), parent.getClassLoader(),
+    return new MuleApplicationClassLoader(descriptor, parent.getClassLoader(),
                                           nativeLibraryFinderFactory.create(descriptor.getName()), urls,
                                           classLoaderLookupPolicy, artifactPluginClassLoaders);
   }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/ApplicationDescriptor.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/ApplicationDescriptor.java
@@ -34,6 +34,15 @@ public class ApplicationDescriptor extends DeployableArtifactDescriptor {
   private File logConfigFile;
   private Set<ArtifactPluginDescriptor> plugins = new HashSet<>(0);
 
+  /**
+   * Creates a new application descriptor
+   *
+   * @param name application name. Non empty.
+   */
+  public ApplicationDescriptor(String name) {
+    super(name);
+  }
+
   public String getEncoding() {
     return encoding;
   }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/DeployableArtifactDescriptor.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/DeployableArtifactDescriptor.java
@@ -21,6 +21,15 @@ public class DeployableArtifactDescriptor extends ArtifactDescriptor {
   private URL[] runtimeLibs = new URL[0];
   private URL[] sharedRuntimeLibs = new URL[0];
 
+  /**
+   * Creates a new deployable artifact descriptor
+   *
+   * @param name artifact name. Non empty.
+   */
+  public DeployableArtifactDescriptor(String name) {
+    super(name);
+  }
+
   public boolean isRedeploymentEnabled() {
     return redeploymentEnabled;
   }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/DomainDescriptor.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/DomainDescriptor.java
@@ -10,4 +10,13 @@ package org.mule.runtime.module.deployment.internal.descriptor;
  * Represents the description of a domain.
  */
 public class DomainDescriptor extends DeployableArtifactDescriptor {
+
+  /**
+   * Creates a new domain descriptor
+   *
+   * @param name domain name. Non empty.
+   */
+  public DomainDescriptor(String name) {
+    super(name);
+  }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/DomainDescriptorParser.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/DomainDescriptorParser.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.module.deployment.internal.descriptor;
 
+import static java.lang.Boolean.TRUE;
+import static org.apache.commons.lang.BooleanUtils.toBoolean;
 import static org.mule.runtime.core.util.PropertiesUtils.loadProperties;
 import static org.mule.runtime.module.deployment.internal.descriptor.PropertiesDescriptorParser.PROPERTY_REDEPLOYMENT_ENABLED;
 
@@ -13,8 +15,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
-
-import org.apache.commons.lang.BooleanUtils;
 
 /**
  * Descriptor parser exclusive for domains.
@@ -24,10 +24,9 @@ public class DomainDescriptorParser implements DescriptorParser<DomainDescriptor
   @Override
   public DomainDescriptor parse(File descriptor, String artifactName) throws IOException {
     final Properties properties = loadProperties(new FileInputStream(descriptor));
-    DomainDescriptor domainDescriptor = new DomainDescriptor();
-    domainDescriptor.setName(artifactName);
-    domainDescriptor.setRedeploymentEnabled(BooleanUtils
-        .toBoolean(properties.getProperty(PROPERTY_REDEPLOYMENT_ENABLED, Boolean.TRUE.toString())));
+    final DomainDescriptor domainDescriptor = new DomainDescriptor(artifactName);
+    domainDescriptor.setRedeploymentEnabled(toBoolean(properties.getProperty(PROPERTY_REDEPLOYMENT_ENABLED, TRUE.toString())));
+
     return domainDescriptor;
   }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/EmptyApplicationDescriptor.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/EmptyApplicationDescriptor.java
@@ -17,7 +17,7 @@ import java.io.File;
 public class EmptyApplicationDescriptor extends ApplicationDescriptor {
 
   public EmptyApplicationDescriptor(String appName) {
-    setName(appName);
+    super(appName);
     setConfigResources(new String[] {MuleServer.DEFAULT_CONFIGURATION});
     File configPathFile = MuleContainerBootstrapUtils.getMuleAppDefaultConfigFile(appName);
     String configPath = String.format(configPathFile.getAbsolutePath());

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/EmptyDomainDescriptor.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/EmptyDomainDescriptor.java
@@ -12,6 +12,6 @@ package org.mule.runtime.module.deployment.internal.descriptor;
 public class EmptyDomainDescriptor extends DomainDescriptor {
 
   public EmptyDomainDescriptor(String name) {
-    this.setName(name);
+    super(name);
   }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/PropertiesDescriptorParser.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/descriptor/PropertiesDescriptorParser.java
@@ -29,33 +29,33 @@ public class PropertiesDescriptorParser implements DescriptorParser<ApplicationD
 
   @Override
   public ApplicationDescriptor parse(File descriptor, String artifactName) throws IOException {
-    final Properties p = PropertiesUtils.loadProperties(new FileInputStream(descriptor));
+    final Properties properties = PropertiesUtils.loadProperties(new FileInputStream(descriptor));
 
-    ApplicationDescriptor d = new ApplicationDescriptor();
-    d.setName(artifactName);
-    d.setEncoding(p.getProperty(PROPERTY_ENCODING));
-    d.setDomain(p.getProperty(PROPERTY_DOMAIN));
+    ApplicationDescriptor appDescriptor = new ApplicationDescriptor(artifactName);
+    appDescriptor.setEncoding(properties.getProperty(PROPERTY_ENCODING));
+    appDescriptor.setDomain(properties.getProperty(PROPERTY_DOMAIN));
 
-    final String resProps = p.getProperty(PROPERTY_CONFIG_RESOURCES);
+    final String resProps = properties.getProperty(PROPERTY_CONFIG_RESOURCES);
     String[] urls;
     if (StringUtils.isBlank(resProps)) {
       urls = new String[] {DEFAULT_CONFIGURATION_RESOURCE};
     } else {
       urls = resProps.split(",");
     }
-    d.setConfigResources(urls);
+    appDescriptor.setConfigResources(urls);
 
     String[] absoluteResourcePaths = convertConfigResourcesToAbsolutePatch(urls, artifactName);
-    d.setAbsoluteResourcePaths(absoluteResourcePaths);
-    d.setConfigResourcesFile(convertConfigResourcesToFile(absoluteResourcePaths));
+    appDescriptor.setAbsoluteResourcePaths(absoluteResourcePaths);
+    appDescriptor.setConfigResourcesFile(convertConfigResourcesToFile(absoluteResourcePaths));
 
     // supports true (case insensitive), yes, on as positive values
-    d.setRedeploymentEnabled(BooleanUtils.toBoolean(p.getProperty(PROPERTY_REDEPLOYMENT_ENABLED, Boolean.TRUE.toString())));
+    appDescriptor.setRedeploymentEnabled(BooleanUtils
+        .toBoolean(properties.getProperty(PROPERTY_REDEPLOYMENT_ENABLED, Boolean.TRUE.toString())));
 
-    if (p.containsKey(PROPERTY_LOG_CONFIG_FILE)) {
-      d.setLogConfigFile(new File(p.getProperty(PROPERTY_LOG_CONFIG_FILE)));
+    if (properties.containsKey(PROPERTY_LOG_CONFIG_FILE)) {
+      appDescriptor.setLogConfigFile(new File(properties.getProperty(PROPERTY_LOG_CONFIG_FILE)));
     }
-    return d;
+    return appDescriptor;
   }
 
   private File[] convertConfigResourcesToFile(String[] absoluteResourcePaths) {

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginDescriptor.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginDescriptor.java
@@ -22,6 +22,15 @@ public class ArtifactPluginDescriptor extends DeployableArtifactDescriptor {
   private Set<String> pluginDependencies = new HashSet<>();
   private List<ArtifactPluginDescriptor> artifactPluginDescriptors = new ArrayList<>();
 
+  /**
+   * Creates a new artifact plugin descriptor
+   *
+   * @param name artifact plugin name. Non empty.
+   */
+  public ArtifactPluginDescriptor(String name) {
+    super(name);
+  }
+
   public URL getRuntimeClassesDir() {
     return runtimeClassesDir;
   }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginDescriptorFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginDescriptorFactory.java
@@ -51,9 +51,8 @@ public class ArtifactPluginDescriptorFactory implements ArtifactDescriptorFactor
   @Override
   public ArtifactPluginDescriptor create(File pluginFolder) throws ArtifactDescriptorCreateException {
     final String pluginName = pluginFolder.getName();
-    final ArtifactPluginDescriptor descriptor = new ArtifactPluginDescriptor();
+    final ArtifactPluginDescriptor descriptor = new ArtifactPluginDescriptor(pluginName);
     descriptor.setRootFolder(pluginFolder);
-    descriptor.setName(pluginName);
 
     final File pluginPropsFile = new File(pluginFolder, PLUGIN_PROPERTIES);
     if (pluginPropsFile.exists()) {

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDescriptorFactoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDescriptorFactoryTestCase.java
@@ -160,8 +160,7 @@ public class ApplicationDescriptorFactoryTestCase extends AbstractMuleTestCase {
     copyFile(createApplicationPluginFile(), new File(pluginDir, "plugin1.zip"));
 
     final ArtifactPluginRepository applicationPluginRepository = mock(ArtifactPluginRepository.class);
-    final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor();
-    plugin2Descriptor.setName("plugin2");
+    final ArtifactPluginDescriptor plugin2Descriptor = new ArtifactPluginDescriptor("plugin2");
     final Set<String> exportedPackages = new HashSet<>();
     exportedPackages.add("org.foo");
     exportedPackages.add("org.bar");

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
@@ -45,19 +45,18 @@ import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainFolder;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getServicesFolder;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;
 import static org.mule.runtime.core.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.EXPORTED_CLASS_PACKAGES_PROPERTY;
+import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.EXPORTED_RESOURCE_PROPERTY;
 import static org.mule.runtime.module.deployment.api.application.ApplicationStatus.DESTROYED;
 import static org.mule.runtime.module.deployment.api.application.ApplicationStatus.STOPPED;
 import static org.mule.runtime.module.deployment.api.domain.Domain.DEFAULT_DOMAIN_NAME;
 import static org.mule.runtime.module.deployment.api.domain.Domain.DOMAIN_CONFIG_FILE_LOCATION;
 import static org.mule.runtime.module.deployment.internal.DeploymentDirectoryWatcher.CHANGE_CHECK_INTERVAL_PROPERTY;
+import static org.mule.runtime.module.deployment.internal.MuleDeploymentService.PARALLEL_DEPLOYMENT_PROPERTY;
 import static org.mule.runtime.module.deployment.internal.application.TestApplicationFactory.createTestApplicationFactory;
 import static org.mule.runtime.module.deployment.internal.descriptor.PropertiesDescriptorParser.PROPERTY_DOMAIN;
-import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.EXPORTED_CLASS_PACKAGES_PROPERTY;
-import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.EXPORTED_RESOURCE_PROPERTY;
-import static org.mule.runtime.module.deployment.internal.MuleDeploymentService.PARALLEL_DEPLOYMENT_PROPERTY;
 import static org.mule.runtime.module.service.ServiceDescriptorFactory.SERVICE_PROVIDER_CLASS_NAME;
 import static org.mule.tck.junit4.AbstractMuleContextTestCase.TEST_MESSAGE;
-import static org.mule.tck.junit4.AbstractMuleTestCase.TEST_CONNECTOR;
 import org.mule.runtime.core.DefaultMessageContext;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.MuleEvent;
@@ -74,10 +73,12 @@ import org.mule.runtime.core.util.FileUtils;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.runtime.core.util.StringUtils;
 import org.mule.runtime.core.util.concurrent.Latch;
+import org.mule.runtime.module.artifact.builder.TestArtifactDescriptor;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.module.deployment.api.application.Application;
-import org.mule.runtime.module.deployment.api.domain.Domain;
 import org.mule.runtime.module.deployment.api.application.ApplicationStatus;
+import org.mule.runtime.module.deployment.api.domain.Domain;
 import org.mule.runtime.module.deployment.internal.application.MuleApplicationClassLoaderFactory;
 import org.mule.runtime.module.deployment.internal.application.TestApplicationFactory;
 import org.mule.runtime.module.deployment.internal.builder.ApplicationFileBuilder;
@@ -88,8 +89,6 @@ import org.mule.runtime.module.deployment.internal.domain.DefaultDomainManager;
 import org.mule.runtime.module.deployment.internal.domain.DefaultMuleDomain;
 import org.mule.runtime.module.deployment.internal.domain.DomainClassLoaderFactory;
 import org.mule.runtime.module.deployment.internal.domain.TestDomainFactory;
-import org.mule.runtime.module.artifact.builder.TestArtifactDescriptor;
-import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.deployment.internal.nativelib.DefaultNativeLibraryFinderFactory;
 import org.mule.runtime.module.service.ServiceManager;
 import org.mule.runtime.module.service.ServiceRepository;
@@ -2968,11 +2967,9 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
   }
 
   private DefaultMuleDomain createDefaultDomain() {
-    DomainDescriptor descriptor = new DomainDescriptor();
-    descriptor.setName(DEFAULT_DOMAIN_NAME);
-
-    return new DefaultMuleDomain(descriptor, new DomainClassLoaderFactory(getClass().getClassLoader())
-        .create(containerClassLoader, descriptor, emptyList()));
+    return new DefaultMuleDomain(new DomainDescriptor(DEFAULT_DOMAIN_NAME),
+                                 new DomainClassLoaderFactory(getClass().getClassLoader())
+                                     .create(containerClassLoader, new DomainDescriptor(DEFAULT_DOMAIN_NAME), emptyList()));
   }
 
   /**

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/MuleApplicationClassLoaderTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/MuleApplicationClassLoaderTestCase.java
@@ -20,6 +20,7 @@ import org.mule.runtime.container.api.MuleFoldersUtil;
 import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.core.util.FileUtils;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -88,11 +89,12 @@ public class MuleApplicationClassLoaderTestCase extends AbstractMuleTestCase {
     FileUtils.stringToFile(new File(domainDir, RESOURCE_JUST_IN_DOMAIN).getAbsolutePath(), "Some text");
 
     // Create app class loader
-    domainCL = new MuleSharedDomainClassLoader(DOMAIN_NAME, Thread.currentThread().getContextClassLoader(),
-                                               mock(ClassLoaderLookupPolicy.class), emptyList());
+    domainCL =
+        new MuleSharedDomainClassLoader(new ArtifactDescriptor(DOMAIN_NAME), Thread.currentThread().getContextClassLoader(),
+                                        mock(ClassLoaderLookupPolicy.class), emptyList());
 
-    appCL =
-        new MuleApplicationClassLoader(APP_NAME, domainCL, null, urls, mock(ClassLoaderLookupPolicy.class), emptyList());
+    appCL = new MuleApplicationClassLoader(new ArtifactDescriptor(APP_NAME), domainCL, null, urls,
+                                           mock(ClassLoaderLookupPolicy.class), emptyList());
   }
 
   @After
@@ -114,9 +116,9 @@ public class MuleApplicationClassLoaderTestCase extends AbstractMuleTestCase {
 
     // Ensure app resources are only loaded from classes directory
     assertLoadedFromClassesDir(appCL.findLocalResource(RESOURCE_IN_CLASSES_AND_JAR));
-    assertNotLoaded(appCL.findLocalResource(RESOURCE_JUST_IN_JAR));
     assertLoadedFromClassesDir(appCL.findLocalResource(RESOURCE_JUST_IN_CLASSES));
-    assertLoadedFromDomainDir(appCL.findLocalResource(RESOURCE_JUST_IN_DOMAIN));
+    assertNotLoaded(appCL.findLocalResource(RESOURCE_JUST_IN_JAR));
+    assertNotLoaded(appCL.findLocalResource(RESOURCE_JUST_IN_DOMAIN));
   }
 
   private void assertLoadedFromClassesDir(URL resource) {

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/MuleSharedDomainClassLoaderTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/MuleSharedDomainClassLoaderTestCase.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
@@ -59,8 +60,8 @@ public class MuleSharedDomainClassLoaderTestCase extends AbstractMuleTestCase {
     final File resourceFile = createDomainResource(DEFAULT_DOMAIN_NAME, RESOURCE_FILE_NAME);
     final List<URL> urls = Collections.singletonList(resourceFile.toURI().toURL());
 
-    MuleSharedDomainClassLoader classLoader =
-        new MuleSharedDomainClassLoader(DEFAULT_DOMAIN_NAME, getClass().getClassLoader(), lookupPolicy, urls);
+    MuleSharedDomainClassLoader classLoader = new MuleSharedDomainClassLoader(new ArtifactDescriptor(DEFAULT_DOMAIN_NAME),
+                                                                              getClass().getClassLoader(), lookupPolicy, urls);
 
     assertThat(classLoader.findResource(RESOURCE_FILE_NAME), notNullValue());
   }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/PropertyOverridesTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/PropertyOverridesTestCase.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  */
 public class PropertyOverridesTestCase extends AbstractMuleTestCase {
 
-  private Map<String, String> existingProperties = new HashMap<String, String>();
+  private Map<String, String> existingProperties = new HashMap<>();
 
   private void setSystemProperties() {
     setSystemProperty("texas", "province");
@@ -61,7 +61,7 @@ public class PropertyOverridesTestCase extends AbstractMuleTestCase {
     IOUtils.copy(input, output);
     input.close();
     output.close();
-    ApplicationDescriptor descriptor = new ApplicationDescriptor();
+    ApplicationDescriptor descriptor = new ApplicationDescriptor("app");
     ApplicationDescriptorFactory applicationDescriptorFactory =
         new ApplicationDescriptorFactory(new ArtifactPluginDescriptorLoader(new ArtifactPluginDescriptorFactory(new ArtifactClassLoaderFilterFactory())),
                                          applicationPluginRepository);
@@ -76,7 +76,7 @@ public class PropertyOverridesTestCase extends AbstractMuleTestCase {
 
     try {
       setSystemProperties();
-      descriptor = new ApplicationDescriptor();
+      descriptor = new ApplicationDescriptor("app");
       applicationDescriptorFactory.setApplicationProperties(descriptor, tempProps);
       appProps = descriptor.getAppProperties();
       assertEquals("state", appProps.get("texas"));
@@ -87,7 +87,7 @@ public class PropertyOverridesTestCase extends AbstractMuleTestCase {
       assertEquals("ipaas", appProps.get("mule.ion"));
       assertEquals("evenCooler", appProps.get("mule.mmc"));
 
-      descriptor = new ApplicationDescriptor();
+      descriptor = new ApplicationDescriptor("app");
       applicationDescriptorFactory.setApplicationProperties(descriptor, new File("nonexistent.nonexistent"));
       appProps = descriptor.getAppProperties();
       assertNull(appProps.get("texas"));

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactoryTestCase.java
@@ -70,8 +70,7 @@ public class DefaultApplicationFactoryTestCase extends AbstractMuleTestCase {
 
   @Test
   public void createsApplication() throws Exception {
-    final ApplicationDescriptor descriptor = new ApplicationDescriptor();
-    descriptor.setName(APP_NAME);
+    final ApplicationDescriptor descriptor = new ApplicationDescriptor(APP_NAME);
     descriptor.setDomain(DOMAIN_NAME);
     final File[] resourceFiles = new File[0];
     descriptor.setConfigResourcesFile(resourceFiles);
@@ -148,8 +147,7 @@ public class DefaultApplicationFactoryTestCase extends AbstractMuleTestCase {
 
   @Test
   public void applicationDesployFailDueToDomainNotDeployed() throws Exception {
-    final ApplicationDescriptor descriptor = new ApplicationDescriptor();
-    descriptor.setName(APP_NAME);
+    final ApplicationDescriptor descriptor = new ApplicationDescriptor(APP_NAME);
     descriptor.setDomain(DOMAIN_NAME);
     when(applicationDescriptorFactory.create(any())).thenReturn(descriptor);
 

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultArtifactPluginFactoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultArtifactPluginFactoryTestCase.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptor;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -36,9 +37,9 @@ public class DefaultArtifactPluginFactoryTestCase extends AbstractMuleTestCase {
     URL[] urls = new URL[] {getClass().getClassLoader().getResource("lib/bar-1.0.jar")};
     when(descriptor.getRuntimeLibs()).thenReturn(urls);
     when(descriptor.getRuntimeClassesDir()).thenReturn(getClass().getClassLoader().getResource("org/foo/"));
-
-    ArtifactClassLoader parentClassLoader = new MuleArtifactClassLoader("mule", new URL[0], getClass().getClassLoader(),
-                                                                        new MuleClassLoaderLookupPolicy(emptyMap(), emptySet()));
+    ArtifactClassLoader parentClassLoader =
+        new MuleArtifactClassLoader(new ArtifactDescriptor("mule"), new URL[0], getClass().getClassLoader(),
+                                    new MuleClassLoaderLookupPolicy(emptyMap(), emptySet()));
     ArtifactPlugin appPlugin =
         new DefaultArtifactPluginFactory(new ArtifactPluginClassLoaderFactory()).create(descriptor, parentClassLoader);
 

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/MuleApplicationClassLoaderFactoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/MuleApplicationClassLoaderFactoryTestCase.java
@@ -85,8 +85,7 @@ public class MuleApplicationClassLoaderFactoryTestCase extends AbstractMuleTestC
 
     MuleApplicationClassLoaderFactory classLoaderFactory = new MuleApplicationClassLoaderFactory(nativeLibraryFinderFactory);
 
-    final ApplicationDescriptor descriptor = new ApplicationDescriptor();
-    descriptor.setName(APP_NAME);
+    final ApplicationDescriptor descriptor = new ApplicationDescriptor(APP_NAME);
     descriptor.setDomain(DOMAIN_NAME);
 
     final MuleApplicationClassLoader artifactClassLoader =

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/AbstractDomainTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/AbstractDomainTestCase.java
@@ -14,6 +14,7 @@ import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
 
@@ -34,7 +35,7 @@ public class AbstractDomainTestCase extends AbstractMuleTestCase {
       new SystemProperty(MuleProperties.MULE_HOME_DIRECTORY_PROPERTY, temporaryFolder.getRoot().getCanonicalPath());
   protected final File muleHomeFolder;
   protected final ArtifactClassLoader containerClassLoader =
-      new MuleArtifactClassLoader("mule", new URL[0], getClass().getClassLoader(),
+      new MuleArtifactClassLoader(new ArtifactDescriptor("mule"), new URL[0], getClass().getClassLoader(),
                                   new MuleClassLoaderLookupPolicy(emptyMap(), emptySet()));
 
   public AbstractDomainTestCase() throws IOException {

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/DomainClassLoaderFactoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/DomainClassLoaderFactoryTestCase.java
@@ -88,8 +88,7 @@ public class DomainClassLoaderFactoryTestCase extends AbstractDomainTestCase {
   }
 
   private DomainDescriptor getTestDescriptor(String name) {
-    DomainDescriptor descriptor = new DomainDescriptor();
-    descriptor.setName(name);
+    DomainDescriptor descriptor = new DomainDescriptor(name);
     descriptor.setRedeploymentEnabled(false);
     return descriptor;
   }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginRepositoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginRepositoryTestCase.java
@@ -49,11 +49,8 @@ public class ArtifactPluginRepositoryTestCase extends AbstractMuleTestCase {
   @Before
   public void setUp() throws IOException {
     System.setProperty(MULE_HOME_DIRECTORY_PROPERTY, muleHomeFolder.getRoot().getCanonicalPath());
-    when(artifactPluginDescriptorFactory.create(anyObject())).thenAnswer(invocation -> {
-      ArtifactPluginDescriptor descriptor = new ArtifactPluginDescriptor();
-      descriptor.setName(((File) invocation.getArguments()[0]).getName());
-      return descriptor;
-    });
+    when(artifactPluginDescriptorFactory.create(anyObject()))
+        .thenAnswer(invocation -> new ArtifactPluginDescriptor(((File) invocation.getArguments()[0]).getName()));
 
     pluginsLibFolder = createContainerAppPluginsFolder();
   }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/plugin/NamePluginDependenciesResolverTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/plugin/NamePluginDependenciesResolverTestCase.java
@@ -31,20 +31,13 @@ import org.junit.rules.ExpectedException;
 public class NamePluginDependenciesResolverTestCase extends AbstractMuleTestCase {
 
 
-  private final ArtifactPluginDescriptor fooPlugin = createArtifactPluginDescriptor("foo");
-  private final ArtifactPluginDescriptor barPlugin = createArtifactPluginDescriptor("bar");
-  private final ArtifactPluginDescriptor bazPlugin = createArtifactPluginDescriptor("baz");
+  private final ArtifactPluginDescriptor fooPlugin = new ArtifactPluginDescriptor("foo");
+  private final ArtifactPluginDescriptor barPlugin = new ArtifactPluginDescriptor("bar");
+  private final ArtifactPluginDescriptor bazPlugin = new ArtifactPluginDescriptor("baz");
   private final PluginDependenciesResolver dependenciesResolver = new NamePluginDependenciesResolver();
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
-
-  private ArtifactPluginDescriptor createArtifactPluginDescriptor(String name) {
-    final ArtifactPluginDescriptor result = new ArtifactPluginDescriptor();
-    result.setName(name);
-
-    return result;
-  }
 
   @Test
   public void resolvesIndependentPlugins() throws Exception {

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelector.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelector.java
@@ -8,6 +8,7 @@ package org.mule.runtime.module.launcher.log4j2;
 
 import org.mule.runtime.core.api.lifecycle.Disposable;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 import org.mule.runtime.module.artifact.classloader.ShutdownListener;
 
 import java.net.URI;
@@ -91,8 +92,14 @@ class ArtifactAwareContextSelector implements ContextSelector, Disposable {
     ClassLoader loggerClassLoader = classLoader == null ? Thread.currentThread().getContextClassLoader() : classLoader;
     if (!(loggerClassLoader instanceof ArtifactClassLoader)) {
       loggerClassLoader = loggerClassLoader.getSystemClassLoader();
+    } else if (isRegionClassLoaderMember(loggerClassLoader)) {
+      loggerClassLoader = loggerClassLoader.getParent();
     }
     return loggerClassLoader;
+  }
+
+  private static boolean isRegionClassLoaderMember(ClassLoader loggerClassLoader) {
+    return !(loggerClassLoader instanceof RegionClassLoader) && loggerClassLoader.getParent() instanceof RegionClassLoader;
   }
 
   @Override

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelector.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelector.java
@@ -98,8 +98,8 @@ class ArtifactAwareContextSelector implements ContextSelector, Disposable {
     return loggerClassLoader;
   }
 
-  private static boolean isRegionClassLoaderMember(ClassLoader loggerClassLoader) {
-    return !(loggerClassLoader instanceof RegionClassLoader) && loggerClassLoader.getParent() instanceof RegionClassLoader;
+  private static boolean isRegionClassLoaderMember(ClassLoader classLoader) {
+    return !(classLoader instanceof RegionClassLoader) && classLoader.getParent() instanceof RegionClassLoader;
   }
 
   @Override

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextConfigurer.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextConfigurer.java
@@ -246,7 +246,7 @@ final class LoggerContextConfigurer {
   }
 
   private LoggerConfig getRootLogger(LoggerContext context) {
-    return ((AbstractConfiguration) context.getConfiguration()).getRootLogger();
+    return context.getConfiguration().getRootLogger();
   }
 
   private void removeAppender(LoggerContext context, Appender appender) {

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLoggerContext.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLoggerContext.java
@@ -8,10 +8,9 @@ package org.mule.runtime.module.launcher.log4j2;
 
 import static org.reflections.ReflectionUtils.getAllFields;
 import static org.reflections.ReflectionUtils.withName;
-
 import org.mule.runtime.core.logging.LogConfigChangeSubject;
-import org.mule.runtime.module.deployment.internal.application.ApplicationClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 
 import java.beans.PropertyChangeListener;
 import java.lang.reflect.Field;
@@ -69,7 +68,7 @@ class MuleLoggerContext extends LoggerContext implements LogConfigChangeSubject 
     if (ownerClassLoader instanceof ArtifactClassLoader) {
       artifactClassloader = true;
       artifactName = ((ArtifactClassLoader) ownerClassLoader).getArtifactName();
-      applicationClassloader = ownerClassLoader instanceof ApplicationClassLoader;
+      applicationClassloader = ownerClassLoader instanceof RegionClassLoader;
     } else {
       artifactClassloader = false;
       applicationClassloader = false;

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLoggerContextFactory.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLoggerContextFactory.java
@@ -6,30 +6,20 @@
  */
 package org.mule.runtime.module.launcher.log4j2;
 
-import static java.util.Collections.emptyList;
 import static org.mule.runtime.core.config.i18n.MessageFactory.createStaticMessage;
 import org.mule.runtime.core.api.MuleRuntimeException;
-import org.mule.runtime.module.deployment.internal.descriptor.ApplicationDescriptor;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
-import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilterFactory;
 import org.mule.runtime.module.artifact.classloader.DirectoryResourceLocator;
 import org.mule.runtime.module.artifact.classloader.LocalResourceLocator;
 import org.mule.runtime.module.artifact.classloader.ShutdownListener;
-import org.mule.runtime.module.deployment.internal.ApplicationDescriptorFactory;
-import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptor;
-import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptorFactory;
-import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptorLoader;
-import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginRepository;
-import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorFactory;
+import org.mule.runtime.module.deployment.internal.descriptor.ApplicationDescriptor;
 import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.List;
 
 import org.apache.logging.log4j.core.LoggerContext;
 
@@ -89,7 +79,7 @@ public class MuleLoggerContextFactory {
   private URI getArtifactLoggingConfig(ArtifactClassLoader muleCL) {
     URI appLogConfig;
     try {
-      ApplicationDescriptor appDescriptor = fetchApplicationDescriptor(muleCL);
+      ApplicationDescriptor appDescriptor = muleCL.getArtifactDescriptor();
 
       if (appDescriptor.getLogConfigFile() == null) {
         appLogConfig = getLogConfig(muleCL);
@@ -153,20 +143,6 @@ public class MuleLoggerContextFactory {
     } catch (URISyntaxException e) {
       throw new MuleRuntimeException(createStaticMessage("Could not read log file " + appLogConfig), e);
     }
-  }
-
-  public ApplicationDescriptor fetchApplicationDescriptor(ArtifactClassLoader muleCL) throws IOException {
-    // TODO(pablo.kraan): MULE-9778 - MuleLoggerContextFactory should not create artifact descriptors
-    ArtifactDescriptorFactory<ApplicationDescriptor> applicationDescriptorFactory =
-        new ApplicationDescriptorFactory(new ArtifactPluginDescriptorLoader(new ArtifactPluginDescriptorFactory(new ArtifactClassLoaderFilterFactory())),
-                                         new ArtifactPluginRepository() {
-
-                                           public List<ArtifactPluginDescriptor> getContainerArtifactPluginDescriptors() {
-                                             // Don't need plugins, just need to get the descriptor to access log configuration
-                                             return emptyList();
-                                           }
-                                         });
-    return applicationDescriptorFactory.create(new File(MuleContainerBootstrapUtils.getMuleAppsDir(), muleCL.getArtifactName()));
   }
 
   private class NewContextParameters {

--- a/modules/service/src/main/java/org/mule/runtime/module/service/ServiceClassLoaderFactory.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/ServiceClassLoaderFactory.java
@@ -44,7 +44,7 @@ public class ServiceClassLoaderFactory implements ArtifactClassLoaderFactory<Ser
     addDirectoryToClassLoader(urls, new File(rootFolder, CLASSES_DIR));
     loadJarsFromFolder(urls, new File(rootFolder, LIB_DIR));
 
-    return new MuleArtifactClassLoader(descriptor.getName(), urls.toArray(new URL[0]), parent.getClassLoader(),
+    return new MuleArtifactClassLoader(descriptor, urls.toArray(new URL[0]), parent.getClassLoader(),
                                        parent.getClassLoaderLookupPolicy());
   }
 

--- a/modules/service/src/main/java/org/mule/runtime/module/service/ServiceDescriptor.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/ServiceDescriptor.java
@@ -21,6 +21,15 @@ public class ServiceDescriptor extends ArtifactDescriptor {
 
   private String serviceProviderClassName;
 
+  /**
+   * Creates a new service descriptor
+   *
+   * @param name service name. Non empty.
+   */
+  public ServiceDescriptor(String name) {
+    super(name);
+  }
+
   public String getServiceProviderClassName() {
     return serviceProviderClassName;
   }

--- a/modules/service/src/main/java/org/mule/runtime/module/service/ServiceDescriptorFactory.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/ServiceDescriptorFactory.java
@@ -29,9 +29,8 @@ public class ServiceDescriptorFactory implements ArtifactDescriptorFactory<Servi
       throw new IllegalArgumentException("Service folder does not exists: " + artifactFolder.getAbsolutePath());
     }
     final String serviceName = artifactFolder.getName();
-    final ServiceDescriptor descriptor = new ServiceDescriptor();
+    final ServiceDescriptor descriptor = new ServiceDescriptor(serviceName);
     descriptor.setRootFolder(artifactFolder);
-    descriptor.setName(serviceName);
 
     final File servicePropsFile = new File(artifactFolder, SERVICE_PROPERTIES);
     if (!servicePropsFile.exists()) {

--- a/modules/service/src/test/java/org/mule/runtime/module/service/ServiceClassLoaderFactoryTestCase.java
+++ b/modules/service/src/test/java/org/mule/runtime/module/service/ServiceClassLoaderFactoryTestCase.java
@@ -39,8 +39,7 @@ public class ServiceClassLoaderFactoryTestCase extends AbstractMuleTestCase {
 
   @Before
   public void setUp() throws Exception {
-    descriptor = new ServiceDescriptor();
-    descriptor.setName("testService");
+    descriptor = new ServiceDescriptor("testService");
     descriptor.setRootFolder(serviceFolder.getRoot());
 
     parentClassLoader = mock(ArtifactClassLoader.class);

--- a/tests/functional/src/main/java/org/mule/functional/classloading/isolation/classloader/IsolatedClassLoaderFactory.java
+++ b/tests/functional/src/main/java/org/mule/functional/classloading/isolation/classloader/IsolatedClassLoaderFactory.java
@@ -32,6 +32,7 @@ import org.mule.runtime.module.artifact.classloader.FilteringArtifactClassLoader
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.runtime.module.artifact.util.FileJarExplorer;
 import org.mule.runtime.module.artifact.util.JarInfo;
 import org.mule.runtime.module.extension.internal.manager.DefaultExtensionManager;
@@ -90,7 +91,8 @@ public class IsolatedClassLoaderFactory {
     ClassLoaderLookupPolicy childClassLoaderLookupPolicy = testContainerClassLoaderFactory.getContainerClassLoaderLookupPolicy();
 
     RegionClassLoader regionClassLoader =
-        new RegionClassLoader("Region", containerClassLoader.getClassLoader(), childClassLoaderLookupPolicy);
+        new RegionClassLoader(new ArtifactDescriptor("Region"), containerClassLoader.getClassLoader(),
+                              childClassLoaderLookupPolicy);
 
     final List<ArtifactClassLoader> filteredPluginsArtifactClassLoaders = new ArrayList<>();
     final List<ArtifactClassLoader> pluginsArtifactClassLoaders = new ArrayList<>();
@@ -100,9 +102,9 @@ public class IsolatedClassLoaderFactory {
       for (PluginUrlClassification pluginUrlClassification : artifactUrlClassification.getPluginClassificationUrls()) {
         logClassLoaderUrls("PLUGIN (" + pluginUrlClassification.getName() + ")", pluginUrlClassification.getUrls());
 
-        MuleArtifactClassLoader pluginCL =
-            new MuleArtifactClassLoader(pluginUrlClassification.getName(), pluginUrlClassification.getUrls().toArray(new URL[0]),
-                                        regionClassLoader, childClassLoaderLookupPolicy);
+        MuleArtifactClassLoader pluginCL = new MuleArtifactClassLoader(new ArtifactDescriptor(pluginUrlClassification.getName()),
+                                                                       pluginUrlClassification.getUrls().toArray(new URL[0]),
+                                                                       regionClassLoader, childClassLoaderLookupPolicy);
         pluginsArtifactClassLoaders.add(pluginCL);
 
         ArtifactClassLoaderFilter filter = createArtifactClassLoaderFilter(pluginUrlClassification, pluginCL);
@@ -158,7 +160,8 @@ public class IsolatedClassLoaderFactory {
                                                                    ArtifactUrlClassification artifactUrlClassification) {
     logClassLoaderUrls("CONTAINER", artifactUrlClassification.getContainerUrls());
     MuleArtifactClassLoader launcherArtifact =
-        new MuleArtifactClassLoader("launcher", new URL[0], IsolatedClassLoaderFactory.class.getClassLoader(),
+        new MuleArtifactClassLoader(new ArtifactDescriptor("launcher"), new URL[0],
+                                    IsolatedClassLoaderFactory.class.getClassLoader(),
                                     new MuleClassLoaderLookupPolicy(Collections.emptyMap(), Collections.<String>emptySet()));
     final List<MuleModule> muleModules = Collections.<MuleModule>emptyList();
     ClassLoaderFilter filteredClassLoaderLauncher = new ContainerClassLoaderFilterFactory()
@@ -215,7 +218,8 @@ public class IsolatedClassLoaderFactory {
                                                                      ClassLoaderLookupPolicy childClassLoaderLookupPolicy,
                                                                      ArtifactUrlClassification artifactUrlClassification) {
     logClassLoaderUrls("APP", artifactUrlClassification.getApplicationUrls());
-    return new MuleArtifactClassLoader("app", artifactUrlClassification.getApplicationUrls().toArray(new URL[0]), parent,
+    return new MuleArtifactClassLoader(new ArtifactDescriptor("app"),
+                                       artifactUrlClassification.getApplicationUrls().toArray(new URL[0]), parent,
                                        childClassLoaderLookupPolicy);
   }
 

--- a/tests/functional/src/main/java/org/mule/functional/classloading/isolation/classloader/TestContainerClassLoaderFactory.java
+++ b/tests/functional/src/main/java/org/mule/functional/classloading/isolation/classloader/TestContainerClassLoaderFactory.java
@@ -16,6 +16,7 @@ import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -68,13 +69,16 @@ public class TestContainerClassLoaderFactory extends ContainerClassLoaderFactory
    *        it has all the class path
    * @param containerLookupPolicy the default {@link ClassLoaderLookupPolicy} defined for a container but will be ignored due to
    *        it has to be different when running with a full class path as parent {@link ClassLoader}
+   * @param artifactDescriptor
    * @return the {@link ArtifactClassLoader} to be used for the container
    */
   @Override
   protected ArtifactClassLoader createArtifactClassLoader(final ClassLoader parentClassLoader, final List<MuleModule> muleModules,
-                                                          final ClassLoaderLookupPolicy containerLookupPolicy) {
+                                                          final ClassLoaderLookupPolicy containerLookupPolicy,
+                                                          ArtifactDescriptor artifactDescriptor) {
+    final ArtifactDescriptor containerDescriptor = new ArtifactDescriptor("mule");
     final ArtifactClassLoader containerClassLoader =
-        new MuleArtifactClassLoader("mule", urls, parentClassLoader,
+        new MuleArtifactClassLoader(containerDescriptor, urls, parentClassLoader,
                                     new MuleClassLoaderLookupPolicy(Collections.emptyMap(), getBootPackages()));
     return createContainerFilteringClassLoader(withContextClassLoader(classLoader, () -> discoverModules()),
                                                containerClassLoader);

--- a/tests/functional/src/main/resources/maven-module-mapping.properties
+++ b/tests/functional/src/main/resources/maven-module-mapping.properties
@@ -80,3 +80,5 @@ mule-api=/mule-api/
 mule-extensions-api=/mule-extensions-api/mule-extensions-api/
 mule-extensions-api-persistence=/mule-extensions-api/mule-extensions-api-persistence/
 mule-extensions-api-xml-dsl=/mule-extensions-api/mule-extensions-api-xml-dsl/
+mule-extensions-api-dsql=/mule-extensions-api/mule-extensions-api-dsql/
+


### PR DESCRIPTION
_ Using appplication's RegionClassLoader to log everything coming from the app.
_ Cleaining how to loggers are obtained avoiding the creation of extra ArtifactDescriptors
_ Adding artifact descriptor to each artifact classloader
_ Making artifact descriptor's name fixed on the constructor
_ Implementing dispose on Region classlaoder to clean up every region's member
_ Extra cleanup