### PR TITLE
MULE-11017 use schemas to validate xml files

### DIFF
--- a/extensions/db/src/test/resources/integration/delete/bulk-delete-config.xml
+++ b/extensions/db/src/test/resources/integration/delete/bulk-delete-config.xml
@@ -25,7 +25,7 @@
             <db:sql>select * from PLANET</db:sql>
         </db:select>
 
-        <db:bulk-update parameterValues="#[payload]">
+        <db:bulk-update>
             <db:sql>update PLANET set NAME='Mercury' where POSITION=:position</db:sql>
         </db:bulk-update>
     </flow>

--- a/extensions/db/src/test/resources/integration/delete/delete-metadata-config.xml
+++ b/extensions/db/src/test/resources/integration/delete/delete-metadata-config.xml
@@ -6,13 +6,13 @@
             http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd">
 
     <flow name="deleteMetadata">
-        <db:delete parameterValues="#[payload]">
+        <db:delete>
             <db:sql>DELETE FROM PLANET WHERE name = :name</db:sql>
         </db:delete>
     </flow>
 
     <flow name="bulkDeleteMetadata">
-        <db:bulk-delete parameterValues="#[payload]">
+        <db:bulk-delete>
             <db:sql>DELETE FROM PLANET WHERE name = :name</db:sql>
         </db:bulk-delete>
     </flow>

--- a/extensions/db/src/test/resources/integration/insert/insert-metadata-config.xml
+++ b/extensions/db/src/test/resources/integration/insert/insert-metadata-config.xml
@@ -12,7 +12,7 @@
     </flow>
 
     <flow name="bulkInsertMetadata">
-        <db:bulk-insert parameterValues="#[payload]">
+        <db:bulk-insert>
             <db:sql>INSERT INTO PLANET(POSITION, NAME) VALUES (777, :name)</db:sql>
         </db:bulk-insert>
     </flow>

--- a/extensions/db/src/test/resources/integration/update/update-metadata-config.xml
+++ b/extensions/db/src/test/resources/integration/update/update-metadata-config.xml
@@ -12,7 +12,7 @@
     </flow>
 
     <flow name="bulkUpdateMetadata">
-        <db:bulk-update parameterValues="#[payload]">
+        <db:bulk-update>
             <db:sql>update PLANET set NAME='Mercury' where NAME= :name</db:sql>
         </db:bulk-update>
     </flow>

--- a/extensions/db/src/test/resources/integration/update/update-name-param-override-config.xml
+++ b/extensions/db/src/test/resources/integration/update/update-name-param-override-config.xml
@@ -6,10 +6,10 @@
             http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd">
 
     <db:query name="updateTemplate">
-        <db:sql>update PLANET set NAME='Mercury' where POSITION= :position</db:sql>
         <db:input-parameters>
             <db:input-parameter key="position" value="4"/>
         </db:input-parameters>
+        <db:sql>update PLANET set NAME='Mercury' where POSITION= :position</db:sql>
     </db:query>
 
     <db:query name="overriddenUpdateParam" template="updateTemplate">

--- a/extensions/http/src/test/resources/http-metadata-config.xml
+++ b/extensions/http/src/test/resources/http-metadata-config.xml
@@ -16,7 +16,7 @@
     <flow name="server">
         <httpn:listener responseStreamingMode="AUTO" path="test" allowedMethods="GET" parseRequest="true"
                         config-ref="lisConfig"/>
-        <logger/>
+        <echo-component/>
     </flow>
 
     <flow name="anyExplicit">

--- a/extensions/http/src/test/resources/http-metadata-config.xml
+++ b/extensions/http/src/test/resources/http-metadata-config.xml
@@ -16,6 +16,7 @@
     <flow name="server">
         <httpn:listener responseStreamingMode="AUTO" path="test" allowedMethods="GET" parseRequest="true"
                         config-ref="lisConfig"/>
+        <logger/>
     </flow>
 
     <flow name="anyExplicit">

--- a/modules/extensions-spring-support/src/test/resources/petstore-exclusion-between-groups-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/petstore-exclusion-between-groups-config.xml
@@ -10,6 +10,6 @@
     </petstore:config>
 
     <flow name="getCashierNestedParams">
-        <petstore:get-cashier config-ref="config" cashierName="Carl" cash="100" debt="-100"/>
+        <petstore:get-cashier cashierName="Carl" cash="100" debt="-100"/>
     </flow>
 </mule>

--- a/modules/extensions-spring-support/src/test/resources/petstore-exclusive-required-parameter.xml
+++ b/modules/extensions-spring-support/src/test/resources/petstore-exclusive-required-parameter.xml
@@ -7,6 +7,7 @@
 
     <flow name="ExclusiveParameterRequiredSource">
         <petstore:pet-source/>
+        <logger/>
     </flow>
 
 </mule>

--- a/modules/extensions-spring-support/src/test/resources/petstore-exclusive-required-parameter.xml
+++ b/modules/extensions-spring-support/src/test/resources/petstore-exclusive-required-parameter.xml
@@ -7,7 +7,7 @@
 
     <flow name="ExclusiveParameterRequiredSource">
         <petstore:pet-source/>
-        <logger/>
+        <echo-component/>
     </flow>
 
 </mule>

--- a/modules/extensions-spring-support/src/test/resources/subtypes-mapping.xml
+++ b/modules/extensions-spring-support/src/test/resources/subtypes-mapping.xml
@@ -158,10 +158,10 @@
             </subtypes:door>
             <subtypes:door-registries>
                 <subtypes:door-registry key="leftDoor">
-                    <subtypes:car-door handle="left"/>
+                    <subtypes:car-door handle="left" color="red"/>
                 </subtypes:door-registry>
                 <subtypes:door-registry key="rightDoor">
-                    <subtypes:car-door handle="right"/>
+                    <subtypes:car-door handle="right" color="red"/>
                 </subtypes:door-registry>
             </subtypes:door-registries>
         </subtypes:process-door>

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/introspection/describer/XmlBasedDescriber.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/introspection/describer/XmlBasedDescriber.java
@@ -146,7 +146,7 @@ public class XmlBasedDescriber implements Describer {
 
   private Document getModuleDocument(XmlConfigurationDocumentLoader xmlConfigurationDocumentLoader, URL resource) {
     try {
-      return xmlConfigurationDocumentLoader.loadDocument(empty(), resource.openStream());
+      return xmlConfigurationDocumentLoader.loadDocument(empty(), resource.getFile(), resource.openStream());
     } catch (IOException e) {
       throw new MuleRuntimeException(
                                      createStaticMessage(format("There was an issue reading the stream for the resource %s",

--- a/modules/http/src/main/java/org/mule/extension/http/api/request/proxy/DefaultProxyConfig.java
+++ b/modules/http/src/main/java/org/mule/extension/http/api/request/proxy/DefaultProxyConfig.java
@@ -7,6 +7,7 @@
 package org.mule.extension.http.api.request.proxy;
 
 import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.dsl.xml.XmlHints;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.display.Password;
@@ -17,6 +18,7 @@ import org.mule.runtime.extension.api.annotation.param.display.Password;
  * @since 4.0
  */
 @Alias("proxy")
+@XmlHints(allowTopLevelDefinition = true)
 public class DefaultProxyConfig implements ProxyConfig {
 
   /**

--- a/modules/http/src/main/java/org/mule/extension/http/api/request/proxy/NtlmProxyConfig.java
+++ b/modules/http/src/main/java/org/mule/extension/http/api/request/proxy/NtlmProxyConfig.java
@@ -7,6 +7,7 @@
 package org.mule.extension.http.api.request.proxy;
 
 import org.mule.runtime.extension.api.annotation.Alias;
+import org.mule.runtime.extension.api.annotation.dsl.xml.XmlHints;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 
@@ -16,6 +17,7 @@ import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
  * @since 4.0
  */
 @Alias("ntlm-proxy")
+@XmlHints(allowTopLevelDefinition = true)
 public class NtlmProxyConfig extends DefaultProxyConfig {
 
   /**

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/DefaultXmlGathererErrorHandlerFactory.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/DefaultXmlGathererErrorHandlerFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXParseException;
+
+/**
+ * Default implementation of {@link XmlGathererErrorHandlerFactory} which will return the {@link DefaultXmlLoggerErrorHandler}
+ * instance that registers all errors when {@link ErrorHandler#error(SAXParseException)} is called, to then return the
+ * complete gathered list of exceptions through {@link XmlGathererErrorHandler#getErrors()} method.
+ *
+ * @since 4.0
+ */
+public class DefaultXmlGathererErrorHandlerFactory implements XmlGathererErrorHandlerFactory {
+
+  @Override
+  public XmlGathererErrorHandler create() {
+    return new DefaultXmlLoggerErrorHandler();
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/DefaultXmlLoggerErrorHandler.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/DefaultXmlLoggerErrorHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring;
+
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.xml.DocumentLoader;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ * Default implementation of {@link XmlGathererErrorHandler} which collects all errors, and on a fatal exception will
+ * propagate an exception.
+ * <p/>
+ * If logging is enabled, it will also log all warnings, errors and fatal when encountered.
+ * <p/>
+ * Instances of this class are not reusable among several readings of {@link DocumentLoader#loadDocument(InputSource, EntityResolver, ErrorHandler, int, boolean)},
+ * as it holds state of the exceptions that were gathered.
+ *
+ * @since 4.0
+ */
+public class DefaultXmlLoggerErrorHandler implements XmlGathererErrorHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultXmlLoggerErrorHandler.class);
+
+  private List<SAXParseException> errors = new ArrayList<>();
+
+  @Override
+  public void warning(SAXParseException e) throws SAXException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(format("Found a waring exception parsing document, message '%s'", e.toString()), e);
+    }
+  }
+
+  @Override
+  public void fatalError(SAXParseException e) throws SAXException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(format("Found a fatal error exception parsing document, message '%s'", e.toString()), e);
+    }
+    throw e;
+  }
+
+  @Override
+  public void error(SAXParseException e) throws SAXException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(format("Found error exception parsing document, message '%s'", e.toString()), e);
+    }
+    errors.add(e);
+  }
+
+  @Override
+  public List<SAXParseException> getErrors() {
+    return errors;
+  }
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/MuleArtifactContext.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/MuleArtifactContext.java
@@ -205,6 +205,7 @@ public class MuleArtifactContext extends AbstractXmlApplicationContext {
       for (Resource springResource : artifactConfigResources) {
         Document document =
             xmlConfigurationDocumentLoader.loadDocument(ofNullable(muleContext.getExtensionManager()),
+                                                        springResource.getFilename(),
                                                         springResource.getInputStream());
         ConfigLine mainConfigLine = xmlApplicationParser.parse(document.getDocumentElement()).get();
         applicationConfigBuilder.addConfigFile(new ConfigFile(getFilename(springResource), asList(mainConfigLine)));

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoader.java
@@ -7,45 +7,80 @@
 package org.mule.runtime.config.spring;
 
 import static java.lang.String.format;
+import static java.lang.System.lineSeparator;
 import static java.util.Optional.empty;
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import org.mule.runtime.api.exception.MuleRuntimeException;
-import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.extension.api.ExtensionManager;
 
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.xml.DocumentLoader;
 import org.w3c.dom.Document;
+import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * Loads a mule configuration file into a {@link Document} object.
+ * <p/>
+ * If when loading the configuration one, or more, {@link ErrorHandler#error(SAXParseException)} are call, at the end of
+ * {@link #loadDocument(Optional, String, InputStream)} will throw an exception containing all the errors.
+ *
+ * @see {@link #loadDocument(Optional, String, InputStream)}
  *
  * @since 4.0
  */
 public class XmlConfigurationDocumentLoader {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(XmlConfigurationDocumentLoader.class);
 
   /**
    * Indicates that XSD validation should be used (found no "DOCTYPE" declaration).
    */
   private static final int VALIDATION_XSD = 3;
 
+  private final XmlGathererErrorHandlerFactory xmlGathererErrorHandlerFactory;
+
+  /**
+   * Creates an {@link XmlConfigurationDocumentLoader} using the default {@link DefaultXmlGathererErrorHandlerFactory}
+   * to instantiate {@link XmlGathererErrorHandler}s objects when executing the {@link #loadDocument(Optional, String, InputStream)}
+   * method.
+   * <p/>
+   * Using the default constructor implies that all XSD validations will take place and, at the end of the parsing, all
+   * the errors will be contained in an {@link MuleRuntimeException} which will be thrown.
+   */
+  public XmlConfigurationDocumentLoader() {
+    this(new DefaultXmlGathererErrorHandlerFactory());
+  }
+
+  /**
+   * Creates an {@link XmlConfigurationDocumentLoader} using a parametrized {@link XmlGathererErrorHandlerFactory}
+   * to instantiate {@link XmlGathererErrorHandler}s objects when executing the {@link #loadDocument(Optional, String, InputStream)}
+   * method.
+   * <p/>
+   * Depending on what type of {@link XmlGathererErrorHandler} the factory returns, the {@link #loadDocument(Optional, String, InputStream)}
+   * method will not thrown any exception if {@link XmlGathererErrorHandler#getErrors()} is an empty list.
+   *
+   * @param xmlGathererErrorHandlerFactory to create {@link XmlGathererErrorHandler} in the {@link #loadDocument(Optional, String, InputStream)}
+   */
+  public XmlConfigurationDocumentLoader(XmlGathererErrorHandlerFactory xmlGathererErrorHandlerFactory) {
+    this.xmlGathererErrorHandlerFactory = xmlGathererErrorHandlerFactory;
+  }
+
   /**
    * Creates a {@link Document} from an {@link InputStream} with the required configuration
    * of a mule configuration file parsing.
    *
+   * @param filename name of the file to display a better error messages (if there are any). Non null.
    * @param inputStream the input stream with the XML configuration content.
    * @return a new {@link Document} object with the provided content.
+   * @throws MuleRuntimeException if an error occurs in {@link DocumentLoader} factory, or if the current {@code filename}
+   * contains 1 or more errors.
+   * @see {@link DefaultXmlLoggerErrorHandler#getErrors()}
    */
-  public Document loadDocument(InputStream inputStream) {
-    return loadDocument(empty(), inputStream);
+  public Document loadDocument(String filename, InputStream inputStream) {
+    return loadDocument(empty(), filename, inputStream);
   }
 
   /**
@@ -53,35 +88,38 @@ public class XmlConfigurationDocumentLoader {
    * of a mule configuration file parsing.
    *
    * @param extensionManager if the current {@code inputStream} relies in other schemas pending to be loaded from an
-   * {@link ExtensionModel}, then it will delegate to the manager for the lookup on them.
-   *
+   * @param filename name of the file to display a better error messages (if there are any). Non null.
    * @param inputStream the input stream with the XML configuration content.
    * @return a new {@link Document} object with the provided content.
-   *
-   * @see ModuleDelegatingEntityResolver#getSchema(ExtensionModel)
+   * @throws MuleRuntimeException if an error occurs in {@link DocumentLoader} factory, or if the current {@code filename}
+   * contains 1 or more errors.
+   * @see {@link DefaultXmlLoggerErrorHandler#getErrors()}
    */
-  public Document loadDocument(Optional<ExtensionManager> extensionManager, InputStream inputStream) {
+  public Document loadDocument(Optional<ExtensionManager> extensionManager, String filename, InputStream inputStream) {
+    final XmlGathererErrorHandler errorHandler = xmlGathererErrorHandlerFactory.create();
+    Document document;
     try {
-      Document document = new MuleDocumentLoader()
+      document = new MuleDocumentLoader()
           .loadDocument(new InputSource(inputStream),
-                        new ModuleDelegatingEntityResolver(extensionManager), new MuleLoggerErrorHandler(),
+                        new ModuleDelegatingEntityResolver(extensionManager), errorHandler,
                         VALIDATION_XSD, true);
-      return document;
     } catch (Exception e) {
       throw new MuleRuntimeException(e);
     }
+    throwExceptionIfErrorsWereFound(errorHandler, filename);
+    return document;
   }
 
-  /**
-   * helper class to gather all errors while applying the found XSDs for the current input stream
-   */
-  private static class MuleLoggerErrorHandler extends DefaultHandler {
-
-    @Override
-    public void error(SAXParseException e) throws SAXException {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug(format("Found exception parsing document, message '%s'", e.toString()), e);
-      }
+  private void throwExceptionIfErrorsWereFound(XmlGathererErrorHandler errorHandler, String filename) {
+    final List<SAXParseException> errors = errorHandler.getErrors();
+    if (!errors.isEmpty()) {
+      final String subMessage = format(errors.size() == 1 ? "was '%s' error" : "were '%s' errors", errors.size());
+      final StringBuilder sb =
+          new StringBuilder(format("There %s while parsing the file '%s'.", subMessage, filename));
+      sb.append(lineSeparator()).append("Full list:");
+      errors.stream().forEach(error -> sb.append(lineSeparator()).append(error));
+      sb.append(lineSeparator());
+      throw new MuleRuntimeException(createStaticMessage(sb.toString()));
     }
   }
 }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlGathererErrorHandler.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlGathererErrorHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXParseException;
+
+/**
+ * Represents a specific type of {@link ErrorHandler} which gathers as many errors as possible to be displayed later for
+ * either logging purposes or to propagate an exception with the full list of errors.
+ * <p/>
+ * Any implementation must be careful on how to treat the {@link ErrorHandler#fatalError(SAXParseException)} method, as
+ * if the exception is not propagated immediately, breaking the current file parsing, the state of the DOM is in most
+ * of the cases unusable.
+ *
+ * @see {@link XmlConfigurationDocumentLoader#loadDocument(Optional, String, InputStream)}
+ *
+ * @since 4.0
+ */
+public interface XmlGathererErrorHandler extends ErrorHandler {
+
+  /**
+   * @return a collection with all the {@link SAXParseException} exceptions gathered from {@link ErrorHandler#error(SAXParseException)}.
+   * <p/>
+   * An empty list means there were no error while parsing the file. Non null.
+   */
+  List<SAXParseException> getErrors();
+}

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlGathererErrorHandlerFactory.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/XmlGathererErrorHandlerFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring;
+
+import org.springframework.beans.factory.xml.DocumentLoader;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+
+/**
+ * Factory object to create instances of {@link XmlGathererErrorHandler} that will be used in the reading of XML files.
+ *
+ * @since 4.0
+ */
+public interface XmlGathererErrorHandlerFactory {
+
+  /**
+   * @return Creates an {@link XmlGathererErrorHandler} to be used when executing {@link DocumentLoader#loadDocument(InputSource, EntityResolver, ErrorHandler, int, boolean)}
+   */
+  XmlGathererErrorHandler create();
+}

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoaderTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoaderTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.spring;
+
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.isNull;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.xpath.XPathExpressionException;
+
+import org.hamcrest.core.StringContains;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+public class XmlConfigurationDocumentLoaderTestCase {
+
+  /**
+   * The following {@link #LINE_NUMBER_ERROR} and {@link #COLUMN_NUMBER_ERROR} are directly related to the mule-config-malformed.xml
+   * document. Any change in that file will directly impact these tests as we assert on the file to be sure the errors
+   * reading is properly done.
+   */
+  private static final int LINE_NUMBER_ERROR = 6;
+  private static final int COLUMN_NUMBER_ERROR = 12;
+
+  @Test
+  public void testWellformedXml() {
+    final Document document = getDocument("mule-config.xml");
+    assertThat(document, not(isNull()));
+    assertThat(document.getDocumentElement().getNodeName(), is("mule"));
+    assertThat(document.getDocumentElement().getChildNodes().getLength(), is(3));
+
+    assertThat(document.getDocumentElement().getChildNodes().item(1).getNodeName(), is("flow"));
+    assertThat(document.getDocumentElement().getChildNodes().item(1).getAttributes().getNamedItem("name").getNodeValue(),
+               is("service"));
+  }
+
+  @Test
+  public void testMalformedXmlDefaultConstructor() throws XPathExpressionException {
+    try {
+      getDocument("mule-config-malformed.xml");
+      fail("Should not have reach here as the document is malformed and an exception should have been thrown using the default constructor");
+    } catch (MuleRuntimeException e) {
+      // We want to be sure that the line and column are properly picked up
+      assertThat(e.getMessage(),
+                 StringContains.containsString("lineNumber: " + LINE_NUMBER_ERROR + "; columnNumber: " + COLUMN_NUMBER_ERROR));
+    }
+  }
+
+  @Test
+  public void testMalformedXmlCustomGatherer() throws XPathExpressionException {
+    // We will use a custom gathered that stores the errors but returns an empty list when asked
+    final XmlGathererErrorHandlerTest xmlGathererErrorHandlerTest = new XmlGathererErrorHandlerTest();
+    final XmlConfigurationDocumentLoader xmlConfigurationDocumentLoader =
+        new XmlConfigurationDocumentLoader(() -> xmlGathererErrorHandlerTest);
+
+    // Validates that the DOM was properly parsed even when it was non-XSD valid
+    final Document document = getDocument("mule-config-malformed.xml", xmlConfigurationDocumentLoader);
+    assertThat(document, not(isNull()));
+    assertThat(document.getDocumentElement().getNodeName(), is("mule"));
+    assertThat(document.getDocumentElement().getChildNodes().getLength(), is(3));
+
+    final Node flow = document.getDocumentElement().getChildNodes().item(1);
+    assertThat(flow.getNodeName(), is("flow"));
+    assertThat(flow.getAttributes().getNamedItem("name").getNodeValue(), is("missing-inner-element"));
+
+    // Asserts over the gathered errors
+    assertThat(xmlGathererErrorHandlerTest.errors.size(), is(1));
+    assertThat(xmlGathererErrorHandlerTest.errors.get(0).getColumnNumber(), is(COLUMN_NUMBER_ERROR));
+    assertThat(xmlGathererErrorHandlerTest.errors.get(0).getLineNumber(), is(LINE_NUMBER_ERROR));
+  }
+
+  private Document getDocument(String filename) {
+    final XmlConfigurationDocumentLoader xmlConfigurationDocumentLoader = new XmlConfigurationDocumentLoader();
+    return getDocument(filename, xmlConfigurationDocumentLoader);
+  }
+
+  private Document getDocument(String filename, XmlConfigurationDocumentLoader xmlConfigurationDocumentLoader) {
+    final InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename);
+    return xmlConfigurationDocumentLoader.loadDocument(filename, inputStream);
+  }
+
+  /**
+   * Custom implementation to count errors for the current XSD validation for testing purposes only
+   */
+  private class XmlGathererErrorHandlerTest implements XmlGathererErrorHandler {
+
+    private final List<SAXParseException> errors = new ArrayList<>();
+
+    @Override
+    public void warning(SAXParseException exception) throws SAXException {
+      throw new UnsupportedOperationException("Current tests only work with ERRORs (found a warning)");
+    }
+
+    @Override
+    public void error(SAXParseException exception) throws SAXException {
+      errors.add(exception);
+    }
+
+    @Override
+    public void fatalError(SAXParseException exception) throws SAXException {
+      throw new UnsupportedOperationException("Current tests only work with ERRORs (found a fatal)");
+    }
+
+    /**
+     * @return {@link Collections#emptyList()} always. We want to make the {@link XmlConfigurationDocumentLoader#loadDocument(java.util.Optional, java.lang.String, java.io.InputStream)}
+     * method believe there was no errors while working with the current file.
+     */
+    @Override
+    public List<SAXParseException> getErrors() {
+      return emptyList();
+    }
+  }
+}

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoaderTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/XmlConfigurationDocumentLoaderTestCase.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.isNull;
 import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -29,7 +30,7 @@ import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-public class XmlConfigurationDocumentLoaderTestCase {
+public class XmlConfigurationDocumentLoaderTestCase extends AbstractMuleTestCase {
 
   /**
    * The following {@link #LINE_NUMBER_ERROR} and {@link #COLUMN_NUMBER_ERROR} are directly related to the mule-config-malformed.xml

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/dsl/model/MinimalApplicationModelGeneratorTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/dsl/model/MinimalApplicationModelGeneratorTestCase.java
@@ -89,7 +89,8 @@ public class MinimalApplicationModelGeneratorTestCase extends AbstractMuleTestCa
 
   private MinimalApplicationModelGenerator createGeneratorForConfig(String configFileName) throws Exception {
     Optional<ConfigLine> configLine = xmlApplicationParser.parse(documentLoader
-        .loadDocument(getClass().getClassLoader().getResourceAsStream("model-generator/" + configFileName)).getDocumentElement());
+        .loadDocument(configFileName, getClass().getClassLoader().getResourceAsStream("model-generator/" + configFileName))
+        .getDocumentElement());
     ConfigFile configFile = new ConfigFile("test", Arrays.asList(configLine.get()));
     ComponentBuildingDefinitionRegistry componentBuildingDefinitionRegistry = new ComponentBuildingDefinitionRegistry();
     CoreComponentBuildingDefinitionProvider coreComponentBuildingDefinitionProvider =

--- a/modules/spring-config/src/test/resources/mule-config-malformed.xml
+++ b/modules/spring-config/src/test/resources/mule-config-malformed.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+    <flow name="missing-inner-element">
+    </flow>
+</mule>

--- a/tests/http/src/test/resources/http-request-multipart-config.xml
+++ b/tests/http/src/test/resources/http-request-multipart-config.xml
@@ -11,7 +11,7 @@
     </httpn:request-config>
 
     <flow name="requestFlow">
-        <httpn:request config-ref="requestConfig" method="GET" path="#[requestPath]"  key="NullPayload"/>
+        <httpn:request config-ref="requestConfig" method="GET" path="#[requestPath]"/>
     </flow>
 
 </mule>

--- a/tests/http/src/test/resources/http-request-paths-config.xml
+++ b/tests/http/src/test/resources/http-request-paths-config.xml
@@ -14,11 +14,11 @@
     </httpn:request-config>
 
     <flow name="requestWithBasePath">
-        <httpn:request config-ref="configWithBasePath" path="#[requestPath]" key="InputStream"/>
+        <httpn:request config-ref="configWithBasePath" path="#[requestPath]"/>
     </flow>
 
     <flow name="requestWithoutBasePath">
-        <httpn:request config-ref="configWithoutBasePath" host="localhost" port="${httpPort}" path="#[requestPath]" key="InputStream"/>
+        <httpn:request config-ref="configWithoutBasePath" host="localhost" port="${httpPort}" path="#[requestPath]"/>
     </flow>
 
 </mule>

--- a/tests/http/src/test/resources/http-request-timeout-config.xml
+++ b/tests/http/src/test/resources/http-request-timeout-config.xml
@@ -11,11 +11,11 @@
     </httpn:request-config>
 
     <flow name="requestFlow">
-        <httpn:request config-ref="requestConfig" method="POST" path="/" responseTimeout="#[timeout]" key="InputStream"/>
+        <httpn:request config-ref="requestConfig" method="POST" path="/" responseTimeout="#[timeout]"/>
     </flow>
 
     <flow name="requestFlowNoTimeout">
-        <httpn:request config-ref="requestConfig" method="POST" path="/" key="InputStream"/>
+        <httpn:request config-ref="requestConfig" method="POST" path="/"/>
     </flow>
 
 </mule>

--- a/tests/integration/src/test/java/org/mule/properties/InvalidSetVariableTestCase.java
+++ b/tests/integration/src/test/java/org/mule/properties/InvalidSetVariableTestCase.java
@@ -7,9 +7,8 @@
 package org.mule.properties;
 
 import static java.util.Arrays.asList;
-
 import org.mule.runtime.config.spring.SpringXmlConfigurationBuilder;
-import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.core.api.config.ConfigurationException;
 import org.mule.runtime.core.context.DefaultMuleContextFactory;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
@@ -34,7 +33,7 @@ public class InvalidSetVariableTestCase extends AbstractMuleTestCase {
     this.muleConfigPath = muleConfigPath;
   }
 
-  @Test(expected = InitialisationException.class)
+  @Test(expected = ConfigurationException.class)
   public void emptyVariableNameValidatedBySchema() throws Exception {
     // TODO MULE-10061 - Review once the MuleContext lifecycle is clearly defined
     new DefaultMuleContextFactory().createMuleContext(new SpringXmlConfigurationBuilder(muleConfigPath));

--- a/tests/integration/src/test/java/org/mule/test/routing/ScatterGatherOneRouteTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/routing/ScatterGatherOneRouteTestCase.java
@@ -7,23 +7,22 @@
 package org.mule.test.routing;
 
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
-
+import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.config.spring.SpringXmlConfigurationBuilder;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationException;
-import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.context.DefaultMuleContextFactory;
 import org.mule.runtime.core.routing.ScatterGatherRouter;
 import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import com.yourkit.util.Asserts;
 
 import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.yourkit.util.Asserts;
 
 public class ScatterGatherOneRouteTestCase extends AbstractMuleTestCase {
 
@@ -42,7 +41,7 @@ public class ScatterGatherOneRouteTestCase extends AbstractMuleTestCase {
   }
 
   // TODO MULE-10061 - Review once the MuleContext lifecycle is clearly defined
-  @Test(expected = InitialisationException.class)
+  @Test(expected = ConfigurationException.class)
   public void oneRouteOnXml() throws Exception {
     new DefaultMuleContextFactory().createMuleContext(new SpringXmlConfigurationBuilder("scatter-gather-one-route-test.xml"));
   }

--- a/tests/integration/src/test/resources/composite-source-start-delay-config.xml
+++ b/tests/integration/src/test/resources/composite-source-start-delay-config.xml
@@ -10,7 +10,7 @@
             http://www.mulesoft.org/schema/mule/httpn http://www.mulesoft.org/schema/mule/httpn/current/mule-httpn.xsd
             http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
-    <httpn:listener-config name="listenerConfig" host="localhost" port="${httpPort}">
+    <httpn:listener-config name="listenerConfig">
     	<httpn:listener-connection host="localhost" port="${httpPort}"/>
     </httpn:listener-config>
 

--- a/tests/test-extensions/petstore-extension/src/main/java/org/mule/test/petstore/extension/PhoneNumber.java
+++ b/tests/test-extensions/petstore-extension/src/main/java/org/mule/test/petstore/extension/PhoneNumber.java
@@ -6,8 +6,10 @@
  */
 package org.mule.test.petstore.extension;
 
+import org.mule.runtime.extension.api.annotation.dsl.xml.XmlHints;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 
+@XmlHints(allowTopLevelDefinition = true)
 public class PhoneNumber {
 
   @Parameter


### PR DESCRIPTION
Before this PR Mule wasn't properly validating the XML files through XSD. What the `XmlConfigurationDocumentLoader` will do is gather ALL errors and display them in the following format when there was 1 error found:
```
org.mule.runtime.core.api.config.ConfigurationException: org.mule.runtime.api.exception.MuleRuntimeException: There was '1' error while parsing the file 'update-name-param-override-config.xml'.
Full list:
org.xml.sax.SAXParseException; lineNumber: 10; columnNumber: 30; cvc-complex-type.2.4.a: Invalid content was found starting with element 'db:input-parameters'. One of '{"http://www.mulesoft.org/schema/mule/db":parameter-types}' is expected.
 (org.mule.runtime.api.exception.MuleRuntimeException)... bla bla bla full stack below
```
or the following when there are 2 or more:
```
org.mule.runtime.core.api.config.ConfigurationException: 
org.mule.runtime.api.exception.MuleRuntimeException: java.lang.IllegalArgumentException: There are '2' errors while parsing the file 'some-xml-filename.xml'.
Full list:
org.xml.sax.SAXParseException; lineNumber: 17; columnNumber: 97; cvc-complex-type.3.2.2: Attribute 'key' is not allowed to appear in element 'httpn:request'.
org.xml.sax.SAXParseException; lineNumber: 21; columnNumber: 136; cvc-complex-type.3.2.2: Attribute 'key' is not allowed to appear in element 'httpn:request'.
 (org.mule.runtime.api.exception.MuleRuntimeException)... bla bla bla full stack below
```

CB build for CE+EE: https://muleesb.ci.cloudbees.com/view/Template%20Jobs/job/CE-EE-Test-4.x/105/ , is almost green =].
It fails the same tests of ToolingServiceTestCase of the EE system tests (consistent on what the current SNAPSHOT build is) com.mulesoft.mule.distributions.server.tooling.ToolingServiceTestCase.getMetadataKeysThroughSer
and com.mulesoft.mule.distributions.server.tooling.ToolingServiceTestCase.getMetadataThroughService 
