### PR TITLE
MULE-10995 Negative threadWaitTimeout used with SEDA processing strat…

### DIFF
--- a/core/src/main/java/org/mule/util/queue/AbstractQueueStoreDelegate.java
+++ b/core/src/main/java/org/mule/util/queue/AbstractQueueStoreDelegate.java
@@ -47,9 +47,9 @@ public abstract class AbstractQueueStoreDelegate implements QueueStoreDelegate
                 long l2 = timeout;
                 while (getSize() >= capacity - room)
                 {
-                    if (l2 <= 0L)
+                    if (l2 < 0L)
                     {
-                        return false;
+                        l2 = 0;
                     }
                     this.wait(l2);
                     l2 = timeout - (System.currentTimeMillis() - l1);

--- a/core/src/main/java/org/mule/util/queue/AbstractQueueStoreDelegate.java
+++ b/core/src/main/java/org/mule/util/queue/AbstractQueueStoreDelegate.java
@@ -47,12 +47,21 @@ public abstract class AbstractQueueStoreDelegate implements QueueStoreDelegate
                 long l2 = timeout;
                 while (getSize() >= capacity - room)
                 {
-                    if (l2 < 0L)
+                    if(timeout < 0)
                     {
-                        l2 = 0;
+                        // If timeout is negative then wait until notified without a
+                        // timeout.
+                        this.wait(0);
                     }
-                    this.wait(l2);
-                    l2 = timeout - (System.currentTimeMillis() - l1);
+                    else
+                    {
+                        if (l2 <= 0L)
+                        {
+                            return false;
+                        }
+                        this.wait(l2);
+                        l2 = timeout - (System.currentTimeMillis() - l1);
+                    }
                 }
             }
             if (o != null)

--- a/core/src/test/java/org/mule/processor/SedaStageInterceptingMessageProcessorTestCase.java
+++ b/core/src/test/java/org/mule/processor/SedaStageInterceptingMessageProcessorTestCase.java
@@ -228,9 +228,9 @@ public class SedaStageInterceptingMessageProcessorTestCase extends AsyncIntercep
         when(flow.getProcessingStrategy()).thenReturn(new AsynchronousProcessingStrategy());
         final MuleEvent event = getTestEvent(TEST_MESSAGE, flow, MessageExchangePattern.ONE_WAY);
 
-        int NUMBER_OF_EVENTS = 3;
+        int numberOfEvents = 3;
 
-        for (int i = 0; i < NUMBER_OF_EVENTS; i++)
+        for (int i = 0; i < numberOfEvents; i++)
         {
             sedaStageInterceptingMessageProcessor.process(event);
         }
@@ -245,7 +245,7 @@ public class SedaStageInterceptingMessageProcessorTestCase extends AsyncIntercep
         ArgumentMatcher<MuleEvent> notSameEvent = createNotSameEventArgumentMatcher(event);
 
         // Three events are processed
-        verify(mockListener, timeout(RECEIVE_TIMEOUT).times(NUMBER_OF_EVENTS)).process(argThat(notSameEvent));
+        verify(mockListener, timeout(RECEIVE_TIMEOUT).times(numberOfEvents)).process(argThat(notSameEvent));
     }
 
     @Test

--- a/core/src/test/java/org/mule/processor/SedaStageInterceptingMessageProcessorTestCase.java
+++ b/core/src/test/java/org/mule/processor/SedaStageInterceptingMessageProcessorTestCase.java
@@ -194,9 +194,8 @@ public class SedaStageInterceptingMessageProcessorTestCase extends AsyncIntercep
     @Test
     public void testProcessOneWayNegativeThreadWaitTimeout() throws Exception
     {
-        final int threadTimeout = -1;
         ThreadingProfile threadingProfile = new ChainedThreadingProfile(muleContext.getDefaultThreadingProfile());
-        threadingProfile.setThreadWaitTimeout(threadTimeout);
+        threadingProfile.setThreadWaitTimeout(-1);
         // Need 2 threads: 1 for polling, 1 to process work
         threadingProfile.setMaxThreadsActive(2);
         threadingProfile.setPoolExhaustedAction(WHEN_EXHAUSTED_WAIT);
@@ -236,10 +235,11 @@ public class SedaStageInterceptingMessageProcessorTestCase extends AsyncIntercep
             sedaStageInterceptingMessageProcessor.process(event);
         }
 
-        // Release latch only after 400ms which is double the default queue timeout.  If the new custom queueTimeout wasn't being
+        // Release latch only after 220ms which is 20ms more than the default queue
+        // timeout.  If the new custom queueTimeout of -1 (unlimited) wasn't being
         // used then event 3 would be rejected, as there is no room for it in the queue while event 1 processing is waiting on
         // the latch.
-        Thread.sleep(400);
+        Thread.sleep(220);
         latch.countDown();
 
         ArgumentMatcher<MuleEvent> notSameEvent = createNotSameEventArgumentMatcher(event);

--- a/modules/spring-config/src/main/resources/META-INF/mule.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule.xsd
@@ -3791,7 +3791,7 @@
         <xsd:attribute name="threadWaitTimeout" type="substitutableInt">
             <xsd:annotation>
                 <xsd:documentation>
-                    How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is negative, it will wait indefinitely.
+                    How long to wait in milliseconds when the pool exhausted action is WAIT. If the value is zero or negative, it will wait indefinitely.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>


### PR DESCRIPTION
…egy fails rather than waiting forever to enqueue.