### PR TITLE
MULE-10252: first support for <module>s 

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/el/context/ModuleOperationVariableMapContext.java
+++ b/core/src/main/java/org/mule/runtime/core/el/context/ModuleOperationVariableMapContext.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.el.context;
+
+import static java.util.Collections.emptyMap;
+import static org.mule.runtime.core.api.Event.getVariableValueOrNull;
+import org.mule.runtime.core.api.Event;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+//TODO until MULE-10291 & MULE-10353 are done, we will use flowVars to store the parameter.value and property.value
+public class ModuleOperationVariableMapContext extends AbstractMapContext<Object> {
+
+  private Event event;
+  private Event.Builder eventBuider;
+  private String prefix;
+
+  public ModuleOperationVariableMapContext(Event event, Event.Builder eventBuider, String prefix) {
+    this.event = event;
+    this.eventBuider = eventBuider;
+    this.prefix = prefix;
+  }
+
+  @Override
+  public Object doGet(String key) {
+    return getVariableValueOrNull(applyPrefix(key), event);
+  }
+
+  @Override
+  public void doPut(String key, Object value) {
+    eventBuider.addVariable(applyPrefix(key), value);
+    event = eventBuider.build();
+  }
+
+  @Override
+  public void doRemove(String key) {
+    eventBuider.removeVariable(applyPrefix(key));
+    event = eventBuider.build();
+  }
+
+  @Override
+  public Set<String> keySet() {
+    return event.getVariableNames();
+  }
+
+  @Override
+  public void clear() {
+    eventBuider.variables(emptyMap());
+    event = eventBuider.build();
+  }
+
+  @Override
+  public String toString() {
+    Map<String, Object> map = new HashMap<>();
+    for (String key : event.getVariableNames()) {
+      String keyWithPrefix = applyPrefix(key);
+      Object value = event.getVariable(keyWithPrefix) != null ? event.getVariable(keyWithPrefix).getValue() : null;
+      map.put(keyWithPrefix, value);
+    }
+    return map.toString();
+  }
+
+  private String applyPrefix(String key) {
+    return prefix + "." + key;
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/el/mvel/MessageVariableResolverFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/el/mvel/MessageVariableResolverFactory.java
@@ -14,6 +14,7 @@ import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.el.context.FlowVariableMapContext;
 import org.mule.runtime.core.el.context.MessageContext;
+import org.mule.runtime.core.el.context.ModuleOperationVariableMapContext;
 import org.mule.runtime.core.el.context.SessionVariableMapContext;
 import org.mule.runtime.core.exception.MessagingException;
 
@@ -30,6 +31,8 @@ public class MessageVariableResolverFactory extends MuleBaseVariableResolverFact
   public static final String MESSAGE_PAYLOAD = MESSAGE + "." + PAYLOAD;
   public static final String FLOW_VARS = "flowVars";
   public static final String SESSION_VARS = "sessionVars";
+  public static final String PARAM_VARS = "param";
+  public static final String PROPERTY_VARS = "property";
 
   protected Event event;
   protected Event.Builder eventBuilder;
@@ -59,7 +62,8 @@ public class MessageVariableResolverFactory extends MuleBaseVariableResolverFact
   @Override
   public boolean isTarget(String name) {
     return MESSAGE.equals(name) || PAYLOAD.equals(name) || FLOW_VARS.equals(name) || EXCEPTION.equals(name) || ERROR.equals(name)
-        || SESSION_VARS.equals(name) || MVELExpressionLanguageContext.MULE_MESSAGE_INTERNAL_VARIABLE.equals(name);
+        || SESSION_VARS.equals(name) || MVELExpressionLanguageContext.MULE_MESSAGE_INTERNAL_VARIABLE.equals(name)
+        || PARAM_VARS.equals(name) || PROPERTY_VARS.equals(name); //TODO until MULE-10291 & MULE-10353 are done, we will use flowVars to store the parameter.value and property.value
   }
 
   @Override
@@ -96,6 +100,11 @@ public class MessageVariableResolverFactory extends MuleBaseVariableResolverFact
       } else if (MVELExpressionLanguageContext.MULE_MESSAGE_INTERNAL_VARIABLE.equals(name)) {
         return new MuleImmutableVariableResolver<>(MVELExpressionLanguageContext.MULE_MESSAGE_INTERNAL_VARIABLE,
                                                    event.getMessage(), null);
+      } else if (PARAM_VARS.equals(name) || PROPERTY_VARS.equals(name)) { //TODO until MULE-10291 & MULE-10353 are done, we will use flowVars to store the parameter.value and property.value
+        return new MuleImmutableVariableResolver<Map<String, Object>>(FLOW_VARS,
+                                                                      new ModuleOperationVariableMapContext(event, eventBuilder,
+                                                                                                            name),
+                                                                      null);
       }
     }
     return super.getNextFactoryVariableResolver(name);

--- a/core/src/main/java/org/mule/runtime/core/processor/chain/ModuleOperationMessageProcessorChainBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/chain/ModuleOperationMessageProcessorChainBuilder.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.processor.chain;
+
+import static org.mule.runtime.core.api.message.InternalMessage.builder;
+import static org.mule.runtime.core.el.mvel.MessageVariableResolverFactory.PARAM_VARS;
+import static org.mule.runtime.core.el.mvel.MessageVariableResolverFactory.PROPERTY_VARS;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.core.api.Event;
+import org.mule.runtime.core.api.el.ExpressionLanguage;
+import org.mule.runtime.core.api.processor.MessageProcessorChain;
+import org.mule.runtime.core.api.processor.MessageProcessorContainer;
+import org.mule.runtime.core.api.processor.MessageProcessorPathElement;
+import org.mule.runtime.core.api.processor.Processor;
+import org.mule.runtime.core.util.NotificationUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Creates a chain for any operation, where it parametrizes two type of values (parameter and property) to the
+ * inner processors through the {@link Event}.
+ *
+ * <p> Both parameter and property could be simple literals or expressions that will be evaluated before passing the new
+ * {@link Event} to the child processors.
+ *
+ * <p> Taking the following sample where the current event passed to {@link ModuleOperationProcessorChain#doProcess(Event)}
+ * has a flow variable under "person" with a value of "stranger!", the result of executing the above processor will be
+ * "howdy stranger!":
+ * <pre>
+ *  <module-operation-chain returnsVoid="false">
+ *    <module-operation-properties/>
+ *    <module-operation-parameters>
+ *      <module-operation-parameter-entry value="howdy" key="value1"/>
+ *      <module-operation-parameter-entry value="#[flowVars.person]" key="value2"/>
+ *    </module-operation-parameters>
+ *    <set-payload value="#[param.value1 + param.value2]"/>
+ * </module-operation-chain>
+ * </pre>
+ */
+public class ModuleOperationMessageProcessorChainBuilder extends ExplicitMessageProcessorChainBuilder {
+
+  private Map<String, String> properties;
+  private Map<String, String> parameters;
+  private boolean returnsVoid;
+  private ExpressionLanguage expressionLanguage;
+
+  public ModuleOperationMessageProcessorChainBuilder(Map<String, String> properties,
+                                                     Map<String, String> parameters, boolean returnsVoid,
+                                                     ExpressionLanguage expressionLanguage) {
+    this.properties = properties;
+    this.parameters = parameters;
+    this.returnsVoid = returnsVoid;
+    this.expressionLanguage = expressionLanguage;
+  }
+
+  @Override
+  protected MessageProcessorChain createInterceptingChain(Processor head, List<Processor> processors,
+                                                          List<Processor> processorForLifecycle) {
+    return new ModuleOperationProcessorChain("wrapping-operation-module-chain", head, processors, processorForLifecycle,
+                                             properties, parameters, returnsVoid,
+                                             expressionLanguage);
+  }
+
+  /**
+   * Generates message processor for a specific set of parameters & properties to be added in a new event.
+   */
+  static class ModuleOperationProcessorChain extends ExplicitMessageProcessorChain
+      implements Processor, MessageProcessorContainer {
+
+    private Map<String, String> properties;
+    private Map<String, String> parameters;
+    private boolean returnsVoid;
+    private ExpressionLanguage expressionLanguage;
+
+    ModuleOperationProcessorChain(String name, Processor head, List<Processor> processors,
+                                  List<Processor> processorsForLifecycle,
+                                  Map<String, String> properties, Map<String, String> parameters,
+                                  boolean returnsVoid,
+                                  ExpressionLanguage expressionLanguage) {
+      super(name, head, processors, processorsForLifecycle);
+      this.properties = properties;
+      this.parameters = parameters;
+      this.returnsVoid = returnsVoid;
+      this.expressionLanguage = expressionLanguage;
+    }
+
+    @Override
+    public void addMessageProcessorPathElements(MessageProcessorPathElement pathElement) {
+      MessageProcessorPathElement subprocessors = pathElement.addChild(name).addChild("subprocessorsModuleOperations");
+      NotificationUtils.addMessageProcessorPathElements(processors, subprocessors);
+    }
+
+    /**
+     * Given an {@code event}, it will consume from it ONLY the defined properties and parameters that were set when
+     * initializing this class to provide scoping for the inner list of processors.
+     *
+     * @param event parameter to consume elements from
+     * @return a modified {@link Event} if the output of the operation was not void, the same event otherwise.
+     * @throws MuleException
+     */
+    @Override
+    protected Event doProcess(Event event) throws MuleException {
+      Event eventResponse = super.doProcess(createEventWithParameters(event));
+
+      if (!returnsVoid) {
+        event = Event.builder(event)
+            .message(builder(eventResponse.getMessage()).build())
+            .build();
+      }
+      return event;
+    }
+
+    private Event createEventWithParameters(Event event) {
+      Event.Builder builder = Event.builder(event.getContext());
+      builder.message(builder().nullPayload().build());
+      properties.forEach(addEvaluatedParam(event, builder, PROPERTY_VARS));
+      parameters.forEach(addEvaluatedParam(event, builder, PARAM_VARS));
+      return builder.build();
+    }
+
+    private BiConsumer<String, String> addEvaluatedParam(Event event, Event.Builder builder, String prefix) {
+      return (name, value) -> builder.addVariable(prefix + "." + name, expressionLanguage.isExpression(value)
+          ? expressionLanguage.evaluate(value, event, flowConstruct)
+          : value);
+
+    }
+  }
+}

--- a/extensions/db/src/test/resources/integration/select/select-streaming-exception-config.xml
+++ b/extensions/db/src/test/resources/integration/select/select-streaming-exception-config.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:dbn="http://www.mulesoft.org/schema/mule/dbn"
+      xmlns:dbn="http://www.mulesoft.org/schema/mule/db"
       xmlns="http://www.mulesoft.org/schema/mule/core"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-            http://www.mulesoft.org/schema/mule/dbn http://www.mulesoft.org/schema/mule/dbn/current/mule-dbn.xsd">
+            http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd">
 
     <flow name="selectStreamingException">
         <dbn:select config-ref="pooledJdbcConfig" streaming="true">

--- a/modules/spring-config/pom.xml
+++ b/modules/spring-config/pom.xml
@@ -84,6 +84,13 @@
             <version>${springCglibVersion}</version>
         </dependency>
 
+        <dependency>
+            <!--TODO MULE-10866 once we move to extension model mechanism, this dependency must be removed -->
+            <groupId>org.apache.ws.xmlschema</groupId>
+            <artifactId>xmlschema-core</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+
         <!-- Unit tests -->
         <dependency>
             <groupId>junit</groupId>
@@ -156,6 +163,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/ModuleDelegatingEntityResolver.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/ModuleDelegatingEntityResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring;
+
+import org.mule.runtime.config.spring.dsl.model.extension.ModuleExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.loader.ModuleExtensionStore;
+import org.mule.runtime.config.spring.dsl.model.extension.schema.ModuleSchemaGenerator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+import org.springframework.beans.factory.xml.DelegatingEntityResolver;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Custom implementation of resolver for schemas where it will delegate in the default {@link DelegatingEntityResolver}
+ * implementation for the XSDs.
+ *
+ * <p>If not found, it will go over the {@link ModuleExtensionStore} and see if there is any <module>s that map to
+ * it, and if it does, it will generate an XSD on the fly thru {@link ModuleSchemaGenerator}.
+ */
+public class ModuleDelegatingEntityResolver implements EntityResolver {
+
+  private final Optional<ModuleExtensionStore> moduleExtensionStore;
+  private final EntityResolver entityResolver;
+
+  public ModuleDelegatingEntityResolver(Optional<ModuleExtensionStore> moduleExtensionStore) {
+    this.entityResolver = new DelegatingEntityResolver(Thread.currentThread().getContextClassLoader());
+    this.moduleExtensionStore = moduleExtensionStore;
+  }
+
+  @Override
+  public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+    InputSource inputSource = entityResolver.resolveEntity(publicId, systemId);
+    if (inputSource == null) {
+      inputSource = generateModuleXsd(publicId, systemId);
+    }
+    return inputSource;
+  }
+
+  private InputSource generateModuleXsd(String publicId, String systemId) {
+    InputSource inputSource = null;
+    if (moduleExtensionStore.isPresent()) {
+      Optional<ModuleExtension> module = moduleExtensionStore.get().lookupByNamespace(systemId);
+      if (module.isPresent()) {
+        InputStream schema = new ModuleSchemaGenerator().getSchema(module.get());
+        inputSource = new InputSource(schema);
+        inputSource.setPublicId(publicId);
+        inputSource.setSystemId(systemId);
+      }
+    }
+    return inputSource;
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/MuleDocumentLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/MuleDocumentLoader.java
@@ -43,7 +43,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * 
  * @since 3.8.0
  */
-final class MuleDocumentLoader implements DocumentLoader {
+final public class MuleDocumentLoader implements DocumentLoader {
 
   private static final String DEFER_NODE_EXPANSION_FEATURE_KEY = "http://apache.org/xml/features/dom/defer-node-expansion";
 

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoader.java
@@ -6,13 +6,19 @@
  */
 package org.mule.runtime.config.spring;
 
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+import org.mule.runtime.config.spring.dsl.model.extension.loader.ModuleExtensionStore;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 
 import java.io.InputStream;
+import java.util.Optional;
 
-import org.springframework.beans.factory.xml.DelegatingEntityResolver;
+import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -35,15 +41,41 @@ public class XmlConfigurationDocumentLoader {
    * @return a new {@link Document} object with the provided content.
    */
   public Document loadDocument(InputStream inputStream) {
+    return loadDocument(empty(), inputStream);
+  }
+
+  public Document loadDocument(Optional<ModuleExtensionStore> moduleExtensionStore, InputStream inputStream) {
     try {
+      MuleLoggerErrorHandler errorHandler = new MuleLoggerErrorHandler();
       Document document = new MuleDocumentLoader()
           .loadDocument(new InputSource(inputStream),
-                        new DelegatingEntityResolver(Thread.currentThread().getContextClassLoader()), new DefaultHandler(),
+                        new ModuleDelegatingEntityResolver(moduleExtensionStore), errorHandler,
                         VALIDATION_XSD, true);
+      errorHandler.throwExceptionIfNeeded();
       return document;
     } catch (Exception e) {
       throw new MuleRuntimeException(e);
     }
   }
 
+  /**
+   * helper class to gather all errors while applying the found XSDs for the current input stream
+   */
+  private static class MuleLoggerErrorHandler extends DefaultHandler {
+
+    StringBuilder sb = new StringBuilder();
+
+    @Override
+    public void error(SAXParseException e) throws SAXException {
+      sb.append(format("\terror:%s\n", e.toString()));
+    }
+
+    public void throwExceptionIfNeeded() {
+      String errors = sb.toString();
+      if (StringUtils.isNotBlank(errors)) {
+        String errorOrErrors = "Gathered errors:";
+        throw new IllegalArgumentException(format(errorOrErrors + " \n %s", errors));
+      }
+    }
+  }
 }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/ComponentModel.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/ComponentModel.java
@@ -101,6 +101,21 @@ public class ComponentModel {
   }
 
   /**
+   * Marked as true if it's a top level configuration.
+   */
+  public void setRoot(boolean root) {
+    this.root = root;
+  }
+
+  /**
+   * @param parameterName name of the configuration parameter.
+   * @param value value contained by the configuration parameter.
+   */
+  public void setParameter(String parameterName, String value) {
+    this.parameters.put(parameterName, value);
+  }
+
+  /**
    * @return the {@code BeanDefinition} created based on the {@code ComponentModel} values.
    */
   public BeanDefinition getBeanDefinition() {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/ComponentModelReader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/ComponentModelReader.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model;
+
+import static org.mule.runtime.config.spring.dsl.model.ApplicationModel.MULE_DOMAIN_ROOT_ELEMENT;
+import static org.mule.runtime.config.spring.dsl.model.ApplicationModel.MULE_ROOT_ELEMENT;
+import static org.mule.runtime.config.spring.dsl.model.ApplicationModel.SPRING_PROPERTY_IDENTIFIER;
+import static org.mule.runtime.config.spring.dsl.model.ApplicationModel.VALUE_ATTRIBUTE;
+import static org.mule.runtime.config.spring.dsl.processor.xml.XmlCustomAttributeHandler.from;
+import static org.mule.runtime.config.spring.dsl.processor.xml.XmlCustomAttributeHandler.to;
+import static org.mule.runtime.dsl.api.xml.DslConstants.CORE_NAMESPACE;
+import org.mule.runtime.config.spring.dsl.processor.ConfigLine;
+import org.mule.runtime.config.spring.dsl.processor.SimpleConfigAttribute;
+import org.mule.runtime.dsl.api.component.ComponentIdentifier;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.springframework.util.PropertyPlaceholderHelper;
+
+/**
+ * Class used to read xml files from {@link ConfigLine}s, unifying knowledge on how to properly read the files returning
+ * the {@link ComponentModel} object.
+ *
+ * It also replaces the values of the attributes by using the {@link Properties} object parametrized in its constructor.
+ */
+public class ComponentModelReader {
+
+  private PropertyPlaceholderHelper propertyPlaceholderHelper = new PropertyPlaceholderHelper("${", "}");
+  private Properties applicationProperties;
+
+  public ComponentModelReader(Properties applicationProperties) {
+    this.applicationProperties = applicationProperties;
+  }
+
+  public ComponentModel extractComponentDefinitionModel(ConfigLine configLine, String configFileName) {
+
+    String namespace = configLine.getNamespace() == null ? CORE_NAMESPACE : configLine.getNamespace();
+    ComponentModel.Builder builder = new ComponentModel.Builder()
+        .setIdentifier(new ComponentIdentifier.Builder().withNamespace(namespace).withName(configLine.getIdentifier()).build())
+        .setTextContent(configLine.getTextContent());
+    to(builder).addNode(from(configLine).getNode()).addConfigFileName(configFileName);
+    for (SimpleConfigAttribute simpleConfigAttribute : configLine.getConfigAttributes().values()) {
+      builder.addParameter(simpleConfigAttribute.getName(), resolveValueIfIsPlaceHolder(simpleConfigAttribute.getValue()),
+                           simpleConfigAttribute.isValueFromSchema());
+    }
+
+    List<ComponentModel> componentModels = configLine.getChildren().stream()
+        .map(childConfigLine -> extractComponentDefinitionModel(childConfigLine, configFileName))
+        .collect(Collectors.toList());
+    componentModels.stream().forEach(componentDefinitionModel -> {
+      if (SPRING_PROPERTY_IDENTIFIER.equals(componentDefinitionModel.getIdentifier())) {
+        String value = componentDefinitionModel.getParameters().get(VALUE_ATTRIBUTE);
+        if (value != null) {
+          builder.addParameter(componentDefinitionModel.getNameAttribute(), resolveValueIfIsPlaceHolder(value), false);
+        }
+      }
+      builder.addChildComponentModel(componentDefinitionModel);
+    });
+    ConfigLine parent = configLine.getParent();
+    if (parent != null && isConfigurationTopComponent(parent)) {
+      builder.markAsRootComponent();
+    }
+    ComponentModel componentModel = builder.build();
+    for (ComponentModel innerComponentModel : componentModel.getInnerComponents()) {
+      innerComponentModel.setParent(componentModel);
+    }
+    return componentModel;
+  }
+
+  private String resolveValueIfIsPlaceHolder(String value) {
+    return propertyPlaceholderHelper.replacePlaceholders(value, applicationProperties);
+  }
+
+  private boolean isConfigurationTopComponent(ConfigLine parent) {
+    return (parent.getIdentifier().equals(MULE_ROOT_ELEMENT) || parent.getIdentifier().equals(MULE_DOMAIN_ROOT_ELEMENT));
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/ModuleExtensionLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/ModuleExtensionLoader.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model;
+
+import static org.mule.runtime.config.spring.dsl.processor.xml.ModuleXmlNamespaceInfoProvider.MODULE_NAMESPACE_NAME;
+import org.mule.metadata.api.builder.BaseTypeBuilder;
+import org.mule.metadata.api.model.MetadataFormat;
+import org.mule.metadata.api.model.MetadataType;
+import org.mule.runtime.config.spring.dsl.model.extension.ModuleExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.OperationExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.ParameterExtension;
+import org.mule.runtime.dsl.api.component.ComponentIdentifier;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Given a {@link ComponentModel} it generates a {@link ModuleExtension} to work later by reading its parameters,
+ * operations and so on. It will also store some direct references to the component model, such as: global elements,
+ * body of any operation, etc., to properly expand the nodes in the final XML application.
+ *
+ */
+public class ModuleExtensionLoader {
+
+  public static final String PARAMETER_NAME = "name";
+  public static final String PARAMETER_DEFAULT_VALUE = "defaultValue";
+  public static final String TYPE_ATTRIBUTE = "type";
+
+  public static final String MODULE_NAME = "name";
+  public static final String MODULE_NAMESPACE_ATTRIBUTE = "namespace";
+  public static final String MODULE_TAG = "module";
+
+  public static final ComponentIdentifier OPERATION_IDENTIFIER =
+      new ComponentIdentifier.Builder().withNamespace(MODULE_NAMESPACE_NAME).withName("operation").build();
+  public static final ComponentIdentifier OPERATION_PROPERTY_IDENTIFIER =
+      new ComponentIdentifier.Builder().withNamespace(MODULE_NAMESPACE_NAME).withName("property").build();
+  public static final ComponentIdentifier OPERATION_PARAMETERS_IDENTIFIER =
+      new ComponentIdentifier.Builder().withNamespace(MODULE_NAMESPACE_NAME).withName("parameters").build();
+  public static final ComponentIdentifier OPERATION_PARAMETER_IDENTIFIER =
+      new ComponentIdentifier.Builder().withNamespace(MODULE_NAMESPACE_NAME).withName("parameter").build();
+  public static final ComponentIdentifier OPERATION_BODY_IDENTIFIER =
+      new ComponentIdentifier.Builder().withNamespace(MODULE_NAMESPACE_NAME).withName("body").build();
+  public static final ComponentIdentifier OPERATION_OUTPUT_IDENTIFIER =
+      new ComponentIdentifier.Builder().withNamespace(MODULE_NAMESPACE_NAME).withName("output").build();
+  public static final ComponentIdentifier MODULE_IDENTIFIER =
+      new ComponentIdentifier.Builder().withNamespace(ModuleExtensionLoader.MODULE_TAG).withName(ModuleExtensionLoader.MODULE_TAG)
+          .build();
+
+  public ModuleExtension loadModule(ComponentModel moduleModel) {
+    ModuleExtension moduleExtension = extractModuleExtension(moduleModel);
+    return moduleExtension;
+  }
+
+  private ModuleExtension extractModuleExtension(ComponentModel moduleModel) {
+    String name = moduleModel.getParameters().get(MODULE_NAME);
+    String namespace = moduleModel.getParameters().get(MODULE_NAMESPACE_ATTRIBUTE);
+    ModuleExtension moduleExtension = new ModuleExtension(name, namespace);
+    moduleExtension.setProperties(loadPropertiesFrom(moduleModel));
+    moduleExtension.setOperations(loadOperationsFrom(moduleModel));
+    moduleExtension.setGlobalElements(loadGlobalElementsFrom(moduleModel));
+    return moduleExtension;
+  }
+
+  private List<ComponentModel> loadGlobalElementsFrom(ComponentModel moduleModel) {
+    return moduleModel.getInnerComponents().stream()
+        .filter(child -> !child.getIdentifier().equals(OPERATION_PROPERTY_IDENTIFIER)
+            && !child.getIdentifier().equals(OPERATION_IDENTIFIER))
+        .collect(Collectors.toList());
+  }
+
+  private List<ParameterExtension> loadPropertiesFrom(ComponentModel moduleModel) {
+    return moduleModel.getInnerComponents().stream()
+        .filter(child -> child.getIdentifier().equals(OPERATION_PROPERTY_IDENTIFIER))
+        .map(param -> extractParameter(param))
+        .collect(Collectors.toList());
+  }
+
+  private Map<String, OperationExtension> loadOperationsFrom(ComponentModel moduleModel) {
+    return moduleModel.getInnerComponents().stream()
+        .filter(child -> child.getIdentifier().equals(OPERATION_IDENTIFIER))
+        .map(operationModel -> extractOperationExtension(operationModel))
+        .collect(Collectors.toMap(OperationExtension::getName, Function.identity()));
+  }
+
+  private OperationExtension extractOperationExtension(ComponentModel operationModel) {
+    OperationExtension operationExtension = new OperationExtension(operationModel.getNameAttribute(), operationModel);
+    operationExtension.setParameters(extractOperationParameters(operationModel));
+    operationExtension.setOutputType(extractOutputType(operationModel));
+    return operationExtension;
+  }
+
+  private List<ParameterExtension> extractOperationParameters(ComponentModel componentModel) {
+    List<ParameterExtension> parameters = Collections.emptyList();
+
+    Optional<ComponentModel> optionalParametersComponentModel = componentModel.getInnerComponents()
+        .stream()
+        .filter(child -> child.getIdentifier().equals(OPERATION_PARAMETERS_IDENTIFIER)).findAny();
+    if (optionalParametersComponentModel.isPresent()) {
+      parameters = optionalParametersComponentModel.get().getInnerComponents()
+          .stream()
+          .filter(child -> child.getIdentifier().equals(OPERATION_PARAMETER_IDENTIFIER))
+          .map(param -> extractParameter(param))
+          .collect(Collectors.toList());
+    }
+    return parameters;
+  }
+
+  private ParameterExtension extractParameter(ComponentModel param) {
+    Map<String, String> parameters = param.getParameters();
+    return new ParameterExtension(parameters.get(PARAMETER_NAME),
+                                  extractParameterType(parameters.get(TYPE_ATTRIBUTE)),
+                                  parameters.get(PARAMETER_DEFAULT_VALUE));
+  }
+
+  private MetadataType extractParameterType(String type) {
+    Optional<MetadataType> metadataType = extractType(type);
+
+    if (!metadataType.isPresent()) {
+      throw new IllegalArgumentException(String.format(
+                                                       "should not have reach here, supported types for <parameter>(simple) are string, boolean, datetime, date, number or time for now. Type obtained [%s]",
+                                                       type));
+    }
+    return metadataType.get();
+  }
+
+  private MetadataType extractOutputType(ComponentModel componentModel) {
+
+    ComponentModel outputComponentModel = componentModel.getInnerComponents()
+        .stream()
+        .filter(child -> child.getIdentifier().equals(OPERATION_OUTPUT_IDENTIFIER)).findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Having an operation without <output> is not supported"));
+
+    String type = outputComponentModel.getParameters().get(TYPE_ATTRIBUTE);
+    Optional<MetadataType> metadataType = extractType(type);
+
+    if (!metadataType.isPresent()) {
+      if ("void".equals(type)) {
+        metadataType = Optional.of(BaseTypeBuilder.create(MetadataFormat.JAVA)
+            .voidType().build());
+      } else {
+        throw new IllegalArgumentException(String.format(
+                                                         "should not have reach here, supported types for <parameter>(simple) are string, boolean, datetime, date, number or time for now. Type obtained [%s]",
+                                                         type));
+      }
+
+    }
+    return metadataType.get();
+  }
+
+  private Optional<MetadataType> extractType(String type) {
+    BaseTypeBuilder baseTypeBuilder = BaseTypeBuilder.create(MetadataFormat.JAVA);
+    switch (type) {
+      case "string":
+        baseTypeBuilder.stringType();
+        break;
+      case "boolean":
+        baseTypeBuilder.booleanType();
+        break;
+      case "datetime":
+        baseTypeBuilder.dateTimeType();
+        break;
+      case "date":
+        baseTypeBuilder.dateType();
+        break;
+      case "integer":
+        baseTypeBuilder.numberType();
+        break;
+      case "time":
+        baseTypeBuilder.timeType();
+        break;
+      default:
+        return Optional.empty();
+    }
+    return Optional.of(baseTypeBuilder.build());
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/ModuleExtension.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/ModuleExtension.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model.extension;
+
+import org.mule.runtime.config.spring.dsl.model.ComponentModel;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class that represents a complete extension read from the XML (aka: smart connector, <module>, etc.).
+ * //TODO MULE-10866 : once implemented, this class should go away or refactored as ExtensionModel will be good enough to model an object for a smart connector
+ */
+public class ModuleExtension {
+
+  private final String name;
+  private final String namespace;
+  private List<ParameterExtension> properties = new ArrayList<>();
+  private Map<String, OperationExtension> operations = new HashMap<>();
+  private List<ComponentModel> globalElements = new ArrayList<>();
+
+  /**
+   * @param name name of the module to look when working in {@link org.mule.runtime.config.spring.dsl.model.ApplicationModel} expanding the macro
+   * @param namespace namespace of the module used when doing the lookup when generating XSD
+   */
+  public ModuleExtension(String name, String namespace) {
+    this.name = name;
+    this.namespace = namespace;
+  }
+
+  /**
+   * @return the name of the module taken from the name attribute
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the namespace of the module taken from the namespace attribute
+   */
+  public String getNamespace() {
+    return namespace;
+  }
+
+  /**
+   * @return the collection of properties used to generate this module
+   */
+  public List<ParameterExtension> getProperties() {
+    return properties;
+  }
+
+  /**
+   * @param properties to set the current module (aka: <property name="username" type="string"/>)
+   */
+  public void setProperties(List<ParameterExtension> properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * @return the map of <operation>s found for this extension, where the key is the name and value is the actual operation
+   */
+  public Map<String, OperationExtension> getOperations() {
+    return operations;
+  }
+
+  /**
+   * @param operations the map of operations supported by this module
+   */
+  public void setOperations(Map<String, OperationExtension> operations) {
+    this.operations = operations;
+  }
+
+  /**
+   * @return the elements that represent global elements at config level. For example it will return the
+   * "<http:requester-config... />" element or any other that is sibling to a "<operation/>"
+   */
+  public List<ComponentModel> getGlobalElements() {
+    return globalElements;
+  }
+
+  /**
+   * @param globalElements the list of global elements this module supports
+   */
+  public void setGlobalElements(List<ComponentModel> globalElements) {
+    this.globalElements = globalElements;
+  }
+
+  /**
+   * @return if this module has at least one <property/> or at least one global element. False otherwise.
+   */
+  public boolean hasConfig() {
+    return (!properties.isEmpty()) || (!globalElements.isEmpty());
+  }
+
+  @Override
+  public String toString() {
+    return "ModuleExtension{" +
+        "name='" + name + '\'' +
+        ", namespace='" + namespace + '\'' +
+        '}';
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/OperationExtension.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/OperationExtension.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model.extension;
+
+import org.mule.metadata.api.model.MetadataType;
+import org.mule.metadata.api.model.VoidType;
+import org.mule.metadata.api.visitor.MetadataTypeVisitor;
+import org.mule.runtime.config.spring.dsl.model.ComponentModel;
+import org.mule.runtime.config.spring.dsl.model.ModuleExtensionLoader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class that represents an <operation/> within a <module/>
+ * //TODO MULE-10866 : once implemented, this class should go away or refactored as ExtensionModel will be good enough to model an object for a smart connector
+ */
+public class OperationExtension {
+
+  private String name;
+  private List<ParameterExtension> parameters = new ArrayList<>();
+  private ComponentModel componentModel;
+  private MetadataType outputType;
+
+  /**
+   * @param name name of the operation
+   * @param componentModel element of the node that's used to look for the MP's defined within the <body/> of the current <operation/>
+     */
+  public OperationExtension(String name, ComponentModel componentModel) {
+    this.name = name;
+    this.componentModel = componentModel;
+  }
+
+  /**
+   * @return the name of the operation
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the list of parameters that are mandatory for this operation
+   */
+  public List<ParameterExtension> getParameters() {
+    return parameters;
+  }
+
+  /**
+   * @param parameters the list of elements that are mandatory for this operation
+   */
+  public void setParameters(List<ParameterExtension> parameters) {
+    this.parameters = parameters;
+  }
+
+  /**
+   * @param outputType defines the output type. Determines if this operation does write the exit payload or not
+   */
+  public void setOutputType(MetadataType outputType) {
+    this.outputType = outputType;
+  }
+
+  /**
+   * @return true if the return type is {@link VoidType}, false otherwise
+   */
+  public boolean returnsVoid() {
+    ReturnsVoidTypeVisitor returnsVoidTypeVisitor = new ReturnsVoidTypeVisitor();
+    outputType.accept(returnsVoidTypeVisitor);
+    return returnsVoidTypeVisitor.returnsVoid;
+  }
+
+  /**
+   * @return the list of MPs to expand them in the xml of the application
+   */
+  public List<ComponentModel> getMessageProcessorsComponentModels() {
+    return componentModel.getInnerComponents()
+        .stream()
+        .filter(childComponent -> childComponent.getIdentifier().equals(ModuleExtensionLoader.OPERATION_BODY_IDENTIFIER))
+        .findAny().get().getInnerComponents();
+  }
+
+  /**
+   * visits all the possible types of a given parameter to realize if it's a "void return type", in which case the
+   * expanded chain will not modify the structure of the event
+   */
+  private class ReturnsVoidTypeVisitor extends MetadataTypeVisitor {
+
+    private boolean returnsVoid = false;
+
+    @Override
+    public void visitVoid(VoidType voidType) {
+      returnsVoid = true;
+    }
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/ParameterExtension.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/ParameterExtension.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model.extension;
+
+import org.mule.metadata.api.model.MetadataType;
+
+import com.google.common.base.Optional;
+
+/**
+ * Class that represents either a <parameter/> in an <operation/> or a <property/> for a <module/>
+ * //TODO MULE-10866 : once implemented, this class should go away or refactored as ExtensionModel will be good enough to model an object for a smart connector
+ */
+public class ParameterExtension {
+
+  private String name;
+  private MetadataType type;
+  private Optional<String> defaultValue;
+
+  /**
+   * @param name of the parameter
+   * @param type of the parameter
+   * @param defaultValue the default value for a parameter, when null it becomes absent
+   */
+  public ParameterExtension(String name, MetadataType type, String defaultValue) {
+    this.name = name;
+    this.type = type;
+    this.defaultValue = Optional.fromNullable(defaultValue);
+  }
+
+  /**
+   * @return the name of the parameter
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the type of the parameter
+   */
+  public MetadataType getType() {
+    return type;
+  }
+
+  /**
+   * @return the default value of a parameter
+   */
+  public Optional<String> getDefaultValue() {
+    return defaultValue;
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/loader/ModuleExtensionStore.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/loader/ModuleExtensionStore.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model.extension.loader;
+
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.config.spring.XmlConfigurationDocumentLoader;
+import org.mule.runtime.config.spring.dsl.model.ComponentModel;
+import org.mule.runtime.config.spring.dsl.model.ComponentModelReader;
+import org.mule.runtime.config.spring.dsl.model.ModuleExtensionLoader;
+import org.mule.runtime.config.spring.dsl.model.extension.ModuleExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.validator.ModuleExtensionValidator;
+import org.mule.runtime.config.spring.dsl.processor.ConfigLine;
+import org.mule.runtime.config.spring.dsl.processor.xml.XmlApplicationParser;
+import org.mule.runtime.core.registry.SpiServiceRegistry;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.w3c.dom.Document;
+
+/**
+ * Class that represents a set of extensions already parsed to look for by either name (aka: prefix namespace for now)
+ * or by the namespace.
+ *
+ * <p>This loader is a temporary class until all plugins behave in the same way, providing a descriptor to read the
+ * {@link org.mule.runtime.api.meta.model.ExtensionModel} to work with.
+ *
+ * <p>Despite it's messy,this class is passing around several objects:
+ * <ul>
+ *  <li>{@link org.mule.runtime.config.spring.dsl.model.ApplicationModel}</li>
+ *  <li>{@link XmlConfigurationDocumentLoader}</li>
+ *  <li>{@link org.mule.runtime.config.spring.MuleArtifactContext}</li>
+ * </ul>
+ * as it holds all the plugins that were consumed
+ * by scanning the classpath (see {@link #getModulesResources()} looking for any file with the format "module-<whatever>.xml"
+ */
+public class ModuleExtensionStore {
+
+  private Map<String, ModuleExtension> extensionsByName;
+
+  public ModuleExtensionStore() {
+    this.extensionsByName = new HashMap<>();
+    loadAllExtensionsFromClasspath();
+  }
+
+  public Optional<ModuleExtension> lookupByName(final String location) {
+    ModuleExtension moduleExtension = extensionsByName.get(location);
+    if (moduleExtension == null) {
+      return empty();
+    }
+    return Optional.of(moduleExtension);
+  }
+
+  public Optional<ModuleExtension> lookupByNamespace(final String namespace) {
+    for (Map.Entry<String, ModuleExtension> entry : extensionsByName.entrySet()) {
+      if (namespace.startsWith(entry.getValue().getNamespace())) {
+        return Optional.of(entry.getValue());
+      }
+    }
+    return empty();
+  }
+
+  private void loadAllExtensionsFromClasspath() {
+    XmlConfigurationDocumentLoader xmlConfigurationDocumentLoader = new XmlConfigurationDocumentLoader();
+
+    Resource[] modulesResources = this.getModulesResources();
+    for (Resource resource : modulesResources) {
+
+      Optional<ModuleExtension> moduleExtension = extractModuleExtension(xmlConfigurationDocumentLoader, resource);
+      if (moduleExtension.isPresent()) {
+        extensionsByName.put(moduleExtension.get().getName(), moduleExtension.get());
+      }
+
+    }
+  }
+
+  /**
+   * This method returns null as the resource might have picked up a file that by convention SEEMS to be a <module>, but it is not.
+   *
+   * @param xmlConfigurationDocumentLoader
+   * @param resource to try to read as a <module>
+   * @return an exension properly loaded, or absent otherwise
+   */
+  private Optional<ModuleExtension> extractModuleExtension(XmlConfigurationDocumentLoader xmlConfigurationDocumentLoader,
+                                                           Resource resource) {
+    Optional<ModuleExtension> result = empty();
+
+    Document moduleDocument = getModuleDocument(xmlConfigurationDocumentLoader, resource);
+    XmlApplicationParser xmlApplicationParser = new XmlApplicationParser(new SpiServiceRegistry());
+    Optional<ConfigLine> parseModule = xmlApplicationParser.parse(moduleDocument.getDocumentElement());
+    if (parseModule.isPresent()) {
+      Properties properties = new Properties(); //no support for properties in modules for now.
+      ComponentModelReader componentModelReader = new ComponentModelReader(properties);
+      ComponentModel componentModel =
+          componentModelReader.extractComponentDefinitionModel(parseModule.get(), resource.getFilename());
+
+      if (componentModel.getIdentifier().equals(ModuleExtensionLoader.MODULE_IDENTIFIER)) {
+        ModuleExtension moduleExtension = new ModuleExtensionLoader().loadModule(componentModel);
+        validate(moduleExtension);
+        result = of(moduleExtension);
+      }
+    }
+    return result;
+  }
+
+  private Document getModuleDocument(XmlConfigurationDocumentLoader xmlConfigurationDocumentLoader, Resource resource) {
+    try {
+      return xmlConfigurationDocumentLoader.loadDocument(of(this), resource.getInputStream());
+    } catch (IOException e) {
+      throw new MuleRuntimeException(
+                                     createStaticMessage(format("There was an issue reading the stream for the resource %s",
+                                                                resource.getFilename())));
+    }
+  }
+
+  private Resource[] getModulesResources() {
+    PathMatchingResourcePatternResolver pathMatchingResourcePatternResolver = new PathMatchingResourcePatternResolver();
+    try {
+      return pathMatchingResourcePatternResolver.getResources("classpath*:**/module-*.xml");
+    } catch (IOException e) {
+      throw new MuleRuntimeException(
+                                     createStaticMessage("There was an issue while trying to load all the modules from the classpath"),
+                                     e);
+    }
+  }
+
+  /**
+   * Runs some semantic validations on an extension, and throws an exception if any was found while validating it.
+   * @param moduleExtension to validate
+   */
+  private void validate(ModuleExtension moduleExtension) {
+    ModuleExtensionValidator moduleExtensionValidator = new ModuleExtensionValidator();
+    moduleExtensionValidator.validate(moduleExtension);
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/schema/ModuleSchemaGenerator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/schema/ModuleSchemaGenerator.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model.extension.schema;
+
+import static org.mule.runtime.config.spring.dsl.model.ApplicationModel.MODULE_CONFIG_GLOBAL_ELEMENT_NAME;
+import static org.mule.runtime.config.spring.dsl.model.ApplicationModel.MODULE_OPERATION_CONFIG_REF;
+import org.mule.metadata.api.model.BooleanType;
+import org.mule.metadata.api.model.DateTimeType;
+import org.mule.metadata.api.model.DateType;
+import org.mule.metadata.api.model.MetadataType;
+import org.mule.metadata.api.model.NumberType;
+import org.mule.metadata.api.model.StringType;
+import org.mule.metadata.api.model.TimeType;
+import org.mule.metadata.api.visitor.MetadataTypeVisitor;
+import org.mule.runtime.config.spring.dsl.model.extension.ModuleExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.OperationExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.ParameterExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+
+import org.apache.ws.commons.schema.XmlSchema;
+import org.apache.ws.commons.schema.XmlSchemaAttribute;
+import org.apache.ws.commons.schema.XmlSchemaAttributeOrGroupRef;
+import org.apache.ws.commons.schema.XmlSchemaCollection;
+import org.apache.ws.commons.schema.XmlSchemaComplexContent;
+import org.apache.ws.commons.schema.XmlSchemaComplexContentExtension;
+import org.apache.ws.commons.schema.XmlSchemaComplexType;
+import org.apache.ws.commons.schema.XmlSchemaElement;
+import org.apache.ws.commons.schema.XmlSchemaForm;
+import org.apache.ws.commons.schema.XmlSchemaImport;
+import org.apache.ws.commons.schema.XmlSchemaUse;
+import org.apache.ws.commons.schema.utils.NamespaceMap;
+
+/**
+ * A class that given a {@link ModuleExtension} returns a schema as an stream when executing {@link #getSchema(ModuleExtension)}.
+ * //TODO MULE-10866 : once we rely the <module>s in {@link org.mule.runtime.api.meta.model.ExtensionModel}, the generation will be not only consistent, but it will also imply this class must be deleted.
+ */
+public class ModuleSchemaGenerator {
+
+  private static final String MULE_SCHEMA_LOCATION = "http://www.mulesoft.org/schema/mule/core/current/mule.xsd";
+  private static final String MULE_NAMESPACE = "http://www.mulesoft.org/schema/mule/core";
+  private static final String XSD_NAMESPACE = "http://www.w3.org/2001/XMLSchema";
+  private static final String MULE_PREFIX = "mule";
+
+  private static final String ABSTRACT_MESSAGE_PROCESSOR_ELEMENT = "abstract-message-processor";
+  private static final String ABSTRACT_MESSAGE_PROCESSOR_TYPE = "abstractMessageProcessorType";
+  private static final String MULE_SUBSTITUTABLE_NAME_TYPE = "substitutableName";
+  private static final String TYPE_SUFFIX = "-type";
+  private static final String ABSTRACT_EXTENSION_ELEMENT = "abstract-extension";
+  private static final String ABSTRACT_EXTENSION_TYPE = "abstractExtensionType";
+  private static final String NAME_ATTRIBUTE = "name";
+
+  private static final QName STRING = new QName(XSD_NAMESPACE, "string", "xs");
+  private static final QName EXPRESSION_STRING = new QName(MULE_NAMESPACE, "expressionString", MULE_PREFIX);
+  private static final QName EXPRESSION_BOOLEAN = new QName(MULE_NAMESPACE, "expressionBoolean", MULE_PREFIX);
+  private static final QName EXPRESSION_INTEGER = new QName(MULE_NAMESPACE, "expressionInt", MULE_PREFIX);
+  private static final QName EXPRESSION_OBJECT = new QName(MULE_NAMESPACE, "expressionObject", MULE_PREFIX);
+  private static final QName EXPRESSION_DATE_TIME = new QName(MULE_NAMESPACE, "expressionDateTime", MULE_PREFIX);
+
+  public InputStream getSchema(ModuleExtension moduleExtension) {
+    InputStream result;
+    XmlSchema xmlSchema = parseModule(moduleExtension);
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      xmlSchema.write(out);
+      result = new ByteArrayInputStream(out.toByteArray());
+    } catch (IOException e) {
+      result = null;
+    }
+    return result;
+  }
+
+  private XmlSchema parseModule(ModuleExtension moduleExtension) {
+    XmlSchema schema =
+        new XmlSchema(XMLConstants.W3C_XML_SCHEMA_NS_URI, moduleExtension.getNamespace(), new XmlSchemaCollection());
+    schema.setTargetNamespace(moduleExtension.getNamespace());
+    schema.setElementFormDefault(XmlSchemaForm.QUALIFIED);
+
+    //adding mule namespace and import
+    NamespaceMap namespaceContext = new NamespaceMap();
+    namespaceContext.add(MULE_PREFIX, MULE_NAMESPACE);
+    schema.setNamespaceContext(namespaceContext);
+
+    XmlSchemaImport muleSchemaImport = new XmlSchemaImport(schema);
+    muleSchemaImport.setNamespace(MULE_NAMESPACE);
+    muleSchemaImport.setSchemaLocation(MULE_SCHEMA_LOCATION);
+
+    //add config element if necessary
+    if (moduleExtension.hasConfig()) {
+      generateConfig(moduleExtension, schema);
+    }
+    //add operations elements
+    moduleExtension.getOperations().forEach((operationName, operationExtension) -> {
+      generateOperation(schema, moduleExtension, operationExtension);
+    });
+
+    return schema;
+  }
+
+  private void generateConfig(ModuleExtension moduleExtension, XmlSchema schema) {
+    final XmlSchemaElement schemaElement = new XmlSchemaElement(schema, true);
+    schemaElement.setName(MODULE_CONFIG_GLOBAL_ELEMENT_NAME);
+
+    XmlSchemaComplexType configSchemaType =
+        generateConfigSchemaType(schema, moduleExtension.getProperties(), MODULE_CONFIG_GLOBAL_ELEMENT_NAME);
+
+    schemaElement.setSchemaTypeName(configSchemaType.getQName());
+
+    QName messageProcessorQName = new QName(MULE_NAMESPACE, ABSTRACT_EXTENSION_ELEMENT, MULE_PREFIX);
+    schemaElement.setSubstitutionGroup(messageProcessorQName);
+  }
+
+  private void generateOperation(XmlSchema schema, ModuleExtension moduleExtension, OperationExtension operationExtension) {
+    final XmlSchemaElement schemaElement = new XmlSchemaElement(schema, true);
+    schemaElement.setName(operationExtension.getName());
+
+    XmlSchemaComplexType operationSchemaType = generateOperationSchemaType(schema, moduleExtension, operationExtension);
+    schemaElement.setSchemaTypeName(operationSchemaType.getQName());
+
+    QName messageProcessorQName = new QName(MULE_NAMESPACE, ABSTRACT_MESSAGE_PROCESSOR_ELEMENT, MULE_PREFIX);
+    schemaElement.setSubstitutionGroup(messageProcessorQName);
+  }
+
+  private XmlSchemaComplexType generateOperationSchemaType(XmlSchema schema, ModuleExtension moduleExtension,
+                                                           OperationExtension operationExtension) {
+    ArrayList<XmlSchemaAttributeOrGroupRef> attributes = generateAttributes(schema, operationExtension.getParameters());
+    if (moduleExtension.hasConfig()) {
+      XmlSchemaAttribute configRefAttribute = new XmlSchemaAttribute(schema, false);
+      configRefAttribute.setName(MODULE_OPERATION_CONFIG_REF);
+      QName attributeTypeQName = new QName(MULE_NAMESPACE, MULE_SUBSTITUTABLE_NAME_TYPE, MULE_PREFIX);
+      configRefAttribute.setSchemaTypeName(attributeTypeQName);
+      configRefAttribute.setUse(XmlSchemaUse.REQUIRED);
+      attributes.add(configRefAttribute);
+    }
+
+    return generateSchemaType(schema, operationExtension.getName(), ABSTRACT_MESSAGE_PROCESSOR_TYPE, attributes);
+  }
+
+  private XmlSchemaComplexType generateConfigSchemaType(XmlSchema schema, List<ParameterExtension> parameters,
+                                                        String operationXmlName) {
+    ArrayList<XmlSchemaAttributeOrGroupRef> attributes = generateAttributes(schema, parameters);
+
+    XmlSchemaAttribute configRefAttribute = new XmlSchemaAttribute(schema, false);
+    configRefAttribute.setName(NAME_ATTRIBUTE);
+    configRefAttribute.setSchemaTypeName(STRING);
+    configRefAttribute.setUse(XmlSchemaUse.REQUIRED);
+    attributes.add(configRefAttribute);
+
+    return generateSchemaType(schema, operationXmlName, ABSTRACT_EXTENSION_TYPE, attributes);
+  }
+
+  private XmlSchemaComplexType generateSchemaType(XmlSchema schema, String xmlElementName, String localPart,
+                                                  List<XmlSchemaAttributeOrGroupRef> attributes) {
+    XmlSchemaComplexType operationSchemaType = new XmlSchemaComplexType(schema, true);
+    operationSchemaType.setName(xmlElementName.concat(TYPE_SUFFIX));
+
+    XmlSchemaComplexContent complexContent = new XmlSchemaComplexContent();
+    XmlSchemaComplexContentExtension complexContentExtension = new XmlSchemaComplexContentExtension();
+
+    QName baseQName = new QName(MULE_NAMESPACE, localPart, MULE_PREFIX);
+    complexContentExtension.setBaseTypeName(baseQName);
+    complexContentExtension.getAttributes().addAll(attributes);
+
+    complexContent.setContent(complexContentExtension);
+    operationSchemaType.setContentModel(complexContent);
+
+    return operationSchemaType;
+  }
+
+  private ArrayList<XmlSchemaAttributeOrGroupRef> generateAttributes(XmlSchema schema, List<ParameterExtension> parameters) {
+    ArrayList<XmlSchemaAttributeOrGroupRef> attributes = new ArrayList<>();
+    for (ParameterExtension parameterExtension : parameters) {
+      XmlSchemaAttribute attribute = new XmlSchemaAttribute(schema, false);
+      attribute.setName(parameterExtension.getName());
+
+      parameterExtension.getType().accept(new MetadataTypeVisitor() {
+
+        @Override
+        protected void defaultVisit(MetadataType metadataType) {
+          attribute.setSchemaTypeName(EXPRESSION_OBJECT);
+        }
+
+        @Override
+        public void visitBoolean(BooleanType booleanType) {
+          attribute.setSchemaTypeName(EXPRESSION_BOOLEAN);
+        }
+
+        @Override
+        public void visitNumber(NumberType numberType) {
+          attribute.setSchemaTypeName(EXPRESSION_INTEGER);
+        }
+
+        @Override
+        public void visitString(StringType stringType) {
+          attribute.setSchemaTypeName(EXPRESSION_STRING);
+        }
+
+        @Override
+        public void visitTime(TimeType timeType) {
+          attribute.setSchemaTypeName(EXPRESSION_DATE_TIME);
+        }
+
+        @Override
+        public void visitDateTime(DateTimeType dateTimeType) {
+          attribute.setSchemaTypeName(EXPRESSION_DATE_TIME);
+        }
+
+        @Override
+        public void visitDate(DateType dateType) {
+          attribute.setSchemaTypeName(EXPRESSION_DATE_TIME);
+        }
+      });
+
+      if (parameterExtension.getDefaultValue().isPresent()) {
+        attribute.setUse(XmlSchemaUse.OPTIONAL);
+        attribute.setDefaultValue(parameterExtension.getDefaultValue().get());
+      } else {
+        attribute.setUse(XmlSchemaUse.REQUIRED);
+      }
+      attributes.add(attribute);
+    }
+    return attributes;
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/validator/ModuleExtensionValidator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/extension/validator/ModuleExtensionValidator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.model.extension.validator;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.config.spring.dsl.model.extension.ModuleExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.ParameterExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Simple validations for a module, such as: prohibiting names with spaces, invalid chars, etc.
+ */
+public class ModuleExtensionValidator {
+
+  private final Set<String> PROPERTY_RESERVED_NAMES =
+      Collections.unmodifiableSet(new HashSet(Arrays.asList(new String[] {"name"})));
+  private final Set<String> PARAMETER_RESERVED_NAMES =
+      Collections.unmodifiableSet(new HashSet(Arrays.asList(new String[] {"config-ref", "target"})));
+
+  private final Pattern VALID_TAG_NAME = Pattern.compile("[A-Za-z]([A-Za-z0-9\\-\\_]*)");
+
+  public void validate(ModuleExtension model) {
+    ErrorGatherer gatherer = new ErrorGatherer();
+
+    doValidate(model, gatherer);
+
+    if (!gatherer.getErrors().isEmpty()) {
+      String errorString = gatherer.getErrors().size() == 1 ? "error" : "errors";
+      StringBuilder sb = new StringBuilder(format("There are [%d] %s for the module [%s]:", gatherer.getErrors().size(),
+                                                  errorString, model.getName()))
+                                                      .append(System.getProperty("line.separator"));
+
+      sb.append(join(System.getProperty("line.separator"), gatherer.getErrors()));
+      throw new MuleRuntimeException(createStaticMessage(sb.toString()));
+    }
+  }
+
+  private void doValidate(ModuleExtension model, ErrorGatherer gatherer) {
+    validateParameters(gatherer, model.getProperties(), "property", PROPERTY_RESERVED_NAMES);
+    model.getOperations().forEach((operationName, operationExtension) -> {
+      if (!VALID_TAG_NAME.matcher(operationExtension.getName()).matches()) {
+        gatherer.addError(String.format("The operation [%s] has invalid characters for an XML element",
+                                        operationExtension.getName()));
+      }
+      ErrorGatherer gathererForOperation = new ErrorGatherer();
+      validateParameters(gathererForOperation, operationExtension.getParameters(), "parameter", PARAMETER_RESERVED_NAMES);
+      gathererForOperation.getErrors()
+          .forEach(error -> gatherer.addError(String.format("%s, for the operation [%s]", error, operationExtension.getName())));
+    });
+  }
+
+  private void validateParameters(ErrorGatherer gatherer, List<ParameterExtension> parameters, String tagName,
+                                  Set<String> reservedNames) {
+    parameters.forEach(parameterExtension -> {
+      String name = parameterExtension.getName();
+      if (reservedNames.contains(name)) {
+        gatherer.addError(String.format("The " + tagName + " [%s] is using the a reserved word", name));
+      }
+      if (!VALID_TAG_NAME.matcher(name).matches()) {
+        gatherer.addError(String.format("The " + tagName + " [%s] has invalid characters for an XML attribute", name));
+      }
+    });
+
+    parameters.stream()
+        .collect(Collectors.groupingBy(parameterExtension -> parameterExtension.getName()))
+        .forEach((parameterName, parameterExtensions) -> {
+          if (parameterExtensions.size() > 1) {
+            gatherer.addError(String.format("The " + tagName + " [%s] is repeated [%d] times", parameterName,
+                                            parameterExtensions.size()));
+          }
+        });
+  }
+
+
+  public class ErrorGatherer {
+
+    private List<String> errors = new ArrayList<>();
+
+    public void addError(String errorMessage) {
+      errors.add(errorMessage);
+    }
+
+    public List<String> getErrors() {
+      return errors;
+    }
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/processor/xml/ModuleXmlNamespaceInfoProvider.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/processor/xml/ModuleXmlNamespaceInfoProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.dsl.processor.xml;
+
+import static java.util.Arrays.asList;
+import org.mule.runtime.dsl.api.xml.XmlNamespaceInfo;
+import org.mule.runtime.dsl.api.xml.XmlNamespaceInfoProvider;
+
+import java.util.Collection;
+
+public class ModuleXmlNamespaceInfoProvider implements XmlNamespaceInfoProvider {
+
+  public static final String MODULE_NAMESPACE_NAME = "module";
+
+  @Override
+  public Collection<XmlNamespaceInfo> getXmlNamespacesInfo() {
+    return asList(new XmlNamespaceInfo() {
+
+      @Override
+      public String getNamespaceUriPrefix() {
+        return "http://www.mulesoft.org/schema/mule/module";
+      }
+
+      @Override
+      public String getNamespace() {
+        return MODULE_NAMESPACE_NAME;
+      }
+    });
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/processor/xml/XmlApplicationParser.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/processor/xml/XmlApplicationParser.java
@@ -68,7 +68,7 @@ public class XmlApplicationParser {
     }
     for (XmlNamespaceInfoProvider namespaceInfoProvider : namespaceInfoProviders) {
       Optional<XmlNamespaceInfo> matchingXmlNamespaceInfo = namespaceInfoProvider.getXmlNamespacesInfo().stream()
-          .filter(xmlNamespaceInfo -> namespaceUri.startsWith(xmlNamespaceInfo.getNamespaceUriPrefix())).findFirst();
+          .filter(xmlNamespaceInfo -> namespaceUri.equals(xmlNamespaceInfo.getNamespaceUriPrefix())).findFirst();
       if (matchingXmlNamespaceInfo.isPresent()) {
         return matchingXmlNamespaceInfo.get().getNamespace();
       }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/ModuleOperationMessageProcessorChainFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/ModuleOperationMessageProcessorChainFactoryBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.factories;
+
+import org.mule.runtime.core.api.el.ExpressionLanguage;
+import org.mule.runtime.core.api.processor.MessageProcessorChainBuilder;
+import org.mule.runtime.core.processor.chain.ModuleOperationMessageProcessorChainBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+public class ModuleOperationMessageProcessorChainFactoryBean extends MessageProcessorChainFactoryBean {
+
+  private Map<String, String> properties = new HashMap<>();
+  private Map<String, String> parameters = new HashMap<>();
+  private boolean returnsVoid;
+  @Inject
+  private ExpressionLanguage expressionLanguage;
+
+  @Override
+  protected MessageProcessorChainBuilder getBuilderInstance() {
+    MessageProcessorChainBuilder builder =
+        new ModuleOperationMessageProcessorChainBuilder(properties, parameters, returnsVoid, expressionLanguage);
+    return builder;
+  }
+
+  public void setProperties(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  public void setParameters(Map<String, String> parameters) {
+    this.parameters = parameters;
+  }
+
+  public void setReturnsVoid(boolean returnsVoid) {
+    this.returnsVoid = returnsVoid;
+  }
+}

--- a/modules/spring-config/src/main/resources/META-INF/mule-module.properties
+++ b/modules/spring-config/src/main/resources/META-INF/mule-module.properties
@@ -3,6 +3,8 @@ module.name=spring-config
 artifact.export.classPackages=org.mule.runtime.config.spring.artifact,\
                               org.mule.runtime.config.spring,\
                               org.mule.runtime.config.spring.dsl.model,\
+                              org.mule.runtime.config.spring.dsl.model.extension,\
+                              org.mule.runtime.config.spring.dsl.model.extension.loader,\
                               org.mule.runtime.config.spring.dsl.processor,\
                               org.mule.runtime.config.spring.dsl.processor.xml,\
                               org.mule.runtime.config.spring.dsl.spring,\

--- a/modules/spring-config/src/main/resources/META-INF/mule-module.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule-module.xsd
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema xmlns="http://www.mulesoft.org/schema/mule/module"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+            targetNamespace="http://www.mulesoft.org/schema/mule/module"
+            attributeFormDefault="unqualified"
+            elementFormDefault="qualified">
+
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.mulesoft.org/schema/mule/core"
+                schemaLocation="http://www.mulesoft.org/schema/mule/core/current/mule.xsd"/>
+
+    <xsd:element name="module" type="moduleConfigType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Root element of a module that contains either properties, operations, or mule global elements as child.
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:element name="operation" type="operationType">
+        <xsd:annotation>
+            <xsd:documentation>
+                An operation that will be exposed by the module, it behaves like a function as it has a set of input parameters and a single output
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:complexType name="operationType">
+        <xsd:complexContent>
+            <xsd:extension base="mule:abstractExtensionType">
+                <xsd:sequence>
+                    <xsd:element name="parameters" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                Set of parameters that wil be used to feed a new event, that will be passed through the scope defined by the body
+                            </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="parameter" minOccurs="1" maxOccurs="unbounded">
+                                    <xsd:annotation>
+                                        <xsd:documentation>
+                                            An named element that will be consumed only in the scope of the body element by the list of message processors.
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                    <xsd:complexType>
+                                        <xsd:attribute name="name"/>
+                                        <xsd:attribute name="defaultValue" use="optional"/>
+                                        <xsd:attribute name="type" type="inputType" use="required"/>
+                                    </xsd:complexType>
+                                </xsd:element>
+                            </xsd:sequence>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="body">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                Collection of message processors that can be callable from a scope.
+                            </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:group ref="mule:messageProcessorOrMixedContentMessageProcessor" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name="output" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                Defines the output of the operation if exists, void otherwise.
+                            </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:complexType>
+                            <xsd:attribute name="type" type="outputSimpleType" use="required"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attribute name="name" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Every operation must be named so that it can be called in a mule application.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="moduleConfigType">
+        <xsd:annotation>
+            <xsd:documentation>
+                A module is defined by three types of elements: properties, global elements and operations.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="mule:abstractExtensionType">
+                <xsd:sequence maxOccurs="unbounded" minOccurs="1">
+                    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+                        <xsd:element name="property">
+                            <xsd:annotation>
+                                <xsd:documentation>
+                                    Parametrization of the module when being consumed (similarly to what an operation is).
+                                </xsd:documentation>
+                            </xsd:annotation>
+                            <xsd:complexType>
+                                <xsd:attribute name="name" use="required"/>
+                                <xsd:attribute name="defaultValue" use="optional"/>
+                                <xsd:attribute name="type" type="inputType" use="required"/>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element ref="operation" />
+                        <xsd:group ref="mule:muleRootElements">
+                            <xsd:annotation>
+                                <xsd:documentation>
+                                    Any global element that can be used in a mule application must be able to put within a module.
+                                </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:group>
+                    </xsd:choice>
+                </xsd:sequence>
+                <xsd:attribute name="name" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Name of the module that identifies it.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="namespace" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            Expected namespace of the module to look for when generating the schemas.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="inputType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Set of defined primitive types inputs for any operation or property.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="string"/>
+            <xsd:enumeration value="boolean"/>
+            <xsd:enumeration value="datetime"/>
+            <xsd:enumeration value="date"/>
+            <xsd:enumeration value="integer"/>
+            <xsd:enumeration value="time"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="outputSimpleType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Set of defined primitive types output for any operation.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="string"/>
+            <xsd:enumeration value="boolean"/>
+            <xsd:enumeration value="datetime"/>
+            <xsd:enumeration value="date"/>
+            <xsd:enumeration value="integer"/>
+            <xsd:enumeration value="time"/>
+            <xsd:enumeration value="void"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/modules/spring-config/src/main/resources/META-INF/services/org.mule.runtime.dsl.api.xml.XmlNamespaceInfoProvider
+++ b/modules/spring-config/src/main/resources/META-INF/services/org.mule.runtime.dsl.api.xml.XmlNamespaceInfoProvider
@@ -1,1 +1,2 @@
 org.mule.runtime.config.spring.dsl.processor.xml.CoreXmlNamespaceInfoProvider
+org.mule.runtime.config.spring.dsl.processor.xml.ModuleXmlNamespaceInfoProvider

--- a/modules/spring-config/src/main/resources/META-INF/spring.schemas
+++ b/modules/spring-config/src/main/resources/META-INF/spring.schemas
@@ -25,3 +25,4 @@ http\://www.springframework.org/schema/beans/spring-beans-current.xsd=org/spring
 http\://www.springframework.org/schema/context/spring-context-current.xsd=org/springframework/context/config/spring-context-3.2.xsd
 http\://www.springframework.org/schema/security/spring-security-current.xsd=org/springframework/security/config/spring-security-3.1.xsd
 http\://www.springframework.org/schema/util/spring-util-current.xsd=org/springframework/beans/factory/xml/spring-util-3.2.xsd
+http\://www.mulesoft.org/schema/mule/module/current/mule-module.xsd=META-INF/mule-module.xsd

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/dsl/model/MinimalApplicationModelGeneratorTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/dsl/model/MinimalApplicationModelGeneratorTestCase.java
@@ -91,7 +91,7 @@ public class MinimalApplicationModelGeneratorTestCase extends AbstractMuleTestCa
     coreComponentBuildingDefinitionProvider.getComponentBuildingDefinitions()
         .stream().forEach(componentBuildingDefinitionRegistry::register);
     return new MinimalApplicationModelGenerator(new ApplicationModel(new ArtifactConfig.Builder().addConfigFile(configFile)
-        .build(), new ArtifactConfiguration(emptyList()), Optional.of(componentBuildingDefinitionRegistry)),
+        .build(), new ArtifactConfiguration(emptyList()), Optional.empty(), Optional.of(componentBuildingDefinitionRegistry)),
                                                 componentBuildingDefinitionRegistry);
   }
 

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/extension/schema/ModuleSchemaGeneratorTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/extension/schema/ModuleSchemaGeneratorTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring.extension.schema;
+
+import static java.util.stream.Collectors.toList;
+import org.mule.runtime.config.spring.dsl.model.extension.ModuleExtension;
+import org.mule.runtime.config.spring.dsl.model.extension.loader.ModuleExtensionStore;
+import org.mule.runtime.config.spring.dsl.model.extension.schema.ModuleSchemaGenerator;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.custommonkey.xmlunit.DetailedDiff;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.Difference;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ModuleSchemaGeneratorTestCase extends AbstractMuleTestCase {
+
+  private ModuleSchemaGenerator schemaGenerator;
+
+  @Parameterized.Parameter
+  public ModuleExtension moduleExtension;
+
+  @Parameterized.Parameter(1)
+  public String expectedXSD;
+
+  @Parameterized.Parameters(name = "{index}: Validating xsd for {0}")
+  public static Collection<Object[]> data() {
+    final Class classLoader = ModuleSchemaGeneratorTestCase.class;
+    final ModuleExtensionStore moduleExtensionStore = new ModuleExtensionStore();
+    final List<String> extensions = new ArrayList<String>() {
+
+      {
+        add("module-param-default-types");
+        add("module-param-types");
+        add("module-properties-default-types");
+        add("module-properties-types");
+        add("module-single-operation");
+        add("module-single-op-with-property");
+      }
+    };
+
+    Function<String, Object[]> stringFunction = moduleName -> {
+      final String namespaceTestPrefix = "http://www.mulesoft.org/schema/mule/";
+      final String namespace = namespaceTestPrefix + moduleName;
+      Optional<ModuleExtension> module = moduleExtensionStore.lookupByNamespace(namespace);
+      if (module.isPresent()) {
+        try {
+          return new Object[] {module.get(),
+              IOUtils.getResourceAsString("modules/" + moduleName + ".xsd", classLoader)
+          };
+        } catch (IOException e) {
+          throw new IllegalArgumentException(String.format("Couldn't load .xsd for the [%s] module", moduleName));
+        }
+      }
+      throw new IllegalArgumentException(String.format("Couldn't find module for the [%s] namespace", namespace));
+    };
+    return extensions.stream().map(stringFunction).collect(toList());
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    this.schemaGenerator = new ModuleSchemaGenerator();
+  }
+
+  @Test
+  public void generateXsd() throws Exception {
+    String schema = IOUtils.toString(schemaGenerator.getSchema(moduleExtension));
+    compareXML(expectedXSD, schema);
+  }
+
+  private void compareXML(String expected, String actual) throws Exception {
+    XMLUnit.setNormalizeWhitespace(true);
+    XMLUnit.setIgnoreWhitespace(true);
+    XMLUnit.setIgnoreComments(true);
+    XMLUnit.setIgnoreAttributeOrder(false);
+
+    Diff diff = XMLUnit.compareXML(expected, actual);
+    if (!(diff.similar() && diff.identical())) {
+      DetailedDiff detDiff = new DetailedDiff(diff);
+      @SuppressWarnings("rawtypes")
+      List differences = detDiff.getAllDifferences();
+      StringBuilder diffLines = new StringBuilder();
+      for (Object object : differences) {
+        Difference difference = (Difference) object;
+        diffLines.append(difference.toString() + '\n');
+      }
+      throw new IllegalArgumentException("Actual XML differs from expected: \n" + diffLines.toString());
+    }
+  }
+}

--- a/modules/spring-config/src/test/resources/model-generator/no-elements-config.xml
+++ b/modules/spring-config/src/test/resources/model-generator/no-elements-config.xml
@@ -4,6 +4,7 @@
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="flow">
+        <echo-component/>
     </flow>
 
 </mule>

--- a/modules/spring-config/src/test/resources/modules/module-param-default-types.xml
+++ b/modules/spring-config/src/test/resources/modules/module-param-default-types.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-param-default-types"
+        namespace="http://www.mulesoft.org/schema/mule/module-param-default-types"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <operation name="integer-param-operation">
+        <parameters>
+            <parameter name="integerParam" type="integer" defaultValue="11"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="boolean-param-operation">
+        <parameters>
+            <parameter name="booleanParam" type="boolean" defaultValue="false"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="date-param-operation">
+        <parameters>
+            <parameter name="dateParam" type="date" defaultValue="1959-09-07T00:00:00"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="datetime-param-operation">
+        <parameters>
+            <parameter name="datetimeParam" type="datetime" defaultValue="1959-09-07T00:00:00"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="string-param-operation">
+        <parameters>
+            <parameter name="stringParam" type="string" defaultValue="hello world"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="time-param-operation">
+        <parameters>
+            <parameter name="timeParam" type="time" defaultValue="1959-09-07T00:00:00"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+</module>

--- a/modules/spring-config/src/test/resources/modules/module-param-default-types.xsd
+++ b/modules/spring-config/src/test/resources/modules/module-param-default-types.xsd
@@ -1,0 +1,51 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:mule="http://www.mulesoft.org/schema/mule/core" xmlns:tns="http://www.mulesoft.org/schema/mule/module-param-default-types" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.mulesoft.org/schema/mule/module-param-default-types">
+    <import namespace="http://www.mulesoft.org/schema/mule/core" schemaLocation="http://www.mulesoft.org/schema/mule/core/current/mule.xsd"/>
+    <element name="boolean-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:boolean-param-operation-type"/>
+    <complexType name="boolean-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute default="false" name="booleanParam" type="mule:expressionBoolean" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="time-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:time-param-operation-type"/>
+    <complexType name="time-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute default="1959-09-07T00:00:00" name="timeParam" type="mule:expressionDateTime" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="date-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:date-param-operation-type"/>
+    <complexType name="date-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute default="1959-09-07T00:00:00" name="dateParam" type="mule:expressionDateTime" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="integer-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:integer-param-operation-type"/>
+    <complexType name="integer-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute default="11" name="integerParam" type="mule:expressionInt" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="datetime-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:datetime-param-operation-type"/>
+    <complexType name="datetime-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute default="1959-09-07T00:00:00" name="datetimeParam" type="mule:expressionDateTime" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="string-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:string-param-operation-type"/>
+    <complexType name="string-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute default="hello world" name="stringParam" type="mule:expressionString" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/modules/spring-config/src/test/resources/modules/module-param-types.xml
+++ b/modules/spring-config/src/test/resources/modules/module-param-types.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-param-types"
+        namespace="http://www.mulesoft.org/schema/mule/module-param-types"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <operation name="integer-param-operation">
+        <parameters>
+            <parameter name="integerParam" type="integer"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="boolean-param-operation">
+        <parameters>
+            <parameter name="booleanParam" type="boolean"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="date-param-operation">
+        <parameters>
+            <parameter name="dateParam" type="date"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="datetime-param-operation">
+        <parameters>
+            <parameter name="datetimeParam" type="datetime"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="string-param-operation">
+        <parameters>
+            <parameter name="stringParam" type="string"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="time-param-operation">
+        <parameters>
+            <parameter name="timeParam" type="time"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="some value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+</module>

--- a/modules/spring-config/src/test/resources/modules/module-param-types.xsd
+++ b/modules/spring-config/src/test/resources/modules/module-param-types.xsd
@@ -1,0 +1,51 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:mule="http://www.mulesoft.org/schema/mule/core" xmlns:tns="http://www.mulesoft.org/schema/mule/module-param-types" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.mulesoft.org/schema/mule/module-param-types">
+    <import namespace="http://www.mulesoft.org/schema/mule/core" schemaLocation="http://www.mulesoft.org/schema/mule/core/current/mule.xsd"/>
+    <element name="boolean-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:boolean-param-operation-type"/>
+    <complexType name="boolean-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute name="booleanParam" type="mule:expressionBoolean" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="time-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:time-param-operation-type"/>
+    <complexType name="time-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute name="timeParam" type="mule:expressionDateTime" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="date-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:date-param-operation-type"/>
+    <complexType name="date-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute name="dateParam" type="mule:expressionDateTime" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="integer-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:integer-param-operation-type"/>
+    <complexType name="integer-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute name="integerParam" type="mule:expressionInt" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="datetime-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:datetime-param-operation-type"/>
+    <complexType name="datetime-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute name="datetimeParam" type="mule:expressionDateTime" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <element name="string-param-operation" substitutionGroup="mule:abstract-message-processor" type="tns:string-param-operation-type"/>
+    <complexType name="string-param-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute name="stringParam" type="mule:expressionString" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/modules/spring-config/src/test/resources/modules/module-properties-default-types.xml
+++ b/modules/spring-config/src/test/resources/modules/module-properties-default-types.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-properties-default-types"
+        namespace="http://www.mulesoft.org/schema/mule/module-properties-default-types"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd">
+
+    <!-- shows that the xsd will have a global element called config, for the following properties with default values-->
+    <property name="integerParam" type="integer" defaultValue="11"/>
+    <property name="booleanParam" type="boolean" defaultValue="false"/>
+    <property name="dateParam" type="date" defaultValue="1959-09-07T00:00:00"/>
+    <property name="datetimeParam" type="datetime" defaultValue="1959-09-07T00:00:00"/>
+    <property name="stringParam" type="string" defaultValue="hello world"/>
+    <property name="timeParam" type="time" defaultValue="1959-09-07T00:00:00"/>
+
+</module>

--- a/modules/spring-config/src/test/resources/modules/module-properties-default-types.xsd
+++ b/modules/spring-config/src/test/resources/modules/module-properties-default-types.xsd
@@ -1,0 +1,17 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:mule="http://www.mulesoft.org/schema/mule/core" xmlns:tns="http://www.mulesoft.org/schema/mule/module-properties-default-types" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.mulesoft.org/schema/mule/module-properties-default-types">
+    <import namespace="http://www.mulesoft.org/schema/mule/core" schemaLocation="http://www.mulesoft.org/schema/mule/core/current/mule.xsd"/>
+    <element name="config" substitutionGroup="mule:abstract-extension" type="tns:config-type"/>
+    <complexType name="config-type">
+        <complexContent>
+            <extension base="mule:abstractExtensionType">
+                <attribute default="11" name="integerParam" type="mule:expressionInt" use="optional"/>
+                <attribute default="false" name="booleanParam" type="mule:expressionBoolean" use="optional"/>
+                <attribute default="1959-09-07T00:00:00" name="dateParam" type="mule:expressionDateTime" use="optional"/>
+                <attribute default="1959-09-07T00:00:00" name="datetimeParam" type="mule:expressionDateTime" use="optional"/>
+                <attribute default="hello world" name="stringParam" type="mule:expressionString" use="optional"/>
+                <attribute default="1959-09-07T00:00:00" name="timeParam" type="mule:expressionDateTime" use="optional"/>
+                <attribute name="name" type="string" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/modules/spring-config/src/test/resources/modules/module-properties-types.xml
+++ b/modules/spring-config/src/test/resources/modules/module-properties-types.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-properties-types"
+        namespace="http://www.mulesoft.org/schema/mule/module-properties-types"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd">
+
+    <!-- shows that the xsd will have a global element called config, for the following properties-->
+    <property name="integerParam" type="integer"/>
+    <property name="booleanParam" type="boolean"/>
+    <property name="dateParam" type="date"/>
+    <property name="datetimeParam" type="datetime"/>
+    <property name="stringParam" type="string"/>
+    <property name="timeParam" type="time"/>
+
+</module>

--- a/modules/spring-config/src/test/resources/modules/module-properties-types.xsd
+++ b/modules/spring-config/src/test/resources/modules/module-properties-types.xsd
@@ -1,0 +1,17 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:mule="http://www.mulesoft.org/schema/mule/core" xmlns:tns="http://www.mulesoft.org/schema/mule/module-properties-types" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.mulesoft.org/schema/mule/module-properties-types">
+    <import namespace="http://www.mulesoft.org/schema/mule/core" schemaLocation="http://www.mulesoft.org/schema/mule/core/current/mule.xsd"/>
+    <element name="config" substitutionGroup="mule:abstract-extension" type="tns:config-type"/>
+    <complexType name="config-type">
+        <complexContent>
+            <extension base="mule:abstractExtensionType">
+                <attribute name="integerParam" type="mule:expressionInt" use="required"/>
+                <attribute name="booleanParam" type="mule:expressionBoolean" use="required"/>
+                <attribute name="dateParam" type="mule:expressionDateTime" use="required"/>
+                <attribute name="datetimeParam" type="mule:expressionDateTime" use="required"/>
+                <attribute name="stringParam" type="mule:expressionString" use="required"/>
+                <attribute name="timeParam" type="mule:expressionDateTime" use="required"/>
+                <attribute name="name" type="string" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/modules/spring-config/src/test/resources/modules/module-single-op-with-property.xml
+++ b/modules/spring-config/src/test/resources/modules/module-single-op-with-property.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-single-op-with-property"
+        namespace="http://www.mulesoft.org/schema/mule/module-single-op-with-property"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <property name="some-property" type="string" />
+    <operation name="some-operation">
+        <body>
+            <mule:set-payload value="hardcoded value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+</module>

--- a/modules/spring-config/src/test/resources/modules/module-single-op-with-property.xsd
+++ b/modules/spring-config/src/test/resources/modules/module-single-op-with-property.xsd
@@ -1,0 +1,27 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:tns="http://www.mulesoft.org/schema/mule/module-single-op-with-property"
+        attributeFormDefault="unqualified"
+        elementFormDefault="qualified"
+        targetNamespace="http://www.mulesoft.org/schema/mule/module-single-op-with-property">
+    <import namespace="http://www.mulesoft.org/schema/mule/core" schemaLocation="http://www.mulesoft.org/schema/mule/core/current/mule.xsd"/>
+    <element name="config" substitutionGroup="mule:abstract-extension" type="tns:config-type"/>
+    <complexType name="config-type">
+        <complexContent>
+            <extension base="mule:abstractExtensionType">
+                <attribute name="some-property" type="mule:expressionString" use="required"/>
+                <attribute name="name" type="string" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+
+
+    <element name="some-operation" substitutionGroup="mule:abstract-message-processor" type="tns:some-operation-type"/>
+    <complexType name="some-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType">
+                <attribute name="config-ref" type="mule:substitutableName" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+</schema>

--- a/modules/spring-config/src/test/resources/modules/module-single-operation.xml
+++ b/modules/spring-config/src/test/resources/modules/module-single-operation.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-single-operation"
+        namespace="http://www.mulesoft.org/schema/mule/module-single-operation"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <operation name="some-operation">
+        <body>
+            <mule:set-payload value="hardcoded value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+</module>

--- a/modules/spring-config/src/test/resources/modules/module-single-operation.xsd
+++ b/modules/spring-config/src/test/resources/modules/module-single-operation.xsd
@@ -1,0 +1,14 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:tns="http://www.mulesoft.org/schema/mule/module-single-operation"
+        attributeFormDefault="unqualified"
+        elementFormDefault="qualified"
+        targetNamespace="http://www.mulesoft.org/schema/mule/module-single-operation">
+    <import namespace="http://www.mulesoft.org/schema/mule/core" schemaLocation="http://www.mulesoft.org/schema/mule/core/current/mule.xsd"/>
+    <element name="some-operation" substitutionGroup="mule:abstract-message-processor" type="tns:some-operation-type"/>
+    <complexType name="some-operation-type">
+        <complexContent>
+            <extension base="mule:abstractMessageProcessorType"/>
+        </complexContent>
+    </complexType>
+</schema>

--- a/tests/integration/src/test/java/org/mule/test/operation/ModuleSimpleTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/operation/ModuleSimpleTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.operation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import org.mule.runtime.core.api.Event;
+import org.mule.test.AbstractIntegrationTestCase;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+public class ModuleSimpleTestCase extends AbstractIntegrationTestCase {
+
+  @Override
+  protected String getConfigFile() {
+    return "module/flows-using-module-simple.xml";
+  }
+
+  @Test
+  public void testSetPayloadHardcodedFlow() throws Exception {
+    Event event = flowRunner("testSetPayloadHardcodedFlow").run();
+    assertThat(event.getMessage().getPayload().getValue(), Is.is("hardcoded value"));
+  }
+
+  @Test
+  public void testSetPayloadParamFlow() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadParamFlow").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("new payload"));
+  }
+
+  @Test
+  public void testSetPayloadParamDefaultFlow() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadParamDefaultFlow").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("15"));
+  }
+
+  @Test
+  public void testSetPayloadNoSideEffectFlowVariable() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadNoSideEffectFlowVariable").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("10"));
+    assertThat(muleEvent.getVariable("testVar").getValue(), Is.is("unchanged value"));
+  }
+
+  @Test
+  public void testDoNothingFlow() throws Exception {
+    Event muleEvent = flowRunner("testDoNothingFlow").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("before calling"));
+    assertThat(muleEvent.getVariable("variableBeforeCalling").getValue(), Is.is("value of flowvar before calling"));
+  }
+
+  @Test
+  public void testSetPayloadParamValueAppender() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadParamValueAppender").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("new payload from module"));
+  }
+
+  @Test
+  public void testSetPayloadConcatParamsValues() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadConcatParamsValues").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("105"));
+  }
+
+  @Test
+  public void testSetPayloadUsingUndefinedParam() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadUsingUndefinedParam").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is(nullValue()));
+  }
+}

--- a/tests/integration/src/test/java/org/mule/test/operation/ModuleWithGlobalElementTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/operation/ModuleWithGlobalElementTestCase.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.operation;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import org.mule.extension.http.api.request.validator.ResponseValidatorException;
+import org.mule.runtime.core.api.Event;
+import org.mule.runtime.core.exception.MessagingException;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.test.AbstractIntegrationTestCase;
+
+import java.io.IOException;
+import java.util.Base64;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.hamcrest.core.Is;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ModuleWithGlobalElementTestCase extends AbstractIntegrationTestCase {
+
+  @Rule
+  public DynamicPort httpPort = new DynamicPort("httpPort");
+
+  private Server server;
+
+  @Before
+  public void startServer() throws Exception {
+    server = new Server(httpPort.getNumber());
+    server.setHandler(new SimpleBasicAuthentication());
+    server.start();
+  }
+
+  @After
+  public void stopServer() throws Exception {
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  @Override
+  protected String getConfigFile() {
+    return "module/flows-using-module-global-elements.xml";
+  }
+
+  //@Override
+  //protected Class<?>[] getAnnotatedExtensionClasses() {
+  //  //TODO until MULE-10383 is fixed both Socket and Http extensions will be exposed, instead of just the Http one
+  //  return new Class[] {SocketsExtension.class, HttpConnector.class};
+  //}
+  //
+  ///**
+  // * The test cannot run with isolation due to http ext doesn't have anymore the mule-module.properties. This test needs to have
+  // * the complete access to all the classes and resources therefore it just returns the class loader that loaded the test class.
+  // * (taken from AbstractTlsRestrictedProtocolsAndCiphersTestCase test)
+  // *
+  // * @return the {@link ClassLoader} that loaded the test.
+  // */
+  //@Override
+  //protected ClassLoader getExecutionClassLoader() {
+  //  return this.getClass().getClassLoader();
+  //}
+
+  @Test
+  public void testHttpDoLogin() throws Exception {
+    Event muleEvent = flowRunner("testHttpDoLogin").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("success with basic-authentication for user: userLP"));
+  }
+
+  @Test
+  public void testHttpDontLogin() throws Exception {
+    try {
+      flowRunner("testHttpDontLogin").run();
+      fail("Should not have reach here");
+    } catch (MessagingException me) {
+      assertThat(me.getCause(), instanceOf(ResponseValidatorException.class));
+      assertThat(me.getCause().getMessage(), Is.is("Response code 401 mapped as failure"));
+    }
+  }
+
+  @Test
+  public void testHttpDoLoginGonnet() throws Exception {
+    Event muleEvent = flowRunner("testHttpDoLoginGonnet").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("success with basic-authentication for user: userGonnet"));
+  }
+
+  /**
+   * Really simple handler for basic authentication where the user and pass, once decoded, must match the path of the request.
+   * For example: "/basic-aith/userLP/passLP" request must have an "Authorization" header with "userLP:passLP" encoded in Base64
+   * to return 200, otherwise it will be 401 (unauthorized)
+   */
+  private class SimpleBasicAuthentication extends AbstractHandler {
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+        throws IOException, ServletException {
+      int scUnauthorized;
+      String message;
+
+      String userAndPass = new String(Base64.getDecoder().decode(request.getHeader("Authorization").substring("Basic ".length())))
+          .replace(':', '/');
+      if (target.endsWith(userAndPass)) {
+        scUnauthorized = HttpServletResponse.SC_OK;
+        message = "User and pass validated";
+      } else {
+        scUnauthorized = HttpServletResponse.SC_UNAUTHORIZED;
+        message = "User and pass wrong";
+      }
+      response.setStatus(scUnauthorized);
+      response.getWriter().print(message);
+      response.setContentType("text/html");
+      baseRequest.setHandled(true);
+    }
+  }
+}

--- a/tests/integration/src/test/java/org/mule/test/operation/ModuleWithPropertiesTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/operation/ModuleWithPropertiesTestCase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.operation;
+
+import static org.junit.Assert.assertThat;
+import org.mule.runtime.core.api.Event;
+import org.mule.test.AbstractIntegrationTestCase;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+public class ModuleWithPropertiesTestCase extends AbstractIntegrationTestCase {
+
+  @Override
+  protected String getConfigFile() {
+    return "module/flows-using-module-properties.xml";
+  }
+
+  @Test
+  public void testSetPayloadHardcodedFromModuleFlow() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadHardcodedFromModuleFlow").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("hardcoded value from module"));
+  }
+
+  @Test
+  public void testSetPayloadParamFromModuleFlow() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadParamFromModuleFlow").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("new payload from module"));
+  }
+
+  @Test
+  public void testSetPayloadConfigParamFlow() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadConfigParamFlow").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("some config-value-parameter"));
+  }
+
+  @Test
+  public void testSetPayloadConfigDefaultParamFlow() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadConfigDefaultParamFlow").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("some default-config-value-parameter"));
+  }
+
+  @Test
+  public void testSetPayloadAddParamAndPropertyValues() throws Exception {
+    Event muleEvent = flowRunner("testSetPayloadAddParamAndPropertyValues").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), Is.is("a parameter value some config-value-parameter"));
+  }
+}

--- a/tests/integration/src/test/resources/module/flows-using-module-global-elements.xml
+++ b/tests/integration/src/test/resources/module/flows-using-module-global-elements.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:module-global-element="http://www.mulesoft.org/schema/mule/module-global-element"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/module-global-element http://www.mulesoft.org/schema/mule/module-global-element/module-global-element.xsd">
+
+    <module-global-element:config name="la-plata-config" someUserConfig="userLP" somePassConfig="passLP" port="${httpPort}"/>
+    <module-global-element:config name="gonnet-config" someUserConfig="userGonnet" somePassConfig="passGonnet" port="${httpPort}"/>
+
+    <flow name="testHttpDoLogin">
+        <module-global-element:do-login config-ref="la-plata-config" someUser="userLP" somePass="passLP" />
+    </flow>
+
+    <flow name="testHttpDontLogin">
+        <module-global-element:do-login config-ref="la-plata-config" someUser="userGonnet" somePass="passGonnet"/>
+    </flow>
+
+    <flow name="testHttpDoLoginGonnet">
+        <module-global-element:do-login config-ref="gonnet-config" someUser="userGonnet" somePass="passGonnet"/>
+    </flow>
+</mule>

--- a/tests/integration/src/test/resources/module/flows-using-module-properties.xml
+++ b/tests/integration/src/test/resources/module/flows-using-module-properties.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:module-properties="http://www.mulesoft.org/schema/mule/module-properties"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/module-properties http://www.mulesoft.org/schema/mule/module-properties/module-properties.xsd">
+
+    <module-properties:config name="instantiatedConfig"  configParam="some config-value-parameter" />
+
+    <flow name="testSetPayloadHardcodedFromModuleFlow">
+        <module-properties:set-payload-hardcoded-value config-ref="instantiatedConfig" />
+    </flow>
+
+    <flow name="testSetPayloadParamFromModuleFlow">
+        <module-properties:set-payload-param-value config-ref="instantiatedConfig" value="new payload"/>
+    </flow>
+
+    <flow name="testSetPayloadConfigParamFlow">
+        <module-properties:set-payload-config-param-value config-ref="instantiatedConfig" />
+    </flow>
+
+    <flow name="testSetPayloadConfigDefaultParamFlow">
+        <module-properties:set-payload-config-default-param-value config-ref="instantiatedConfig" />
+    </flow>
+
+    <flow name="testSetPayloadAddParamAndPropertyValues">
+        <module-properties:set-payload-add-param-and-property-values config-ref="instantiatedConfig" value1="a parameter value"/>
+    </flow>
+</mule>

--- a/tests/integration/src/test/resources/module/flows-using-module-simple.xml
+++ b/tests/integration/src/test/resources/module/flows-using-module-simple.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:module-simple="http://www.mulesoft.org/schema/mule/module-simple"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core     http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+      http://www.mulesoft.org/schema/mule/module-simple     http://www.mulesoft.org/schema/mule/module-simple/path-que-no-existe/module-simple/module-simple.xsd">
+
+    <flow name="testSetPayloadHardcodedFlow">
+        <module-simple:set-payload-hardcoded-value />
+    </flow>
+
+    <flow name="testSetPayloadParamFlow">
+        <module-simple:set-payload-param-value value="new payload" />
+    </flow>
+
+    <flow name="testSetPayloadParamDefaultFlow">
+        <module-simple:set-payload-param-default-value  />
+    </flow>
+
+    <flow name="testSetPayloadNoSideEffectFlowVariable">
+        <set-variable variableName="testVar" value="unchanged value"/>
+        <module-simple:set-payload-no-side-effect />
+    </flow>
+
+    <flow name="testDoNothingFlow">
+        <set-variable variableName="variableBeforeCalling" value="value of flowvar before calling"/>
+        <set-payload value="before calling" />
+        <module-simple:do-nothing />
+    </flow>
+
+    <flow name="testSetPayloadParamValueAppender">
+        <module-simple:set-payload-param-value-appender value="new payload" />
+    </flow>
+
+    <flow name="testSetPayloadConcatParamsValues">
+        <module-simple:set-payload-concat-params-values value1="10" value2="5" />
+    </flow>
+
+    <flow name="testSetPayloadUsingUndefinedParam">
+        <module-simple:set-payload-using-undefined-param />
+    </flow>
+</mule>

--- a/tests/integration/src/test/resources/module/module-global-element/module-global-element.xml
+++ b/tests/integration/src/test/resources/module/module-global-element/module-global-element.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-global-element"
+        namespace="http://www.mulesoft.org/schema/mule/module-global-element"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:httpn="http://www.mulesoft.org/schema/mule/httpn"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+           http://www.mulesoft.org/schema/mule/httpn http://www.mulesoft.org/schema/mule/httpn/current/mule-httpn.xsd">
+
+    <property name="someUserConfig" type="string" defaultValue="some-username"/>
+    <property name="somePassConfig" type="string" defaultValue="some-password"/>
+    <property name="port" type="string"/>
+
+    <httpn:request-config name="simple-config" basePath="/basic-auth/">
+        <httpn:request-connection host="localhost" protocol="HTTP" port="#[property.port]">
+            <httpn:authentication>
+                <httpn:basic-authentication username="#[property.someUserConfig]" password="#[property.somePassConfig]"/>
+            </httpn:authentication>
+        </httpn:request-connection>
+    </httpn:request-config>
+
+    <operation name="do-login">
+        <parameters>
+            <parameter name="someUser" type="string" defaultValue="usernameX"/>
+            <parameter name="somePass" type="string" defaultValue="passwordX"/>
+        </parameters>
+        <body>
+            <httpn:request config-ref="simple-config" method="GET" path="/{aUser}/{aPass}">
+                <httpn:request-builder>
+                    <httpn:uri-params>
+                        <httpn:uri-param key="aUser" value="#[param.someUser]"/>
+                        <httpn:uri-param key="aPass" value="#[param.somePass]"/>
+                    </httpn:uri-params>
+                </httpn:request-builder>
+            </httpn:request>
+            <mule:set-payload value="#['success with basic-authentication for user: ' + param.someUser]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+</module>

--- a/tests/integration/src/test/resources/module/module-properties/module-properties.xml
+++ b/tests/integration/src/test/resources/module/module-properties/module-properties.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-properties"
+        namespace="http://www.mulesoft.org/schema/mule/module-properties"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <property name="configParam" type="string"/>
+    <property name="defaultConfigParam" defaultValue="some default-config-value-parameter" type="string"/>
+
+    <operation name="set-payload-hardcoded-value">
+        <body>
+            <mule:set-payload value="hardcoded value from module"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-param-value">
+        <parameters>
+            <parameter name="value" type="string"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="#[param.value + ' from module']"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-config-param-value">
+        <body>
+            <mule:set-payload value="#[property.configParam]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-config-default-param-value">
+        <body>
+            <mule:set-payload value="#[property.defaultConfigParam]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-add-param-and-property-values">
+        <parameters>
+            <parameter name="value1" type="string"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="#[param.value1 + ' ' + property.configParam]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+</module>

--- a/tests/integration/src/test/resources/module/module-simple/module-simple.xml
+++ b/tests/integration/src/test/resources/module/module-simple/module-simple.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-simple"
+        namespace="http://www.mulesoft.org/schema/mule/module-simple"
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <operation name="set-payload-hardcoded-value">
+        <body>
+            <mule:set-payload value="hardcoded value"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-param-value">
+        <parameters>
+            <parameter name="value" type="string"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="#[param.value]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-param-default-value">
+        <parameters>
+            <parameter name="value" type="string" defaultValue="15"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="#[param.value]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-no-side-effect">
+        <body>
+            <mule:set-payload value="10"/>
+            <mule:set-variable variableName="testVar" value="inside the operation value changed"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="do-nothing">
+        <body>
+            <mule:set-payload value="despite writing the payload, it won't be propagated because of the void return type" />
+        </body>
+        <output type="void"/>
+    </operation>
+
+    <operation name="set-payload-param-value-appender">
+        <parameters>
+            <parameter name="value" type="string"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="#[param.value + ' from module']"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-concat-params-values">
+        <parameters>
+            <parameter name="value1" type="string"/>
+            <parameter name="value2" type="string"/>
+        </parameters>
+        <body>
+            <mule:set-payload value="#[param.value1 + param.value2]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-using-undefined-param">
+        <body>
+            <mule:set-payload value="#[param.value1]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+</module>


### PR DESCRIPTION
@pablolagreca if possible, try reviewing this WIP so that I can move forward with other issues.

All the heavy work is done under _mule-module-spring-config_, reading the XMLs from the classpath by convention: (a) every file with the name `module-<something-here>.xml` will be open), to then (b) read the root element to see if it's equal to `<module>`, and if applies (c) store them in an object for two types of usages:
- generating XSD dynamically when reading the app
- expanding the `<operation>` templates in the `ApplicationModel` class

-Current integration tests:
https://github.com/mulesoft/mule/tree/MULE-10252/tests/integration/src/test/java/org/mule/test/operation
- XMLs resources (both mule and modules): https://github.com/mulesoft/mule/tree/MULE-10252/tests/integration/src/test/resources/module
