### PR TITLE
MULE-9439: Improve serialization of isolated objects

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/MuleEventTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/MuleEventTestCase.java
@@ -107,8 +107,8 @@ public class MuleEventTestCase extends AbstractMuleContextTestCase {
         .exchangePattern(REQUEST_RESPONSE)
         .build();
     setCurrentEvent(testEvent);
-    byte[] serializedEvent = muleContext.getObjectSerializer().serialize(testEvent);
-    testEvent = muleContext.getObjectSerializer().deserialize(serializedEvent);
+    byte[] serializedEvent = muleContext.getObjectSerializer().getExternalProtocol().serialize(testEvent);
+    testEvent = muleContext.getObjectSerializer().getExternalProtocol().deserialize(serializedEvent);
 
     assertArrayEquals((byte[]) testEvent.getMessage().getPayload().getValue(), payload.toString().getBytes());
   }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/ObjectToInputStreamTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/ObjectToInputStreamTestCase.java
@@ -56,7 +56,8 @@ public class ObjectToInputStreamTestCase extends AbstractMuleContextTestCase {
   @Test
   public void testTransformSerializable() {
     Apple apple = new Apple();
-    InputStream serializedApple = new ByteArrayInputStream(muleContext.getObjectSerializer().serialize(apple));
+    InputStream serializedApple =
+        new ByteArrayInputStream(muleContext.getObjectSerializer().getExternalProtocol().serialize(apple));
     try {
       assertTrue(compare(serializedApple, (InputStream) transformer.transform(apple)));
     } catch (Exception e) {

--- a/core-tests/src/test/java/org/mule/runtime/core/processor/IdempotentRedeliveryPolicyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/processor/IdempotentRedeliveryPolicyTestCase.java
@@ -193,19 +193,19 @@ public class IdempotentRedeliveryPolicyTestCase extends AbstractMuleTestCase {
 
     @Override
     public void store(Serializable key, AtomicInteger value) throws ObjectStoreException {
-      store.put(key, serializer.serialize(value));
+      store.put(key, serializer.getExternalProtocol().serialize(value));
     }
 
     @Override
     public AtomicInteger retrieve(Serializable key) throws ObjectStoreException {
       Serializable serializable = store.get(key);
-      return serializer.deserialize((byte[]) serializable);
+      return serializer.getExternalProtocol().deserialize((byte[]) serializable);
     }
 
     @Override
     public AtomicInteger remove(Serializable key) throws ObjectStoreException {
       Serializable serializable = store.remove(key);
-      return serializer.deserialize((byte[]) serializable);
+      return serializer.getExternalProtocol().deserialize((byte[]) serializable);
     }
 
     @Override

--- a/core-tests/src/test/java/org/mule/runtime/core/serialization/AbstractSerializerProtocolContractTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/serialization/AbstractSerializerProtocolContractTestCase.java
@@ -13,10 +13,9 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.core.api.serialization.ObjectSerializer;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
 import org.mule.runtime.core.el.datetime.DateTime;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
@@ -27,34 +26,34 @@ import java.util.Locale;
 
 import org.junit.Test;
 
-public abstract class AbstractObjectSerializerContractTestCase extends AbstractMuleContextTestCase {
+public abstract class AbstractSerializerProtocolContractTestCase extends AbstractMuleContextTestCase {
 
   private static final String STRING_MESSAGE = "Hello World";
 
-  protected ObjectSerializer serializer;
+  protected SerializationProtocol serializerProtocol;
 
   @Test(expected = IllegalArgumentException.class)
   public final void nullBytes() throws Exception {
-    serializer.deserialize((byte[]) null);
+    serializerProtocol.deserialize((byte[]) null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public final void nullStream() throws Exception {
-    serializer.deserialize((InputStream) null);
+    serializerProtocol.deserialize((InputStream) null);
   }
 
   @Test
   public final void nullObject() throws Exception {
-    byte[] bytes = serializer.serialize(null);
-    Object object = serializer.deserialize(bytes);
+    byte[] bytes = serializerProtocol.serialize(null);
+    Object object = serializerProtocol.deserialize(bytes);
     assertNull(object);
   }
 
   @Test
   public final void inputStreamClosed() throws Exception {
-    final byte[] bytes = serializer.serialize(STRING_MESSAGE);
+    final byte[] bytes = serializerProtocol.serialize(STRING_MESSAGE);
     InputStream inputStream = spy(new ByteArrayInputStream(bytes));
-    String output = serializer.deserialize(inputStream);
+    String output = serializerProtocol.deserialize(inputStream);
 
     verify(inputStream, atLeastOnce()).close();
     assertThat(output, equalTo(STRING_MESSAGE));
@@ -69,9 +68,9 @@ public abstract class AbstractObjectSerializerContractTestCase extends AbstractM
     dateTime.changeTimeZone("Pacific/Midway");
 
     Event event = eventBuilder().message(InternalMessage.of(dateTime)).build();
-    byte[] bytes = serializer.serialize(event.getMessage());
+    byte[] bytes = serializerProtocol.serialize(event.getMessage());
 
-    InternalMessage message = serializer.deserialize(bytes);
+    InternalMessage message = serializerProtocol.deserialize(bytes);
     DateTime deserealized = (DateTime) message.getPayload().getValue();
 
     assertEquals(calendar, deserealized.toCalendar());

--- a/core-tests/src/test/java/org/mule/runtime/core/serialization/JavaExternalSerializerProtocolProtocolTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/serialization/JavaExternalSerializerProtocolProtocolTestCase.java
@@ -10,16 +10,16 @@ import org.mule.runtime.core.api.serialization.SerializationException;
 
 import org.junit.Test;
 
-public class JavaObjectSerializerTestCase extends AbstractObjectSerializerContractTestCase {
+public class JavaExternalSerializerProtocolProtocolTestCase extends AbstractSerializerProtocolContractTestCase {
 
   @Override
   protected void doSetUp() throws Exception {
-    serializer = muleContext.getObjectSerializer();
+    serializerProtocol = muleContext.getObjectSerializer().getExternalProtocol();
   }
 
   @Test(expected = SerializationException.class)
   public void notSerializable() throws Exception {
-    serializer.serialize(new Object());
+    serializerProtocol.serialize(new Object());
   }
 
 }

--- a/core-tests/src/test/java/org/mule/runtime/core/transformer/compression/GZipTransformerObjectTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/transformer/compression/GZipTransformerObjectTestCase.java
@@ -22,7 +22,7 @@ public class GZipTransformerObjectTestCase extends GZipTransformerTestCase {
   @Override
   public Object getResultData() {
     try {
-      return strat.compressByteArray(muleContext.getObjectSerializer().serialize(TEST_OBJECT));
+      return strat.compressByteArray(muleContext.getObjectSerializer().getExternalProtocol().serialize(TEST_OBJECT));
     } catch (Exception e) {
       fail(e.getMessage());
       return null;

--- a/core-tests/src/test/java/org/mule/runtime/core/util/store/QueuePersistenceObjectStoreTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/util/store/QueuePersistenceObjectStoreTestCase.java
@@ -199,7 +199,7 @@ public class QueuePersistenceObjectStoreTestCase extends AbstractObjectStoreCont
     storeFile.getParentFile().mkdir();
 
     FileOutputStream fos = new FileOutputStream(storeFile);
-    muleContext.getObjectSerializer().serialize(payload, fos);
+    muleContext.getObjectSerializer().getExternalProtocol().serialize(payload, fos);
 
     return storeFile;
   }

--- a/core/src/main/java/org/mule/runtime/core/api/serialization/ObjectSerializer.java
+++ b/core/src/main/java/org/mule/runtime/core/api/serialization/ObjectSerializer.java
@@ -6,109 +6,30 @@
  */
 package org.mule.runtime.core.api.serialization;
 
-import org.mule.runtime.core.util.store.DeserializationPostInitialisable;
-
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
-
 /**
- * Defines a component capable to serialize/deserialize objects into/from an array of {@link byte}s. Unlike usual serializing
- * components, this one doesn't enforce the serialized object to implement {@link Serializable}. However, some implementations
- * might require that condition and throw {@link IllegalArgumentException} if not met.
- * <p/>
- * Implementations are also responsible for the correct initialization of classes implementing the
- * {@link DeserializationPostInitialisable} interface.
- * <p/>
- * <p/>
- * Unexpected behavior can result of deserializing objects that were generated with a different implementation of
- * {@link ObjectSerializer}.
- * <p/>
- * Implementations are required to be thread-safe
- *
- * @since 3.7.0
+ * Provides access to the different {@link SerializationProtocol} used in the container.
  */
 public interface ObjectSerializer {
 
   /**
-   * Serializes the given object into a an array of {@link byte}s
+   * Provides access to the serialization protocol used for internal consumption, that is, when objects are serialized
+   * on the container to reuse them later inside the container.
+   * <p/>
+   * Internal serialization uses a custom serialization protocol intended to overcome the limitations imposed by the classloading isolation.
+   * This custom protocol requires of the artifact classloader structure defined at runtime in order to deserialize objects.
    *
-   * @param object the object to be serialized. Might be <code>null</code>
-   * @return an array of {@link byte}
-   * @throws SerializationException in case of unexpected exception
+   * @return the internal serialization protocol
    */
-  byte[] serialize(Object object) throws SerializationException;
+  SerializationProtocol getInternalProtocol();
 
   /**
-   * Serializes the given object and writes the result into {@code out}
+   * Provides access to the serialization protocol used for external consumption, that is, when objects are serialized
+   * on the container to be consumed later outside the container.
+   * <p/>
+   * External serialization does not requires knowledge about the artifact classloader structure at runtime. Every serialized object's class
+   * is assumed to be available on the consumer side.
    *
-   * @param object the object to be serialized. Might be <code>null</code>
-   * @param out an {@link OutputStream} where the result will be written
-   * @return an array of {@link byte}
-   * @throws SerializationException in case of unexpected exception
+   * @return the external serialization protocol
    */
-  void serialize(Object object, OutputStream out) throws SerializationException;
-
-  /**
-   * Deserializes the given bytes. Unexpected behavior can result of deserializing a byte[] that was generated with another
-   * implementation.
-   * <p/>
-   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
-   * properly initializing the object before returning it.
-   * <p/>
-   * Implementation will choose the {@link java.lang.ClassLoader} to use for deserialization.
-   *
-   * @param bytes an array of byte that an original object was serialized into
-   * @return the deserialized object
-   * @throws IllegalArgumentException if {@code bytes} is {@code null}
-   * @throws SerializationException in case of unexpected exception
-   */
-  <T> T deserialize(byte[] bytes) throws SerializationException;
-
-  /**
-   * Deserializes the given bytes.
-   * <p/>
-   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
-   * properly initializing the object before returning it.
-   *
-   * @param bytes an array of byte that an original object was serialized into
-   * @param classLoader the {@link java.lang.ClassLoader} to deserialize with
-   * @return the deserialized object
-   * @throws IllegalArgumentException if {@code bytes} is {@code null}
-   * @throws SerializationException in case of unexpected exception
-   */
-  <T> T deserialize(byte[] bytes, ClassLoader classLoader) throws SerializationException;
-
-  /**
-   * Deserializes the given stream of bytes.
-   * <p/>
-   * Implementation will choose the {@link java.lang.ClassLoader} to use for deserialization.
-   * <p/>
-   * Even if deserialization fails, this method will close the {@code inputStream}
-   * <p/>
-   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
-   * properly initializing the object before returning it.
-   *
-   * @param inputStream a stream of bytes that an original object was serialized into
-   * @return the deserialized object
-   * @throws IllegalArgumentException if {@code inputStream} is {@code null}
-   * @throws SerializationException in case of unexpected exception
-   */
-  <T> T deserialize(InputStream inputStream) throws SerializationException;
-
-  /**
-   * Deserializes the given stream of bytes.
-   * <p/>
-   * Even if deserialization fails, this method will close the {@code inputStream}
-   * <p/>
-   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
-   * properly initializing the object before returning it.
-   *
-   * @param inputStream a stream of bytes that an original object was serialized into
-   * @param classLoader the {@link java.lang.ClassLoader} to deserialize with
-   * @return the deserialized object
-   * @throws IllegalArgumentException if {@code inputStream} is {@code null}
-   * @throws SerializationException in case of unexpected exception
-   */
-  <T> T deserialize(InputStream inputStream, ClassLoader classLoader) throws SerializationException;
+  SerializationProtocol getExternalProtocol();
 }

--- a/core/src/main/java/org/mule/runtime/core/api/serialization/SerializationProtocol.java
+++ b/core/src/main/java/org/mule/runtime/core/api/serialization/SerializationProtocol.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.core.api.serialization;
+
+import org.mule.runtime.core.util.store.DeserializationPostInitialisable;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+/**
+ * Defines a component capable to serialize/deserialize objects into/from an array of {@link byte}s. Unlike usual serializing
+ * components, this one doesn't enforce the serialized object to implement {@link Serializable}. However, some implementations
+ * might require that condition and throw {@link IllegalArgumentException} if not met.
+ * <p/>
+ * Implementations are also responsible for the correct initialization of classes implementing the
+ * {@link DeserializationPostInitialisable} interface.
+ * <p/>
+ * <p/>
+ * Unexpected behavior can result of deserializing objects that were generated with a different implementation of
+ * {@link SerializationProtocol}.
+ * <p/>
+ * Implementations are required to be thread-safe
+ */
+public interface SerializationProtocol {
+
+  /**
+   * Serializes the given object into a an array of {@link byte}s
+   *
+   * @param object the object to be serialized. Might be <code>null</code>
+   * @return an array of {@link byte}
+   * @throws SerializationException in case of unexpected exception
+   */
+  byte[] serialize(Object object) throws SerializationException;
+
+  /**
+   * Serializes the given object and writes the result into {@code out}
+   *
+   * @param object the object to be serialized. Might be <code>null</code>
+   * @param out an {@link OutputStream} where the result will be written
+   * @return an array of {@link byte}
+   * @throws SerializationException in case of unexpected exception
+   */
+  void serialize(Object object, OutputStream out) throws SerializationException;
+
+  /**
+   * Deserializes the given bytes. Unexpected behavior can result of deserializing a byte[] that was generated with another
+   * implementation.
+   * <p/>
+   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
+   * properly initializing the object before returning it.
+   * <p/>
+   * Implementation will choose the {@link java.lang.ClassLoader} to use for deserialization.
+   *
+   * @param bytes an array of byte that an original object was serialized into
+   * @return the deserialized object
+   * @throws IllegalArgumentException if {@code bytes} is {@code null}
+   * @throws SerializationException in case of unexpected exception
+   */
+  <T> T deserialize(byte[] bytes) throws SerializationException;
+
+  /**
+   * Deserializes the given bytes.
+   * <p/>
+   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
+   * properly initializing the object before returning it.
+   *
+   * @param bytes an array of byte that an original object was serialized into
+   * @param classLoader the {@link java.lang.ClassLoader} to deserialize with
+   * @return the deserialized object
+   * @throws IllegalArgumentException if {@code bytes} is {@code null}
+   * @throws SerializationException in case of unexpected exception
+   */
+  <T> T deserialize(byte[] bytes, ClassLoader classLoader) throws SerializationException;
+
+  /**
+   * Deserializes the given stream of bytes.
+   * <p/>
+   * Implementation will choose the {@link java.lang.ClassLoader} to use for deserialization.
+   * <p/>
+   * Even if deserialization fails, this method will close the {@code inputStream}
+   * <p/>
+   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
+   * properly initializing the object before returning it.
+   *
+   * @param inputStream a stream of bytes that an original object was serialized into
+   * @return the deserialized object
+   * @throws IllegalArgumentException if {@code inputStream} is {@code null}
+   * @throws SerializationException in case of unexpected exception
+   */
+  <T> T deserialize(InputStream inputStream) throws SerializationException;
+
+  /**
+   * Deserializes the given stream of bytes.
+   * <p/>
+   * Even if deserialization fails, this method will close the {@code inputStream}
+   * <p/>
+   * If the obtained object implements {@link DeserializationPostInitialisable} then this serializer will be responsible for
+   * properly initializing the object before returning it.
+   *
+   * @param inputStream a stream of bytes that an original object was serialized into
+   * @param classLoader the {@link java.lang.ClassLoader} to deserialize with
+   * @return the deserialized object
+   * @throws IllegalArgumentException if {@code inputStream} is {@code null}
+   * @throws SerializationException in case of unexpected exception
+   */
+  <T> T deserialize(InputStream inputStream, ClassLoader classLoader) throws SerializationException;
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToOutputHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/ObjectToOutputHandler.java
@@ -71,7 +71,7 @@ public class ObjectToOutputHandler extends AbstractTransformer implements Discov
 
         @Override
         public void write(Event event, OutputStream out) throws IOException {
-          muleContext.getObjectSerializer().serialize(src, out);
+          muleContext.getObjectSerializer().getExternalProtocol().serialize(src, out);
         }
       };
     } else {

--- a/core/src/main/java/org/mule/runtime/core/routing/MessageChunkAggregator.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/MessageChunkAggregator.java
@@ -67,7 +67,7 @@ public class MessageChunkAggregator extends AbstractAggregator {
 
           // try to deserialize message, since ChunkingRouter might have serialized the object...
           try {
-            builder.payload(muleContext.getObjectSerializer().deserialize(baos.toByteArray()));
+            builder.payload(muleContext.getObjectSerializer().getInternalProtocol().deserialize(baos.toByteArray()));
           } catch (SerializationException e) {
             builder.payload(baos.toByteArray());
           }

--- a/core/src/main/java/org/mule/runtime/core/serialization/internal/AbstractSerializationProtocol.java
+++ b/core/src/main/java/org/mule/runtime/core/serialization/internal/AbstractSerializationProtocol.java
@@ -9,8 +9,8 @@ package org.mule.runtime.core.serialization.internal;
 import static org.mule.runtime.core.util.Preconditions.checkArgument;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.context.MuleContextAware;
-import org.mule.runtime.core.api.serialization.ObjectSerializer;
 import org.mule.runtime.core.api.serialization.SerializationException;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.runtime.core.util.store.DeserializationPostInitialisable;
 
@@ -20,12 +20,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * Base class for implementations of {@link org.mule.runtime.core.api.serialization.ObjectSerializer} This class implements all
- * the base behavioral contract allowing its extensions to only care about the actual serialization/deserialization part.
- *
- * @since 3.7.0
+ * Base class for implementations of {@link SerializationProtocol} This class implements all the base behavioral
+ * contract allowing its extensions to only care about the actual serialization/deserialization part.
  */
-public abstract class AbstractObjectSerializer implements ObjectSerializer, MuleContextAware {
+public abstract class AbstractSerializationProtocol implements SerializationProtocol, MuleContextAware {
 
   protected MuleContext muleContext;
 

--- a/core/src/main/java/org/mule/runtime/core/serialization/internal/JavaExternalSerializerProtocol.java
+++ b/core/src/main/java/org/mule/runtime/core/serialization/internal/JavaExternalSerializerProtocol.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.serialization.internal;
+
+import static org.mule.runtime.core.util.Preconditions.checkArgument;
+import org.mule.runtime.core.api.serialization.SerializationException;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
+import org.mule.runtime.core.util.SerializationUtils;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+/**
+ * Implementation of {@link SerializationProtocol} that uses Java's default serialization mechanism. This means
+ * that exceptions will come from serializing objects that do not implement {@link Serializable}
+ */
+public class JavaExternalSerializerProtocol extends AbstractSerializationProtocol {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void serialize(Object object, OutputStream out) throws SerializationException {
+    validateForSerialization(object);
+    SerializationUtils.serialize((Serializable) object, out);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected byte[] doSerialize(Object object) throws Exception {
+    validateForSerialization(object);
+    return SerializationUtils.serialize((Serializable) object);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected <T> T doDeserialize(InputStream inputStream, ClassLoader classLoader) throws Exception {
+    checkArgument(inputStream != null, "Cannot deserialize a null stream");
+    checkArgument(classLoader != null, "Cannot deserialize with a null classloader");
+
+    return (T) SerializationUtils.deserialize(inputStream, classLoader, muleContext);
+  }
+
+  @Override
+  protected <T> T postInitialize(T object) {
+    // does nothing since SerializationUtils already does this on its own
+    return object;
+  }
+
+  private void validateForSerialization(Object object) {
+    if (object != null && !(object instanceof Serializable)) {
+      throw new SerializationException(String.format("Was expecting a Serializable type. %s was found instead",
+                                                     object.getClass().getName()));
+    }
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/serialization/internal/JavaObjectSerializer.java
+++ b/core/src/main/java/org/mule/runtime/core/serialization/internal/JavaObjectSerializer.java
@@ -4,63 +4,33 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
+
 package org.mule.runtime.core.serialization.internal;
 
-import static org.mule.runtime.core.util.Preconditions.checkArgument;
-import org.mule.runtime.core.api.serialization.SerializationException;
-import org.mule.runtime.core.util.SerializationUtils;
-
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.context.MuleContextAware;
+import org.mule.runtime.core.api.serialization.ObjectSerializer;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
 
 /**
- * Implementation of {@link org.mule.runtime.core.api.serialization.ObjectSerializer} that uses Java's default serialization
- * mechanism. This means that exceptions will come from serializing objects that do not implement {@link Serializable}
- *
- * @since 3.7.0
+ * Serializes objects using the default Java serialization mechanism provided by writeObject and readObject methods.
  */
-public class JavaObjectSerializer extends AbstractObjectSerializer {
+public class JavaObjectSerializer implements ObjectSerializer, MuleContextAware {
 
-  /**
-   * {@inheritDoc}
-   */
+  private volatile JavaExternalSerializerProtocol javaSerializerProtocol = new JavaExternalSerializerProtocol();
+
   @Override
-  public void serialize(Object object, OutputStream out) throws SerializationException {
-    validateForSerialization(object);
-    SerializationUtils.serialize((Serializable) object, out);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  protected byte[] doSerialize(Object object) throws Exception {
-    validateForSerialization(object);
-    return SerializationUtils.serialize((Serializable) object);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  protected <T> T doDeserialize(InputStream inputStream, ClassLoader classLoader) throws Exception {
-    checkArgument(inputStream != null, "Cannot deserialize a null stream");
-    checkArgument(classLoader != null, "Cannot deserialize with a null classloader");
-
-    return (T) SerializationUtils.deserialize(inputStream, classLoader, muleContext);
+  public SerializationProtocol getInternalProtocol() {
+    return javaSerializerProtocol;
   }
 
   @Override
-  protected <T> T postInitialize(T object) {
-    // does nothing since SerializationUtils already does this on its own
-    return object;
+  public SerializationProtocol getExternalProtocol() {
+    return javaSerializerProtocol;
   }
 
-  private void validateForSerialization(Object object) {
-    if (object != null && !(object instanceof Serializable)) {
-      throw new SerializationException(String.format("Was expecting a Serializable type. %s was found instead",
-                                                     object.getClass().getName()));
-    }
+  @Override
+  public void setMuleContext(MuleContext context) {
+    javaSerializerProtocol.setMuleContext(context);
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/transformer/compression/GZipCompressTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/transformer/compression/GZipCompressTransformer.java
@@ -41,7 +41,7 @@ public class GZipCompressTransformer extends AbstractCompressionTransformer {
         } else if (src instanceof String) {
           data = ((String) src).getBytes(outputEncoding);
         } else {
-          data = muleContext.getObjectSerializer().serialize(src);
+          data = muleContext.getObjectSerializer().getExternalProtocol().serialize(src);
         }
         return getStrategy().compressByteArray(data);
       }

--- a/core/src/main/java/org/mule/runtime/core/transformer/compression/GZipUncompressTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/transformer/compression/GZipUncompressTransformer.java
@@ -45,14 +45,14 @@ public class GZipUncompressTransformer extends AbstractCompressionTransformer {
           return new String(buffer, outputEncoding);
         } else if (!DataType.OBJECT.isCompatibleWith(returnDataType) && !DataType.BYTE_ARRAY.isCompatibleWith(returnDataType)) {
           try {
-            return muleContext.getObjectSerializer().deserialize(buffer);
+            return muleContext.getObjectSerializer().getExternalProtocol().deserialize(buffer);
           } catch (SerializationException e) {
             throw new TransformerException(this, e);
           }
         } else {
           // First try to deserialize the byte array. If it can be deserialized, then it was originally serialized.
           try {
-            return muleContext.getObjectSerializer().deserialize(buffer);
+            return muleContext.getObjectSerializer().getExternalProtocol().deserialize(buffer);
           } catch (SerializationException e) {
             // If it fails, ignore it. We assume it was not serialized in the first place and return the buffer as it is.
             return buffer;

--- a/core/src/main/java/org/mule/runtime/core/transformer/simple/ByteArrayToSerializable.java
+++ b/core/src/main/java/org/mule/runtime/core/transformer/simple/ByteArrayToSerializable.java
@@ -37,9 +37,9 @@ public class ByteArrayToSerializable extends AbstractTransformer implements Disc
     try {
       final Object result;
       if (src instanceof byte[]) {
-        result = serializer.deserialize((byte[]) src);
+        result = serializer.getExternalProtocol().deserialize((byte[]) src);
       } else {
-        result = serializer.deserialize((InputStream) src);
+        result = serializer.getExternalProtocol().deserialize((InputStream) src);
       }
       return result;
     } catch (Exception e) {

--- a/core/src/main/java/org/mule/runtime/core/transformer/simple/MuleMessageToByteArray.java
+++ b/core/src/main/java/org/mule/runtime/core/transformer/simple/MuleMessageToByteArray.java
@@ -22,6 +22,6 @@ public class MuleMessageToByteArray extends AbstractMessageTransformer {
 
   @Override
   public Object transformMessage(Event event, Charset outputEncoding) {
-    return muleContext.getObjectSerializer().serialize(event.getMessage());
+    return muleContext.getObjectSerializer().getExternalProtocol().serialize(event.getMessage());
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/transformer/simple/SerializableToByteArray.java
+++ b/core/src/main/java/org/mule/runtime/core/transformer/simple/SerializableToByteArray.java
@@ -53,7 +53,7 @@ public class SerializableToByteArray extends AbstractTransformer implements Disc
      */
 
     try {
-      return muleContext.getObjectSerializer().serialize(src);
+      return muleContext.getObjectSerializer().getExternalProtocol().serialize(src);
     } catch (Exception e) {
       throw new TransformerException(this, e);
     }

--- a/core/src/main/java/org/mule/runtime/core/util/journal/queue/AbstractQueueTxJournalEntry.java
+++ b/core/src/main/java/org/mule/runtime/core/util/journal/queue/AbstractQueueTxJournalEntry.java
@@ -78,7 +78,7 @@ public abstract class AbstractQueueTxJournalEntry<T> implements JournalEntry<T> 
     byte[] valueAsBytes = new byte[valueSize];
     inputStream.read(valueAsBytes, 0, valueSize);
     queueName = new String(queueNameAsBytes);
-    value = muleContext.getObjectSerializer().deserialize(valueAsBytes);
+    value = muleContext.getObjectSerializer().getInternalProtocol().deserialize(valueAsBytes);
   }
 
   public void write(DataOutputStream outputStream, MuleContext muleContext) {
@@ -91,7 +91,7 @@ public abstract class AbstractQueueTxJournalEntry<T> implements JournalEntry<T> 
       }
       outputStream.write(queueName.length());
       outputStream.write(queueName.getBytes());
-      byte[] serializedValue = muleContext.getObjectSerializer().serialize(value);
+      byte[] serializedValue = muleContext.getObjectSerializer().getInternalProtocol().serialize(value);
       outputStream.writeInt(serializedValue.length);
       outputStream.write(serializedValue);
       outputStream.flush();

--- a/core/src/main/java/org/mule/runtime/core/util/queue/DualRandomAccessFileQueueStoreDelegate.java
+++ b/core/src/main/java/org/mule/runtime/core/util/queue/DualRandomAccessFileQueueStoreDelegate.java
@@ -98,14 +98,14 @@ public class DualRandomAccessFileQueueStoreDelegate extends AbstractQueueStoreDe
   @Override
   protected void addFirst(Serializable item) throws InterruptedException {
     switchWriteFileIfFull();
-    byte[] serialiazedObject = serializer.serialize(item);
+    byte[] serialiazedObject = serializer.getInternalProtocol().serialize(item);
     readFile.addFirst(serialiazedObject);
   }
 
   @Override
   protected void add(Serializable item) {
     switchWriteFileIfFull();
-    byte[] serialiazedObject = serializer.serialize(item);
+    byte[] serialiazedObject = serializer.getInternalProtocol().serialize(item);
     writeFile.addLast(serialiazedObject);
   }
 
@@ -209,7 +209,7 @@ public class DualRandomAccessFileQueueStoreDelegate extends AbstractQueueStoreDe
   }
 
   private Serializable deserialize(byte[] valuesAsBytes) {
-    return serializer.deserialize(valuesAsBytes);
+    return serializer.getInternalProtocol().deserialize(valuesAsBytes);
   }
 
   public void remove(Serializable value) {

--- a/core/src/main/java/org/mule/runtime/core/util/store/PersistentObjectStorePartition.java
+++ b/core/src/main/java/org/mule/runtime/core/util/store/PersistentObjectStorePartition.java
@@ -321,7 +321,7 @@ public class PersistentObjectStorePartition<T extends Serializable> implements L
     try {
       out = new FileOutputStream(outputFile);
       ObjectOutputStream objectOutputStream = new ObjectOutputStream(out);
-      serializer.serialize(storeValue, objectOutputStream);
+      serializer.getInternalProtocol().serialize(storeValue, objectOutputStream);
     } catch (Exception se) {
       throw new ObjectStoreException(se);
     } finally {
@@ -340,7 +340,7 @@ public class PersistentObjectStorePartition<T extends Serializable> implements L
     ObjectInputStream objectInputStream = null;
     try {
       objectInputStream = new ObjectInputStream(new FileInputStream(file));
-      StoreValue<T> storedValue = serializer.deserialize(objectInputStream);
+      StoreValue<T> storedValue = serializer.getInternalProtocol().deserialize(objectInputStream);
       if (storedValue.getValue() instanceof DeserializationPostInitialisable) {
         DeserializationPostInitialisable.Implementation.init(storedValue.getValue(), muleContext);
       }

--- a/core/src/main/java/org/mule/runtime/core/util/store/QueuePersistenceObjectStore.java
+++ b/core/src/main/java/org/mule/runtime/core/util/store/QueuePersistenceObjectStore.java
@@ -225,7 +225,7 @@ public class QueuePersistenceObjectStore<T extends Serializable> extends Abstrac
   protected void serialize(T value, File outputFile) throws ObjectStoreException {
     try {
       FileOutputStream out = new FileOutputStream(outputFile);
-      out.write(muleContext.getObjectSerializer().serialize(value));
+      out.write(muleContext.getObjectSerializer().getInternalProtocol().serialize(value));
       out.flush();
     } catch (SerializationException se) {
       throw new ObjectStoreException(se);
@@ -264,7 +264,7 @@ public class QueuePersistenceObjectStore<T extends Serializable> extends Abstrac
   protected T deserialize(File file) throws ObjectStoreException {
     try {
       FileInputStream in = new FileInputStream(file);
-      return muleContext.getObjectSerializer().deserialize(in);
+      return muleContext.getObjectSerializer().getInternalProtocol().deserialize(in);
     } catch (SerializationException se) {
       throw new ObjectStoreException(se);
     } catch (FileNotFoundException fnfe) {

--- a/extensions/sockets/src/main/java/org/mule/extension/socket/internal/SocketUtils.java
+++ b/extensions/sockets/src/main/java/org/mule/extension/socket/internal/SocketUtils.java
@@ -53,14 +53,14 @@ public final class SocketUtils {
         return getByteArray(((Message) data).getPayload().getValue(), payloadOnly, streamingIsAllowed, encoding,
                             objectSerializer);
       } else {
-        return objectSerializer.serialize(data);
+        return objectSerializer.getExternalProtocol().serialize(data);
       }
     } else if (data instanceof byte[]) {
       return (byte[]) data;
     } else if (data instanceof String) {
       return ((String) data).getBytes(encoding);
     } else if (data instanceof Serializable) {
-      return objectSerializer.serialize(data);
+      return objectSerializer.getExternalProtocol().serialize(data);
     }
 
     throw new IllegalArgumentException(format("Cannot serialize data: '%s'", data));

--- a/extensions/sockets/src/test/java/org/mule/extension/socket/SocketExtensionTestCase.java
+++ b/extensions/sockets/src/test/java/org/mule/extension/socket/SocketExtensionTestCase.java
@@ -112,7 +112,8 @@ public abstract class SocketExtensionTestCase extends MuleArtifactFunctionalTest
   }
 
   protected Object deserializeMessage(Message message) throws Exception {
-    return muleContext.getObjectSerializer().deserialize(IOUtils.toByteArray((InputStream) message.getPayload().getValue()));
+    return muleContext.getObjectSerializer().getExternalProtocol()
+        .deserialize(IOUtils.toByteArray((InputStream) message.getPayload().getValue()));
   }
 
   protected Message receiveConnection() {

--- a/tests/integration/src/test/java/org/mule/test/config/spring/InjectDefaultObjectSerializerTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/config/spring/InjectDefaultObjectSerializerTestCase.java
@@ -12,11 +12,10 @@ import static org.junit.Assert.assertThat;
 import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.core.api.serialization.DefaultObjectSerializer;
 import org.mule.runtime.core.api.serialization.ObjectSerializer;
-import org.mule.runtime.core.serialization.internal.AbstractObjectSerializer;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
 import org.mule.test.AbstractIntegrationTestCase;
 import org.mule.test.runner.RunnerDelegateTo;
 
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -67,15 +66,16 @@ public class InjectDefaultObjectSerializerTestCase extends AbstractIntegrationTe
     }
   }
 
-  public static class TestObjectSerializer extends AbstractObjectSerializer {
+  public static class TestSerializationProtocol implements ObjectSerializer {
+
 
     @Override
-    protected byte[] doSerialize(Object object) throws Exception {
-      return new byte[0];
+    public SerializationProtocol getInternalProtocol() {
+      return null;
     }
 
     @Override
-    protected <T> T doDeserialize(InputStream inputStream, ClassLoader classLoader) throws Exception {
+    public SerializationProtocol getExternalProtocol() {
       return null;
     }
   }

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/SerializationOnResponseAggregatorTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/SerializationOnResponseAggregatorTestCase.java
@@ -58,14 +58,14 @@ public class SerializationOnResponseAggregatorTestCase extends AbstractIntegrati
 
     @Override
     protected void doStore(Serializable key, Serializable value) throws ObjectStoreException {
-      byte[] serialized = serializer.serialize(value);
+      byte[] serialized = serializer.getExternalProtocol().serialize(value);
       super.doStore(key, serialized);
     }
 
     @Override
     protected Serializable doRetrieve(Serializable key) {
       Serializable serialized = super.doRetrieve(key);
-      return serializer.deserialize((byte[]) serialized);
+      return serializer.getExternalProtocol().deserialize((byte[]) serialized);
     }
   }
 }

--- a/tests/integration/src/test/java/org/mule/test/usecases/sync/HttpTransformTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/sync/HttpTransformTestCase.java
@@ -63,7 +63,8 @@ public class HttpTransformTestCase extends AbstractIntegrationTestCase {
     payload.add(42);
     InternalMessage message =
         client.send(String.format("http://localhost:%d/RemoteService", httpPort2.getNumber()),
-                    InternalMessage.of(muleContext.getObjectSerializer().serialize(payload)), HTTP_REQUEST_OPTIONS)
+                    InternalMessage.of(muleContext.getObjectSerializer().getExternalProtocol().serialize(payload)),
+                    HTTP_REQUEST_OPTIONS)
             .getRight();
     assertNotNull(message);
     ByteArrayToSerializable bas = new ByteArrayToSerializable();

--- a/tests/integration/src/test/resources/custom-object-serializer-config.xml
+++ b/tests/integration/src/test/resources/custom-object-serializer-config.xml
@@ -9,7 +9,7 @@
 
     <spring:beans>
         <spring:bean name="customObjectSerializer"
-                     class="org.mule.test.config.spring.InjectDefaultObjectSerializerTestCase$TestObjectSerializer"/>
+                     class="org.mule.test.config.spring.InjectDefaultObjectSerializerTestCase.TestSerializationProtocol"/>
     </spring:beans>
 
     <configuration defaultObjectSerializer-ref="customObjectSerializer"/>

--- a/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/MuleEventTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/MuleEventTestCase.java
@@ -19,6 +19,7 @@ import org.mule.runtime.core.api.MuleException;
 import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.registry.MuleRegistry;
 import org.mule.runtime.core.api.routing.filter.Filter;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
 import org.mule.runtime.core.api.transformer.Transformer;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.routing.MessageFilter;
@@ -113,8 +114,9 @@ public class MuleEventTestCase extends AbstractMuleContextEndpointTestCase {
     }
     Event testEvent = eventBuilder().message(InternalMessage.of(new ByteArrayInputStream(payload.toString().getBytes()))).build();
     setCurrentEvent(testEvent);
-    byte[] serializedEvent = muleContext.getObjectSerializer().serialize(testEvent);
-    testEvent = muleContext.getObjectSerializer().deserialize(serializedEvent);
+    SerializationProtocol serializationProtocol = muleContext.getObjectSerializer().getExternalProtocol();
+    byte[] serializedEvent = serializationProtocol.serialize(testEvent);
+    testEvent = serializationProtocol.deserialize(serializedEvent);
 
     assertArrayEquals((byte[]) testEvent.getMessage().getPayload().getValue(), payload.toString().getBytes());
   }

--- a/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/session/SessionPropertiesTestCase.java
+++ b/transports/core-transports-tests/src/test/java/org/mule/compatibility/core/session/SessionPropertiesTestCase.java
@@ -26,6 +26,7 @@ import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.MuleSession;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.serialization.ObjectSerializer;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
 import org.mule.runtime.core.construct.Flow;
 import org.mule.runtime.core.processor.AsyncInterceptingMessageProcessor;
 import org.mule.tck.SensingNullMessageProcessor;
@@ -100,7 +101,8 @@ public class SessionPropertiesTestCase extends AbstractMuleContextTestCase {
     event.getSession().setProperty("key", "value");
 
     ObjectSerializer serializer = muleContext.getObjectSerializer();
-    Event deserializedEvent = serializer.deserialize(serializer.serialize(event));
+    SerializationProtocol serializationProtocol = serializer.getExternalProtocol();
+    Event deserializedEvent = serializationProtocol.deserialize(serializationProtocol.serialize(event));
 
     // Event and session are both copied
     assertNotSame(deserializedEvent, event);
@@ -170,7 +172,8 @@ public class SessionPropertiesTestCase extends AbstractMuleContextTestCase {
     event.getSession().setProperty("key2", "value2");
 
     ObjectSerializer serializer = muleContext.getObjectSerializer();
-    Event deserialized = serializer.deserialize(serializer.serialize(event));
+    SerializationProtocol serializationProtocol = serializer.getExternalProtocol();
+    Event deserialized = serializationProtocol.deserialize(serializationProtocol.serialize(event));
 
     // Serialization no longer fails as in 3.1.x/3.2.x
 

--- a/transports/core/src/main/java/org/mule/compatibility/core/session/AbstractSessionHandler.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/session/AbstractSessionHandler.java
@@ -28,7 +28,7 @@ public abstract class AbstractSessionHandler implements SessionHandler {
 
   protected <T> T deserialize(InternalMessage message, byte[] bytes, MuleContext muleContext) {
     T object = objectSerializerLocator.getObjectSerializer(message, muleContext)
-        .deserialize(bytes, muleContext.getExecutionClassLoader());
+        .getExternalProtocol().deserialize(bytes, muleContext.getExecutionClassLoader());
     if (object instanceof DeserializationPostInitialisable) {
       try {
         DeserializationPostInitialisable.Implementation.init(object, muleContext);
@@ -41,7 +41,7 @@ public abstract class AbstractSessionHandler implements SessionHandler {
   }
 
   protected byte[] serialize(InternalMessage message, Object object, MuleContext muleContext) {
-    return objectSerializerLocator.getObjectSerializer(message, muleContext).serialize(object);
+    return objectSerializerLocator.getObjectSerializer(message, muleContext).getExternalProtocol().serialize(object);
   }
 
   @Inject

--- a/transports/core/src/main/java/org/mule/compatibility/core/session/SerializeOnlySessionHandler.java
+++ b/transports/core/src/main/java/org/mule/compatibility/core/session/SerializeOnlySessionHandler.java
@@ -41,7 +41,8 @@ public class SerializeOnlySessionHandler extends AbstractSessionHandler {
   @Override
   public InternalMessage storeSessionInfoToMessage(MuleSession session, InternalMessage message, MuleContext context)
       throws MuleException {
-    byte[] serializedSession = context.getObjectSerializer().serialize(removeNonSerializableProperties(session, context));
+    byte[] serializedSession =
+        context.getObjectSerializer().getExternalProtocol().serialize(removeNonSerializableProperties(session, context));
 
     if (logger.isDebugEnabled()) {
       logger.debug("Adding serialized Session header to message: " + serializedSession);

--- a/transports/http/src/main/java/org/mule/compatibility/transport/http/transformers/ObjectToHttpClientMethodRequest.java
+++ b/transports/http/src/main/java/org/mule/compatibility/transport/http/transformers/ObjectToHttpClientMethodRequest.java
@@ -328,7 +328,7 @@ public class ObjectToHttpClientMethodRequest extends AbstractMessageTransformer 
         final Event eventFromContext = getCurrentEvent();
         postMethod.setRequestEntity(new StreamPayloadRequestEntity((OutputHandler) src, eventFromContext));
       } else {
-        final byte[] buffer = muleContext.getObjectSerializer().serialize(src);
+        final byte[] buffer = muleContext.getObjectSerializer().getExternalProtocol().serialize(src);
         postMethod.setRequestEntity(new ByteArrayRequestEntity(buffer, outboundMimeType));
       }
     } else if (msg.getOutboundAttachmentNames() != null && msg.getOutboundAttachmentNames().size() > 0) {

--- a/transports/jms/src/test/java/org/mule/compatibility/transport/jms/integration/JmsDeadLetterQueueTestCase.java
+++ b/transports/jms/src/test/java/org/mule/compatibility/transport/jms/integration/JmsDeadLetterQueueTestCase.java
@@ -79,7 +79,7 @@ public class JmsDeadLetterQueueTestCase extends AbstractJmsFunctionalTestCase {
       if (message instanceof BytesMessage) {
         byte[] messageBytes = new byte[(int) ((BytesMessage) message).getBodyLength()];
         ((BytesMessage) message).readBytes(messageBytes);
-        obj = muleContext.getObjectSerializer().deserialize(messageBytes);
+        obj = muleContext.getObjectSerializer().getExternalProtocol().deserialize(messageBytes);
       }
       // ExceptionMessage did not get serialized by JMS provider
       else if (message instanceof ObjectMessage) {

--- a/transports/tcp/src/main/java/org/mule/compatibility/transport/tcp/protocols/AbstractByteProtocol.java
+++ b/transports/tcp/src/main/java/org/mule/compatibility/transport/tcp/protocols/AbstractByteProtocol.java
@@ -78,7 +78,7 @@ public abstract class AbstractByteProtocol implements TcpProtocol {
       // a separate "stringEncoding" property on the protocol
       writeByteArray(os, ((String) data).getBytes());
     } else if (data instanceof Serializable) {
-      writeByteArray(os, objectSerializer.serialize(data));
+      writeByteArray(os, objectSerializer.getExternalProtocol().serialize(data));
     } else {
       throw new IllegalArgumentException("Cannot serialize data: " + data);
     }

--- a/transports/vm/src/test/java/org/mule/compatibility/transport/vm/functional/VMUsersDefaultObjectSerializerTestCase.java
+++ b/transports/vm/src/test/java/org/mule/compatibility/transport/vm/functional/VMUsersDefaultObjectSerializerTestCase.java
@@ -13,7 +13,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-
 import org.mule.functional.extensions.CompatibilityFunctionalTestCase;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.lifecycle.LifecycleUtils;
@@ -65,12 +64,12 @@ public class VMUsersDefaultObjectSerializerTestCase extends CompatibilityFunctio
     assertThat(getPayloadAsString(response), is(payload));
 
     ArgumentCaptor<InternalMessage> messageArgumentCaptor = ArgumentCaptor.forClass(InternalMessage.class);
-    verify(objectSerializer, atLeastOnce()).serialize(messageArgumentCaptor.capture());
+    verify(objectSerializer, atLeastOnce()).getExternalProtocol().serialize(messageArgumentCaptor.capture());
     InternalMessage capturedMessage = messageArgumentCaptor.getValue();
     assertThat(capturedMessage, is(notNullValue()));
     assertThat(getPayloadAsString(capturedMessage), is(payload));
 
-    verify(objectSerializer, atLeastOnce()).deserialize(any(byte[].class));
+    verify(objectSerializer, atLeastOnce()).getExternalProtocol().deserialize(any(byte[].class));
   }
 
 }


### PR DESCRIPTION
_ Adding SerializationProtocol to differentiate between internal/external serialization (both returned serializers protocols are the same until the next pull request)
_ Moving ObjectSerializer API to SerializationProtocol
_ Updating ObjectSerializer to provide internal/external serialization protocols
_ Using internal/external serializer depending on the context