### PR TITLE
MULE-10730: Event.Builder.variables does not clear previous values

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/DefaultMuleMessageSerializationTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/DefaultMuleMessageSerializationTestCase.java
@@ -8,7 +8,7 @@ package org.mule.runtime.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.message.InternalMessage;

--- a/core-tests/src/test/java/org/mule/runtime/core/MuleEventTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/MuleEventTestCase.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.message.InternalMessage;

--- a/core-tests/src/test/java/org/mule/runtime/core/el/mvel/datatype/FlowVarEnricherDataTypePropagatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/el/mvel/datatype/FlowVarEnricherDataTypePropagatorTestCase.java
@@ -8,7 +8,7 @@
 package org.mule.runtime.core.el.mvel.datatype;
 
 import static org.mule.runtime.core.el.mvel.MessageVariableResolverFactory.FLOW_VARS;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.Event;

--- a/core-tests/src/test/java/org/mule/runtime/core/execution/MessageProcessorNotificationExecutionInterceptorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/execution/MessageProcessorNotificationExecutionInterceptorTestCase.java
@@ -17,8 +17,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.exception.MessagingException;
 import org.mule.runtime.core.api.MuleContext;

--- a/core-tests/src/test/java/org/mule/runtime/core/message/DefaultMuleMessageBuilderTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/message/DefaultMuleMessageBuilderTestCase.java
@@ -39,6 +39,7 @@ import javax.activation.DataHandler;
 import org.junit.Test;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 /**
  *
@@ -163,6 +164,17 @@ public class DefaultMuleMessageBuilderTestCase extends AbstractMuleTestCase {
   }
 
   @Test
+  public void inboundClear() {
+    Map<String, Serializable> inboundProperties = singletonMap(PROPERTY_KEY, PROPERTY_VALUE);
+    InternalMessage source = new DefaultMessageBuilder(new DefaultMessageBuilder().payload(TEST_PAYLOAD)
+        .inboundProperties(inboundProperties).build()).build();
+
+    InternalMessage copy = new DefaultMessageBuilder(source).clearInboundProperties().build();
+
+    assertThat(copy.getInboundPropertyNames(), is(empty()));
+  }
+
+  @Test
   public void inboundPropertyMapCopy() {
     Map<String, Serializable> inboundProperties = singletonMap(PROPERTY_KEY, PROPERTY_VALUE);
     InternalMessage copy = new DefaultMessageBuilder(new DefaultMessageBuilder().payload(TEST_PAYLOAD)
@@ -195,6 +207,17 @@ public class DefaultMuleMessageBuilderTestCase extends AbstractMuleTestCase {
     assertThat(copy.getOutboundPropertyDataType(PROPERTY_KEY), equalTo(STRING));
     assertThat(copy.getOutboundPropertyNames(), hasSize(1));
     assertThat(copy.getOutboundPropertyNames(), hasItem(PROPERTY_KEY));
+  }
+
+  @Test
+  public void outboundClear() {
+    Map<String, Serializable> outboundProperties = singletonMap(PROPERTY_KEY, PROPERTY_VALUE);
+    InternalMessage source = new DefaultMessageBuilder(new DefaultMessageBuilder().payload(TEST_PAYLOAD)
+        .outboundProperties(outboundProperties).build()).build();
+
+    InternalMessage copy = new DefaultMessageBuilder(source).clearOutboundProperties().build();
+
+    assertThat(copy.getOutboundPropertyNames(), is(empty()));
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/message/DefaultMuleMessageBuilderTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/message/DefaultMuleMessageBuilderTestCase.java
@@ -39,7 +39,6 @@ import javax.activation.DataHandler;
 import org.junit.Test;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 /**
  *
@@ -164,17 +163,6 @@ public class DefaultMuleMessageBuilderTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  public void inboundClear() {
-    Map<String, Serializable> inboundProperties = singletonMap(PROPERTY_KEY, PROPERTY_VALUE);
-    InternalMessage source = new DefaultMessageBuilder(new DefaultMessageBuilder().payload(TEST_PAYLOAD)
-        .inboundProperties(inboundProperties).build()).build();
-
-    InternalMessage copy = new DefaultMessageBuilder(source).clearInboundProperties().build();
-
-    assertThat(copy.getInboundPropertyNames(), is(empty()));
-  }
-
-  @Test
   public void inboundPropertyMapCopy() {
     Map<String, Serializable> inboundProperties = singletonMap(PROPERTY_KEY, PROPERTY_VALUE);
     InternalMessage copy = new DefaultMessageBuilder(new DefaultMessageBuilder().payload(TEST_PAYLOAD)
@@ -207,17 +195,6 @@ public class DefaultMuleMessageBuilderTestCase extends AbstractMuleTestCase {
     assertThat(copy.getOutboundPropertyDataType(PROPERTY_KEY), equalTo(STRING));
     assertThat(copy.getOutboundPropertyNames(), hasSize(1));
     assertThat(copy.getOutboundPropertyNames(), hasItem(PROPERTY_KEY));
-  }
-
-  @Test
-  public void outboundClear() {
-    Map<String, Serializable> outboundProperties = singletonMap(PROPERTY_KEY, PROPERTY_VALUE);
-    InternalMessage source = new DefaultMessageBuilder(new DefaultMessageBuilder().payload(TEST_PAYLOAD)
-        .outboundProperties(outboundProperties).build()).build();
-
-    InternalMessage copy = new DefaultMessageBuilder(source).clearOutboundProperties().build();
-
-    assertThat(copy.getOutboundPropertyNames(), is(empty()));
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/message/DefaultMultiPartPayloadTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/message/DefaultMultiPartPayloadTestCase.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.message.DefaultMultiPartPayload.BODY_ATTRIBUTES;
 import static org.mule.runtime.core.util.IOUtils.getResourceAsUrl;
 import static org.mule.runtime.core.util.IOUtils.toMuleMessagePart;

--- a/core-tests/src/test/java/org/mule/runtime/core/message/processing/AsyncResponseFlowProcessingPhaseTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/message/processing/AsyncResponseFlowProcessingPhaseTestCase.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_ERROR_RESPONSE;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_RESPONSE;
 

--- a/core-tests/src/test/java/org/mule/runtime/core/mule/enricher/MessageEnricherTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/mule/enricher/MessageEnricherTestCase.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;
 import static org.mule.runtime.core.api.processor.MessageProcessors.newChain;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.DefaultEventContext;
 import org.mule.runtime.core.api.Event;

--- a/core-tests/src/test/java/org/mule/runtime/core/mule/model/LegacyEntryPointResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/mule/model/LegacyEntryPointResolverTestCase.java
@@ -9,8 +9,8 @@ package org.mule.runtime.core.mule.model;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 
 import org.mule.runtime.core.DefaultEventContext;

--- a/core-tests/src/test/java/org/mule/runtime/core/mule/model/ReflectionEntryPointResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/mule/model/ReflectionEntryPointResolverTestCase.java
@@ -8,8 +8,8 @@ package org.mule.runtime.core.mule.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 
 import org.mule.runtime.core.DefaultEventContext;

--- a/core-tests/src/test/java/org/mule/runtime/core/processor/NonBlockingMessageProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/processor/NonBlockingMessageProcessorTestCase.java
@@ -12,8 +12,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.api.execution.CompletionHandler;
 import org.mule.runtime.core.DefaultEventContext;

--- a/core-tests/src/test/java/org/mule/runtime/core/processor/chain/BlockingProcessorExecutorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/processor/chain/BlockingProcessorExecutorTestCase.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.MessageExchangePattern.ONE_WAY;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;
 

--- a/core-tests/src/test/java/org/mule/runtime/core/registry/RequestContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/registry/RequestContextTestCase.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.core.registry;
 
 import static org.junit.Assert.assertEquals;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.createErrorMock;
 
 import org.mule.runtime.core.api.Event;

--- a/core-tests/src/test/java/org/mule/runtime/core/routing/RoundRobinRoutingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/routing/RoundRobinRoutingStrategyTestCase.java
@@ -10,7 +10,7 @@ package org.mule.runtime.core.routing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.MuleException;

--- a/core-tests/src/test/java/org/mule/runtime/core/routing/SynchronousUntilSuccessfulProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/routing/SynchronousUntilSuccessfulProcessingStrategyTestCase.java
@@ -18,8 +18,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 
 import org.mule.runtime.core.VoidMuleEvent;

--- a/core-tests/src/test/java/org/mule/runtime/core/transformer/AbstractTransformerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/transformer/AbstractTransformerTestCase.java
@@ -10,7 +10,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.fail;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.message.InternalMessage;

--- a/core-tests/src/test/java/org/mule/runtime/core/transformer/simple/SerializedMuleMessageTransformersTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/transformer/simple/SerializedMuleMessageTransformersTestCase.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.transformer.simple;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.transformer.Transformer;

--- a/core-tests/src/test/java/org/mule/runtime/core/work/MuleEventWorkTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/work/MuleEventWorkTestCase.java
@@ -10,8 +10,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.message.InternalMessage;

--- a/core/src/main/java/org/mule/runtime/core/api/Event.java
+++ b/core/src/main/java/org/mule/runtime/core/api/Event.java
@@ -38,7 +38,10 @@ import java.util.NoSuchElementException;
  */
 public interface Event extends MuleEvent {
 
-  static final ThreadLocal<Event> currentEvent = new ThreadLocal<>();
+  static class CurrentEventHolder {
+
+    private static final ThreadLocal<Event> currentEvent = new ThreadLocal<>();
+  }
 
   /**
    * @return the context applicable to all events created from the same root {@link Event} from a {@link MessageSource}.
@@ -451,7 +454,7 @@ public interface Event extends MuleEvent {
    * @return event for currently executing thread.
    */
   public static Event getCurrentEvent() {
-    return currentEvent.get();
+    return CurrentEventHolder.currentEvent.get();
   }
 
   /**
@@ -460,7 +463,7 @@ public interface Event extends MuleEvent {
    * @param event event for currently executing thread.
    */
   public static void setCurrentEvent(Event event) {
-    currentEvent.set(event);
+    CurrentEventHolder.currentEvent.set(event);
   }
 
 }

--- a/core/src/main/java/org/mule/runtime/core/api/Event.java
+++ b/core/src/main/java/org/mule/runtime/core/api/Event.java
@@ -38,7 +38,7 @@ import java.util.NoSuchElementException;
  */
 public interface Event extends MuleEvent {
 
-  public static final ThreadLocal<Event> currentEvent = new ThreadLocal<>();
+  static final ThreadLocal<Event> currentEvent = new ThreadLocal<>();
 
   /**
    * @return the context applicable to all events created from the same root {@link Event} from a {@link MessageSource}.
@@ -320,13 +320,6 @@ public interface Event extends MuleEvent {
      * @return the builder instance
      */
     Builder removeVariable(String key);
-
-    /**
-     * Removes all variables.
-     *
-     * @return the builder instance
-     */
-    Builder clearVariables();
 
     /**
      * Set correlationId overriding the correlationId from {@link EventContext#getCorrelationId()} that came from the source

--- a/core/src/main/java/org/mule/runtime/core/api/message/InternalMessage.java
+++ b/core/src/main/java/org/mule/runtime/core/api/message/InternalMessage.java
@@ -173,6 +173,20 @@ public interface InternalMessage extends Message, MessageProperties, MessageAtta
     Builder removeOutboundProperty(String key);
 
     /**
+     * @return
+     * @deprecated Transport infrastructure is deprecated. Use {@link Attributes} instead.
+     */
+    @Deprecated
+    Builder clearInboundProperties();
+
+    /**
+     * @return
+     * @deprecated Transport infrastructure is deprecated. Use {@link Attributes} instead.
+     */
+    @Deprecated
+    Builder clearOutboundProperties();
+
+    /**
      * @param key
      * @param value
      * @return
@@ -205,6 +219,20 @@ public interface InternalMessage extends Message, MessageProperties, MessageAtta
      */
     @Deprecated
     Builder removeOutboundAttachment(String key);
+
+    /**
+     * @return
+     * @deprecated Transport infrastructure is deprecated. Use {@link DefaultMultiPartPayload} instead.
+     */
+    @Deprecated
+    Builder clearInboundAttachments();
+
+    /**
+     * @return
+     * @deprecated Transport infrastructure is deprecated. Use {@link DefaultMultiPartPayload} instead.
+     */
+    @Deprecated
+    Builder clearOutboundAttachments();
 
     /**
      * @param inboundProperties

--- a/core/src/main/java/org/mule/runtime/core/api/message/InternalMessage.java
+++ b/core/src/main/java/org/mule/runtime/core/api/message/InternalMessage.java
@@ -173,20 +173,6 @@ public interface InternalMessage extends Message, MessageProperties, MessageAtta
     Builder removeOutboundProperty(String key);
 
     /**
-     * @return
-     * @deprecated Transport infrastructure is deprecated. Use {@link Attributes} instead.
-     */
-    @Deprecated
-    Builder clearInboundProperties();
-
-    /**
-     * @return
-     * @deprecated Transport infrastructure is deprecated. Use {@link Attributes} instead.
-     */
-    @Deprecated
-    Builder clearOutboundProperties();
-
-    /**
      * @param key
      * @param value
      * @return
@@ -219,20 +205,6 @@ public interface InternalMessage extends Message, MessageProperties, MessageAtta
      */
     @Deprecated
     Builder removeOutboundAttachment(String key);
-
-    /**
-     * @return
-     * @deprecated Transport infrastructure is deprecated. Use {@link DefaultMultiPartPayload} instead.
-     */
-    @Deprecated
-    Builder clearInboundAttachments();
-
-    /**
-     * @return
-     * @deprecated Transport infrastructure is deprecated. Use {@link DefaultMultiPartPayload} instead.
-     */
-    @Deprecated
-    Builder clearOutboundAttachments();
 
     /**
      * @param inboundProperties

--- a/core/src/main/java/org/mule/runtime/core/component/AbstractComponent.java
+++ b/core/src/main/java/org/mule/runtime/core/component/AbstractComponent.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.core.component;
 
 import static java.util.Collections.singletonList;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.util.SystemUtils.getDefaultEncoding;
 
 import org.mule.runtime.api.metadata.DataType;

--- a/core/src/main/java/org/mule/runtime/core/construct/Flow.java
+++ b/core/src/main/java/org/mule/runtime/core/construct/Flow.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.construct;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.execution.ErrorHandlingExecutionTemplate.createErrorHandlingExecutionTemplate;
 
 import org.mule.runtime.api.message.Error;

--- a/core/src/main/java/org/mule/runtime/core/el/context/FlowVariableMapContext.java
+++ b/core/src/main/java/org/mule/runtime/core/el/context/FlowVariableMapContext.java
@@ -7,11 +7,10 @@
 package org.mule.runtime.core.el.context;
 
 import static java.util.Collections.emptyMap;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
-import org.mule.runtime.core.api.Event;
-import org.mule.runtime.core.message.DefaultEventBuilder;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 
-import java.util.Collections;
+import org.mule.runtime.core.api.Event;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +59,7 @@ public class FlowVariableMapContext extends AbstractMapContext<Object> {
 
   @Override
   public String toString() {
-    Map<String, Object> map = new HashMap<String, Object>();
+    Map<String, Object> map = new HashMap<>();
     for (String key : event.getVariableNames()) {
       Object value = event.getVariable(key) != null ? event.getVariable(key).getValue() : null;
       map.put(key, value);

--- a/core/src/main/java/org/mule/runtime/core/enricher/MessageEnricher.java
+++ b/core/src/main/java/org/mule/runtime/core/enricher/MessageEnricher.java
@@ -9,7 +9,7 @@ package org.mule.runtime.core.enricher;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.setMuleContextIfNeeded;
 import static org.mule.runtime.core.api.processor.MessageProcessors.newChain;
 import static org.mule.runtime.core.api.processor.MessageProcessors.newExplicitChain;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.NonBlockingVoidMuleEvent;
 import org.mule.runtime.core.VoidMuleEvent;

--- a/core/src/main/java/org/mule/runtime/core/exception/AbstractMessagingExceptionStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/exception/AbstractMessagingExceptionStrategy.java
@@ -6,8 +6,8 @@
  */
 package org.mule.runtime.core.exception;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.context.notification.ExceptionStrategyNotification.PROCESS_END;
 import static org.mule.runtime.core.context.notification.ExceptionStrategyNotification.PROCESS_START;
 

--- a/core/src/main/java/org/mule/runtime/core/exception/AbstractSystemExceptionStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/exception/AbstractSystemExceptionStrategy.java
@@ -6,8 +6,8 @@
  */
 package org.mule.runtime.core.exception;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.api.message.ExceptionPayload;
 import org.mule.runtime.core.api.Event;

--- a/core/src/main/java/org/mule/runtime/core/execution/AsyncResponseFlowProcessingPhase.java
+++ b/core/src/main/java/org/mule/runtime/core/execution/AsyncResponseFlowProcessingPhase.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.execution;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_ERROR_RESPONSE;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_RECEIVED;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_RESPONSE;

--- a/core/src/main/java/org/mule/runtime/core/execution/CommitTransactionInterceptor.java
+++ b/core/src/main/java/org/mule/runtime/core/execution/CommitTransactionInterceptor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.execution;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 import org.mule.runtime.core.VoidMuleEvent;
 import org.mule.runtime.core.exception.MessagingException;
 import org.mule.runtime.core.api.Event;

--- a/core/src/main/java/org/mule/runtime/core/execution/MessageProcessorNotificationExecutionInterceptor.java
+++ b/core/src/main/java/org/mule/runtime/core/execution/MessageProcessorNotificationExecutionInterceptor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.execution;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.context.notification.MessageProcessorNotification.MESSAGE_PROCESSOR_POST_INVOKE;
 import static org.mule.runtime.core.context.notification.MessageProcessorNotification.MESSAGE_PROCESSOR_PRE_INVOKE;
 

--- a/core/src/main/java/org/mule/runtime/core/execution/NotificationFiringProcessingPhase.java
+++ b/core/src/main/java/org/mule/runtime/core/execution/NotificationFiringProcessingPhase.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.execution;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.VoidMuleEvent;
 import org.mule.runtime.core.api.MuleContext;

--- a/core/src/main/java/org/mule/runtime/core/interceptor/AbstractEnvelopeInterceptor.java
+++ b/core/src/main/java/org/mule/runtime/core/interceptor/AbstractEnvelopeInterceptor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.interceptor;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.NonBlockingVoidMuleEvent;
 import org.mule.runtime.core.api.CoreEventContext;

--- a/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToByteArray.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToByteArray.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.internal.transformer.simple;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.transformer.TransformerException;

--- a/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToInputStream.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToInputStream.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.internal.transformer.simple;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.transformer.TransformerException;

--- a/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToString.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToString.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.internal.transformer.simple;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.transformer.DiscoverableTransformer;

--- a/core/src/main/java/org/mule/runtime/core/message/DefaultEventBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/message/DefaultEventBuilder.java
@@ -122,6 +122,7 @@ public class DefaultEventBuilder implements Event.Builder {
 
   @Override
   public Event.Builder variables(Map<String, Object> flowVariables) {
+    flowVariables.clear();
     flowVariables.forEach((s, o) -> this.flowVariables.put(s, new DefaultTypedValue<>(o, DataType.fromObject(o))));
     this.modified = true;
     return this;
@@ -145,13 +146,6 @@ public class DefaultEventBuilder implements Event.Builder {
   @Override
   public Event.Builder removeVariable(String key) {
     flowVariables.remove(key);
-    this.modified = true;
-    return this;
-  }
-
-  @Override
-  public Builder clearVariables() {
-    flowVariables.clear();
     this.modified = true;
     return this;
   }

--- a/core/src/main/java/org/mule/runtime/core/message/DefaultEventBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/message/DefaultEventBuilder.java
@@ -122,7 +122,7 @@ public class DefaultEventBuilder implements Event.Builder {
 
   @Override
   public Event.Builder variables(Map<String, Object> flowVariables) {
-    flowVariables.clear();
+    this.flowVariables.clear();
     flowVariables.forEach((s, o) -> this.flowVariables.put(s, new DefaultTypedValue<>(o, DataType.fromObject(o))));
     this.modified = true;
     return this;

--- a/core/src/main/java/org/mule/runtime/core/message/DefaultMessageBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/message/DefaultMessageBuilder.java
@@ -227,18 +227,6 @@ public class DefaultMessageBuilder
   }
 
   @Override
-  public InternalMessage.Builder clearInboundProperties() {
-    inboundProperties.clear();
-    return this;
-  }
-
-  @Override
-  public InternalMessage.Builder clearOutboundProperties() {
-    outboundProperties.clear();
-    return this;
-  }
-
-  @Override
   public InternalMessage.Builder addInboundAttachment(String key, DataHandler value) {
     inboundAttachments.put(key, value);
     return this;
@@ -259,18 +247,6 @@ public class DefaultMessageBuilder
   @Override
   public InternalMessage.Builder removeOutboundAttachment(String key) {
     outboundAttachments.remove(key);
-    return this;
-  }
-
-  @Override
-  public InternalMessage.Builder clearInboundAttachments() {
-    inboundAttachments.clear();
-    return this;
-  }
-
-  @Override
-  public InternalMessage.Builder clearOutboundAttachments() {
-    outboundAttachments.clear();
     return this;
   }
 

--- a/core/src/main/java/org/mule/runtime/core/message/DefaultMessageBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/message/DefaultMessageBuilder.java
@@ -10,8 +10,11 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.PropertyScope.INBOUND;
+import static org.mule.runtime.core.PropertyScope.OUTBOUND;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 import static org.mule.runtime.core.message.NullAttributes.NULL_ATTRIBUTES;
 import static org.mule.runtime.core.util.ObjectUtils.getBoolean;
 import static org.mule.runtime.core.util.ObjectUtils.getByte;
@@ -27,19 +30,17 @@ import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.DataTypeBuilder;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.MuleException;
 import org.mule.runtime.core.api.message.ExceptionPayload;
 import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.message.InternalMessage.CollectionBuilder;
-import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.MuleException;
 import org.mule.runtime.core.api.transformer.Transformer;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.config.i18n.CoreMessages;
 import org.mule.runtime.core.metadata.DefaultCollectionDataType;
 import org.mule.runtime.core.metadata.DefaultTypedValue;
 import org.mule.runtime.core.util.CaseInsensitiveMapWrapper;
-import org.mule.runtime.core.util.ObjectUtils;
-import org.mule.runtime.core.util.StringMessageUtils;
 import org.mule.runtime.core.util.store.DeserializationPostInitialisable;
 
 import java.io.DataInputStream;
@@ -53,6 +54,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
 
 import javax.activation.DataHandler;
 
@@ -224,6 +227,18 @@ public class DefaultMessageBuilder
   }
 
   @Override
+  public InternalMessage.Builder clearInboundProperties() {
+    inboundProperties.clear();
+    return this;
+  }
+
+  @Override
+  public InternalMessage.Builder clearOutboundProperties() {
+    outboundProperties.clear();
+    return this;
+  }
+
+  @Override
   public InternalMessage.Builder addInboundAttachment(String key, DataHandler value) {
     inboundAttachments.put(key, value);
     return this;
@@ -244,6 +259,18 @@ public class DefaultMessageBuilder
   @Override
   public InternalMessage.Builder removeOutboundAttachment(String key) {
     outboundAttachments.remove(key);
+    return this;
+  }
+
+  @Override
+  public InternalMessage.Builder clearInboundAttachments() {
+    inboundAttachments.clear();
+    return this;
+  }
+
+  @Override
+  public InternalMessage.Builder clearOutboundAttachments() {
+    outboundAttachments.clear();
     return this;
   }
 
@@ -357,14 +384,54 @@ public class DefaultMessageBuilder
       buf.append(LINE_SEPARATOR);
       buf.append("  payload=").append(getPayload().getDataType().getType().getName());
       buf.append(LINE_SEPARATOR);
+      buf.append("  attributes=").append(getAttributes().toString());
+      buf.append(LINE_SEPARATOR);
       buf.append("  mediaType=").append(getPayload().getDataType().getMediaType());
       buf.append(LINE_SEPARATOR);
-      buf.append("  exceptionPayload=").append(ObjectUtils.defaultIfNull(exceptionPayload, NOT_SET));
+      buf.append("  exceptionPayload=").append(defaultIfNull(exceptionPayload, NOT_SET));
       buf.append(LINE_SEPARATOR);
-      buf.append(StringMessageUtils.headersToString(this));
+
+      if (!getInboundPropertyNames().isEmpty() || !getOutboundPropertyNames().isEmpty()) {
+        headersToStringBuilder(this, buf);
+      }
       // no new line here, as headersToString() adds one
       buf.append('}');
       return buf.toString();
+    }
+
+    public static void headersToStringBuilder(InternalMessage m, StringBuilder buf) {
+      buf.append("  Message properties:").append(LINE_SEPARATOR);
+
+      try {
+        if (!m.getInboundPropertyNames().isEmpty()) {
+          Set<String> inboundNames = new TreeSet(m.getInboundPropertyNames());
+          buf.append("    ").append(INBOUND.toString().toUpperCase()).append(" scoped properties:").append(LINE_SEPARATOR);
+          appendPropertyValues(m, buf, inboundNames, name -> m.getInboundProperty(name));
+        }
+
+        if (!m.getOutboundPropertyNames().isEmpty()) {
+          Set<String> outboundNames = new TreeSet(m.getOutboundPropertyNames());
+          buf.append("    ").append(OUTBOUND.toString().toUpperCase()).append(" scoped properties:").append(LINE_SEPARATOR);
+          appendPropertyValues(m, buf, outboundNames, name -> m.getOutboundProperty(name));
+        }
+      } catch (IllegalArgumentException e) {
+        // ignored
+      }
+    }
+
+    private static void appendPropertyValues(InternalMessage m, StringBuilder buf, Set<String> names,
+                                             Function<String, Serializable> valueResolver) {
+      for (String name : names) {
+        Serializable value = valueResolver.apply(name);
+        // avoid calling toString recursively on Messages
+        if (value instanceof InternalMessage) {
+          value = "<<<Message>>>";
+        }
+        if (name.equals("password") || name.toString().contains("secret") || name.equals("pass")) {
+          value = "****";
+        }
+        buf.append("    ").append(name).append("=").append(value).append(LINE_SEPARATOR);
+      }
     }
 
     @Override
@@ -527,11 +594,6 @@ public class DefaultMessageBuilder
     public Attributes getAttributes() {
       return attributes;
     }
-
-    // @Override
-    // public DataType getDataType() {
-    // return typedValue.getDataType();
-    // }
 
     @Override
     public Serializable getInboundProperty(String name) {

--- a/core/src/main/java/org/mule/runtime/core/model/resolvers/MethodHeaderPropertyEntryPointResolver.java
+++ b/core/src/main/java/org/mule/runtime/core/model/resolvers/MethodHeaderPropertyEntryPointResolver.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.model.resolvers;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.MuleEventContext;

--- a/core/src/main/java/org/mule/runtime/core/processor/AbstractNonBlockingMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/AbstractNonBlockingMessageProcessor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.processor;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.api.execution.CompletionHandler;
 import org.mule.runtime.api.execution.ExceptionCallback;

--- a/core/src/main/java/org/mule/runtime/core/processor/AbstractRequestResponseMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/AbstractRequestResponseMessageProcessor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.processor;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.NonBlockingVoidMuleEvent;
 import org.mule.runtime.core.api.Event;

--- a/core/src/main/java/org/mule/runtime/core/processor/AsyncDelegateMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/AsyncDelegateMessageProcessor.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.core.processor;
 
 import static java.util.Collections.emptyMap;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.MessageExchangePattern.ONE_WAY;
 
 import org.mule.runtime.core.VoidMuleEvent;

--- a/core/src/main/java/org/mule/runtime/core/processor/BlockingProcessorExecutor.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/BlockingProcessorExecutor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.processor;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.VoidMuleEvent;
 import org.mule.runtime.core.api.Event;

--- a/core/src/main/java/org/mule/runtime/core/processor/NonBlockingProcessorExecutor.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/NonBlockingProcessorExecutor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.processor;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.MessageExchangePattern;
 import org.mule.runtime.core.NonBlockingVoidMuleEvent;

--- a/core/src/main/java/org/mule/runtime/core/routing/AsynchronousUntilSuccessfulProcessingStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/AsynchronousUntilSuccessfulProcessingStrategy.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.routing;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 import static org.mule.runtime.core.routing.UntilSuccessful.DEFAULT_PROCESS_ATTEMPT_COUNT_PROPERTY_VALUE;
 import static org.mule.runtime.core.routing.UntilSuccessful.PROCESS_ATTEMPT_COUNT_PROPERTY_NAME;
 import static org.mule.runtime.core.util.StringUtils.DASH;

--- a/core/src/main/java/org/mule/runtime/core/routing/DefaultRouterResultsHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/DefaultRouterResultsHandler.java
@@ -8,7 +8,7 @@ package org.mule.runtime.core.routing;
 
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.VoidMuleEvent;
 import org.mule.runtime.core.api.Event;

--- a/core/src/main/java/org/mule/runtime/core/routing/ScatterGatherRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/ScatterGatherRouter.java
@@ -10,7 +10,7 @@ package org.mule.runtime.core.routing;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.mule.runtime.core.api.processor.MessageProcessors.newExplicitChain;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import org.mule.runtime.core.VoidMuleEvent;
 import org.mule.runtime.core.api.DefaultMuleException;
 import org.mule.runtime.core.api.Event;

--- a/core/src/main/java/org/mule/runtime/core/routing/SynchronousUntilSuccessfulProcessingStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/SynchronousUntilSuccessfulProcessingStrategy.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.routing;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import org.mule.runtime.core.VoidMuleEvent;
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.Event.Builder;

--- a/core/src/main/java/org/mule/runtime/core/routing/WireTap.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/WireTap.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.routing;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.MuleException;

--- a/core/src/main/java/org/mule/runtime/core/routing/correlation/EventCorrelator.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/correlation/EventCorrelator.java
@@ -130,7 +130,7 @@ public class EventCorrelator implements Startable, Stoppable, Disposable {
                                    groupId, StringMessageUtils
                                        .truncate(StringMessageUtils.toString(event.getMessage().getPayload().getValue()), 200,
                                                  false),
-                                   StringMessageUtils.headersToString(event.getMessage())));
+                                   event.getMessage().toString()));
       } catch (Exception e) {
         // ignore
       }

--- a/core/src/main/java/org/mule/runtime/core/routing/requestreply/AbstractAsyncRequestReplyRequester.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/requestreply/AbstractAsyncRequestReplyRequester.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.routing.requestreply;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_SESSION_PROPERTY;
 import static org.mule.runtime.core.config.i18n.CoreMessages.responseTimedOutWaitingForId;
 import static org.mule.runtime.core.context.notification.RoutingNotification.MISSED_ASYNC_REPLY;

--- a/core/src/main/java/org/mule/runtime/core/source/polling/PollingMessageSource.java
+++ b/core/src/main/java/org/mule/runtime/core/source/polling/PollingMessageSource.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.core.source.polling;
 
 import static org.mule.runtime.core.DefaultEventContext.create;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.MessageExchangePattern.ONE_WAY;
 import static org.mule.runtime.core.config.i18n.CoreMessages.pollSourceReturnedNull;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_RECEIVED;

--- a/core/src/main/java/org/mule/runtime/core/source/polling/PollingWorker.java
+++ b/core/src/main/java/org/mule/runtime/core/source/polling/PollingWorker.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.source.polling;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import org.mule.runtime.core.exception.MessagingException;
 import org.mule.runtime.core.api.MuleException;
 import org.mule.runtime.core.api.exception.SystemExceptionHandler;

--- a/core/src/main/java/org/mule/runtime/core/util/StringMessageUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/util/StringMessageUtils.java
@@ -6,12 +6,9 @@
  */
 package org.mule.runtime.core.util;
 
-import org.mule.runtime.core.PropertyScope;
-import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.MuleRuntimeException;
 import org.mule.runtime.core.config.i18n.CoreMessages;
 
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -19,9 +16,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Function;
 
 /**
  * Useful methods for formatting message strings for logging or exceptions.
@@ -181,44 +175,6 @@ public final class StringMessageUtils {
       return CollectionUtils.toString((Collection<?>) o, MAX_ELEMENTS);
     } else {
       return o.toString();
-    }
-  }
-
-  public static String headersToString(InternalMessage m) {
-    if (m == null) {
-      return null;
-    }
-    StringBuilder buf = new StringBuilder();
-    buf.append(SystemUtils.LINE_SEPARATOR).append("Message properties:").append(SystemUtils.LINE_SEPARATOR);
-
-    try {
-      Set<String> inboundNames = new TreeSet(m.getInboundPropertyNames());
-      buf.append("  ").append(PropertyScope.INBOUND.toString().toUpperCase()).append(" scoped properties:")
-          .append(SystemUtils.LINE_SEPARATOR);
-      appendPropertyValues(m, buf, inboundNames, name -> m.getInboundProperty(name));
-
-      Set<String> outboundNames = new TreeSet(m.getOutboundPropertyNames());
-      buf.append("  ").append(PropertyScope.OUTBOUND.toString().toUpperCase()).append(" scoped properties:")
-          .append(SystemUtils.LINE_SEPARATOR);
-      appendPropertyValues(m, buf, outboundNames, name -> m.getOutboundProperty(name));
-    } catch (IllegalArgumentException e) {
-      // ignored
-    }
-    return buf.toString();
-  }
-
-  private static void appendPropertyValues(InternalMessage m, StringBuilder buf, Set<String> names,
-                                           Function<String, Serializable> valueResolver) {
-    for (String name : names) {
-      Serializable value = valueResolver.apply(name);
-      // avoid calling toString recursively on Messages
-      if (value instanceof InternalMessage) {
-        value = "<<<Message>>>";
-      }
-      if (name.equals("password") || name.toString().contains("secret") || name.equals("pass")) {
-        value = "****";
-      }
-      buf.append("    ").append(name).append("=").append(value).append(SystemUtils.LINE_SEPARATOR);
     }
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/work/AbstractMuleEventWork.java
+++ b/core/src/main/java/org/mule/runtime/core/work/AbstractMuleEventWork.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.work;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.session.DefaultMuleSession;

--- a/core/src/main/java/org/mule/runtime/core/work/WorkerContext.java
+++ b/core/src/main/java/org/mule/runtime/core/work/WorkerContext.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.work;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.util.ClassUtils.withContextClassLoader;
 
 import org.mule.runtime.core.transaction.TransactionCoordination;

--- a/extensions/http/src/main/java/org/mule/extension/http/internal/listener/HttpListener.java
+++ b/extensions/http/src/main/java/org/mule/extension/http/internal/listener/HttpListener.java
@@ -10,7 +10,7 @@ import static org.mule.extension.http.internal.HttpConnector.CONFIGURATION_OVERR
 import static org.mule.extension.http.internal.HttpConnector.RESPONSE_SETTINGS;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.exception.Errors.ComponentIdentifiers.SECURITY;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
 import static org.mule.runtime.extension.api.annotation.param.display.Placement.ADVANCED;
 import static org.mule.runtime.module.http.api.HttpConstants.HttpStatus.BAD_REQUEST;

--- a/modules/cxf/src/main/java/org/mule/runtime/module/cxf/CxfInboundMessageProcessor.java
+++ b/modules/cxf/src/main/java/org/mule/runtime/module/cxf/CxfInboundMessageProcessor.java
@@ -16,7 +16,7 @@ import static org.mule.runtime.api.metadata.MediaType.ANY;
 import static org.mule.runtime.api.metadata.MediaType.TEXT;
 import static org.mule.runtime.api.metadata.MediaType.XML;
 import static org.mule.runtime.api.metadata.MediaType.parse;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.module.cxf.SoapConstants.SOAP_ACTION_PROPERTY;
 import static org.mule.runtime.module.cxf.SoapConstants.SOAP_ACTION_PROPERTY_CAPS;
 

--- a/modules/cxf/src/main/java/org/mule/runtime/module/cxf/CxfOutboundMessageProcessor.java
+++ b/modules/cxf/src/main/java/org/mule/runtime/module/cxf/CxfOutboundMessageProcessor.java
@@ -10,7 +10,7 @@ import static java.util.Arrays.asList;
 import static org.mule.extension.http.api.HttpConstants.ResponseProperties.HTTP_STATUS_PROPERTY;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_METHOD_PROPERTY;
 import static org.mule.runtime.core.config.i18n.I18nMessageFactory.createStaticMessage;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 import static org.mule.runtime.core.util.IOUtils.toDataHandler;
 import static org.mule.runtime.module.cxf.CxfConstants.OPERATION;
 import static org.mule.runtime.module.cxf.SoapConstants.SOAP_ACTION_PROPERTY;

--- a/modules/cxf/src/main/java/org/mule/runtime/module/cxf/MuleInvoker.java
+++ b/modules/cxf/src/main/java/org/mule/runtime/module/cxf/MuleInvoker.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.cxf;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 import static org.mule.runtime.core.execution.ErrorHandlingExecutionTemplate.createErrorHandlingExecutionTemplate;
 import static org.mule.runtime.module.cxf.CxfConstants.UNWRAP_MULE_EXCEPTIONS;
 

--- a/modules/cxf/src/main/java/org/mule/runtime/module/cxf/config/WsConfig.java
+++ b/modules/cxf/src/main/java/org/mule/runtime/module/cxf/config/WsConfig.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.cxf.config;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.Event;

--- a/modules/cxf/src/main/java/org/mule/runtime/module/cxf/support/CopyAttachmentOutInterceptor.java
+++ b/modules/cxf/src/main/java/org/mule/runtime/module/cxf/support/CopyAttachmentOutInterceptor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.cxf.support;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 import static org.mule.runtime.module.cxf.CxfConstants.ATTACHMENTS;
 import org.mule.runtime.core.NonBlockingVoidMuleEvent;
 import org.mule.runtime.core.api.Event;

--- a/modules/cxf/src/main/java/org/mule/runtime/module/cxf/support/MuleSecurityManagerValidator.java
+++ b/modules/cxf/src/main/java/org/mule/runtime/module/cxf/support/MuleSecurityManagerValidator.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.cxf.support;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.security.Authentication;
 import org.mule.runtime.core.api.security.SecurityContext;

--- a/modules/cxf/src/main/java/org/mule/runtime/module/cxf/transport/MuleUniversalConduit.java
+++ b/modules/cxf/src/main/java/org/mule/runtime/module/cxf/transport/MuleUniversalConduit.java
@@ -9,7 +9,7 @@ package org.mule.runtime.module.cxf.transport;
 import static org.apache.cxf.message.Message.DECOUPLED_CHANNEL_MESSAGE;
 import static org.mule.runtime.api.metadata.MediaType.XML;
 import static org.mule.runtime.core.DefaultEventContext.create;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.MediaType;

--- a/modules/cxf/src/test/java/org/mule/runtime/module/cxf/wssec/GreeterWithLatch.java
+++ b/modules/cxf/src/test/java/org/mule/runtime/module/cxf/wssec/GreeterWithLatch.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.cxf.wssec;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.security.SecurityContext;
 import org.mule.runtime.core.util.concurrent.Latch;

--- a/modules/http/src/main/java/org/mule/runtime/module/http/internal/listener/DefaultHttpListener.java
+++ b/modules/http/src/main/java/org/mule/runtime/module/http/internal/listener/DefaultHttpListener.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.http.internal.listener;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.module.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
 import static org.mule.runtime.module.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
 

--- a/modules/http/src/main/java/org/mule/runtime/module/http/internal/request/DefaultHttpRequester.java
+++ b/modules/http/src/main/java/org/mule/runtime/module/http/internal/request/DefaultHttpRequester.java
@@ -8,7 +8,7 @@ package org.mule.runtime.module.http.internal.request;
 
 import static java.lang.Integer.MAX_VALUE;
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.api.debug.FieldDebugInfoFactory.createFieldDebugInfo;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_REQUEST_BEGIN;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_REQUEST_END;

--- a/modules/http/src/test/java/org/mule/runtime/module/http/internal/listener/HttpListenerTestCase.java
+++ b/modules/http/src/test/java/org/mule/runtime/module/http/internal/listener/HttpListenerTestCase.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 import static org.mule.runtime.module.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
 import static org.mule.runtime.module.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.runtime.module.http.api.HttpConstants.Protocols.HTTP;

--- a/modules/pgp/src/main/java/org/mule/runtime/module/pgp/KeyBasedEncryptionStrategy.java
+++ b/modules/pgp/src/main/java/org/mule/runtime/module/pgp/KeyBasedEncryptionStrategy.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.pgp;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.lifecycle.InitialisationException;

--- a/modules/pgp/src/test/java/org/mule/test/module/pgp/KBEStrategyUsingEncryptionTransformerTestCase.java
+++ b/modules/pgp/src/test/java/org/mule/test/module/pgp/KBEStrategyUsingEncryptionTransformerTestCase.java
@@ -9,7 +9,7 @@ package org.mule.test.module.pgp;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.transformer.encryption.EncryptionTransformer;
 import org.mule.runtime.core.transformer.simple.ByteArrayToObject;

--- a/modules/spring-security/src/test/java/org/mule/test/module/spring/security/filters/http/HttpBasicAuthenticationFilterTestCase.java
+++ b/modules/spring-security/src/test/java/org/mule/test/module/spring/security/filters/http/HttpBasicAuthenticationFilterTestCase.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.module.http.api.HttpHeaders.Names.AUTHORIZATION;
 
 import org.mule.extension.http.api.HttpRequestAttributes;

--- a/modules/ws/src/main/java/org/mule/runtime/module/ws/consumer/WSConsumer.java
+++ b/modules/ws/src/main/java/org/mule/runtime/module/ws/consumer/WSConsumer.java
@@ -9,7 +9,7 @@ package org.mule.runtime.module.ws.consumer;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getVariableValueOrNull;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
 import static org.mule.runtime.core.message.DefaultMultiPartPayload.BODY_ATTRIBUTES;
 import static org.mule.runtime.core.util.IOUtils.toDataHandler;
 import static org.mule.runtime.module.http.api.HttpConstants.ResponseProperties.HTTP_STATUS_PROPERTY;

--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/el/XPath3Function.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/el/XPath3Function.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.xml.el;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.util.Preconditions.checkState;
 

--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/filters/AbstractJaxpFilter.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/filters/AbstractJaxpFilter.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.xml.filters;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.Event;

--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/filters/XPathFilter.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/filters/XPathFilter.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.xml.filters;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 import static org.mule.runtime.core.util.ClassUtils.equal;
 import static org.mule.runtime.core.util.ClassUtils.hash;
 

--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/XPathExtractor.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/transformer/XPathExtractor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.xml.transformer;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.MuleContext;

--- a/modules/xml/src/main/java/org/mule/runtime/module/xml/util/XMLUtils.java
+++ b/modules/xml/src/main/java/org/mule/runtime/module/xml/util/XMLUtils.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.xml.util;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.MuleContext;

--- a/modules/xml/src/test/java/org/mule/runtime/module/xml/el/XPath3FunctionTestCase.java
+++ b/modules/xml/src/test/java/org/mule/runtime/module/xml/el/XPath3FunctionTestCase.java
@@ -13,7 +13,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.Event.Builder;

--- a/modules/xml/src/test/java/org/mule/runtime/module/xml/transformers/xml/xquery/ParallelXQueryTransformerTestCase.java
+++ b/modules/xml/src/test/java/org/mule/runtime/module/xml/transformers/xml/xquery/ParallelXQueryTransformerTestCase.java
@@ -10,7 +10,7 @@ import static java.lang.Runtime.getRuntime;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertTrue;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.DefaultEventContext;

--- a/tests/functional/src/main/java/org/mule/functional/functional/FunctionalTestComponent.java
+++ b/tests/functional/src/main/java/org/mule/functional/functional/FunctionalTestComponent.java
@@ -6,15 +6,15 @@
  */
 package org.mule.functional.functional;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.functional.exceptions.FunctionalTestException;
 import org.mule.runtime.core.DefaultMuleEventContext;
-import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.Event;
+import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.MuleEventContext;
 import org.mule.runtime.core.api.MuleException;
-import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.construct.FlowConstructAware;
 import org.mule.runtime.core.api.context.MuleContextAware;
@@ -23,10 +23,10 @@ import org.mule.runtime.core.api.lifecycle.Disposable;
 import org.mule.runtime.core.api.lifecycle.Initialisable;
 import org.mule.runtime.core.api.lifecycle.Startable;
 import org.mule.runtime.core.api.lifecycle.Stoppable;
+import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.util.ClassUtils;
 import org.mule.runtime.core.util.NumberUtils;
 import org.mule.runtime.core.util.StringMessageUtils;
-import org.mule.runtime.core.util.SystemUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -228,9 +228,9 @@ public class FunctionalTestComponent
     if (isLogMessageDetails() && logger.isInfoEnabled()) {
       StringBuilder sb = new StringBuilder();
 
-      sb.append("Full Message payload: ").append(SystemUtils.LINE_SEPARATOR);
-      sb.append(message.getPayload().getValue().toString()).append(SystemUtils.LINE_SEPARATOR);
-      sb.append(StringMessageUtils.headersToString(message));
+      sb.append("Full Message: ").append(LINE_SEPARATOR);
+      sb.append(message.getPayload().getValue().toString()).append(LINE_SEPARATOR);
+      sb.append(message.toString());
       logger.info(sb.toString());
     }
 

--- a/tests/functional/src/main/java/org/mule/functional/testmodels/services/TestReceiver.java
+++ b/tests/functional/src/main/java/org/mule/functional/testmodels/services/TestReceiver.java
@@ -6,7 +6,7 @@
  */
 package org.mule.functional.testmodels.services;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.util.StringMessageUtils;
 

--- a/tests/integration-tranports/src/test/java/org/mule/shutdown/ShutdownAppInDomainTestCase.java
+++ b/tests/integration-tranports/src/test/java/org/mule/shutdown/ShutdownAppInDomainTestCase.java
@@ -8,7 +8,7 @@ package org.mule.shutdown;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.functional.junit4.DomainFunctionalTestCase;
 import org.mule.runtime.core.api.MuleContext;

--- a/tests/integration/src/test/java/org/mule/shutdown/ShutdownAppInDomainTestCase.java
+++ b/tests/integration/src/test/java/org/mule/shutdown/ShutdownAppInDomainTestCase.java
@@ -8,7 +8,7 @@ package org.mule.shutdown;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.functional.junit4.DomainFunctionalTestCase;
 import org.mule.runtime.core.api.MuleContext;

--- a/tests/integration/src/test/java/org/mule/test/integration/PollingTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/PollingTestCase.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.MuleException;

--- a/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchExceptionHandlingTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/client/MuleClientDispatchExceptionHandlingTestCase.java
@@ -9,7 +9,7 @@ package org.mule.test.integration.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.DefaultMuleException;
 import org.mule.runtime.core.api.Event;

--- a/tests/integration/src/test/java/org/mule/test/integration/message/GetProperty.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/message/GetProperty.java
@@ -6,7 +6,7 @@
  */
 package org.mule.test.integration.message;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.transformer.AbstractTransformer;

--- a/tests/integration/src/test/java/org/mule/test/integration/message/SetProperty.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/message/SetProperty.java
@@ -6,7 +6,7 @@
  */
 package org.mule.test.integration.message;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.transformer.AbstractTransformer;

--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleTestCase.java
@@ -9,7 +9,7 @@ package org.mule.tck.junit4;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 
 import org.mule.runtime.core.DefaultEventContext;

--- a/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/MuleEventTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/MuleEventTestCase.java
@@ -8,7 +8,7 @@ package org.mule.compatibility.core;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 
 import org.mule.compatibility.core.api.endpoint.EndpointBuilder;

--- a/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/endpoint/inbound/InboundEndpointTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/endpoint/inbound/InboundEndpointTestCase.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 import static org.mule.compatibility.core.DefaultMuleEventEndpointUtils.populateFieldsFromInboundEndpoint;
 import static org.mule.runtime.core.MessageExchangePattern.ONE_WAY;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.createErrorMock;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 

--- a/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/endpoint/outbound/OutboundEndpointPropertyMessageProcessorTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/endpoint/outbound/OutboundEndpointPropertyMessageProcessorTestCase.java
@@ -8,7 +8,7 @@ package org.mule.compatibility.core.endpoint.outbound;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.compatibility.core.api.endpoint.OutboundEndpoint;
 import org.mule.compatibility.core.processor.AbstractMessageProcessorTestCase;

--- a/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/endpoint/outbound/OutboundEndpointTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/endpoint/outbound/OutboundEndpointTestCase.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 import static org.mule.runtime.core.MessageExchangePattern.ONE_WAY;
 import static org.mule.runtime.core.MessageExchangePattern.REQUEST_RESPONSE;

--- a/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/processor/SecurityFilterMessageProcessorTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/processor/SecurityFilterMessageProcessorTestCase.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.core.api.endpoint.InboundEndpoint;
 import org.mule.runtime.core.MessageExchangePattern;

--- a/transports/core-transports-tests/src/test/java/org/mule/runtime/core/message/DefaultMuleMessageAttachmentsTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/runtime/core/message/DefaultMuleMessageAttachmentsTestCase.java
@@ -13,7 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mule.runtime.api.metadata.MediaType.TEXT;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.message.NullAttributes.NULL_ATTRIBUTES;
 
 import org.mule.runtime.api.message.Attributes;

--- a/transports/core/src/main/java/org/mule/compatibility/core/component/BindingInvocationHandler.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/component/BindingInvocationHandler.java
@@ -6,7 +6,7 @@
  */
 package org.mule.compatibility.core.component;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.compatibility.core.api.component.InterfaceBinding;
 import org.mule.compatibility.core.config.i18n.TransportCoreMessages;

--- a/transports/core/src/main/java/org/mule/compatibility/core/component/DefaultInterfaceBinding.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/component/DefaultInterfaceBinding.java
@@ -6,7 +6,7 @@
  */
 package org.mule.compatibility.core.component;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.core.api.component.InterfaceBinding;
 import org.mule.compatibility.core.api.endpoint.ImmutableEndpoint;

--- a/transports/core/src/main/java/org/mule/compatibility/core/endpoint/inbound/InboundLoggingMessageProcessor.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/endpoint/inbound/InboundLoggingMessageProcessor.java
@@ -36,7 +36,7 @@ public class InboundLoggingMessageProcessor implements Processor {
       try {
         logger.trace("Message Payload: \n"
             + StringMessageUtils.truncate(StringMessageUtils.toString(message.getPayload().getValue()), 200, false));
-        logger.trace("Message detail: \n" + StringMessageUtils.headersToString(message));
+        logger.trace("Message detail: \n" + message.toString());
       } catch (Exception e) {
         // ignore
       }

--- a/transports/core/src/main/java/org/mule/compatibility/core/endpoint/outbound/OutboundEndpointPropertyMessageProcessor.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/endpoint/outbound/OutboundEndpointPropertyMessageProcessor.java
@@ -7,7 +7,7 @@
 package org.mule.compatibility.core.endpoint.outbound;
 
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_ENDPOINT_PROPERTY;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.core.api.endpoint.OutboundEndpoint;
 import org.mule.runtime.api.metadata.MediaType;

--- a/transports/core/src/main/java/org/mule/compatibility/core/transport/AbstractMessageDispatcher.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/transport/AbstractMessageDispatcher.java
@@ -6,7 +6,7 @@
  */
 package org.mule.compatibility.core.transport;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_DISABLE_TRANSPORT_TRANSFORMER_PROPERTY;
 import static org.mule.runtime.core.util.SystemUtils.getDefaultEncoding;
 

--- a/transports/core/src/main/java/org/mule/compatibility/core/transport/AbstractMessageReceiver.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/transport/AbstractMessageReceiver.java
@@ -8,7 +8,7 @@ package org.mule.compatibility.core.transport;
 
 import static org.mule.compatibility.core.DefaultMuleEventEndpointUtils.populateFieldsFromInboundEndpoint;
 import static org.mule.runtime.core.DefaultEventContext.create;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_REMOTE_SYNC_PROPERTY;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_REPLY_TO_PROPERTY;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_DEFAULT_MESSAGE_PROCESSING_MANAGER;

--- a/transports/core/src/main/java/org/mule/compatibility/core/transport/AbstractReceiverWorker.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/transport/AbstractReceiverWorker.java
@@ -7,7 +7,7 @@
 package org.mule.compatibility.core.transport;
 
 import static java.lang.Thread.currentThread;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.execution.TransactionalErrorHandlingExecutionTemplate.createMainExecutionTemplate;
 import static org.mule.runtime.core.execution.TransactionalExecutionTemplate.createTransactionalExecutionTemplate;
 

--- a/transports/core/src/main/java/org/mule/compatibility/core/transport/PollingReceiverWorker.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/transport/PollingReceiverWorker.java
@@ -6,7 +6,7 @@
  */
 package org.mule.compatibility.core.transport;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import org.mule.runtime.core.exception.MessagingException;
 import org.mule.runtime.core.api.MuleException;
 

--- a/transports/file/src/test/java/org/mule/compatibility/transport/file/AutoDeleteOnFileDispatcherReceiverTestCase.java
+++ b/transports/file/src/test/java/org/mule/compatibility/transport/file/AutoDeleteOnFileDispatcherReceiverTestCase.java
@@ -8,7 +8,7 @@ package org.mule.compatibility.transport.file;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.core.api.transport.Connector;
 import org.mule.compatibility.core.registry.MuleRegistryTransportHelper;

--- a/transports/http/src/main/java/org/mule/compatibility/transport/http/HttpMessageProcessTemplate.java
+++ b/transports/http/src/main/java/org/mule/compatibility/transport/http/HttpMessageProcessTemplate.java
@@ -30,7 +30,7 @@ import static org.mule.compatibility.transport.http.HttpConstants.METHOD_PUT;
 import static org.mule.compatibility.transport.http.HttpConstants.METHOD_TRACE;
 import static org.mule.compatibility.transport.http.HttpConstants.SC_BAD_REQUEST;
 import static org.mule.compatibility.transport.http.HttpConstants.SC_CONTINUE;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_PROXY_ADDRESS;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_REMOTE_CLIENT_ADDRESS;
 

--- a/transports/http/src/main/java/org/mule/compatibility/transport/http/HttpResponse.java
+++ b/transports/http/src/main/java/org/mule/compatibility/transport/http/HttpResponse.java
@@ -7,7 +7,7 @@
 package org.mule.compatibility.transport.http;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.MuleContext;

--- a/transports/http/src/main/java/org/mule/compatibility/transport/http/HttpServerConnection.java
+++ b/transports/http/src/main/java/org/mule/compatibility/transport/http/HttpServerConnection.java
@@ -6,7 +6,7 @@
  */
 package org.mule.compatibility.transport.http;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.compatibility.core.api.transport.Connector;
 import org.mule.runtime.core.message.OutputHandler;

--- a/transports/http/src/main/java/org/mule/compatibility/transport/http/transformers/HttpResponseToString.java
+++ b/transports/http/src/main/java/org/mule/compatibility/transport/http/transformers/HttpResponseToString.java
@@ -6,7 +6,7 @@
  */
 package org.mule.compatibility.transport.http.transformers;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.compatibility.transport.http.HttpConstants;
 import org.mule.compatibility.transport.http.HttpResponse;

--- a/transports/http/src/main/java/org/mule/compatibility/transport/http/transformers/ObjectToHttpClientMethodRequest.java
+++ b/transports/http/src/main/java/org/mule/compatibility/transport/http/transformers/ObjectToHttpClientMethodRequest.java
@@ -9,7 +9,7 @@ package org.mule.compatibility.transport.http.transformers;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mule.compatibility.transport.http.HttpConnector.HTTP_PARAMS_PROPERTY;
 import static org.mule.compatibility.transport.http.HttpConstants.HEADER_CONTENT_TYPE;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.compatibility.core.api.endpoint.ImmutableEndpoint;
 import org.mule.compatibility.core.api.transformer.EndpointAwareTransformer;

--- a/transports/http/src/test/java/org/mule/compatibility/transport/http/transformers/ObjectToHttpClientMethodRequestTestCase.java
+++ b/transports/http/src/test/java/org/mule/compatibility/transport/http/transformers/ObjectToHttpClientMethodRequestTestCase.java
@@ -22,7 +22,7 @@ import static org.mule.compatibility.transport.http.HttpConstants.METHOD_GET;
 import static org.mule.compatibility.transport.http.HttpConstants.METHOD_POST;
 import static org.mule.compatibility.transport.http.HttpConstants.METHOD_PUT;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_ENDPOINT_PROPERTY;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.core.api.endpoint.InboundEndpoint;
 import org.mule.compatibility.transport.http.HttpRequest;

--- a/transports/jms/src/test/java/org/mule/compatibility/transport/jms/JmsTransformerTestCase.java
+++ b/transports/jms/src/test/java/org/mule/compatibility/transport/jms/JmsTransformerTestCase.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.transport.jms.transformers.ObjectToJMSMessage;
 import org.mule.runtime.core.api.message.InternalMessage;

--- a/transports/jms/src/test/java/org/mule/compatibility/transport/jms/integration/JmsMessageAwareTransformersMule2685TestCase.java
+++ b/transports/jms/src/test/java/org/mule/compatibility/transport/jms/integration/JmsMessageAwareTransformersMule2685TestCase.java
@@ -9,7 +9,7 @@ package org.mule.compatibility.transport.jms.integration;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.core.routing.outbound.ExpressionRecipientList;
 import org.mule.compatibility.transport.jms.transformers.AbstractJmsTransformer;

--- a/transports/jms/src/test/java/org/mule/compatibility/transport/jms/integration/JmsTransformersTestCase.java
+++ b/transports/jms/src/test/java/org/mule/compatibility/transport/jms/integration/JmsTransformersTestCase.java
@@ -8,7 +8,7 @@ package org.mule.compatibility.transport.jms.integration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 
 import org.mule.compatibility.transport.jms.transformers.AbstractJmsTransformer;
 import org.mule.compatibility.transport.jms.transformers.JMSMessageToObject;

--- a/transports/module-support/src/main/java/org/mule/compatibility/module/cxf/transport/EndpointMuleUniversalConduit.java
+++ b/transports/module-support/src/main/java/org/mule/compatibility/module/cxf/transport/EndpointMuleUniversalConduit.java
@@ -7,7 +7,7 @@
 package org.mule.compatibility.module.cxf.transport;
 
 import static org.mule.runtime.api.metadata.MediaType.XML;
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.setCurrentEvent;
+import static org.mule.runtime.core.api.Event.setCurrentEvent;
 import static org.mule.extension.http.api.HttpConstants.RequestProperties.HTTP_DISABLE_STATUS_CODE_EXCEPTION_CHECK;
 
 import org.mule.compatibility.core.api.config.MuleEndpointProperties;

--- a/transports/tcp/src/main/java/org/mule/compatibility/transport/tcp/protocols/MuleMessageWorker.java
+++ b/transports/tcp/src/main/java/org/mule/compatibility/transport/tcp/protocols/MuleMessageWorker.java
@@ -6,7 +6,7 @@
  */
 package org.mule.compatibility.transport.tcp.protocols;
 
-import static org.mule.runtime.core.message.DefaultEventBuilder.EventImplementation.getCurrentEvent;
+import static org.mule.runtime.core.api.Event.getCurrentEvent;
 
 import org.mule.runtime.core.api.MuleException;
 import org.mule.runtime.core.api.message.InternalMessage;


### PR DESCRIPTION
* Improve Message.toString() representation
* Move getCurrentEvent() and setCurrentEvent() to a less internal
location
* Reduce visibility of internal stuff