### PR TITLE
MULE-10870 - Duplicate content-type created in response builder

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseHeaderBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseHeaderBuilder.java
@@ -6,6 +6,7 @@
  */
 package org.mule.module.http.internal.listener;
 
+import static java.util.Arrays.asList;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_LENGTH;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import static org.mule.module.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
@@ -19,7 +20,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -29,10 +29,10 @@ import org.slf4j.LoggerFactory;
 
 public class HttpResponseHeaderBuilder
 {
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpResponseHeaderBuilder.class);
 
-    private List<String> calculatedHeadersNames = Arrays.asList(TRANSFER_ENCODING, CONTENT_LENGTH);
-    private List<String> uniqueHeadersNames = Arrays.asList(TRANSFER_ENCODING, CONTENT_LENGTH, CONTENT_TYPE);
+    private List<String> calculatedHeadersNames = asList(TRANSFER_ENCODING, CONTENT_LENGTH);
+    private List<String> uniqueHeadersNames = asList(TRANSFER_ENCODING.toLowerCase(), CONTENT_LENGTH.toLowerCase(), CONTENT_TYPE.toLowerCase());
 
     Multimap<String, String> headers =
             Multimaps.newMultimap(new CaseInsensitiveMapWrapper<Collection<String>>(HashMap.class), new Supplier<Collection<String>>(){
@@ -88,10 +88,10 @@ public class HttpResponseHeaderBuilder
      */
     private void logIfHeaderDoesNotSupportMultipleValues(String headerName)
     {
-        if (uniqueHeadersNames.contains(headerName))
+        if (uniqueHeadersNames.contains(headerName.toLowerCase()))
         {
             final Collection<String> values = headers.removeAll(headerName);
-            logger.warn("Header: " + headerName + " does not support multiple values. Removing {}", values);
+            LOGGER.warn("Header: " + headerName + " does not support multiple values. Removing {}", values);
         }
     }
 

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseBuilderTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseBuilderTestCase.java
@@ -6,13 +6,11 @@
  */
 package org.mule.module.http.functional.listener;
 
-import static org.apache.commons.collections.CollectionUtils.exists;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mule.module.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_RELATIVE_PATH;
 import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_REQUEST_PATH_PROPERTY;
@@ -30,7 +28,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
 import org.apache.commons.collections.Transformer;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -45,42 +42,58 @@ public class HttpListenerResponseBuilderTestCase extends FunctionalTestCase
 
     @Rule
     public DynamicPort listenPort = new DynamicPort("port");
+
     @Rule
-    public SystemProperty emptyResponseBuilderPath = new SystemProperty("emptyResponseBuilderPath","emptyResponseBuilderPath");
+    public SystemProperty emptyResponseBuilderPath = new SystemProperty("emptyResponseBuilderPath", "emptyResponseBuilderPath");
+
     @Rule
     public SystemProperty statusResponseBuilderPath = new SystemProperty("statusResponseBuilderPath","statusResponseBuilderPath");
+
     @Rule
     public SystemProperty statusResponseBuilderOverridePath = new SystemProperty("statusResponseBuilderOverridePath", "statusResponseBuilderOverridePath");
+
     @Rule
     public SystemProperty reasonPhraseResponseBuilderOverridePath = new SystemProperty("reasonPhraseResponseBuilderOverridePath", "reasonPhraseResponseBuilderOverridePath");
+
     @Rule
     public SystemProperty statusReasonPhraseResponseBuilderWontOverridePath = new SystemProperty("statusReasonPhraseResponseBuilderWontOverridePath", "statusReasonPhraseResponseBuilderWontOverridePath");
+
     @Rule
     public SystemProperty headerResponseBuilderPath = new SystemProperty("headerResponseBuilderPath","headerResponseBuilderPath");
+
     @Rule
     public SystemProperty headersResponseBuilderPath = new SystemProperty("headersResponseBuilderPath","headersResponseBuilderPath");
+
     @Rule
     public SystemProperty defaultReasonPhraseResponseBuilderPath = new SystemProperty("defaultReasonPhraseResponseBuilderPath", "defaultReasonPhraseResponseBuilderPath");
+
     @Rule
     public SystemProperty noReasonPhraseUnknownStatusCodeResponseBuilderPath = new SystemProperty("noReasonPhraseUnknownStatusCodeResponseBuilderPath", "noReasonPhraseUnknownStatusCodeResponseBuilderPath");
+
     @Rule
     public SystemProperty headerDuplicatesResponseBuilderPath = new SystemProperty("headerDuplicatesResponseBuilderPath","headerDuplicatesResponseBuilderPath");
+
     @Rule
     public SystemProperty errorEmptyResponseBuilderPath = new SystemProperty("emptyResponseBuilderPath","emptyResponseBuilderPath");
+
     @Rule
     public SystemProperty errorStatusResponseBuilderPath = new SystemProperty("statusResponseBuilderPath","statusResponseBuilderPath");
+
     @Rule
     public SystemProperty errorHeaderResponseBuilderPath = new SystemProperty("headerResponseBuilderPath","headerResponseBuilderPath");
+
     @Rule
     public SystemProperty errorHeadersResponseBuilderPath = new SystemProperty("headersResponseBuilderPath","headersResponseBuilderPath");
+
     @Rule
     public SystemProperty errorHeaderDuplicatesResponseBuilderPath = new SystemProperty("headerDuplicatesResponseBuilderPath","headerDuplicatesResponseBuilderPath");
+
     @Rule
     public SystemProperty responseBuilderAndErrorResponseBuilderNotTheSamePath = new SystemProperty("responseBuilderAndErrorResponseBuilderNotTheSamePath","responseBuilderAndErrorResponseBuilderNotTheSamePath");
+
     @Rule
     public SystemProperty httpHeadersResponseBuilderPath = new SystemProperty("httpHeadersResponseBuilderPath","httpHeadersResponseBuilderPath");
-    @Rule
-    public SystemProperty httpContentTypeResponseBuilderPath = new SystemProperty("httpContentTypeResponseBuilderPath","twoContentTypeResponseBuilderFlow");
+
     @Rule
     public SystemProperty twoHeadersResponseBuilderPath = new SystemProperty("twoHeadersResponseBuilderPath","twoHeadersResponseBuilderFlow");
 
@@ -224,11 +237,10 @@ public class HttpListenerResponseBuilderTestCase extends FunctionalTestCase
         final String url = getUrl(twoHeadersResponseBuilderPath);
         final Response response = Request.Get(url).connectTimeout(1000).execute();
         final HttpResponse httpResponse = response.returnResponse();
-        final List<Header> headers = Arrays.asList(httpResponse.getAllHeaders());
+        final List<Header> headers = Arrays.asList(httpResponse.getHeaders("Content-Type"));
 
-        assertTrue(exists(headers, new HeaderPredicate("Content-Type", "application/json")));
-        assertFalse(exists(headers, new HeaderPredicate("Content-Type", "text/x-json")));
-        assertFalse(exists(headers, new HeaderPredicate("Content-Type", "text/javascript")));
+        assertThat(headers, hasSize(1));
+        assertThat(headers.get(0).getValue(), is("application/json"));
     }
 
     private String getUrl(SystemProperty pathSystemProperty)
@@ -294,19 +306,4 @@ public class HttpListenerResponseBuilderTestCase extends FunctionalTestCase
         return true;
     }
 
-    private static class HeaderPredicate implements Predicate {
-
-        private String name;
-        private String value;
-
-        public HeaderPredicate(String name, String value) {
-            this.name = name;
-            this.value = value;
-        }
-
-        @Override public boolean evaluate(Object o) {
-            final Header header = (Header) o;
-            return header.getName().equals(name) && header.getValue().equals(value);
-        }
-    }
 }

--- a/modules/http/src/test/resources/http-listener-response-builder-config.xml
+++ b/modules/http/src/test/resources/http-listener-response-builder-config.xml
@@ -20,12 +20,14 @@
     <flow name="twoHeadersResponseBuilderFlow">
         <http:listener config-ref="listenerConfig" path="${twoHeadersResponseBuilderPath}">
             <http:response-builder >
+                <http:header headerName="content-type" value="text/x-javascript"/>
                 <http:header headerName="Content-Type" value="application/json"/>
             </http:response-builder>
         </http:listener>
         <set-payload value="somePayload"/>
         <set-property propertyName="Content-Type" value="text/x-json"/>
         <set-property propertyName="Content-Type" value="text/javascript"/>
+        <set-property propertyName="content-type" value="application/xml"/>
     </flow>
 
     <flow name="statusResponseBuilderFlow">

--- a/modules/http/src/test/resources/http-listener-response-builder-config.xml
+++ b/modules/http/src/test/resources/http-listener-response-builder-config.xml
@@ -17,6 +17,17 @@
         <echo-component/>
     </flow>
 
+    <flow name="twoHeadersResponseBuilderFlow">
+        <http:listener config-ref="listenerConfig" path="${twoHeadersResponseBuilderPath}">
+            <http:response-builder >
+                <http:header headerName="Content-Type" value="application/json"/>
+            </http:response-builder>
+        </http:listener>
+        <set-payload value="somePayload"/>
+        <set-property propertyName="Content-Type" value="text/x-json"/>
+        <set-property propertyName="Content-Type" value="text/javascript"/>
+    </flow>
+
     <flow name="statusResponseBuilderFlow">
         <http:listener config-ref="listenerConfig" path="${statusResponseBuilderPath}">
             <http:response-builder statusCode="201" reasonPhrase="everything works!"/>


### PR DESCRIPTION
Added a check in the case a given header does not allow multiple values and more than one is set.
In that case, a warn message is shown and the older values are removed from the map instead of throwing an exception. I opted for this solution to keep backwards compatibility and throw the exception in a new commit in Mule 4.


