### PR TITLE
MULE-10717: Flows can start processing messages before referenced flo…

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleContext.java
+++ b/core/src/main/java/org/mule/DefaultMuleContext.java
@@ -9,6 +9,7 @@ package org.mule;
 import static org.mule.api.config.MuleProperties.OBJECT_EXPRESSION_LANGUAGE;
 import static org.mule.api.config.MuleProperties.OBJECT_POLLING_CONTROLLER;
 import static org.mule.api.config.MuleProperties.OBJECT_TRANSACTION_MANAGER;
+import static org.mule.api.lifecycle.LifecycleUtils.startIfNeeded;
 import org.mule.api.Injector;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleException;
@@ -375,24 +376,21 @@ public class DefaultMuleContext implements MuleContext
 
     private void startMessageSource(MessageSource messageSource) throws LifecycleException
     {
-        if (messageSource instanceof Startable)
+        try
         {
-            try
-            {
-                ((Startable) messageSource).start();
-            }
-            catch (ConnectException e)
-            {
-                exceptionListener.handleException(e);
-            }
-            catch (LifecycleException le)
-            {
-                throw le;
-            }
-            catch (Exception e)
-            {
-                throw new LifecycleException(e, messageSource);
-            }
+            startIfNeeded(messageSource);
+        }
+        catch (ConnectException e)
+        {
+            exceptionListener.handleException(e);
+        }
+        catch (LifecycleException le)
+        {
+            throw le;
+        }
+        catch (Exception e)
+        {
+            throw new LifecycleException(e, messageSource);
         }
     }
 

--- a/core/src/main/java/org/mule/construct/AbstractPipeline.java
+++ b/core/src/main/java/org/mule/construct/AbstractPipeline.java
@@ -7,7 +7,6 @@
 package org.mule.construct;
 
 import static org.mule.util.NotificationUtils.buildPathResolver;
-
 import org.mule.api.GlobalNameableObject;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleContext;
@@ -354,21 +353,24 @@ public abstract class AbstractPipeline extends AbstractFlowConstruct implements 
         super.doStart();
         startIfStartable(pipeline);
         canProcessMessage = true;
-        try
+        if (muleContext.isStarted())
         {
-            startIfStartable(messageSource);
-        }
-        // Let connection exceptions bubble up to trigger the reconnection strategy.
-        catch (ConnectException ce)
-        {
-            throw ce;
-        }
-        catch(MuleException e)
-        {
-            // If the messageSource couldn't be started we would need to stop the pipeline (if possible) in order to leave
-            // its LifeciclyManager also as initialise phase so the flow can be disposed later
-            doStop();
-            throw e;
+            try
+            {
+                startIfStartable(messageSource);
+            }
+            // Let connection exceptions bubble up to trigger the reconnection strategy.
+            catch (ConnectException ce)
+            {
+                throw ce;
+            }
+            catch (MuleException e)
+            {
+                // If the messageSource couldn't be started we would need to stop the pipeline (if possible) in order to leave
+                // its LifecycleManager also as initialise phase so the flow can be disposed later
+                doStop();
+                throw e;
+            }
         }
     }
 

--- a/core/src/main/java/org/mule/service/AbstractService.java
+++ b/core/src/main/java/org/mule/service/AbstractService.java
@@ -363,7 +363,10 @@ public abstract class AbstractService extends AbstractAnnotatedObject implements
         startIfStartable(component);
         startIfStartable(messageProcessorChain);
 
-        startIfStartable(messageSource);
+        if (muleContext.isStarted())
+        {
+            startIfStartable(messageSource);
+        }
         if (asyncReplyMessageSource.getEndpoints().size() > 0)
         {
             asyncReplyMessageSource.start();

--- a/core/src/test/java/org/mule/construct/FlowTestCase.java
+++ b/core/src/test/java/org/mule/construct/FlowTestCase.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.mule.MessageExchangePattern.REQUEST_RESPONSE;
-
 import org.mule.MessageExchangePattern;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -253,6 +252,9 @@ public class FlowTestCase extends AbstractFlowConstuctTestCase
     @Test
     public void testFailStartingMessageSourceOnLifecycleShouldStopStartedPipelineProcesses() throws Exception
     {
+        // Need to start mule context to have endpoints started during flow start
+        muleContext.start();
+
         MessageSource mockMessageSource = mock(MessageSource.class, withSettings().extraInterfaces(Startable.class, Stoppable.class));
         doThrow(new LifecycleException(mock(Message.class), "Error starting component")).when(((Startable) mockMessageSource)).start();
         flow.setMessageSource(mockMessageSource);

--- a/core/src/test/java/org/mule/transport/ConnectorLifecycleTestCase.java
+++ b/core/src/test/java/org/mule/transport/ConnectorLifecycleTestCase.java
@@ -370,7 +370,9 @@ public class ConnectorLifecycleTestCase extends AbstractMuleContextTestCase
         connector.start();
         assertEquals(0, connector.receivers.size());
 
-        service.start();
+        // Needs to start the context as the endpoints are not started otherwise
+        muleContext.start();
+
         assertEquals(1, connector.receivers.size());
         assertTrue((connector.receivers.get("in")).isConnected());
         assertTrue(((AbstractMessageReceiver) connector.receivers.get("in")).isStarted());

--- a/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/DefaultHttpCallbackTestCase.java
+++ b/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/DefaultHttpCallbackTestCase.java
@@ -116,6 +116,9 @@ public class DefaultHttpCallbackTestCase extends AbstractMuleContextTestCase
     @Test
     public void withOldHttpTransport() throws Exception
     {
+        // Needs the context to be started so endpoints are available
+        muleContext.start();
+
         callback = createCallback(newOldHttpTransport());
         sendCallbackRequest();
     }

--- a/modules/jbpm/src/test/resources/jbpm-component-functional-test-service.xml
+++ b/modules/jbpm/src/test/resources/jbpm-component-functional-test-service.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:spring="http://www.springframework.org/schema/beans"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:bpm="http://www.mulesoft.org/schema/mule/bpm"
-       xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
-       xmlns:test="http://www.mulesoft.org/schema/mule/test"
-    xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd
-       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:bpm="http://www.mulesoft.org/schema/mule/bpm"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/bpm http://www.mulesoft.org/schema/mule/bpm/current/mule-bpm.xsd
        http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">

--- a/tests/integration/src/test/java/org/mule/test/integration/transformer/TransformerTrackerLifecycleTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/transformer/TransformerTrackerLifecycleTestCase.java
@@ -40,7 +40,7 @@ public class TransformerTrackerLifecycleTestCase extends AbstractServiceAndFlowT
 
         muleContext.dispose();
 
-        assertEquals("[setProperty, setMuleContext, setMuleContext, initialise, setMuleContext, initialise, start, start, stop, stop, dispose]",
+        assertEquals("[setProperty, setMuleContext, setMuleContext, initialise, start, setMuleContext, initialise, start, stop, stop, dispose]",
             ltt.getTracker().toString());
     }
 }


### PR DESCRIPTION
…ws are completely started

_ Delaying message sources  start until the rest of the mule context was started.
_ Message sources as before only when the flow construct is started on an already started mule context
 _ Fixing test that require a started mule context
 _ Removing flakiness from jbmp test case