### PR TITLE
MULE-10440: Define plugin versions and improve plugin dependencies

### DIFF
--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ArtifactDescriptor.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ArtifactDescriptor.java
@@ -19,6 +19,7 @@ public class ArtifactDescriptor {
   private final String name;
   private File rootFolder;
   private ClassLoaderModel classLoaderModel = NULL_CLASSLOADER_MODEL;
+  private BundleDescriptor bundleDescriptor;
 
   /**
    * Creates a new descriptor for a named artifact
@@ -52,6 +53,14 @@ public class ArtifactDescriptor {
 
   public void setClassLoaderModel(ClassLoaderModel classLoaderModel) {
     this.classLoaderModel = classLoaderModel;
+  }
+
+  public BundleDescriptor getBundleDescriptor() {
+    return bundleDescriptor;
+  }
+
+  public void setBundleDescriptor(BundleDescriptor bundleDescriptor) {
+    this.bundleDescriptor = bundleDescriptor;
   }
 
   @Override

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDependency.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDependency.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.artifact.descriptor;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import java.util.Optional;
+
+/**
+ * Describes a dependency on a bundle.
+ *
+ * @since 4.0
+ */
+public class BundleDependency {
+
+  private BundleDescriptor descriptor;
+  private String type;
+  private Optional<String> classifier = empty();
+  private BundleScope scope;
+
+  private BundleDependency() {}
+
+  public String getType() {
+    return type;
+  }
+
+  public Optional<String> getClassifier() {
+    return classifier;
+  }
+
+  public BundleScope getScope() {
+    return scope;
+  }
+
+  public BundleDescriptor getDescriptor() {
+    return descriptor;
+  }
+
+  @Override
+  public String toString() {
+    return "BundleDependency{" +
+        "descriptor=" + descriptor +
+        ", type='" + type + '\'' +
+        ", classifier=" + classifier +
+        ", scope=" + scope +
+        '}';
+  }
+
+  /**
+   * Builder for creating a {@link BundleDependency}
+   */
+  public static class Builder {
+
+    private static final String TYPE = "type";
+    private static final String BUNDLE_DESCRIPTOR = "bundle descriptor";
+    private static final String CLASSIFIER = "classifier";
+    private static final String REQUIRED_FIELD_NOT_FOUND_TEMPLATE = "bundle cannot be created with null or empty %s";
+    private static final String REQUIRED_FIELD_IS_NULL = "bundle cannot be created with null %s";
+
+    private BundleDependency bundleDependency = new BundleDependency();
+
+    /**
+     * This is the descriptor of the bundle.
+     *
+     * @param descriptor the version of the bundle. Cannot be null or empty.
+     * @return the builder
+     */
+    public Builder setDescriptor(BundleDescriptor descriptor) {
+      validateIsNotNull(descriptor, BUNDLE_DESCRIPTOR);
+      this.bundleDependency.descriptor = descriptor;
+
+      return this;
+    }
+
+    /**
+     * Sets the extension type of the bundle.
+     *
+     * @param type the type id of the bundle. Cannot be null or empty.
+     * @return the builder
+     */
+    public Builder setType(String type) {
+      validateIsNotEmpty(type, TYPE);
+      bundleDependency.type = type;
+      return this;
+    }
+
+    /**
+     * Sets the scope of the bundle.
+     *
+     * @param scope scope of the bundle. Non null
+     * @return the builder
+     */
+    public Builder setScope(BundleScope scope) {
+      checkState(scope != null, "scope cannot be null");
+      bundleDependency.scope = scope;
+
+      return this;
+    }
+
+    /**
+     * Sets the classifier of the bundle.
+     *
+     * @param classifier classifier of the bundle. Cannot be empty
+     * @return the builder
+     */
+    public Builder setClassifier(String classifier) {
+      validateIsNotEmpty(classifier, CLASSIFIER);
+      bundleDependency.classifier = of(classifier);
+
+      return this;
+    }
+
+    /**
+     * Sets the descriptor of the bundle.
+     *
+     * @param descriptor describes the bundle which is dependent on. Cannot be null
+     * @return the builder
+     */
+    public Builder sedBundleDescriptor(BundleDescriptor descriptor) {
+      validateIsNotNull(descriptor, BUNDLE_DESCRIPTOR);
+      this.bundleDependency.descriptor = descriptor;
+
+      return this;
+    }
+
+    /**
+     * @return a {@code BundleDescriptor} with the previous provided parameters to the builder.
+     */
+    public BundleDependency build() {
+      validateIsNotEmpty(bundleDependency.type, TYPE);
+      validateIsNotNull(bundleDependency.descriptor, BUNDLE_DESCRIPTOR);
+
+      return this.bundleDependency;
+    }
+
+    private String getEmptyFieldMessage(String field) {
+      return format(REQUIRED_FIELD_NOT_FOUND_TEMPLATE, field);
+    }
+
+    private String getNullFieldMessage(String field) {
+      return format(REQUIRED_FIELD_IS_NULL, field);
+    }
+
+    private void validateIsNotEmpty(String value, String fieldId) {
+      checkState(!isEmpty(value), getEmptyFieldMessage(fieldId));
+    }
+
+    private static boolean isEmpty(String value) {
+      return value == null || value.equals("");
+    }
+
+    private void validateIsNotNull(Object value, String fieldId) {
+      checkState(value != null, getNullFieldMessage(fieldId));
+    }
+  }
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDependency.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDependency.java
@@ -8,10 +8,6 @@ package org.mule.runtime.module.artifact.descriptor;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-
-import java.util.Optional;
 
 /**
  * Describes a dependency on a bundle.
@@ -21,19 +17,9 @@ import java.util.Optional;
 public class BundleDependency {
 
   private BundleDescriptor descriptor;
-  private String type;
-  private Optional<String> classifier = empty();
   private BundleScope scope;
 
   private BundleDependency() {}
-
-  public String getType() {
-    return type;
-  }
-
-  public Optional<String> getClassifier() {
-    return classifier;
-  }
 
   public BundleScope getScope() {
     return scope;
@@ -47,8 +33,6 @@ public class BundleDependency {
   public String toString() {
     return "BundleDependency{" +
         "descriptor=" + descriptor +
-        ", type='" + type + '\'' +
-        ", classifier=" + classifier +
         ", scope=" + scope +
         '}';
   }
@@ -58,9 +42,8 @@ public class BundleDependency {
    */
   public static class Builder {
 
-    private static final String TYPE = "type";
+
     private static final String BUNDLE_DESCRIPTOR = "bundle descriptor";
-    private static final String CLASSIFIER = "classifier";
     private static final String REQUIRED_FIELD_NOT_FOUND_TEMPLATE = "bundle cannot be created with null or empty %s";
     private static final String REQUIRED_FIELD_IS_NULL = "bundle cannot be created with null %s";
 
@@ -80,18 +63,6 @@ public class BundleDependency {
     }
 
     /**
-     * Sets the extension type of the bundle.
-     *
-     * @param type the type id of the bundle. Cannot be null or empty.
-     * @return the builder
-     */
-    public Builder setType(String type) {
-      validateIsNotEmpty(type, TYPE);
-      bundleDependency.type = type;
-      return this;
-    }
-
-    /**
      * Sets the scope of the bundle.
      *
      * @param scope scope of the bundle. Non null
@@ -100,19 +71,6 @@ public class BundleDependency {
     public Builder setScope(BundleScope scope) {
       checkState(scope != null, "scope cannot be null");
       bundleDependency.scope = scope;
-
-      return this;
-    }
-
-    /**
-     * Sets the classifier of the bundle.
-     *
-     * @param classifier classifier of the bundle. Cannot be empty
-     * @return the builder
-     */
-    public Builder setClassifier(String classifier) {
-      validateIsNotEmpty(classifier, CLASSIFIER);
-      bundleDependency.classifier = of(classifier);
 
       return this;
     }
@@ -134,7 +92,6 @@ public class BundleDependency {
      * @return a {@code BundleDescriptor} with the previous provided parameters to the builder.
      */
     public BundleDependency build() {
-      validateIsNotEmpty(bundleDependency.type, TYPE);
       validateIsNotNull(bundleDependency.descriptor, BUNDLE_DESCRIPTOR);
 
       return this.bundleDependency;

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptor.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptor.java
@@ -4,24 +4,20 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.module.repository.api;
+
+package org.mule.runtime.module.artifact.descriptor;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 
-import com.google.common.base.Preconditions;
-
 /**
- * Descriptor to identify a bundle
- *
- * @since 4.0
+ * Describes a bundle by its Maven coordinates.
  */
 public class BundleDescriptor {
 
   private String groupId;
   private String artifactId;
   private String version;
-  private String type;
 
   private BundleDescriptor() {}
 
@@ -37,12 +33,42 @@ public class BundleDescriptor {
     return this.version;
   }
 
-  public String getType() {
-    return type;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BundleDescriptor that = (BundleDescriptor) o;
+
+    if (!groupId.equals(that.groupId)) {
+      return false;
+    }
+    if (!artifactId.equals(that.artifactId)) {
+      return false;
+    }
+    return version.equals(that.version);
+
   }
 
+  @Override
+  public int hashCode() {
+    int result = groupId.hashCode();
+    result = 31 * result + artifactId.hashCode();
+    result = 31 * result + version.hashCode();
+    return result;
+  }
+
+  @Override
   public String toString() {
-    return format("BundleDescriptor { %s:%s:%s:%s }", groupId, artifactId, version, type);
+    return "BundleDescriptor{" +
+        "groupId='" + groupId + '\'' +
+        ", artifactId='" + artifactId + '\'' +
+        ", version='" + version + '\'' +
+        '}';
   }
 
   /**
@@ -52,19 +78,18 @@ public class BundleDescriptor {
 
     private static final String ARTIFACT_ID = "artifact id";
     private static final String VERSION = "version";
-    private static final String TYPE = "type";
     private static final String GROUP_ID = "group id";
     private static final String REQUIRED_FIELD_NOT_FOUND_TEMPLATE = "bundle cannot be created with null or empty %s";
 
-    private BundleDescriptor bundleDescriptor = new BundleDescriptor();
+    private BundleDescriptor bundleDependency = new BundleDescriptor();
 
     /**
      * @param groupId the group id of the bundle. Cannot be null or empty.
      * @return the builder
      */
-    public Builder setGroupId(String groupId) {
+    public BundleDescriptor.Builder setGroupId(String groupId) {
       validateIsNotEmpty(groupId, GROUP_ID);
-      bundleDescriptor.groupId = groupId;
+      bundleDependency.groupId = groupId;
       return this;
     }
 
@@ -72,9 +97,9 @@ public class BundleDescriptor {
      * @param artifactId the artifactId id of the bundle. Cannot be null or empty.
      * @return the builder
      */
-    public Builder setArtifactId(String artifactId) {
+    public BundleDescriptor.Builder setArtifactId(String artifactId) {
       validateIsNotEmpty(artifactId, ARTIFACT_ID);
-      bundleDescriptor.artifactId = artifactId;
+      bundleDependency.artifactId = artifactId;
       return this;
     }
 
@@ -84,21 +109,9 @@ public class BundleDescriptor {
      * @param version the version of the bundle. Cannot be null or empty.
      * @return the builder
      */
-    public Builder setVersion(String version) {
+    public BundleDescriptor.Builder setVersion(String version) {
       validateIsNotEmpty(version, ARTIFACT_ID);
-      bundleDescriptor.version = version;
-      return this;
-    }
-
-    /**
-     * Sets the extension type of the bundle.
-     *
-     * @param type the type id of the bundle. Cannot be null or empty.
-     * @return the builder
-     */
-    public Builder setType(String type) {
-      validateIsNotEmpty(type, TYPE);
-      bundleDescriptor.type = type;
+      bundleDependency.version = version;
       return this;
     }
 
@@ -106,11 +119,11 @@ public class BundleDescriptor {
      * @return a {@code BundleDescriptor} with the previous provided parameters to the builder.
      */
     public BundleDescriptor build() {
-      validateIsNotEmpty(bundleDescriptor.groupId, GROUP_ID);
-      validateIsNotEmpty(bundleDescriptor.artifactId, ARTIFACT_ID);
-      validateIsNotEmpty(bundleDescriptor.version, VERSION);
-      validateIsNotEmpty(bundleDescriptor.type, TYPE);
-      return this.bundleDescriptor;
+      validateIsNotEmpty(bundleDependency.groupId, GROUP_ID);
+      validateIsNotEmpty(bundleDependency.artifactId, ARTIFACT_ID);
+      validateIsNotEmpty(bundleDependency.version, VERSION);
+
+      return this.bundleDependency;
     }
 
     private String getNullFieldMessage(String field) {
@@ -121,9 +134,8 @@ public class BundleDescriptor {
       checkState(!isEmpty(value), getNullFieldMessage(fieldId));
     }
 
-    private boolean isEmpty(String value) {
+    private static boolean isEmpty(String value) {
       return value == null || value.equals("");
     }
-
   }
 }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptor.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptor.java
@@ -9,6 +9,10 @@ package org.mule.runtime.module.artifact.descriptor;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import java.util.Optional;
 
 /**
  * Describes a bundle by its Maven coordinates.
@@ -18,6 +22,8 @@ public class BundleDescriptor {
   private String groupId;
   private String artifactId;
   private String version;
+  private String type = "jar";
+  private Optional<String> classifier = empty();
 
   private BundleDescriptor() {}
 
@@ -31,6 +37,14 @@ public class BundleDescriptor {
 
   public String getVersion() {
     return this.version;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public Optional<String> getClassifier() {
+    return classifier;
   }
 
   @Override
@@ -68,6 +82,8 @@ public class BundleDescriptor {
         "groupId='" + groupId + '\'' +
         ", artifactId='" + artifactId + '\'' +
         ", version='" + version + '\'' +
+        ", type='" + type + '\'' +
+        ", classifier=" + classifier +
         '}';
   }
 
@@ -79,6 +95,8 @@ public class BundleDescriptor {
     private static final String ARTIFACT_ID = "artifact id";
     private static final String VERSION = "version";
     private static final String GROUP_ID = "group id";
+    private static final String TYPE = "type";
+    private static final String CLASSIFIER = "classifier";
     private static final String REQUIRED_FIELD_NOT_FOUND_TEMPLATE = "bundle cannot be created with null or empty %s";
 
     private BundleDescriptor bundleDependency = new BundleDescriptor();
@@ -112,6 +130,31 @@ public class BundleDescriptor {
     public BundleDescriptor.Builder setVersion(String version) {
       validateIsNotEmpty(version, ARTIFACT_ID);
       bundleDependency.version = version;
+      return this;
+    }
+
+    /**
+     * Sets the extension type of the bundle.
+     *
+     * @param type the type id of the bundle. Cannot be null or empty.
+     * @return the builder
+     */
+    public BundleDescriptor.Builder setType(String type) {
+      validateIsNotEmpty(type, TYPE);
+      bundleDependency.type = type;
+      return this;
+    }
+
+    /**
+     * Sets the classifier of the bundle.
+     *
+     * @param classifier classifier of the bundle. Cannot be empty
+     * @return the builder
+     */
+    public BundleDescriptor.Builder setClassifier(String classifier) {
+      validateIsNotEmpty(classifier, CLASSIFIER);
+      bundleDependency.classifier = of(classifier);
+
       return this;
     }
 

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleScope.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleScope.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.descriptor;
+
+/**
+ * Scope in which a bundle is required when used as a dependency.
+ * <p/>
+ * These scopes map to Maven defined scopes.
+ */
+public enum BundleScope {
+
+  COMPILE,
+
+  PROVIDED,
+
+  RUNTIME,
+
+  TEST,
+
+  SYSTEM,
+
+  IMPORT
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ClassLoaderModel.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ClassLoaderModel.java
@@ -30,9 +30,10 @@ public class ClassLoaderModel {
   private final URL[] urls;
   private final Set<String> exportedPackages;
   private final Set<String> exportedResources;
-  private final Set<String> dependencies;
+  private final Set<BundleDependency> dependencies;
 
-  private ClassLoaderModel(URL[] urls, Set<String> exportedPackages, Set<String> exportedResources, Set<String> dependencies) {
+  private ClassLoaderModel(URL[] urls, Set<String> exportedPackages, Set<String> exportedResources,
+                           Set<BundleDependency> dependencies) {
     this.urls = urls;
     this.exportedPackages = exportedPackages;
     this.exportedResources = exportedResources;
@@ -63,7 +64,7 @@ public class ClassLoaderModel {
   /**
    * @return the artifact dependencies required to create the {@link ClassLoader}. Non null
    */
-  public Set<String> getDependencies() {
+  public Set<BundleDependency> getDependencies() {
     return dependencies;
   }
 
@@ -75,7 +76,7 @@ public class ClassLoaderModel {
     private Set<String> packages = new HashSet<>();
     private Set<String> resources = new HashSet<>();
     private List<URL> urls = new ArrayList<>();
-    private Set<String> dependencies = new HashSet<>();
+    private Set<BundleDependency> dependencies = new HashSet<>();
 
     /**
      * Creates an empty builder.
@@ -126,7 +127,7 @@ public class ClassLoaderModel {
      * @param dependencies dependencies on which the model depends on. Non null.
      * @return same builder instance.
      */
-    public ClassLoaderModelBuilder dependingOn(Set<String> dependencies) {
+    public ClassLoaderModelBuilder dependingOn(Set<BundleDependency> dependencies) {
       checkArgument(dependencies != null, "dependencies cannot be null");
       this.dependencies = dependencies;
       return this;

--- a/modules/deployment-model/pom.xml
+++ b/modules/deployment-model/pom.xml
@@ -40,6 +40,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-util</artifactId>
+            <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-api</artifactId>
+            <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-artifact</artifactId>
             <version>${project.version}</version>

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/artifact/DependenciesProvider.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/artifact/DependenciesProvider.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.deployment.model.api.artifact;
 
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
+
 import java.io.File;
 
 /**
@@ -18,9 +20,9 @@ public interface DependenciesProvider {
   /**
    * Given a reference to an artifact, it will look up the plugin's location and it will return it in a {@link File}.
    *
-   * @param artifactName reference to an artifact. Non null. // TODO(fernandezlautaro): MULE-10440 same as the class comment, ideally we should rely in an object like org.mule.runtime.module.repository.api.BundleDescriptor
+   * @param bundleDescriptor indicates which bundle to resolve. Non null.
    * @return an {@link File} pointing to the artifact location's folder (it must be unzipped).
    * @throws DependencyNotFoundException if the dependency to look for wasn't found.
    */
-  File resolve(String artifactName);
+  File resolve(BundleDescriptor bundleDescriptor);
 }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/artifact/InvalidDependencyVersionException.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/artifact/InvalidDependencyVersionException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.api.artifact;
+
+/**
+ * Thrown to indicate that a given bundle dependency version is not well formed.
+ */
+public class InvalidDependencyVersionException extends RuntimeException {
+
+  /**
+   * {@inheritDoc}
+   */
+  public InvalidDependencyVersionException(String message) {
+    super(message);
+  }
+}

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginClassLoaderFactory.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginClassLoaderFactory.java
@@ -7,11 +7,13 @@
 
 package org.mule.runtime.deployment.model.api.plugin;
 
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy;
 import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.descriptor.BundleDependency;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -60,7 +62,15 @@ public class ArtifactPluginClassLoaderFactory implements ArtifactClassLoaderFact
     return parentFirst;
   }
 
-  private boolean isDependencyPlugin(Set<String> pluginDependencies, ArtifactPluginDescriptor dependencyPluginDescriptor) {
-    return pluginDependencies.contains(dependencyPluginDescriptor.getName());
+  private boolean isDependencyPlugin(Set<BundleDependency> pluginDependencies,
+                                     ArtifactPluginDescriptor dependencyPluginDescriptor) {
+    for (BundleDependency pluginDependency : pluginDependencies) {
+      if (pluginDependency.getDescriptor().getArtifactId().equals(dependencyPluginDescriptor.getName())
+          && MULE_PLUGIN_CLASSIFIER.equals(pluginDependency.getClassifier().get())) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginClassLoaderFactory.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginClassLoaderFactory.java
@@ -66,7 +66,7 @@ public class ArtifactPluginClassLoaderFactory implements ArtifactClassLoaderFact
                                      ArtifactPluginDescriptor dependencyPluginDescriptor) {
     for (BundleDependency pluginDependency : pluginDependencies) {
       if (pluginDependency.getDescriptor().getArtifactId().equals(dependencyPluginDescriptor.getName())
-          && MULE_PLUGIN_CLASSIFIER.equals(pluginDependency.getClassifier().get())) {
+          && MULE_PLUGIN_CLASSIFIER.equals(pluginDependency.getDescriptor().getClassifier().get())) {
         return true;
       }
     }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginDescriptor.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginDescriptor.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 public class ArtifactPluginDescriptor extends DeployableArtifactDescriptor {
 
+  public static final String MULE_PLUGIN_CLASSIFIER = "mule-plugin";
+  public static final String EXTENSION_BUNDLE_TYPE = "zip";
   public static final String PLUGIN_PROPERTIES = "plugin.properties";
 
   private List<ArtifactPluginDescriptor> artifactPluginDescriptors = new ArrayList<>();

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/AbstractArtifactClassLoaderBuilder.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/AbstractArtifactClassLoaderBuilder.java
@@ -18,7 +18,7 @@ import org.mule.runtime.deployment.model.api.DeploymentException;
 import org.mule.runtime.deployment.model.api.artifact.DependenciesProvider;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
-import org.mule.runtime.deployment.model.internal.plugin.NamePluginDependenciesResolver;
+import org.mule.runtime.deployment.model.internal.plugin.BundlePluginDependenciesResolver;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilter;
@@ -47,7 +47,7 @@ public abstract class AbstractArtifactClassLoaderBuilder<T extends AbstractArtif
   private final DeployableArtifactClassLoaderFactory artifactClassLoaderFactory;
   private final ArtifactPluginRepository artifactPluginRepository;
   private final ArtifactClassLoaderFactory<ArtifactPluginDescriptor> artifactPluginClassLoaderFactory;
-  private final NamePluginDependenciesResolver namePluginDependenciesResolver;
+  private final BundlePluginDependenciesResolver pluginDependenciesResolver;
   private Set<ArtifactPluginDescriptor> artifactPluginDescriptors = new HashSet<>();
   private String artifactId = UUID.getUUID();
   private ArtifactDescriptor artifactDescriptor;
@@ -76,7 +76,7 @@ public abstract class AbstractArtifactClassLoaderBuilder<T extends AbstractArtif
     this.artifactClassLoaderFactory = artifactClassLoaderFactory;
     this.artifactPluginRepository = artifactPluginRepository;
     this.artifactPluginClassLoaderFactory = artifactPluginClassLoaderFactory;
-    this.namePluginDependenciesResolver = new NamePluginDependenciesResolver(artifactDescriptorFactory, dependenciesProvider);
+    this.pluginDependenciesResolver = new BundlePluginDependenciesResolver(artifactDescriptorFactory, dependenciesProvider);
   }
 
   /**
@@ -135,7 +135,7 @@ public abstract class AbstractArtifactClassLoaderBuilder<T extends AbstractArtif
 
     List<ArtifactPluginDescriptor> pluginDescriptors = createContainerApplicationPlugins();
     pluginDescriptors.addAll(artifactPluginDescriptors);
-    List<ArtifactPluginDescriptor> effectiveArtifactPluginDescriptors = namePluginDependenciesResolver.resolve(pluginDescriptors);
+    List<ArtifactPluginDescriptor> effectiveArtifactPluginDescriptors = pluginDependenciesResolver.resolve(pluginDescriptors);
 
     final List<ArtifactClassLoader> pluginClassLoaders =
         createPluginClassLoaders(artifactId, regionClassLoader, effectiveArtifactPluginDescriptors);

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/artifact/DefaultDependenciesProvider.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/artifact/DefaultDependenciesProvider.java
@@ -9,6 +9,7 @@ package org.mule.runtime.deployment.model.internal.artifact;
 import static java.lang.String.format;
 import org.mule.runtime.deployment.model.api.artifact.DependenciesProvider;
 import org.mule.runtime.deployment.model.api.artifact.DependencyNotFoundException;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
 
 import java.io.File;
 
@@ -21,9 +22,9 @@ import java.io.File;
 public class DefaultDependenciesProvider implements DependenciesProvider {
 
   @Override
-  public File resolve(String artifactName) {
+  public File resolve(BundleDescriptor bundleDescriptor) {
     throw new DependencyNotFoundException(format("Default implementation of DependenciesProvider cannot resolve dependencies. Dependency that trigger the exception is '%s'",
-                                                 artifactName));
+                                                 bundleDescriptor));
   }
 
 }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
@@ -7,11 +7,14 @@
 
 package org.mule.runtime.deployment.model.internal.plugin;
 
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import org.mule.runtime.deployment.model.api.artifact.DependenciesProvider;
 import org.mule.runtime.deployment.model.api.artifact.DependencyNotFoundException;
+import org.mule.runtime.deployment.model.api.artifact.InvalidDependencyVersionException;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
-import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorFactory;
+import org.mule.runtime.module.artifact.descriptor.BundleDependency;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel.ClassLoaderModelBuilder;
 
@@ -23,24 +26,29 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+
 /**
  * Resolves plugin dependencies considering the plugin name only.
  */
-public class NamePluginDependenciesResolver implements PluginDependenciesResolver {
+public class BundlePluginDependenciesResolver implements PluginDependenciesResolver {
 
   private final ArtifactDescriptorFactory<ArtifactPluginDescriptor> artifactDescriptorFactory;
   private final DependenciesProvider dependenciesProvider;
 
   /**
-   * Assembly the complete list of artifacts, while sorting them in a lexicographic order by name to then resolve sanitize
-   * the exported packages and resource by the plugin's dependencies (avoids exporting elements that are already exported
-   * by other plugin).
+   * Assembly the complete list of artifacts, while sorting them in a lexicographic order by name to then resolve sanitize the
+   * exported packages and resource by the plugin's dependencies (avoids exporting elements that are already exported by other
+   * plugin).
    *
-   * @param artifactDescriptorFactory factory to create {@link ArtifactPluginDescriptor} when there's a missing dependency to resolve
+   * @param artifactDescriptorFactory factory to create {@link ArtifactPluginDescriptor} when there's a missing dependency to
+   *        resolve
    * @param dependenciesProvider resolver for missing dependencies.
    */
-  public NamePluginDependenciesResolver(ArtifactDescriptorFactory<ArtifactPluginDescriptor> artifactDescriptorFactory,
-                                        DependenciesProvider dependenciesProvider) {
+  public BundlePluginDependenciesResolver(ArtifactDescriptorFactory<ArtifactPluginDescriptor> artifactDescriptorFactory,
+                                          DependenciesProvider dependenciesProvider) {
     this.artifactDescriptorFactory = artifactDescriptorFactory;
     this.dependenciesProvider = dependenciesProvider;
   }
@@ -48,7 +56,8 @@ public class NamePluginDependenciesResolver implements PluginDependenciesResolve
   @Override
   public List<ArtifactPluginDescriptor> resolve(List<ArtifactPluginDescriptor> descriptors) {
 
-    Set<String> knownPlugins = descriptors.stream().map(ArtifactDescriptor::getName).collect(Collectors.toSet());
+    Set<BundleDescriptor> knownPlugins =
+        descriptors.stream().map(ArtifactPluginDescriptor::getBundleDescriptor).collect(Collectors.toSet());
     descriptors = getArtifactsWithDependencies(descriptors, knownPlugins);
 
 
@@ -87,8 +96,8 @@ public class NamePluginDependenciesResolver implements PluginDependenciesResolve
   }
 
   /**
-   * Goes over the elements in the {@code pluginDescriptors} collection looking if it hasn't been resolved yet. If it hasn't
-   * then it looks it up through the {@link DependenciesProvider} and then creates an {@link ArtifactPluginDescriptor}.
+   * Goes over the elements in the {@code pluginDescriptors} collection looking if it hasn't been resolved yet. If it hasn't then
+   * it looks it up through the {@link DependenciesProvider} and then creates an {@link ArtifactPluginDescriptor}.
    *
    * @param pluginDescriptors plugins to validate.
    * @param visited plugins that are already resolved (by either the container or application initially, or by the resolver).
@@ -96,17 +105,17 @@ public class NamePluginDependenciesResolver implements PluginDependenciesResolve
    * @throws DependencyNotFoundException if any dependency wasn't found properly
    */
   private List<ArtifactPluginDescriptor> getArtifactsWithDependencies(List<ArtifactPluginDescriptor> pluginDescriptors,
-                                                                      Set<String> visited) {
+                                                                      Set<BundleDescriptor> visited) {
     if (!pluginDescriptors.isEmpty()) {
       List<ArtifactPluginDescriptor> foundDependencies = new ArrayList<>();
       pluginDescriptors.stream()
           .filter(pluginDescriptor -> !pluginDescriptor.getClassLoaderModel().getDependencies().isEmpty())
           .forEach(pluginDescriptor -> pluginDescriptor.getClassLoaderModel().getDependencies()
               .forEach(dependency -> {
-                if (!visited.contains(dependency)) {
-                  File mulePluginLocation = dependenciesProvider.resolve(dependency);
+                if (!isResolvedDependency(visited, dependency.getDescriptor())) {
+                  File mulePluginLocation = dependenciesProvider.resolve(dependency.getDescriptor());
                   foundDependencies.add(artifactDescriptorFactory.create(new File(mulePluginLocation.toURI())));
-                  visited.add(dependency);
+                  visited.add(dependency.getDescriptor());
                 }
               }));
 
@@ -129,14 +138,16 @@ public class NamePluginDependenciesResolver implements PluginDependenciesResolve
 
   }
 
-  private Set<String> findDependencyPackageClosure(Set<String> pluginDependencies,
+  private Set<String> findDependencyPackageClosure(Set<BundleDependency> pluginDependencies,
                                                    List<ArtifactPluginDescriptor> resolvedPlugins) {
     Set<String> exportedPackages = new HashSet<>();
-    for (String pluginDependency : pluginDependencies) {
-      ArtifactPluginDescriptor dependencyDescriptor = findArtifactPluginDescriptor(pluginDependency, resolvedPlugins);
-      exportedPackages.addAll(dependencyDescriptor.getClassLoaderModel().getExportedPackages());
-      exportedPackages
-          .addAll(findDependencyPackageClosure(dependencyDescriptor.getClassLoaderModel().getDependencies(), resolvedPlugins));
+    for (BundleDependency pluginDependency : pluginDependencies) {
+      if (MULE_PLUGIN_CLASSIFIER.equals(pluginDependency.getClassifier().get())) {
+        ArtifactPluginDescriptor dependencyDescriptor = findArtifactPluginDescriptor(pluginDependency, resolvedPlugins);
+        exportedPackages.addAll(dependencyDescriptor.getClassLoaderModel().getExportedPackages());
+        exportedPackages
+            .addAll(findDependencyPackageClosure(dependencyDescriptor.getClassLoaderModel().getDependencies(), resolvedPlugins));
+      }
     }
 
     return exportedPackages;
@@ -147,11 +158,13 @@ public class NamePluginDependenciesResolver implements PluginDependenciesResolve
     StringBuilder builder = new StringBuilder("Unable to resolve plugin dependencies:");
     for (ArtifactPluginDescriptor unresolvedPlugin : unresolvedPlugins) {
       builder.append("\nPlugin: ").append(unresolvedPlugin.getName()).append(" missing dependencies:");
-      List<String> missingDependencies = new ArrayList<>();
-      for (String dependency : unresolvedPlugin.getClassLoaderModel().getDependencies()) {
-        final ArtifactPluginDescriptor dependencyDescriptor = findArtifactPluginDescriptor(dependency, resolvedPlugins);
-        if (dependencyDescriptor == null) {
-          missingDependencies.add(dependency);
+      List<BundleDependency> missingDependencies = new ArrayList<>();
+      for (BundleDependency dependency : unresolvedPlugin.getClassLoaderModel().getDependencies()) {
+        if (MULE_PLUGIN_CLASSIFIER.equals(dependency.getClassifier().get())) {
+          final ArtifactPluginDescriptor dependencyDescriptor = findArtifactPluginDescriptor(dependency, resolvedPlugins);
+          if (dependencyDescriptor == null) {
+            missingDependencies.add(dependency);
+          }
         }
       }
 
@@ -161,22 +174,33 @@ public class NamePluginDependenciesResolver implements PluginDependenciesResolve
     return builder.toString();
   }
 
+  private boolean isResolvedDependency(Set<BundleDescriptor> visited, BundleDescriptor descriptor) {
+    for (BundleDescriptor resolvedDependency : visited) {
+      if (isResolvedDependency(resolvedDependency, descriptor)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private boolean isResolvedPlugin(ArtifactPluginDescriptor descriptor, List<ArtifactPluginDescriptor> resolvedPlugins) {
     boolean isResolved = descriptor.getClassLoaderModel().getDependencies().isEmpty();
 
-    if (!isResolved && hasDependenciesResolved(descriptor.getClassLoaderModel().getDependencies(), resolvedPlugins)) {
+    if (!isResolved && hasPluginDependenciesResolved(descriptor.getClassLoaderModel().getDependencies(), resolvedPlugins)) {
       isResolved = true;
     }
 
     return isResolved;
   }
 
-  private static ArtifactPluginDescriptor findArtifactPluginDescriptor(String name,
+  private static ArtifactPluginDescriptor findArtifactPluginDescriptor(BundleDependency bundleDependency,
                                                                        List<ArtifactPluginDescriptor> resolvedPlugins) {
     ArtifactPluginDescriptor result = null;
 
     for (ArtifactPluginDescriptor resolvedPlugin : resolvedPlugins) {
-      if (resolvedPlugin.getName().equals(name)) {
+      BundleDescriptor resolvedBundleDescriptor = resolvedPlugin.getBundleDescriptor();
+      if (isResolvedDependency(resolvedBundleDescriptor, bundleDependency.getDescriptor())) {
         result = resolvedPlugin;
         break;
       }
@@ -185,10 +209,44 @@ public class NamePluginDependenciesResolver implements PluginDependenciesResolve
     return result;
   }
 
-  private boolean hasDependenciesResolved(Set<String> pluginDependencies, List<ArtifactPluginDescriptor> resolvedPlugins) {
+  private static boolean isResolvedDependency(BundleDescriptor availableBundleDescriptor,
+                                              BundleDescriptor expectedBundleDescriptor) {
+    return availableBundleDescriptor.getArtifactId().equals(expectedBundleDescriptor.getArtifactId()) &&
+        availableBundleDescriptor.getGroupId().equals(expectedBundleDescriptor.getGroupId()) &&
+        isCompatibleVersion(availableBundleDescriptor.getVersion(), expectedBundleDescriptor.getVersion());
+  }
+
+  private static boolean isCompatibleVersion(String availableVersion, String expectedVersion) {
+    if (availableVersion.equals(expectedVersion)) {
+      return true;
+    }
+
+    Version available = getBundleVersion(availableVersion);
+    Version expected = getBundleVersion(expectedVersion);
+
+    if (available.compareTo(expected) >= 0) {
+      String availableMajorVersion = availableVersion.substring(0, availableVersion.indexOf("."));
+      String expectedMajorVersion = expectedVersion.substring(0, expectedVersion.indexOf("."));
+
+      return availableMajorVersion.equals(expectedMajorVersion);
+    }
+
+    return false;
+  }
+
+  private static Version getBundleVersion(String version) {
+    try {
+      return new GenericVersionScheme().parseVersion(version);
+    } catch (InvalidVersionSpecificationException e) {
+      throw new InvalidDependencyVersionException("Unable to parse bundle version: " + version);
+    }
+  }
+
+  private boolean hasPluginDependenciesResolved(Set<BundleDependency> pluginDependencies,
+                                                List<ArtifactPluginDescriptor> resolvedPlugins) {
     boolean resolvedDependency = true;
 
-    for (String dependency : pluginDependencies) {
+    for (BundleDependency dependency : pluginDependencies) {
       if (findArtifactPluginDescriptor(dependency, resolvedPlugins) == null) {
         resolvedDependency = false;
         break;

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
@@ -142,7 +142,7 @@ public class BundlePluginDependenciesResolver implements PluginDependenciesResol
                                                    List<ArtifactPluginDescriptor> resolvedPlugins) {
     Set<String> exportedPackages = new HashSet<>();
     for (BundleDependency pluginDependency : pluginDependencies) {
-      if (MULE_PLUGIN_CLASSIFIER.equals(pluginDependency.getClassifier().get())) {
+      if (MULE_PLUGIN_CLASSIFIER.equals(pluginDependency.getDescriptor().getClassifier().get())) {
         ArtifactPluginDescriptor dependencyDescriptor = findArtifactPluginDescriptor(pluginDependency, resolvedPlugins);
         exportedPackages.addAll(dependencyDescriptor.getClassLoaderModel().getExportedPackages());
         exportedPackages
@@ -160,7 +160,7 @@ public class BundlePluginDependenciesResolver implements PluginDependenciesResol
       builder.append("\nPlugin: ").append(unresolvedPlugin.getName()).append(" missing dependencies:");
       List<BundleDependency> missingDependencies = new ArrayList<>();
       for (BundleDependency dependency : unresolvedPlugin.getClassLoaderModel().getDependencies()) {
-        if (MULE_PLUGIN_CLASSIFIER.equals(dependency.getClassifier().get())) {
+        if (MULE_PLUGIN_CLASSIFIER.equals(dependency.getDescriptor().getClassifier().get())) {
           final ArtifactPluginDescriptor dependencyDescriptor = findArtifactPluginDescriptor(dependency, resolvedPlugins);
           if (dependencyDescriptor == null) {
             missingDependencies.add(dependency);

--- a/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolverTestCase.java
+++ b/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolverTestCase.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.EXTENSION_BUNDLE_TYPE;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorFactory;
@@ -48,12 +49,12 @@ public class BundlePluginDependenciesResolverTestCase extends AbstractMuleTestCa
   private static final BundleDependency BAR_PLUGIN_DESCRIPTOR = createBundleDependency(BAR_BUNDLE_DESCRIPTOR);
 
   private static BundleDependency createBundleDependency(BundleDescriptor bundleDescriptor) {
-    return new BundleDependency.Builder().setDescriptor(bundleDescriptor).setType("zip").setClassifier(MULE_PLUGIN_CLASSIFIER)
-        .build();
+    return new BundleDependency.Builder().setDescriptor(bundleDescriptor).build();
   }
 
   private static BundleDescriptor createTestBundleDescriptor(String artifactId, String version) {
-    return new BundleDescriptor.Builder().setGroupId("test").setArtifactId(artifactId).setVersion(version).build();
+    return new BundleDescriptor.Builder().setGroupId("test").setArtifactId(artifactId).setVersion(version)
+        .setType(EXTENSION_BUNDLE_TYPE).setClassifier(MULE_PLUGIN_CLASSIFIER).build();
   }
 
   private final ArtifactPluginDescriptor fooPlugin = new ArtifactPluginDescriptor(FOO_PLUGIN);

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginDescriptorFactory.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/plugin/ArtifactPluginDescriptorFactory.java
@@ -104,7 +104,8 @@ public class ArtifactPluginDescriptorFactory implements ArtifactDescriptorFactor
       String groupId = bundleProperties[0];
       String artifactId = bundleProperties[1];
       String version = bundleProperties[2];
-      bundleDescriptor = new BundleDescriptor.Builder().setArtifactId(artifactId).setGroupId(groupId).setVersion(version).build();
+      bundleDescriptor = new BundleDescriptor.Builder().setArtifactId(artifactId).setGroupId(groupId).setVersion(version)
+          .setType(EXTENSION_BUNDLE_TYPE).setClassifier(MULE_PLUGIN_CLASSIFIER).build();
     } else if (isNameOnlyDefinedBundle(bundleProperties)) {
       // TODO(pablo.kraan): MULE-10966: remove this once extensions and plugins are properly migrated to the new model
       bundleDescriptor = createDefaultPluginBundleDescriptor(bundleProperties[0]);
@@ -113,8 +114,7 @@ public class ArtifactPluginDescriptorFactory implements ArtifactDescriptorFactor
                                                 bundle));
     }
 
-    return new BundleDependency.Builder().setDescriptor(bundleDescriptor).setType(EXTENSION_BUNDLE_TYPE)
-        .setClassifier(MULE_PLUGIN_CLASSIFIER).setScope(COMPILE).build();
+    return new BundleDependency.Builder().setDescriptor(bundleDescriptor).setScope(COMPILE).build();
   }
 
   private boolean isNameOnlyDefinedBundle(String[] bundleProperties) {
@@ -126,6 +126,7 @@ public class ArtifactPluginDescriptorFactory implements ArtifactDescriptorFactor
   }
 
   private BundleDescriptor createDefaultPluginBundleDescriptor(String pluginName) {
-    return new BundleDescriptor.Builder().setArtifactId(pluginName).setGroupId("test").setVersion("1.0").build();
+    return new BundleDescriptor.Builder().setArtifactId(pluginName).setGroupId("test").setVersion("1.0")
+        .setClassifier(MULE_PLUGIN_CLASSIFIER).setType(EXTENSION_BUNDLE_TYPE).build();
   }
 }

--- a/modules/repository/pom.xml
+++ b/modules/repository/pom.xml
@@ -24,6 +24,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.mule.modules</groupId>
+            <artifactId>mule-module-artifact</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-api</artifactId>
             <version>${aetherVersion}</version>

--- a/modules/repository/src/main/java/org/mule/runtime/module/repository/api/RepositoryService.java
+++ b/modules/repository/src/main/java/org/mule/runtime/module/repository/api/RepositoryService.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.module.repository.api;
 
+import org.mule.runtime.module.artifact.descriptor.BundleDependency;
+
 import java.io.File;
 
 /**
@@ -25,12 +27,12 @@ public interface RepositoryService {
    * If the bundle does not exists in the local repository but was found in an external repository then it will be stored in the
    * local repositories to avoid a remote fetch if the bundle is requested again.
    *
-   * @param bundleDescriptor descriptor to identify the bundle
+   * @param bundleDependency descriptor to identify the bundle
    * @return a {@code File} where the bundle is stored in the local repository
    * @throws BundleNotFoundException when the bundle could not be located in any of the configured repositories.
    * @throws RepositoryConnectionException when there was a problem connecting to one of the external repositories.
    * @throws RepositoryServiceDisabledException when the repository service has not been properly configured.
    */
-  File lookupBundle(BundleDescriptor bundleDescriptor);
+  File lookupBundle(BundleDependency bundleDependency);
 
 }

--- a/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
+++ b/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.module.repository.internal;
 
 import static org.mule.runtime.module.repository.internal.RepositoryServiceFactory.MULE_REMOTE_REPOSITORIES_PROPERTY;
-import org.mule.runtime.module.repository.api.BundleDescriptor;
+import org.mule.runtime.module.artifact.descriptor.BundleDependency;
 import org.mule.runtime.module.repository.api.BundleNotFoundException;
 import org.mule.runtime.module.repository.api.RepositoryConnectionException;
 import org.mule.runtime.module.repository.api.RepositoryService;
@@ -44,14 +44,14 @@ public class DefaultRepositoryService implements RepositoryService {
   }
 
   @Override
-  public File lookupBundle(BundleDescriptor bundleDescriptor) {
+  public File lookupBundle(BundleDependency bundleDependency) {
     try {
       if (remoteRepositories.isEmpty()) {
         throw new RepositoryServiceDisabledException("Repository service has not been configured so it's disabled. "
             + "To enable it you must configure the set of repositories to use using the system property: "
             + MULE_REMOTE_REPOSITORIES_PROPERTY);
       }
-      DefaultArtifact artifact = toArtifact(bundleDescriptor);
+      DefaultArtifact artifact = toArtifact(bundleDependency);
       ArtifactRequest getArtifactRequest = new ArtifactRequest();
       getArtifactRequest.setRepositories(remoteRepositories);
       getArtifactRequest.setArtifact(artifact);
@@ -59,7 +59,7 @@ public class DefaultRepositoryService implements RepositoryService {
       return artifactResult.getArtifact().getFile();
     } catch (ArtifactResolutionException e) {
       if (e.getCause() instanceof ArtifactNotFoundException) {
-        throw new BundleNotFoundException("Couldn't find bundle " + bundleDescriptor.toString(), e);
+        throw new BundleNotFoundException("Couldn't find bundle " + bundleDependency.toString(), e);
       } else {
         throw new RepositoryConnectionException("There was a problem connecting to one of the repositories", e);
 
@@ -67,8 +67,9 @@ public class DefaultRepositoryService implements RepositoryService {
     }
   }
 
-  private DefaultArtifact toArtifact(BundleDescriptor bundleDescriptor) {
-    return new DefaultArtifact(bundleDescriptor.getGroupId(), bundleDescriptor.getArtifactId(), bundleDescriptor.getType(),
-                               bundleDescriptor.getVersion());
+  private DefaultArtifact toArtifact(BundleDependency bundleDependency) {
+    return new DefaultArtifact(bundleDependency.getDescriptor().getGroupId(), bundleDependency.getDescriptor().getArtifactId(),
+                               bundleDependency.getType(),
+                               bundleDependency.getDescriptor().getVersion());
   }
 }

--- a/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
+++ b/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
@@ -69,7 +69,7 @@ public class DefaultRepositoryService implements RepositoryService {
 
   private DefaultArtifact toArtifact(BundleDependency bundleDependency) {
     return new DefaultArtifact(bundleDependency.getDescriptor().getGroupId(), bundleDependency.getDescriptor().getArtifactId(),
-                               bundleDependency.getType(),
+                               bundleDependency.getDescriptor().getType(),
                                bundleDependency.getDescriptor().getVersion());
   }
 }

--- a/modules/repository/src/test/java/org/mule/runtime/module/repository/internal/RepositorySystemTestCase.java
+++ b/modules/repository/src/test/java/org/mule/runtime/module/repository/internal/RepositorySystemTestCase.java
@@ -33,7 +33,7 @@ public class RepositorySystemTestCase extends AbstractMuleTestCase {
   private static final BundleDescriptor VALID_BUNDLE_DESCRIPTOR =
       new BundleDescriptor.Builder().setGroupId("ant").setArtifactId("ant-antlr").setVersion("1.6").build();
   private static final BundleDependency VALID_BUNDLE =
-      new BundleDependency.Builder().sedBundleDescriptor(VALID_BUNDLE_DESCRIPTOR).setType("jar").build();
+      new BundleDependency.Builder().sedBundleDescriptor(VALID_BUNDLE_DESCRIPTOR).build();
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -59,7 +59,7 @@ public class RepositorySystemTestCase extends AbstractMuleTestCase {
           new BundleDescriptor.Builder().setGroupId("no").setArtifactId("existent").setVersion("bundle").build();
       expectedException.expect(BundleNotFoundException.class);
       defaultRepositoryService
-          .lookupBundle(new BundleDependency.Builder().sedBundleDescriptor(bundleDescriptor).setType("jar").build());
+          .lookupBundle(new BundleDependency.Builder().sedBundleDescriptor(bundleDescriptor).build());
     });
   }
 

--- a/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/DefaultConnectivityTestingServiceBuilder.java
+++ b/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/DefaultConnectivityTestingServiceBuilder.java
@@ -10,10 +10,11 @@ import static org.mule.runtime.api.util.Preconditions.checkState;
 import org.mule.runtime.core.api.connectivity.ConnectivityTestingService;
 import org.mule.runtime.core.api.registry.ServiceRegistry;
 import org.mule.runtime.dsl.api.config.ArtifactConfiguration;
+import org.mule.runtime.module.artifact.descriptor.BundleDependency;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
 import org.mule.runtime.module.deployment.internal.artifact.TemporaryArtifact;
 import org.mule.runtime.module.deployment.internal.artifact.TemporaryArtifactBuilder;
 import org.mule.runtime.module.deployment.internal.artifact.TemporaryArtifactBuilderFactory;
-import org.mule.runtime.module.repository.api.BundleDescriptor;
 import org.mule.runtime.module.repository.api.RepositoryService;
 import org.mule.runtime.module.tooling.api.connectivity.ConnectivityTestingServiceBuilder;
 
@@ -31,7 +32,7 @@ class DefaultConnectivityTestingServiceBuilder implements ConnectivityTestingSer
   private final RepositoryService repositoryService;
   private final TemporaryArtifactBuilderFactory artifactBuilderFactory;
   private ServiceRegistry serviceRegistry;
-  private List<BundleDescriptor> bundleDescriptors = new ArrayList<>();
+  private List<BundleDependency> bundleDependencies = new ArrayList<>();
   private ArtifactConfiguration artifactConfiguration;
   private TemporaryArtifact temporaryArtifact;
 
@@ -48,8 +49,10 @@ class DefaultConnectivityTestingServiceBuilder implements ConnectivityTestingSer
    */
   @Override
   public ConnectivityTestingServiceBuilder addExtension(String groupId, String artifactId, String artifactVersion) {
-    this.bundleDescriptors.add(new BundleDescriptor.Builder().setGroupId(groupId).setArtifactId(artifactId)
-        .setType(EXTENSION_BUNDLE_TYPE).setVersion(artifactVersion).build());
+    BundleDescriptor bundleDescriptor =
+        new BundleDescriptor.Builder().setGroupId(groupId).setArtifactId(artifactId).setVersion(artifactVersion).build();
+    this.bundleDependencies
+        .add(new BundleDependency.Builder().setDescriptor(bundleDescriptor).setType(EXTENSION_BUNDLE_TYPE).build());
     return this;
   }
 

--- a/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/DefaultConnectivityTestingServiceBuilder.java
+++ b/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/DefaultConnectivityTestingServiceBuilder.java
@@ -50,9 +50,10 @@ class DefaultConnectivityTestingServiceBuilder implements ConnectivityTestingSer
   @Override
   public ConnectivityTestingServiceBuilder addExtension(String groupId, String artifactId, String artifactVersion) {
     BundleDescriptor bundleDescriptor =
-        new BundleDescriptor.Builder().setGroupId(groupId).setArtifactId(artifactId).setVersion(artifactVersion).build();
+        new BundleDescriptor.Builder().setGroupId(groupId).setArtifactId(artifactId).setVersion(artifactVersion)
+            .setType(EXTENSION_BUNDLE_TYPE).build();
     this.bundleDependencies
-        .add(new BundleDependency.Builder().setDescriptor(bundleDescriptor).setType(EXTENSION_BUNDLE_TYPE).build());
+        .add(new BundleDependency.Builder().setDescriptor(bundleDescriptor).build());
     return this;
   }
 
@@ -70,7 +71,7 @@ class DefaultConnectivityTestingServiceBuilder implements ConnectivityTestingSer
   @Override
   public ConnectivityTestingService build() {
     checkState(artifactConfiguration != null, "artifact configuration cannot be null");
-    checkState(!bundleDescriptors.isEmpty(), "no extensions were configured");
+    checkState(!bundleDependencies.isEmpty(), "no extensions were configured");
     TemporaryArtifact temporaryArtifact = buildArtifact();
     return new TemporaryArtifactConnectivityTestingService(temporaryArtifact);
   }
@@ -83,7 +84,7 @@ class DefaultConnectivityTestingServiceBuilder implements ConnectivityTestingSer
     TemporaryArtifactBuilder temporaryArtifactBuilder = artifactBuilderFactory.newBuilder()
         .setArtifactConfiguration(artifactConfiguration);
 
-    bundleDescriptors.stream()
+    bundleDependencies.stream()
         .forEach(bundleDescriptor -> temporaryArtifactBuilder
             .addArtifactPluginFile(repositoryService.lookupBundle(bundleDescriptor)));
     temporaryArtifact = temporaryArtifactBuilder.build();

--- a/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
@@ -23,6 +23,7 @@ import static org.eclipse.aether.util.filter.DependencyFilterUtils.classpathFilt
 import static org.eclipse.aether.util.filter.DependencyFilterUtils.orFilter;
 import static org.mule.runtime.api.util.Preconditions.checkNotNull;
 import static org.mule.runtime.core.util.PropertiesUtils.loadProperties;
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import static org.mule.test.runner.api.ArtifactClassificationType.APPLICATION;
 import static org.mule.test.runner.api.ArtifactClassificationType.MODULE;
 import static org.mule.test.runner.api.ArtifactClassificationType.PLUGIN;
@@ -85,7 +86,6 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
   private static final String MAVEN_COORDINATES_SEPARATOR = ":";
   private static final String JAR_EXTENSION = "jar";
   private static final String SNAPSHOT_WILCARD_FILE_FILTER = "*-SNAPSHOT*.*";
-  private static final String MULE_PLUGIN_CLASSIFIER = "mule-plugin";
   private static final String TESTS_CLASSIFIER = "tests";
   private static final String TESTS_JAR = "-tests.jar";
   private static final String SERVICE_PROPERTIES_FILE_NAME = "service.properties";

--- a/tests/runner/src/main/java/org/mule/test/runner/api/ArtifactClassificationTypeResolver.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/ArtifactClassificationTypeResolver.java
@@ -8,6 +8,7 @@
 package org.mule.test.runner.api;
 
 import static org.mule.runtime.api.util.Preconditions.checkNotNull;
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import static org.mule.test.runner.api.ArtifactClassificationType.APPLICATION;
 import static org.mule.test.runner.api.ArtifactClassificationType.MODULE;
 import static org.mule.test.runner.api.ArtifactClassificationType.PLUGIN;
@@ -30,7 +31,6 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
  */
 public class ArtifactClassificationTypeResolver {
 
-  private static final String MULE_PLUGIN_CLASSIFIER = "mule-plugin";
   private static final String MULE_EXTENSION_CLASSIFIER = "mule-extension";
   private static final String MULE_MODULE_PROPERTIES = "META-INF/mule-module.properties";
   private static final String PLUGIN_PROPERTIES = "plugin.properties";
@@ -60,7 +60,7 @@ public class ArtifactClassificationTypeResolver {
       if (isMulePlugin(artifact, artifactClassLoader)) {
         return PLUGIN;
       }
-      if (isMuleModule(artifact, artifactClassLoader)) {
+      if (isMuleModule(artifactClassLoader)) {
         return MODULE;
       }
       return APPLICATION;
@@ -72,7 +72,7 @@ public class ArtifactClassificationTypeResolver {
   /**
    * @param artifact {@link Artifact} to check if it is a plugin
    * @param artifactClassLoader {@link ClassLoader} for the given artifact
-   * @return true if it is classified as {@value #MULE_PLUGIN_CLASSIFIER} or {@value #MULE_EXTENSION_CLASSIFIER} or it has a
+   * @return true if it is classified as {@value org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor2#MULE_PLUGIN_CLASSIFIER} or {@value #MULE_EXTENSION_CLASSIFIER} or it has a
    *         {@value #PLUGIN_PROPERTIES} file.
    */
   private boolean isMulePlugin(Artifact artifact, ClassLoader artifactClassLoader) {
@@ -81,11 +81,10 @@ public class ArtifactClassificationTypeResolver {
   }
 
   /**
-   * @param artifact {@link Artifact} to check if it is a plugin.
    * @param artifactClassLoader {@link ClassLoader} for the given artifact.
    * @return true if it has a {@value #MULE_MODULE_PROPERTIES} file.
    */
-  private boolean isMuleModule(Artifact artifact, ClassLoader artifactClassLoader) {
+  private boolean isMuleModule(ClassLoader artifactClassLoader) {
     return hasResource(artifactClassLoader, MULE_MODULE_PROPERTIES);
   }
 


### PR DESCRIPTION
_ Splitting BundleDescriptor in two: BundleDescriptor contains bundle identifier, BundleDependency defines how a dependency is used
_ Updating plugin factory to manage bundleDescriptors instead of plain names
_ Updating plugin dependencies resolver to manage different types of versions