### PR TITLE
MULE-10985: Parallel deployment causes runtime contention on Logger.

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/log4j2/LoggerContextCache.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/log4j2/LoggerContextCache.java
@@ -122,7 +122,7 @@ final class LoggerContextCache implements Disposable
         }
     }
 
-    synchronized LoggerContext getLoggerContext(final ClassLoader classLoader)
+    LoggerContext getLoggerContext(final ClassLoader classLoader)
     {
         final LoggerContext ctx;
         try
@@ -155,7 +155,13 @@ final class LoggerContextCache implements Disposable
 
         if (ctx.getState() == LifeCycle.State.INITIALIZED)
         {
-            ctx.start();
+            synchronized (this)
+            {
+                if (ctx.getState() == LifeCycle.State.INITIALIZED)
+                {
+                    ctx.start();
+                }
+            }
         }
 
         return ctx;


### PR DESCRIPTION
_ Reduning scope of synchronization to reduce contention when logger contexts are already initialized