### PR TITLE
MULE-10955: When shutting down a scheduler, it takes the timeout time

### DIFF
--- a/services/scheduler/src/main/java/org/mule/service/scheduler/internal/RunnableFutureDecorator.java
+++ b/services/scheduler/src/main/java/org/mule/service/scheduler/internal/RunnableFutureDecorator.java
@@ -65,7 +65,9 @@ class RunnableFutureDecorator<V> extends AbstractRunnableFutureDecorator<V> {
     if (logger.isDebugEnabled()) {
       logger.debug("Cancelling task " + this.toString() + " (mayInterruptIfRunning=" + mayInterruptIfRunning + ")...");
     }
-    return task.cancel(mayInterruptIfRunning);
+    boolean success = task.cancel(mayInterruptIfRunning);
+    scheduler.taskFinished(this);
+    return success;
   }
 
   @Override

--- a/services/scheduler/src/main/java/org/mule/service/scheduler/internal/ScheduledFutureDecorator.java
+++ b/services/scheduler/src/main/java/org/mule/service/scheduler/internal/ScheduledFutureDecorator.java
@@ -48,7 +48,9 @@ class ScheduledFutureDecorator<V> implements ScheduledFuture<V> {
 
   @Override
   public boolean cancel(boolean mayInterruptIfRunning) {
-    return scheduled.cancel(mayInterruptIfRunning) || task.cancel(mayInterruptIfRunning);
+    boolean scheduledCancelled = scheduled.cancel(mayInterruptIfRunning);
+    boolean taskCancelled = task.cancel(mayInterruptIfRunning);
+    return scheduledCancelled || taskCancelled;
   }
 
   @Override


### PR DESCRIPTION
even in there's no pending work to do