### PR TITLE
MULE-10913: DB Pool retrieving invalid connections

### DIFF
--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/database/DataSourceFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/database/DataSourceFactory.java
@@ -134,6 +134,7 @@ public class DataSourceFactory implements MuleContextAware, Disposable
         config.put("checkoutTimeout", poolingProfile.getMaxWaitMillis());
         config.put("acquireIncrement", poolingProfile.getAcquireIncrement());
         config.put("maxStatements", 0);
+        config.put("testConnectionOnCheckout", "true");
         config.put("maxStatementsPerConnection", poolingProfile.getPreparedStatementCacheSize());
 
         return DataSources.pooledDataSource(dataSource, config);

--- a/modules/db/src/test/java/org/mule/module/db/integration/config/StalePooledConnectionResetTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/integration/config/StalePooledConnectionResetTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.db.integration.config;
+
+import static java.sql.DriverManager.getConnection;
+import static java.sql.DriverManager.registerDriver;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
+import static org.mule.module.db.integration.TestDbConfig.getDerbyResource;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.LocalMuleClient;
+import org.mule.module.db.integration.AbstractDbIntegrationTestCase;
+import org.mule.module.db.integration.model.AbstractTestDatabase;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+public class StalePooledConnectionResetTestCase extends AbstractDbIntegrationTestCase
+{
+
+    public StalePooledConnectionResetTestCase(String dataSourceConfigResource, AbstractTestDatabase testDatabase)
+    {
+        super(dataSourceConfigResource, testDatabase);
+    }
+
+    @Parameterized.Parameters
+    public static List<Object[]> parameters()
+    {
+        return getDerbyResource();
+    }
+
+    @Override
+    protected String[] getFlowConfigurationResources()
+    {
+        return new String[] {"integration/config/derby-db-pool-reset-config.xml"};
+    }
+
+    @Test
+    public void resetsStalePooledConnection() throws Exception
+    {
+        LocalMuleClient client = muleContext.getClient();
+
+        // Request to open a DB connection
+        MuleMessage response = client.send("vm://testIn", TEST_MESSAGE, null);
+        assertThat(response.getExceptionPayload(), is(nullValue()));
+
+        stopDatabase();
+        startDatabase();
+
+        // Must process the second request without errors
+        response = client.send("vm://testIn", TEST_MESSAGE, null);
+        assertThat(response.getExceptionPayload(), is(nullValue()));
+    }
+
+    private void startDatabase() throws SQLException
+    {
+        registerDriver(new org.apache.derby.jdbc.EmbeddedDriver());
+    }
+
+    private void stopDatabase()
+    {
+        try
+        {
+            getConnection("jdbc:derby:;shutdown=true");
+            fail("Expected to throw an exception while shutting down the database");
+        }
+        catch (Exception e)
+        {
+            // Expected
+        }
+    }
+
+}

--- a/modules/db/src/test/resources/integration/config/derby-db-pool-reset-config.xml
+++ b/modules/db/src/test/resources/integration/config/derby-db-pool-reset-config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:db="http://www.mulesoft.org/schema/mule/db"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd">
+
+    <db:derby-config name = "pooledDbConfig" url="jdbc:derby:muleEmbeddedDB;create=true">
+        <db:pooling-profile maxPoolSize="1" minPoolSize="1" maxWaitMillis="1000"/>
+    </db:derby-config>
+
+    <flow name="main">
+        <inbound-endpoint address="vm://testIn" exchange-pattern="request-response"/>
+
+        <db:select config-ref="pooledDbConfig">
+            <db:parameterized-query>select * from PLANET order by ID</db:parameterized-query>
+        </db:select>
+    </flow>
+
+</mule>


### PR DESCRIPTION
_ Validating connections on checkout. This will use JDBC 4 connection checking, which should be usually available as most of the connector functionality depends on it. If this is not the case, a default query will be used to validate the connection.