### PR TITLE
MULE-10847: Implement internal object serializers

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/serialization/AbstractSerializerProtocolContractTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/serialization/AbstractSerializerProtocolContractTestCase.java
@@ -30,30 +30,30 @@ public abstract class AbstractSerializerProtocolContractTestCase extends Abstrac
 
   private static final String STRING_MESSAGE = "Hello World";
 
-  protected SerializationProtocol serializerProtocol;
+  protected SerializationProtocol serializationProtocol;
 
   @Test(expected = IllegalArgumentException.class)
   public final void nullBytes() throws Exception {
-    serializerProtocol.deserialize((byte[]) null);
+    serializationProtocol.deserialize((byte[]) null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public final void nullStream() throws Exception {
-    serializerProtocol.deserialize((InputStream) null);
+    serializationProtocol.deserialize((InputStream) null);
   }
 
   @Test
   public final void nullObject() throws Exception {
-    byte[] bytes = serializerProtocol.serialize(null);
-    Object object = serializerProtocol.deserialize(bytes);
+    byte[] bytes = serializationProtocol.serialize(null);
+    Object object = serializationProtocol.deserialize(bytes);
     assertNull(object);
   }
 
   @Test
   public final void inputStreamClosed() throws Exception {
-    final byte[] bytes = serializerProtocol.serialize(STRING_MESSAGE);
+    final byte[] bytes = serializationProtocol.serialize(STRING_MESSAGE);
     InputStream inputStream = spy(new ByteArrayInputStream(bytes));
-    String output = serializerProtocol.deserialize(inputStream);
+    String output = serializationProtocol.deserialize(inputStream);
 
     verify(inputStream, atLeastOnce()).close();
     assertThat(output, equalTo(STRING_MESSAGE));
@@ -68,9 +68,9 @@ public abstract class AbstractSerializerProtocolContractTestCase extends Abstrac
     dateTime.changeTimeZone("Pacific/Midway");
 
     Event event = eventBuilder().message(InternalMessage.of(dateTime)).build();
-    byte[] bytes = serializerProtocol.serialize(event.getMessage());
+    byte[] bytes = serializationProtocol.serialize(event.getMessage());
 
-    InternalMessage message = serializerProtocol.deserialize(bytes);
+    InternalMessage message = serializationProtocol.deserialize(bytes);
     DateTime deserealized = (DateTime) message.getPayload().getValue();
 
     assertEquals(calendar, deserealized.toCalendar());

--- a/core-tests/src/test/java/org/mule/runtime/core/serialization/JavaExternalSerializerProtocolProtocolTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/serialization/JavaExternalSerializerProtocolProtocolTestCase.java
@@ -14,12 +14,12 @@ public class JavaExternalSerializerProtocolProtocolTestCase extends AbstractSeri
 
   @Override
   protected void doSetUp() throws Exception {
-    serializerProtocol = muleContext.getObjectSerializer().getExternalProtocol();
+    serializationProtocol = muleContext.getObjectSerializer().getExternalProtocol();
   }
 
   @Test(expected = SerializationException.class)
   public void notSerializable() throws Exception {
-    serializerProtocol.serialize(new Object());
+    serializationProtocol.serialize(new Object());
   }
 
 }

--- a/core/src/main/java/org/mule/runtime/core/api/config/MuleProperties.java
+++ b/core/src/main/java/org/mule/runtime/core/api/config/MuleProperties.java
@@ -117,6 +117,7 @@ public class MuleProperties {
   public static final String OBJECT_OBJECT_NAME_PROCESSOR = "_muleObjectNameProcessor";
   public static final String OBJECT_LIFECYCLE_MANAGER = "_muleLifecycleManager";
   public static final String OBJECT_SERIALIZER = "_muleDefaultObjectSerializer";
+  public static final String OBJECT_CLASSLOADER_REPOSITORY = "_muleClassLoaderRepository";
   public static final String OBJECT_SECURITY_MANAGER = "_muleSecurityManager";
   public static final String OBJECT_TRANSACTION_MANAGER = "_muleTransactionManager";
   public static final String OBJECT_QUEUE_MANAGER = "_muleQueueManager";

--- a/core/src/main/java/org/mule/runtime/core/api/context/MuleContextBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/api/context/MuleContextBuilder.java
@@ -9,6 +9,7 @@ package org.mule.runtime.core.api.context;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.MuleConfiguration;
 import org.mule.runtime.core.api.lifecycle.LifecycleManager;
+import org.mule.runtime.core.api.serialization.ObjectSerializer;
 import org.mule.runtime.core.context.notification.ServerNotificationManager;
 
 import javax.resource.spi.work.WorkListener;
@@ -39,4 +40,9 @@ public interface MuleContextBuilder {
    * @param executionClassLoader classloader to use on the created context. Non null.
    */
   void setExecutionClassLoader(ClassLoader executionClassLoader);
+
+  /**
+   * @param objectSerializer object serializer to use on the created context. Non null.
+   */
+  void setObjectSerializer(ObjectSerializer objectSerializer);
 }

--- a/core/src/main/java/org/mule/runtime/core/context/DefaultMuleContextBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/context/DefaultMuleContextBuilder.java
@@ -31,6 +31,7 @@ import org.mule.runtime.core.api.context.notification.SecurityNotificationListen
 import org.mule.runtime.core.api.context.notification.TransactionNotificationListener;
 import org.mule.runtime.core.api.exception.SystemExceptionHandler;
 import org.mule.runtime.core.api.lifecycle.LifecycleManager;
+import org.mule.runtime.core.api.serialization.ObjectSerializer;
 import org.mule.runtime.core.client.DefaultLocalMuleClient;
 import org.mule.runtime.core.config.DefaultMuleConfiguration;
 import org.mule.runtime.core.config.ImmutableThreadingProfile;
@@ -97,6 +98,8 @@ public class DefaultMuleContextBuilder implements MuleContextBuilder {
 
   protected ClassLoader executionClassLoader;
 
+  protected ObjectSerializer objectSerializer;
+
   /**
    * {@inheritDoc}
    */
@@ -122,14 +125,24 @@ public class DefaultMuleContextBuilder implements MuleContextBuilder {
     muleContext
         .setBootstrapServiceDiscoverer(injectMuleContextIfRequired(getBootstrapPropertiesServiceDiscoverer(), muleContext));
 
-    JavaObjectSerializer defaultObjectSerializer = new JavaObjectSerializer();
-    defaultObjectSerializer.setMuleContext(muleContext);
-    muleContext.setObjectSerializer(defaultObjectSerializer);
+    getObjectSerializer(muleContext);
     ErrorTypeRepository defaultErrorTypeRepository = createDefaultErrorTypeRepository();
     muleContext.setErrorTypeRepository(defaultErrorTypeRepository);
     muleContext.setErrorTypeLocator(createDefaultErrorTypeLocator(defaultErrorTypeRepository));
 
     return muleContext;
+  }
+
+  private void getObjectSerializer(DefaultMuleContext muleContext) {
+    if (objectSerializer == null) {
+      objectSerializer = new JavaObjectSerializer();
+    }
+
+    if (objectSerializer instanceof MuleContextAware) {
+      ((MuleContextAware) objectSerializer).setMuleContext(muleContext);
+    }
+
+    muleContext.setObjectSerializer(objectSerializer);
   }
 
   protected SystemExceptionHandler createExceptionListener(DefaultMuleContext muleContext) {
@@ -175,6 +188,11 @@ public class DefaultMuleContextBuilder implements MuleContextBuilder {
   @Override
   public void setExecutionClassLoader(ClassLoader executionClassLoader) {
     this.executionClassLoader = executionClassLoader;
+  }
+
+  @Override
+  public void setObjectSerializer(ObjectSerializer objectSerializer) {
+    this.objectSerializer = objectSerializer;
   }
 
   protected ClassLoader getExecutionClassLoader() {

--- a/modules/artifact/pom.xml
+++ b/modules/artifact/pom.xml
@@ -33,6 +33,13 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule</groupId>
+            <artifactId>mule-core-tests</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/ClassLoaderRepository.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/ClassLoaderRepository.java
@@ -8,9 +8,9 @@
 package org.mule.runtime.module.artifact.classloader;
 
 /**
- * Provides access to the {@link ArtifactClassLoader} registered on the container.
+ * Provides access to the {@link ClassLoader} registered on the container.
  */
-public interface ArtifactClassLoaderRepository {
+public interface ClassLoaderRepository {
 
   /**
    * Returns a class loader with a given ID.
@@ -18,6 +18,13 @@ public interface ArtifactClassLoaderRepository {
    * @param classLoaderId identifies the class loader to find. Non empty.
    * @return the classloader registered under the given ID, null if no class loader with that ID is registered.
    */
-  ArtifactClassLoader find(String classLoaderId);
+  ClassLoader find(String classLoaderId);
 
+  /**
+   * Returns the ID for a given class loader
+   *
+   * @param classLoader instance for which the ID is searched for.
+   * @return the class loader ID if the class loader is registered. Null otherwise
+   */
+  String getId(ClassLoader classLoader);
 }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/ClassLoaderRepository.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/ClassLoaderRepository.java
@@ -7,6 +7,8 @@
 
 package org.mule.runtime.module.artifact.classloader;
 
+import java.util.Optional;
+
 /**
  * Provides access to the {@link ClassLoader} registered on the container.
  */
@@ -16,15 +18,14 @@ public interface ClassLoaderRepository {
    * Returns a class loader with a given ID.
    *
    * @param classLoaderId identifies the class loader to find. Non empty.
-   * @return the classloader registered under the given ID, null if no class loader with that ID is registered.
+   * @return an {@link Optional} {@link ClassLoader} for the provided ID.
    */
-  ClassLoader find(String classLoaderId);
+  Optional<ClassLoader> find(String classLoaderId);
 
   /**
    * Returns the ID for a given class loader
    *
-   * @param classLoader instance for which the ID is searched for.
-   * @return the class loader ID if the class loader is registered. Null otherwise
+   * @return an {@link Optional} {@link String} corresponding to the ID which is being searched for.
    */
-  String getId(ClassLoader classLoader);
+  Optional<String> getId(ClassLoader classLoader);
 }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/FineGrainedControlClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/FineGrainedControlClassLoader.java
@@ -126,7 +126,7 @@ public class FineGrainedControlClassLoader extends URLClassLoader
 
   private void logLoadedClass(String name, Class<?> result) {
     final boolean loadedFromChild = result.getClassLoader() == this;
-    final String message = format("Class '%s' loaded from %s: %s", name, (loadedFromChild ? "child" : "parent"),
+    final String message = format("Loaded class '%s' from %s: %s", name, (loadedFromChild ? "child" : "parent"),
                                   (loadedFromChild ? this : getParent()));
     doVerboseLogging(message);
   }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectInputStream.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectInputStream.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.serializer;
+
+import static java.lang.Class.forName;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+/**
+ * Customized version of {@link ObjectInputStream} that reads the identifier of the class loader that loaded the
+ * class of the serialized object.
+ * <p/>
+ * Is intended to be used along with {@link ArtifactClassLoaderObjectOutputStream}.
+ */
+public class ArtifactClassLoaderObjectInputStream extends ObjectInputStream {
+
+  private final ClassLoaderRepository classLoaderRepository;
+
+  /**
+   * Creates a new stream instance.
+   *
+   * @param classLoaderRepository contains the registered classloaders that can be used to load serialized classes. Non null.
+   * @param input input stream to read from. Non null.
+   * @throws  IOException if an I/O error occurs while reading stream header
+   */
+  public ArtifactClassLoaderObjectInputStream(ClassLoaderRepository classLoaderRepository, InputStream input)
+      throws IOException {
+    super(input);
+    this.classLoaderRepository = classLoaderRepository;
+  }
+
+  @Override
+  protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+    int val = readByte();
+    if (val == -1) {
+      return super.resolveClass(desc);
+    }
+
+    byte[] bytes = new byte[val];
+    if (read(bytes) == -1) {
+      throw new IOException("Stream does not contain a classloader ID");
+    }
+
+    String classLoaderId = new String(bytes);
+    final ClassLoader classLoader = classLoaderRepository.find(classLoaderId);
+    if (classLoader == null) {
+      throw new IOException("Artifact class loader not found: " + classLoaderId);
+    }
+
+    return forName(desc.getName(), false, classLoader);
+  }
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectInputStream.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectInputStream.java
@@ -51,10 +51,8 @@ public class ArtifactClassLoaderObjectInputStream extends ObjectInputStream {
     }
 
     String classLoaderId = new String(bytes);
-    final ClassLoader classLoader = classLoaderRepository.find(classLoaderId);
-    if (classLoader == null) {
-      throw new IOException("Artifact class loader not found: " + classLoaderId);
-    }
+    ClassLoader classLoader = classLoaderRepository.find(classLoaderId)
+        .orElseThrow(() -> new IOException("Artifact class loader not found: " + classLoaderId));
 
     return forName(desc.getName(), false, classLoader);
   }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectOutputStream.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectOutputStream.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.serializer;
+
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+
+/**
+ * Customized version of {@link ObjectOutputStream} that for each serialized object, writes the identifier of the classLoader
+ * that loaded the object's class.
+ * <p/>
+ * Is intended to be used along with {@link ArtifactClassLoaderObjectInputStream}.
+ */
+
+public class ArtifactClassLoaderObjectOutputStream extends ObjectOutputStream {
+
+  private final ClassLoaderRepository classLoaderRepository;
+
+  /**
+   * Creates a new output stream.
+   *
+   * @param classLoaderRepository
+   * @param out output stream to write to
+   * @throws IOException if an I/O error occurs while writing stream header
+   */
+  public ArtifactClassLoaderObjectOutputStream(ClassLoaderRepository classLoaderRepository, OutputStream out) throws IOException {
+    super(out);
+    this.classLoaderRepository = classLoaderRepository;
+  }
+
+  @Override
+  protected void annotateClass(Class<?> clazz) throws IOException {
+    String id = classLoaderRepository.getId(clazz.getClassLoader());
+    if (id != null) {
+      this.writeByte(id.length());
+      this.writeBytes(id);
+    } else {
+      this.writeByte(-1);
+    }
+  }
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectOutputStream.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectOutputStream.java
@@ -12,6 +12,7 @@ import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.util.Optional;
 
 /**
  * Customized version of {@link ObjectOutputStream} that for each serialized object, writes the identifier of the classLoader
@@ -38,10 +39,10 @@ public class ArtifactClassLoaderObjectOutputStream extends ObjectOutputStream {
 
   @Override
   protected void annotateClass(Class<?> clazz) throws IOException {
-    String id = classLoaderRepository.getId(clazz.getClassLoader());
-    if (id != null) {
-      this.writeByte(id.length());
-      this.writeBytes(id);
+    Optional<String> id = classLoaderRepository.getId(clazz.getClassLoader());
+    if (id.isPresent()) {
+      this.writeByte(id.get().length());
+      this.writeBytes(id.get());
     } else {
       this.writeByte(-1);
     }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactObjectSerializer.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactObjectSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.serializer;
+
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.context.MuleContextAware;
+import org.mule.runtime.core.api.serialization.ObjectSerializer;
+import org.mule.runtime.core.api.serialization.SerializationProtocol;
+import org.mule.runtime.core.serialization.internal.JavaExternalSerializerProtocol;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+
+public class ArtifactObjectSerializer implements ObjectSerializer, MuleContextAware {
+
+  private volatile JavaExternalSerializerProtocol javaExternalSerializerProtocol;
+  private volatile CustomJavaSerializationProtocol javaInternalSerializerProtocol;
+
+  public ArtifactObjectSerializer(ClassLoaderRepository classLoaderRepository) {
+    checkArgument(classLoaderRepository != null, "ClassLoaderRepository cannot be null");
+
+    javaExternalSerializerProtocol = new JavaExternalSerializerProtocol();
+    javaInternalSerializerProtocol = new CustomJavaSerializationProtocol(classLoaderRepository);
+  }
+
+  @Override
+  public SerializationProtocol getInternalProtocol() {
+    return javaInternalSerializerProtocol;
+  }
+
+  @Override
+  public SerializationProtocol getExternalProtocol() {
+    return javaExternalSerializerProtocol;
+  }
+
+  @Override
+  public void setMuleContext(MuleContext context) {
+    javaInternalSerializerProtocol.setMuleContext(context);
+    javaExternalSerializerProtocol.setMuleContext(context);
+  }
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocol.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocol.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.serializer;
+
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.core.api.serialization.SerializationException;
+import org.mule.runtime.core.serialization.internal.AbstractSerializationProtocol;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * Custom serialization protocol that uses {@link ArtifactClassLoaderObjectInputStream} and {@link ArtifactClassLoaderObjectOutputStream}
+ * to write and read serialized objects to support deserialization of non exported classes.
+ */
+public class CustomJavaSerializationProtocol extends AbstractSerializationProtocol {
+
+  private final ClassLoaderRepository classLoaderRepository;
+
+  /**
+   * Creates a new serialization protocol to serialize/deserialize classes provided by any class loader
+   * defined in the provided class loader repository.
+   *  @param classLoaderRepository contains the registered classloaders that can be used to load serialized classes. Non null.
+   *
+   */
+  public CustomJavaSerializationProtocol(ClassLoaderRepository classLoaderRepository) {
+    checkArgument(classLoaderRepository != null, "artifactClassLoaderRepository cannot be null");
+    this.classLoaderRepository = classLoaderRepository;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected byte[] doSerialize(Object object) throws Exception {
+    validateForSerialization(object);
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream(512);
+
+    try (ObjectOutputStream out = new ArtifactClassLoaderObjectOutputStream(classLoaderRepository, outputStream)) {
+      out.writeObject(object);
+    } catch (IOException ex) {
+      throw new SerializationException("Cannot serialize object", ex);
+    }
+    return outputStream.toByteArray();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected <T> T doDeserialize(InputStream inputStream, ClassLoader classLoader) throws Exception {
+    checkArgument(inputStream != null, "Cannot deserialize a null stream");
+    checkArgument(classLoader != null, "Cannot deserialize with a null classloader");
+
+    try (ObjectInputStream in = new ArtifactClassLoaderObjectInputStream(classLoaderRepository, inputStream)) {
+      Object obj = in.readObject();
+
+      return (T) obj;
+    } catch (Exception ex) {
+      throw new SerializationException("Cannot deserialize object", ex);
+    }
+  }
+
+  private void validateForSerialization(Object object) {
+    if (object != null && !(object instanceof Serializable)) {
+      throw new SerializationException(String.format("Was expecting a Serializable type. %s was found instead",
+                                                     object.getClass().getName()));
+    }
+  }
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocol.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocol.java
@@ -7,6 +7,7 @@
 
 package org.mule.runtime.module.artifact.serializer;
 
+import static java.lang.String.format;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import org.mule.runtime.core.api.serialization.SerializationException;
 import org.mule.runtime.core.serialization.internal.AbstractSerializationProtocol;
@@ -74,8 +75,8 @@ public class CustomJavaSerializationProtocol extends AbstractSerializationProtoc
 
   private void validateForSerialization(Object object) {
     if (object != null && !(object instanceof Serializable)) {
-      throw new SerializationException(String.format("Was expecting a Serializable type. %s was found instead",
-                                                     object.getClass().getName()));
+      throw new SerializationException(format("Was expecting a Serializable type. %s was found instead",
+                                              object.getClass().getName()));
     }
   }
 }

--- a/modules/artifact/src/main/resources/META-INF/mule-module.properties
+++ b/modules/artifact/src/main/resources/META-INF/mule-module.properties
@@ -3,5 +3,6 @@ module.name=artifact
 artifact.export.classPackages=org.mule.runtime.module.artifact,\
                               org.mule.runtime.module.artifact.classloader,\
                               org.mule.runtime.module.artifact.descriptor,\
-                              org.mule.runtime.module.artifact.util
+                              org.mule.runtime.module.artifact.util,\
+                              org.mule.runtime.module.artifact.serializer
 

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocolTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocolTestCase.java
@@ -7,6 +7,8 @@
 
 package org.mule.runtime.module.artifact.serializer;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
@@ -17,9 +19,9 @@ import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.serialization.SerializationException;
 import org.mule.runtime.core.serialization.AbstractSerializerProtocolContractTestCase;
-import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.tck.util.CompilerUtils;
@@ -48,6 +50,8 @@ public class CustomJavaSerializationProtocolTestCase extends AbstractSerializerP
   @Override
   protected void doSetUp() throws Exception {
     classLoaderRepository = mock(ClassLoaderRepository.class);
+    when(classLoaderRepository.getId(getClass().getClassLoader())).thenReturn(empty());
+    when(classLoaderRepository.getId(null)).thenReturn(empty());
     serializationProtocol = new CustomJavaSerializationProtocol(classLoaderRepository);
 
     initialiseIfNeeded(serializationProtocol, muleContext);
@@ -75,8 +79,8 @@ public class CustomJavaSerializationProtocolTestCase extends AbstractSerializerP
     final MuleArtifactClassLoader artifactClassLoader =
         new MuleArtifactClassLoader(ARTIFACT_ID, new ArtifactDescriptor(ARTIFACT_NAME), urls, getClass().getClassLoader(),
                                     lookupPolicy);
-    when(classLoaderRepository.getId(artifactClassLoader)).thenReturn(ARTIFACT_ID);
-    when(classLoaderRepository.find(ARTIFACT_ID)).thenReturn(artifactClassLoader);
+    when(classLoaderRepository.getId(artifactClassLoader)).thenReturn(of(ARTIFACT_ID));
+    when(classLoaderRepository.find(ARTIFACT_ID)).thenReturn(of(artifactClassLoader));
 
     final Class<?> echoTestClass = artifactClassLoader.loadClass(SERIALIZABLE_CLASS);
     final Object payload = echoTestClass.newInstance();

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocolTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocolTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.serializer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import org.mule.runtime.core.api.Event;
+import org.mule.runtime.core.api.message.InternalMessage;
+import org.mule.runtime.core.api.serialization.SerializationException;
+import org.mule.runtime.core.serialization.AbstractSerializerProtocolContractTestCase;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy;
+import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+import org.mule.tck.util.CompilerUtils;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CustomJavaSerializationProtocolTestCase extends AbstractSerializerProtocolContractTestCase {
+
+  public static final String INSTANCE_NAME = "serializedInstance";
+  public static final String SERIALIZABLE_CLASS = "org.foo.SerializableClass";
+  public static final String ARTIFACT_ID = "testId";
+  public static final String ARTIFACT_NAME = "test";
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private ClassLoaderRepository classLoaderRepository;
+
+  @Override
+  protected void doSetUp() throws Exception {
+    classLoaderRepository = mock(ClassLoaderRepository.class);
+    serializationProtocol = new CustomJavaSerializationProtocol(classLoaderRepository);
+
+    initialiseIfNeeded(serializationProtocol, muleContext);
+  }
+
+  @Test(expected = SerializationException.class)
+  public void notSerializable() throws Exception {
+    serializationProtocol.serialize(new Object());
+  }
+
+  @Test
+  public final void serializeWithoutDefaultConstructorFromArtifactClassLoader() throws Exception {
+
+    final File compiledClasses = new File(temporaryFolder.getRoot(), "compiledClasses");
+    compiledClasses.mkdirs();
+
+    final File sourceFile = new File(getClass().getResource("/org/foo/SerializableClass.java").getFile());
+
+    CompilerUtils.SingleClassCompiler compiler = new CompilerUtils.SingleClassCompiler();
+    compiler.compile(sourceFile);
+
+    final URL[] urls = new URL[] {compiler.getTargetFolder().toURL()};
+    final ClassLoaderLookupPolicy lookupPolicy = mock(ClassLoaderLookupPolicy.class);
+    when(lookupPolicy.getLookupStrategy(any())).thenReturn(ClassLoaderLookupStrategy.PARENT_FIRST);
+    final MuleArtifactClassLoader artifactClassLoader =
+        new MuleArtifactClassLoader(ARTIFACT_ID, new ArtifactDescriptor(ARTIFACT_NAME), urls, getClass().getClassLoader(),
+                                    lookupPolicy);
+    when(classLoaderRepository.getId(artifactClassLoader)).thenReturn(ARTIFACT_ID);
+    when(classLoaderRepository.find(ARTIFACT_ID)).thenReturn(artifactClassLoader);
+
+    final Class<?> echoTestClass = artifactClassLoader.loadClass(SERIALIZABLE_CLASS);
+    final Object payload = echoTestClass.newInstance();
+    setObjectName(payload);
+
+    Event event = eventBuilder().message(InternalMessage.of(payload)).build();
+    byte[] bytes = serializationProtocol.serialize(event.getMessage());
+
+    InternalMessage message = serializationProtocol.deserialize(bytes);
+    Object deserialized = message.getPayload().getValue();
+
+    assertThat(deserialized.getClass().getName(), equalTo(SERIALIZABLE_CLASS));
+    assertThat(deserialized.getClass().getClassLoader(), equalTo(artifactClassLoader));
+    assertThat(deserialized, equalTo(payload));
+    assertThat(getObjectName(deserialized), equalTo(INSTANCE_NAME));
+  }
+
+  private void setObjectName(Object payload) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    final Method setNameMethod = payload.getClass().getMethod("setName", new Class[] {String.class});
+    setNameMethod.invoke(payload, INSTANCE_NAME);
+  }
+
+  private String getObjectName(Object payload) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    final Method getNameMethod = payload.getClass().getMethod("getName");
+    return (String) getNameMethod.invoke(payload);
+  }
+
+}

--- a/modules/artifact/src/test/resources/org/foo/SerializableClass.java
+++ b/modules/artifact/src/test/resources/org/foo/SerializableClass.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.foo;
+
+import java.io.Serializable;
+
+/**
+ * Class used to test serialization
+ */
+public class SerializableClass implements Serializable {
+
+  private String name = "unknown";
+
+  public void setName(String name)
+  {
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SerializableClass that = (SerializableClass) o;
+
+    if (name != null ? !name.equals(that.name) : that.name != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return name != null ? name.hashCode() : 0;
+  }
+
+  public String getName()
+  {
+   return name;
+  }
+}

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultClassLoaderManager.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultClassLoaderManager.java
@@ -11,7 +11,7 @@ import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import org.mule.runtime.core.util.StringUtils;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderManager;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
-import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderRepository;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Tracks all the {@link ArtifactClassLoader} created on the container.
  */
-public class DefaultArtifactClassLoaderManager implements ArtifactClassLoaderManager, ArtifactClassLoaderRepository {
+public class DefaultClassLoaderManager implements ArtifactClassLoaderManager, ClassLoaderRepository {
 
   private final Map<String, ArtifactClassLoader> artifactClassLoaders = new ConcurrentHashMap<>();
 
@@ -39,10 +39,21 @@ public class DefaultArtifactClassLoaderManager implements ArtifactClassLoaderMan
   }
 
   @Override
-  public ArtifactClassLoader find(String classLoaderId) {
+  public ClassLoader find(String classLoaderId) {
     checkClassLoaderId(classLoaderId);
 
-    return artifactClassLoaders.get(classLoaderId);
+    ClassLoader result = null;
+    ArtifactClassLoader artifactClassLoader = artifactClassLoaders.get(classLoaderId);
+    if (artifactClassLoader != null) {
+      result = artifactClassLoader.getClassLoader();
+    }
+
+    return result;
+  }
+
+  @Override
+  public String getId(ClassLoader classLoader) {
+    return null;
   }
 
   private void checkClassLoaderId(String classLoaderId) {

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultClassLoaderManager.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultClassLoaderManager.java
@@ -7,13 +7,16 @@
 
 package org.mule.runtime.module.deployment.internal;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import org.mule.runtime.core.util.StringUtils;
-import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderManager;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderManager;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -39,21 +42,17 @@ public class DefaultClassLoaderManager implements ArtifactClassLoaderManager, Cl
   }
 
   @Override
-  public ClassLoader find(String classLoaderId) {
+  public Optional<ClassLoader> find(String classLoaderId) {
     checkClassLoaderId(classLoaderId);
 
-    ClassLoader result = null;
     ArtifactClassLoader artifactClassLoader = artifactClassLoaders.get(classLoaderId);
-    if (artifactClassLoader != null) {
-      result = artifactClassLoader.getClassLoader();
-    }
 
-    return result;
+    return of(artifactClassLoader.getClassLoader());
   }
 
   @Override
-  public String getId(ClassLoader classLoader) {
-    return null;
+  public Optional<String> getId(ClassLoader classLoader) {
+    return empty();
   }
 
   private void checkClassLoaderId(String classLoaderId) {

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleArtifactResourcesRegistry.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleArtifactResourcesRegistry.java
@@ -58,20 +58,21 @@ public class MuleArtifactResourcesRegistry {
   private final ArtifactClassLoader containerClassLoader;
   private final MuleServiceManager serviceManager;
   private final ArtifactClassLoaderFactory<ArtifactPluginDescriptor> artifactPluginClassLoaderFactory;
-  private final DefaultArtifactClassLoaderManager artifactClassLoaderManager;
+  private final DefaultClassLoaderManager artifactClassLoaderManager;
 
   /**
    * Creates a repository for resources required for mule artifacts.
    */
   public MuleArtifactResourcesRegistry() {
     containerClassLoader = new ContainerClassLoaderFactory().createContainerClassLoader(getClass().getClassLoader());
-    artifactClassLoaderManager = new DefaultArtifactClassLoaderManager();
+    artifactClassLoaderManager = new DefaultClassLoaderManager();
 
     domainManager = new DefaultDomainManager();
     this.domainClassLoaderFactory = trackDeployableArtifactClassLoaderFactory(
                                                                               new DomainClassLoaderFactory(containerClassLoader
                                                                                   .getClassLoader()));
-    domainFactory = new DefaultDomainFactory(this.domainClassLoaderFactory, domainManager, containerClassLoader);
+    domainFactory =
+        new DefaultDomainFactory(this.domainClassLoaderFactory, domainManager, containerClassLoader, artifactClassLoaderManager);
     this.artifactPluginClassLoaderFactory = trackArtifactClassLoaderFactory(new ArtifactPluginClassLoaderFactory());
     final ArtifactPluginDescriptorFactory artifactPluginDescriptorFactory =
         new ArtifactPluginDescriptorFactory(new ArtifactClassLoaderFilterFactory());
@@ -92,7 +93,8 @@ public class MuleArtifactResourcesRegistry {
                                                             new ReflectionServiceResolver(new ReflectionServiceProviderResolutionHelper())));
 
     applicationFactory = new DefaultApplicationFactory(applicationClassLoaderBuilderFactory, applicationDescriptorFactory,
-                                                       artifactPluginRepository, domainManager, serviceManager);
+                                                       artifactPluginRepository, domainManager, serviceManager,
+                                                       artifactClassLoaderManager);
     temporaryApplicationFactory = new TemporaryApplicationFactory(applicationClassLoaderBuilderFactory,
                                                                   new TemporaryApplicationDescriptorFactory(artifactPluginDescriptorLoader,
                                                                                                             artifactPluginRepository),
@@ -185,7 +187,7 @@ public class MuleArtifactResourcesRegistry {
   /**
    * @return the artifact classLoader manager
    */
-  public DefaultArtifactClassLoaderManager getArtifactClassLoaderManager() {
+  public DefaultClassLoaderManager getArtifactClassLoaderManager() {
     return artifactClassLoaderManager;
   }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactory.java
@@ -19,6 +19,7 @@ import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.module.deployment.internal.artifact.ArtifactFactory;
@@ -41,12 +42,15 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
   private final ApplicationClassLoaderBuilderFactory applicationClassLoaderBuilderFactory;
   private final ArtifactPluginRepository artifactPluginRepository;
   private final ServiceRepository serviceRepository;
+  private final ClassLoaderRepository classLoaderRepository;
   protected DeploymentListener deploymentListener;
 
   public DefaultApplicationFactory(ApplicationClassLoaderBuilderFactory applicationClassLoaderBuilderFactory,
                                    ApplicationDescriptorFactory applicationDescriptorFactory,
                                    ArtifactPluginRepository artifactPluginRepository, DomainRepository domainRepository,
-                                   ServiceRepository serviceRepository) {
+                                   ServiceRepository serviceRepository,
+                                   ClassLoaderRepository classLoaderRepository) {
+    this.classLoaderRepository = classLoaderRepository;
     checkArgument(applicationClassLoaderBuilderFactory != null, "Application classloader builder factory cannot be null");
     checkArgument(applicationDescriptorFactory != null, "Application descriptor factory cannot be null");
     checkArgument(artifactPluginRepository != null, "Artifact plugin repository cannot be null");
@@ -101,7 +105,7 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
 
     DefaultMuleApplication delegate =
         new DefaultMuleApplication(descriptor, applicationClassLoader, artifactPlugins, domainRepository,
-                                   serviceRepository, descriptor.getArtifactLocation());
+                                   serviceRepository, descriptor.getArtifactLocation(), classLoaderRepository);
 
     if (deploymentListener != null) {
       delegate.setDeploymentListener(deploymentListener);

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultMuleApplication.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/DefaultMuleApplication.java
@@ -33,14 +33,15 @@ import org.mule.runtime.deployment.model.api.InstallException;
 import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
 import org.mule.runtime.deployment.model.api.application.ApplicationStatus;
+import org.mule.runtime.deployment.model.api.artifact.ArtifactContext;
 import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.DisposableClassLoader;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
-import org.mule.runtime.deployment.model.api.artifact.ArtifactContext;
 import org.mule.runtime.module.deployment.internal.artifact.ArtifactContextBuilder;
 import org.mule.runtime.module.deployment.internal.artifact.MuleContextDeploymentListener;
 import org.mule.runtime.module.deployment.internal.domain.DomainRepository;
@@ -63,6 +64,7 @@ public class DefaultMuleApplication implements Application {
   private final DomainRepository domainRepository;
   private final List<ArtifactPlugin> artifactPlugins;
   private final ServiceRepository serviceRepository;
+  private final ClassLoaderRepository classLoaderRepository;
   private final File location;
   private ApplicationStatus status;
 
@@ -74,10 +76,12 @@ public class DefaultMuleApplication implements Application {
   public DefaultMuleApplication(ApplicationDescriptor descriptor,
                                 MuleDeployableArtifactClassLoader deploymentClassLoader,
                                 List<ArtifactPlugin> artifactPlugins, DomainRepository domainRepository,
-                                ServiceRepository serviceRepository, File location) {
+                                ServiceRepository serviceRepository, File location,
+                                ClassLoaderRepository classLoaderRepository) {
     this.descriptor = descriptor;
     this.domainRepository = domainRepository;
     this.serviceRepository = serviceRepository;
+    this.classLoaderRepository = classLoaderRepository;
     this.deploymentListener = new NullDeploymentListener();
     this.artifactPlugins = artifactPlugins;
     this.location = location;
@@ -175,7 +179,8 @@ public class DefaultMuleApplication implements Application {
               .setArtifactName(descriptor.getName()).setArtifactInstallationDirectory(descriptor.getArtifactLocation())
               .setConfigurationFiles(descriptor.getAbsoluteResourcePaths()).setDefaultEncoding(descriptor.getEncoding())
               .setArtifactPlugins(artifactPlugins).setExecutionClassloader(deploymentClassLoader.getClassLoader())
-              .setEnableLazyInit(lazy).setServiceRepository(serviceRepository);
+              .setEnableLazyInit(lazy).setServiceRepository(serviceRepository)
+              .setClassLoaderRepository(classLoaderRepository);
 
       Domain domain = domainRepository.getDomain(descriptor.getDomain());
       if (domain.getMuleContext() != null) {

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/TemporaryApplicationFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/application/TemporaryApplicationFactory.java
@@ -26,7 +26,7 @@ public class TemporaryApplicationFactory extends DefaultApplicationFactory {
                                      ArtifactPluginRepository artifactPluginRepository, DomainRepository domainRepository,
                                      ServiceRepository serviceRepository) {
     super(applicationClassLoaderBuilderFactory, applicationDescriptorFactory, artifactPluginRepository, domainRepository,
-          serviceRepository);
+          serviceRepository, null);
   }
 
   @Override

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/domain/DefaultDomainFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/domain/DefaultDomainFactory.java
@@ -15,6 +15,7 @@ import static org.mule.runtime.deployment.model.internal.domain.DomainClassLoade
 import static org.mule.runtime.module.deployment.internal.artifact.ArtifactFactoryUtils.getDeploymentFile;
 import static org.mule.runtime.module.reboot.MuleContainerBootstrapUtils.getMuleDomainsDir;
 
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.deployment.model.api.domain.DomainDescriptor;
@@ -29,12 +30,15 @@ public class DefaultDomainFactory implements DomainFactory {
   private final DeployableArtifactClassLoaderFactory<DomainDescriptor> domainClassLoaderFactory;
   private final DomainManager domainManager;
   private final DomainDescriptorParser domainDescriptorParser;
+  private final ClassLoaderRepository classLoaderRepository;
 
   protected DeploymentListener deploymentListener;
   private final ArtifactClassLoader containerClassLoader;
 
   public DefaultDomainFactory(DeployableArtifactClassLoaderFactory<DomainDescriptor> domainClassLoaderFactory,
-                              DomainManager domainManager, ArtifactClassLoader containerClassLoader) {
+                              DomainManager domainManager, ArtifactClassLoader containerClassLoader,
+                              ClassLoaderRepository classLoaderRepository) {
+    this.classLoaderRepository = classLoaderRepository;
     checkArgument(domainManager != null, "Domain manager cannot be null");
     checkArgument(containerClassLoader != null, "Container classLoader cannot be null");
     this.containerClassLoader = containerClassLoader;
@@ -61,7 +65,8 @@ public class DefaultDomainFactory implements DomainFactory {
     // TODO MULE-9653 - use the plugins class loader maps when plugins are allowed in domains
     DefaultMuleDomain defaultMuleDomain =
         new DefaultMuleDomain(descriptor, domainClassLoaderFactory.create(getDomainId(DEFAULT_DOMAIN_NAME), containerClassLoader,
-                                                                          descriptor, emptyList()));
+                                                                          descriptor, emptyList()),
+                              classLoaderRepository);
     defaultMuleDomain.setDeploymentListener(deploymentListener);
     DomainWrapper domainWrapper = new DomainWrapper(defaultMuleDomain, this);
     domainManager.addDomain(domainWrapper);

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/domain/DefaultMuleDomain.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/domain/DefaultMuleDomain.java
@@ -26,6 +26,7 @@ import org.mule.runtime.deployment.model.api.DeploymentStopException;
 import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.deployment.model.api.domain.DomainDescriptor;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.module.deployment.internal.MuleDeploymentService;
 import org.mule.runtime.module.deployment.internal.application.NullDeploymentListener;
@@ -52,12 +53,15 @@ public class DefaultMuleDomain implements Domain {
   private final DomainDescriptor descriptor;
   private DeploymentListener deploymentListener;
   private ArtifactClassLoader deploymentClassLoader;
+  private final ClassLoaderRepository classLoaderRepository;
 
   private File configResourceFile;
   private ArtifactContext artifactContext;
 
-  public DefaultMuleDomain(DomainDescriptor descriptor, ArtifactClassLoader deploymentClassLoader) {
+  public DefaultMuleDomain(DomainDescriptor descriptor, ArtifactClassLoader deploymentClassLoader,
+                           ClassLoaderRepository classLoaderRepository) {
     this.deploymentClassLoader = deploymentClassLoader;
+    this.classLoaderRepository = classLoaderRepository;
     this.deploymentListener = new NullDeploymentListener();
     this.descriptor = descriptor;
     refreshClassLoaderAndLoadConfigResourceFile();
@@ -134,7 +138,7 @@ public class DefaultMuleDomain implements Domain {
             .setExecutionClassloader(deploymentClassLoader.getClassLoader())
             .setArtifactInstallationDirectory(new File(MuleContainerBootstrapUtils.getMuleDomainsDir(), getArtifactName()))
             .setConfigurationFiles(new String[] {this.configResourceFile.getAbsolutePath()}).setArtifactType(DOMAIN)
-            .setEnableLazyInit(lazy);
+            .setEnableLazyInit(lazy).setClassLoaderRepository(classLoaderRepository);
 
         if (deploymentListener != null) {
           artifactBuilder.setMuleContextListener(new MuleContextDeploymentListener(getArtifactName(), deploymentListener));

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DefaultArtifactClassLoaderManagerTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DefaultArtifactClassLoaderManagerTestCase.java
@@ -33,7 +33,7 @@ public class DefaultArtifactClassLoaderManagerTestCase extends AbstractMuleTestC
 
     manager.register(artifactClassLoader);
 
-    assertThat(manager.find(ARTIFACT_ID), is(expectedClassLoader));
+    assertThat(manager.find(ARTIFACT_ID).get(), is(expectedClassLoader));
   }
 
   @Test

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DefaultArtifactClassLoaderManagerTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DefaultArtifactClassLoaderManagerTestCase.java
@@ -22,16 +22,18 @@ public class DefaultArtifactClassLoaderManagerTestCase extends AbstractMuleTestC
 
   public static final String ARTIFACT_ID = "ID";
 
-  private final DefaultArtifactClassLoaderManager manager = new DefaultArtifactClassLoaderManager();
+  private final DefaultClassLoaderManager manager = new DefaultClassLoaderManager();
 
   @Test
   public void registersArtifactClassLoader() throws Exception {
     ArtifactClassLoader artifactClassLoader = mock(ArtifactClassLoader.class);
     when(artifactClassLoader.getArtifactId()).thenReturn(ARTIFACT_ID);
+    ClassLoader expectedClassLoader = getClass().getClassLoader();
+    when(artifactClassLoader.getClassLoader()).thenReturn(expectedClassLoader);
 
     manager.register(artifactClassLoader);
 
-    assertThat(manager.find(ARTIFACT_ID), is(artifactClassLoader));
+    assertThat(manager.find(ARTIFACT_ID), is(expectedClassLoader));
   }
 
   @Test

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
@@ -150,7 +150,7 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
   private static final String BAD_APP_CONFIG_XML = "/bad-app-config.xml";
   private static final String BROKEN_CONFIG_XML = "/broken-config.xml";
   private static final String EMPTY_DOMAIN_CONFIG_XML = "/empty-domain-config.xml";
-  private DefaultArtifactClassLoaderManager artifactClassLoaderManager;
+  private DefaultClassLoaderManager artifactClassLoaderManager;
 
   @Parameterized.Parameters(name = "Parallel: {0}")
   public static List<Object[]> parameters() {
@@ -2301,7 +2301,7 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
 
     TestDomainFactory testDomainFactory =
         new TestDomainFactory(new DomainClassLoaderFactory(getClass().getClassLoader()),
-                              containerClassLoader);
+                              containerClassLoader, artifactClassLoaderManager);
     testDomainFactory.setFailOnStopApplication();
 
     deploymentService.setDomainFactory(testDomainFactory);
@@ -2322,7 +2322,7 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
 
     TestDomainFactory testDomainFactory =
         new TestDomainFactory(new DomainClassLoaderFactory(getClass().getClassLoader()),
-                              containerClassLoader);
+                              containerClassLoader, artifactClassLoaderManager);
     testDomainFactory.setFailOnDisposeApplication();
     deploymentService.setDomainFactory(testDomainFactory);
     startDeployment();
@@ -3203,7 +3203,8 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
     return new DefaultMuleDomain(new DomainDescriptor(DEFAULT_DOMAIN_NAME),
                                  new DomainClassLoaderFactory(getClass().getClassLoader())
                                      .create("domain/" + DEFAULT_DOMAIN_NAME, containerClassLoader,
-                                             new DomainDescriptor(DEFAULT_DOMAIN_NAME), emptyList()));
+                                             new DomainDescriptor(DEFAULT_DOMAIN_NAME), emptyList()),
+                                 null);
   }
 
   /**

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultApplicationFactoryTestCase.java
@@ -59,7 +59,7 @@ public class DefaultApplicationFactoryTestCase extends AbstractMuleTestCase {
   private final ServiceRepository serviceRepository = mock(ServiceRepository.class);
   private final DefaultApplicationFactory applicationFactory =
       new DefaultApplicationFactory(applicationClassLoaderBuilderFactory, applicationDescriptorFactory,
-                                    applicationPluginRepository, domainRepository, serviceRepository);
+                                    applicationPluginRepository, domainRepository, serviceRepository, null);
 
   @Rule
   public TemporaryFolder muleHome = new SystemPropertyTemporaryFolder(MuleProperties.MULE_HOME_DIRECTORY_PROPERTY);

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultMuleApplicationStatusTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/DefaultMuleApplicationStatusTestCase.java
@@ -47,7 +47,8 @@ public class DefaultMuleApplicationStatusTestCase extends AbstractMuleContextTes
     ArtifactContext mockArtifactContext = mock(ArtifactContext.class);
     when(mockArtifactContext.getMuleContext()).thenReturn(muleContext);
     application = new DefaultMuleApplication(null, parentArtifactClassLoader, emptyList(),
-                                             null, mock(ServiceRepository.class), appLocation);
+                                             null, mock(ServiceRepository.class), appLocation,
+                                             null);
     application.setArtifactContext(mockArtifactContext);
   }
 
@@ -90,7 +91,7 @@ public class DefaultMuleApplicationStatusTestCase extends AbstractMuleContextTes
 
     DefaultMuleApplication application =
         new DefaultMuleApplication(descriptor, mock(MuleApplicationClassLoader.class), emptyList(), null,
-                                   null, appLocation);
+                                   null, appLocation, null);
     application.install();
     assertThat(application.deploymentClassLoader, is(notNullValue()));
     application.dispose();

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/TestApplicationFactory.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/application/TestApplicationFactory.java
@@ -12,8 +12,9 @@ import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
 import org.mule.runtime.deployment.model.internal.application.MuleApplicationClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilterFactory;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.TrackingArtifactClassLoaderFactory;
-import org.mule.runtime.module.deployment.internal.DefaultArtifactClassLoaderManager;
+import org.mule.runtime.module.deployment.internal.DefaultClassLoaderManager;
 import org.mule.runtime.module.deployment.internal.domain.DomainManager;
 import org.mule.runtime.module.deployment.internal.domain.DomainRepository;
 import org.mule.runtime.module.deployment.internal.plugin.ArtifactPluginDescriptorFactory;
@@ -37,9 +38,9 @@ public class TestApplicationFactory extends DefaultApplicationFactory {
   public TestApplicationFactory(ApplicationClassLoaderBuilderFactory applicationClassLoaderBuilderFactory,
                                 ApplicationDescriptorFactory applicationDescriptorFactory,
                                 ArtifactPluginRepository artifactPluginRepository, DomainRepository domainRepository,
-                                ServiceRepository serviceRepository) {
+                                ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository) {
     super(applicationClassLoaderBuilderFactory, applicationDescriptorFactory, artifactPluginRepository, domainRepository,
-          serviceRepository);
+          serviceRepository, classLoaderRepository);
   }
 
   public static TestApplicationFactory createTestApplicationFactory(MuleApplicationClassLoaderFactory applicationClassLoaderFactory,
@@ -53,13 +54,13 @@ public class TestApplicationFactory extends DefaultApplicationFactory {
     TestEmptyApplicationPluginRepository applicationPluginRepository = new TestEmptyApplicationPluginRepository();
     ApplicationDescriptorFactory applicationDescriptorFactory =
         new ApplicationDescriptorFactory(artifactPluginDescriptorLoader, applicationPluginRepository);
-    final DefaultArtifactClassLoaderManager artifactClassLoaderManager = new DefaultArtifactClassLoaderManager();
+    final DefaultClassLoaderManager artifactClassLoaderManager = new DefaultClassLoaderManager();
     ApplicationClassLoaderBuilderFactory applicationClassLoaderBuilderFactory =
         new ApplicationClassLoaderBuilderFactory(applicationClassLoaderFactory, applicationPluginRepository,
                                                  new TrackingArtifactClassLoaderFactory<>(artifactClassLoaderManager,
                                                                                           new ArtifactPluginClassLoaderFactory()));
     return new TestApplicationFactory(applicationClassLoaderBuilderFactory, applicationDescriptorFactory,
-                                      applicationPluginRepository, domainManager, serviceRepository);
+                                      applicationPluginRepository, domainManager, serviceRepository, artifactClassLoaderManager);
   }
 
   @Override

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/DefaultDomainFactoryTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/DefaultDomainFactoryTestCase.java
@@ -32,7 +32,7 @@ public class DefaultDomainFactoryTestCase extends AbstractDomainTestCase {
   private final ArtifactClassLoaderManager artifactClassLoaderManager = mock(ArtifactClassLoaderManager.class);
   private final DomainFactory domainFactory = new DefaultDomainFactory(
                                                                        new DomainClassLoaderFactory(getClass().getClassLoader()),
-                                                                       new DefaultDomainManager(), containerClassLoader);
+                                                                       new DefaultDomainManager(), containerClassLoader, null);
 
   public DefaultDomainFactoryTestCase() throws IOException {}
 

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/TestDomainFactory.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/domain/TestDomainFactory.java
@@ -9,6 +9,7 @@ package org.mule.runtime.module.deployment.internal.domain;
 import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.deployment.model.api.domain.DomainDescriptor;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
 
 import java.io.File;
@@ -20,8 +21,8 @@ public class TestDomainFactory extends DefaultDomainFactory {
   private boolean failOnDispose;
 
   public TestDomainFactory(DeployableArtifactClassLoaderFactory<DomainDescriptor> domainClassLoaderFactory,
-                           ArtifactClassLoader containerClassLoader) {
-    super(domainClassLoaderFactory, new DefaultDomainManager(), containerClassLoader);
+                           ArtifactClassLoader containerClassLoader, ClassLoaderRepository classLoaderRepository) {
+    super(domainClassLoaderFactory, new DefaultDomainManager(), containerClassLoader, classLoaderRepository);
   }
 
   @Override

--- a/tests/functional/src/main/java/org/mule/functional/junit4/ArtifactFunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/ArtifactFunctionalTestCase.java
@@ -7,6 +7,9 @@
 
 package org.mule.functional.junit4;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
 import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CLASSLOADER_REPOSITORY;
@@ -37,6 +40,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -236,19 +240,19 @@ public abstract class ArtifactFunctionalTestCase extends FunctionalTestCase {
     }
 
     @Override
-    public ClassLoader find(String classLoaderId) {
-      return classLoaders.get(classLoaderId);
+    public Optional<ClassLoader> find(String classLoaderId) {
+      return ofNullable(classLoaders.get(classLoaderId));
     }
 
     @Override
-    public String getId(ClassLoader classLoader) {
+    public Optional<String> getId(ClassLoader classLoader) {
       for (String key : classLoaders.keySet()) {
         if (classLoaders.get(key) == classLoader) {
-          return key;
+          return of(key);
         }
       }
 
-      return null;
+      return empty();
     }
   }
 }

--- a/tests/functional/src/main/java/org/mule/functional/junit4/ArtifactFunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/ArtifactFunctionalTestCase.java
@@ -9,12 +9,17 @@ package org.mule.functional.junit4;
 
 import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 import static org.junit.Assert.assertThat;
+import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CLASSLOADER_REPOSITORY;
 import static org.mule.test.runner.utils.AnnotationUtils.getAnnotationAttributeFrom;
-
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.config.spring.SpringXmlConfigurationBuilder;
+import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
+import org.mule.runtime.core.api.registry.RegistrationException;
+import org.mule.runtime.core.api.serialization.ObjectSerializer;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+import org.mule.runtime.module.artifact.serializer.ArtifactObjectSerializer;
 import org.mule.runtime.module.service.DefaultServiceDiscoverer;
 import org.mule.runtime.module.service.MuleServiceManager;
 import org.mule.runtime.module.service.ReflectionServiceProviderResolutionHelper;
@@ -28,8 +33,12 @@ import org.mule.test.runner.api.ClassPathClassifier;
 import org.mule.test.runner.api.IsolatedClassLoaderExtensionsManagerConfigurationBuilder;
 import org.mule.test.runner.api.IsolatedServiceProviderDiscoverer;
 
+import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 /**
@@ -71,6 +80,24 @@ public abstract class ArtifactFunctionalTestCase extends FunctionalTestCase {
   private static ClassLoader containerClassLoader;
 
   private static MuleServiceManager serviceRepository;
+  private static ClassLoaderRepository classLoaderRepository;
+
+  @BeforeClass
+  public static void configureClassLoaderRepository() throws RegistrationException {
+    classLoaderRepository = new TestClassLoaderRepository();
+  }
+
+  @Override
+  protected ObjectSerializer getObjectSerializer() {
+    return new ArtifactObjectSerializer(classLoaderRepository);
+  }
+
+  @Override
+  protected MuleContext createMuleContext() throws Exception {
+    MuleContext muleContext = super.createMuleContext();
+    muleContext.getRegistry().registerObject(OBJECT_CLASSLOADER_REPOSITORY, classLoaderRepository);
+    return muleContext;
+  }
 
   /**
    * @return thread context class loader has to be the application {@link ClassLoader} created by the runner.
@@ -163,4 +190,65 @@ public abstract class ArtifactFunctionalTestCase extends FunctionalTestCase {
                                                                            pluginClassLoaders));
   }
 
+  /**
+   * Defines a {@link ClassLoaderRepository} with all the class loaders configured in the {@link ArtifactFunctionalTestCase} class.
+   */
+  private static class TestClassLoaderRepository implements ClassLoaderRepository {
+
+    private Map<String, ClassLoader> classLoaders = new HashMap<>();
+
+    public TestClassLoaderRepository() {
+      registerClassLoader(Thread.currentThread().getContextClassLoader());
+      registerClassLoader(containerClassLoader);
+      for (Object classLoader : serviceClassLoaders) {
+        registerClassLoader(classLoader);
+      }
+      for (Object classLoader : pluginClassLoaders) {
+        registerClassLoader(classLoader);
+      }
+    }
+
+    private void registerClassLoader(Object classLoader) {
+      if (isArtifactClassLoader(classLoader)) {
+        try {
+          Method getArtifactIdMethod = classLoader.getClass().getMethod("getArtifactId");
+          String artifactId = (String) getArtifactIdMethod.invoke(classLoader);
+          classLoaders.put(artifactId, (ClassLoader) classLoader);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+    }
+
+    private boolean isArtifactClassLoader(Object classLoader) {
+      Class clazz = classLoader.getClass();
+      while (clazz.getSuperclass() != null) {
+        for (Class interfaceClass : clazz.getInterfaces()) {
+          if (interfaceClass.getName().equals(ArtifactClassLoader.class.getName())) {
+            return true;
+          }
+        }
+        clazz = clazz.getSuperclass();
+      }
+
+      return false;
+    }
+
+    @Override
+    public ClassLoader find(String classLoaderId) {
+      return classLoaders.get(classLoaderId);
+    }
+
+    @Override
+    public String getId(ClassLoader classLoader) {
+      for (String key : classLoaders.keySet()) {
+        if (classLoaders.get(key) == classLoader) {
+          return key;
+        }
+      }
+
+      return null;
+    }
+  }
 }

--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
@@ -28,6 +28,7 @@ import org.mule.runtime.core.api.context.notification.MuleContextNotificationLis
 import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.registry.RegistrationException;
+import org.mule.runtime.core.api.serialization.ObjectSerializer;
 import org.mule.runtime.core.component.DefaultJavaComponent;
 import org.mule.runtime.core.config.DefaultMuleConfiguration;
 import org.mule.runtime.core.config.builders.DefaultsConfigurationBuilder;
@@ -37,6 +38,7 @@ import org.mule.runtime.core.context.DefaultMuleContextBuilder;
 import org.mule.runtime.core.context.DefaultMuleContextFactory;
 import org.mule.runtime.core.context.notification.MuleContextNotification;
 import org.mule.runtime.core.object.SingletonObjectFactory;
+import org.mule.runtime.core.serialization.internal.JavaObjectSerializer;
 import org.mule.runtime.core.util.ClassUtils;
 import org.mule.runtime.core.util.FileUtils;
 import org.mule.runtime.core.util.StringUtils;
@@ -204,6 +206,7 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase {
         muleConfiguration.setWorkingDirectory(workingDirectory);
         contextBuilder.setMuleConfiguration(muleConfiguration);
         contextBuilder.setExecutionClassLoader(executionClassLoader);
+        contextBuilder.setObjectSerializer(getObjectSerializer());
         configureMuleContext(contextBuilder);
         context = muleContextFactory.createMuleContext(builders, contextBuilder);
         if (!isGracefulShutdown()) {
@@ -214,6 +217,13 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase {
       }
     }
     return context;
+  }
+
+  /**
+   * @return the {@link ObjectSerializer} to use on the test's {@link MuleContext}
+   */
+  protected ObjectSerializer getObjectSerializer() {
+    return new JavaObjectSerializer();
   }
 
   protected ClassLoader getExecutionClassLoader() {

--- a/tests/unit/src/main/java/org/mule/tck/util/CompilerUtils.java
+++ b/tests/unit/src/main/java/org/mule/tck/util/CompilerUtils.java
@@ -106,6 +106,8 @@ public class CompilerUtils {
    */
   public static class SingleClassCompiler extends AbstractCompiler<SingleClassCompiler> {
 
+    private File targetFolder;
+
     /**
      * Compiles a single Java file.
      *
@@ -115,12 +117,19 @@ public class CompilerUtils {
     public File compile(File source) {
       checkArgument(source != null, "source cannot be null");
 
-      File targetFolder = createTargetFolder();
+      targetFolder = createTargetFolder();
       sources = new File[] {source};
 
       compileJavaSources(targetFolder);
 
       return getCompiledClass(targetFolder, source.getName());
+    }
+
+    /**
+     * @return the folder where compiled classes where written or null if {@link #compile(File)} was not execute yet.
+     */
+    public File getTargetFolder() {
+      return targetFolder;
     }
 
     private File getCompiledClass(File targetFolder, String name) {


### PR DESCRIPTION
_ Injecting the ObjectSerializer on the application on creation (through builder and factory)
_ Renaming ArtifactClassLoaderRepository to ClassLoaderRepository: can’t depend on ArtifactClassLoader because it does not work when the isolated test runner is used (because classloader classes are loaded on a different classloader)
_ Registering ClassLoaderRepository on the muleContext, as serializers can be defined from the mule config and they will need a reference to it
_ Adding custom Java object serializer
_ Adding custom object input and output streams