### PR TITLE
MULE-10717: Flows can start processing messages before referenced flo…

### DIFF
--- a/tests/integration/src/test/java/org/mule/test/integration/schedule/PollScheduleTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/schedule/PollScheduleTestCase.java
@@ -31,7 +31,7 @@ public class PollScheduleTestCase extends AbstractIntegrationTestCase {
   private static List<String> foo = new ArrayList<String>();
   private static List<String> bar = new ArrayList<String>();
 
-  Prober workingPollProber = new PollingProber(5000, 1000l);
+  Prober workingPollProber = new PollingProber(10000, 100l);
 
   @BeforeClass
   public static void setProperties() {


### PR DESCRIPTION
…ws are completely started

_ Fixing test: increasing timeout as now message source is started later during the mule context start phase