### PR TITLE
MULE-10986: Fix conflict Similar HTTP Listener Path with Wildcards

### DIFF
--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/WildcardPathsTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/WildcardPathsTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.http.internal.listener;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.runners.Parameterized.Parameters;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.tck.junit4.rule.SystemProperty;
+
+import java.util.Collection;
+
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class WildcardPathsTestCase extends FunctionalTestCase
+{
+
+    private static final String response1 = "V1 Flow invoked";
+    private static final String response2 = "V2 flow invoked";
+    private static final String response3 = "V2 - Healthcheck";
+    private static final String path1 = "/*";
+    private static final String path2 = "V2/*";
+    private static final String path3 = "V2/taxes/healthcheck";
+    private static final String URL = "http://localhost:%s/%s";
+    private final String path;
+    private final String response;
+
+    @Rule
+    public DynamicPort listenPort = new DynamicPort("port");
+
+    @Rule
+    public SystemProperty path1SystemProperty = new SystemProperty("path1", path1);
+
+    @Rule
+    public SystemProperty path2SystemProperty = new SystemProperty("path2", path2);
+
+    @Rule
+    public SystemProperty path3SystemProperty = new SystemProperty("path3", path3);
+
+    @Rule
+    public SystemProperty response1SystemProperty = new SystemProperty("response1", response1);
+
+    @Rule
+    public SystemProperty response2systemProperty = new SystemProperty("response2", response2);
+
+    @Rule
+    public SystemProperty response3SystemProperty = new SystemProperty("response3", response3);
+
+
+    public WildcardPathsTestCase(String path, String response)
+    {
+        this.path = path;
+        this.response = response;
+    }
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "HttpTestPathsWildcard.xml";
+    }
+
+    @Parameters
+    public static Collection<Object[]> data()
+    {
+        return asList(new Object[][] {
+                {"", response1}, {"taxes", response1},
+                {"taxes/healtcheck", response1},
+                {"taxes/1", response1},
+                {"V2", response2},
+                {"V2/taxes", response2},
+                {"V2/console", response2},
+                {"V2/taxes/1", response2},
+                {"V2/taxes/healthcheck", response3}});
+    }
+
+    @Test
+    public void testPath() throws Exception
+    {
+        final String url = String.format(URL, listenPort.getNumber(), path);
+        final Response httpResponse = Request.Get(url).execute();
+        assertThat(httpResponse.returnContent().asString(), is(response));
+    }
+
+}

--- a/modules/http/src/test/resources/HttpTestPathsWildcard.xml
+++ b/modules/http/src/test/resources/HttpTestPathsWildcard.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+    <http:listener-config name="HTTP_Listener_Configuration" host="0.0.0.0" port="${port}"/>
+    <flow name="taxes-main-v1">
+        <http:listener path="${path1}" config-ref="HTTP_Listener_Configuration"/>
+        <set-payload value="${response1}"/>
+    </flow>
+    <flow name="taxes-main-v2">
+        <http:listener path="${path2}" config-ref="HTTP_Listener_Configuration"/>
+        <set-payload value="${response2}"/>
+    </flow>
+    <flow name="HealthcheckV2">
+        <http:listener path="${path3}" config-ref="HTTP_Listener_Configuration"/>
+        <set-payload value="${response3}"/>
+    </flow>
+</mule>


### PR DESCRIPTION
In HttpListenerRegistry was modified the routing of HttpListeners Path with wildcards.
WildcardPathsTestCase was created.
HttpTestPathsWilcard.xml configuration was added.
Fixes by Code Review in WildcardPathsTestCase.
Format in Code and imports