### PR TITLE
MULE-11084: Improve schema for validations

### DIFF
--- a/extensions/db/src/main/java/org/mule/extension/db/internal/domain/connection/DbConnectionProvider.java
+++ b/extensions/db/src/main/java/org/mule/extension/db/internal/domain/connection/DbConnectionProvider.java
@@ -67,14 +67,6 @@ public abstract class DbConnectionProvider implements ConnectionProvider<DbConne
   private MuleContext muleContext;
 
   /**
-   * Specifies non-standard custom data types
-   */
-  @Parameter
-  @Optional
-  @Expression(NOT_SUPPORTED)
-  private List<CustomDataType> customDataTypes = emptyList();
-
-  /**
    * Provides a way to configure database connection pooling.
    */
   @Parameter
@@ -82,6 +74,15 @@ public abstract class DbConnectionProvider implements ConnectionProvider<DbConne
   @Expression(NOT_SUPPORTED)
   @Placement(tab = ADVANCED_TAB)
   private DbPoolingProfile poolingProfile;
+
+  /**
+   * Specifies non-standard custom data types
+   */
+  @Parameter
+  @Optional
+  @Expression(NOT_SUPPORTED)
+  private List<CustomDataType> customDataTypes = emptyList();
+
 
   private DataSourceFactory dataSourceFactory;
   private List<DbType> resolvedCustomTypes = emptyList();

--- a/extensions/db/src/test/resources/integration/config/derby-pooling-db-config.xml
+++ b/extensions/db/src/test/resources/integration/config/derby-pooling-db-config.xml
@@ -7,11 +7,11 @@
 
     <db:config name="pooledJdbcConfig">
         <db:derby-connection database="target/muleEmbeddedDB" create="true">
-            <db:pooling-profile maxPoolSize="2" minPoolSize="0" maxWait="1" maxWaitUnit="SECONDS"/>
             <db:custom-data-types>
                 <!-- Derby uses JAVA_OBJECT for UDT-->
                 <db:custom-data-type typeName="CONTACT_DETAILS" id="2000"/>
             </db:custom-data-types>
+            <db:pooling-profile maxPoolSize="2" minPoolSize="0" maxWait="1" maxWaitUnit="SECONDS"/>
         </db:derby-connection>
     </db:config>
 

--- a/extensions/db/src/test/resources/integration/config/derby-pooling-db-config.xml
+++ b/extensions/db/src/test/resources/integration/config/derby-pooling-db-config.xml
@@ -7,11 +7,11 @@
 
     <db:config name="pooledJdbcConfig">
         <db:derby-connection database="target/muleEmbeddedDB" create="true">
+            <db:pooling-profile maxPoolSize="2" minPoolSize="0" maxWait="1" maxWaitUnit="SECONDS"/>
             <db:custom-data-types>
                 <!-- Derby uses JAVA_OBJECT for UDT-->
                 <db:custom-data-type typeName="CONTACT_DETAILS" id="2000"/>
             </db:custom-data-types>
-            <db:pooling-profile maxPoolSize="2" minPoolSize="0" maxWait="1" maxWaitUnit="SECONDS"/>
         </db:derby-connection>
     </db:config>
 

--- a/extensions/sockets/src/test/resources/custom-protocol-ref-config.xml
+++ b/extensions/sockets/src/test/resources/custom-protocol-ref-config.xml
@@ -11,8 +11,8 @@
 
     <sockets:request-config name="tcp-requester">
         <sockets:tcp-requester-connection host="localhost" port="${port}" protocol="myProtocolRef" failOnUnresolvedHost="true" sendTcpNoDelay="true">
-            <pooling-profile maxActive="1"/>
             <reconnect blocking="false" />
+            <pooling-profile maxActive="1"/>
         </sockets:tcp-requester-connection>
     </sockets:request-config>
 

--- a/extensions/sockets/src/test/resources/ssl-certificate-config.xml
+++ b/extensions/sockets/src/test/resources/ssl-certificate-config.xml
@@ -19,8 +19,8 @@
                                           failOnUnresolvedHost="true"
                                           sendTcpNoDelay="true"
                                           tlsContext="tlsContext">
-            <pooling-profile maxActive="1"/>
             <reconnect blocking="false" />
+            <pooling-profile maxActive="1"/>
         </sockets:tcp-requester-connection>
     </sockets:request-config>
 

--- a/extensions/sockets/src/test/resources/tcp-connection-timeout-config.xml
+++ b/extensions/sockets/src/test/resources/tcp-connection-timeout-config.xml
@@ -10,8 +10,8 @@
         <sockets:tcp-requester-connection host="10.255.255.255" port="${port}"
                                           connectionTimeout="100"
                                           sendTcpNoDelay="true">
-            <pooling-profile maxActive="1"/>
             <reconnect blocking="false" />
+            <pooling-profile maxActive="1"/>
         </sockets:tcp-requester-connection>
     </sockets:request-config>
 

--- a/extensions/sockets/src/test/resources/tcp-reading-timeout-config.xml
+++ b/extensions/sockets/src/test/resources/tcp-reading-timeout-config.xml
@@ -9,8 +9,8 @@
 
     <sockets:request-config name="tcp-requester">
         <sockets:tcp-requester-connection host="localhost" port="${port}" clientTimeout="100" sendTcpNoDelay="true">
-            <pooling-profile maxActive="1"/>
             <reconnect blocking="false" />
+            <pooling-profile maxActive="1"/>
             <sockets:protocol>
                 <!--Necessary to catch the exception in the test-->
                 <sockets:length-protocol rethrowExceptionOnRead="true"/>

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/CollectionSchemaDelegate.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/CollectionSchemaDelegate.java
@@ -10,6 +10,7 @@ import static java.lang.String.format;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 import static org.mule.runtime.module.extension.internal.util.ExtensionMetadataTypeUtils.getId;
+import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.MAX_ONE;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.UNBOUNDED;
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.MetadataType;
@@ -21,6 +22,8 @@ import org.mule.runtime.module.extension.internal.capability.xml.schema.model.Ex
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.LocalComplexType;
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.ObjectFactory;
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.TopLevelElement;
+
+import java.util.Map;
 
 /**
  * Builder delegation class to generate an XSD schema that describes an {@link ArrayType}
@@ -37,14 +40,16 @@ class CollectionSchemaDelegate {
   }
 
   void generateCollectionElement(ArrayType metadataType, DslElementSyntax collectionDsl, String description, boolean required,
-                                 ExplicitGroup all) {
+                                 Map<String, TopLevelElement> all) {
     LocalComplexType collectionComplexType = generateCollectionComplexType(collectionDsl, metadataType);
 
-    TopLevelElement collectionElement = builder.createTopLevelElement(collectionDsl.getElementName(), required ? ONE : ZERO, "1");
+    TopLevelElement collectionElement = builder.createTopLevelElement(collectionDsl.getElementName(),
+                                                                      required ? ONE : ZERO,
+                                                                      MAX_ONE);
     collectionElement.setAnnotation(builder.createDocAnnotation(description));
-    all.getParticle().add(objectFactory.createElement(collectionElement));
-
     collectionElement.setComplexType(collectionComplexType);
+
+    all.put(collectionDsl.getElementName(), collectionElement);
   }
 
   private LocalComplexType generateCollectionComplexType(DslElementSyntax collectionDsl, final ArrayType metadataType) {

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/MapSchemaDelegate.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/MapSchemaDelegate.java
@@ -14,6 +14,7 @@ import static org.mule.runtime.api.meta.ExpressionSupport.SUPPORTED;
 import static org.mule.runtime.module.extension.internal.util.ExtensionMetadataTypeUtils.getId;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.ATTRIBUTE_NAME_KEY;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.ATTRIBUTE_NAME_VALUE;
+import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.MAX_ONE;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.UNBOUNDED;
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.DictionaryType;
@@ -29,6 +30,7 @@ import org.mule.runtime.module.extension.internal.capability.xml.schema.model.Ob
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.TopLevelElement;
 
 import java.math.BigInteger;
+import java.util.Map;
 
 /**
  * Builder delegation class to generate an XSD schema that describes an {@link DictionaryType}
@@ -45,15 +47,15 @@ final class MapSchemaDelegate {
   }
 
   void generateMapElement(DictionaryType metadataType, DslElementSyntax paramDsl, String description, boolean required,
-                          ExplicitGroup all) {
+                          Map<String, TopLevelElement> all) {
     BigInteger minOccurs = required ? ONE : ZERO;
     LocalComplexType mapComplexType = generateMapComplexType(paramDsl, metadataType);
 
-    TopLevelElement mapElement = builder.createTopLevelElement(paramDsl.getElementName(), minOccurs, "1");
+    TopLevelElement mapElement = builder.createTopLevelElement(paramDsl.getElementName(), minOccurs, MAX_ONE);
     mapElement.setAnnotation(builder.createDocAnnotation(description));
-    all.getParticle().add(objectFactory.createElement(mapElement));
-
     mapElement.setComplexType(mapComplexType);
+
+    all.put(paramDsl.getElementName(), mapElement);
   }
 
   private LocalComplexType generateMapComplexType(DslElementSyntax mapDsl, final DictionaryType metadataType) {

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/SchemaBuilder.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/SchemaBuilder.java
@@ -9,14 +9,18 @@ package org.mule.runtime.module.extension.internal.capability.xml.schema.builder
 import static java.lang.String.format;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
+import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
 import static org.mule.runtime.api.meta.ExpressionSupport.SUPPORTED;
+import static org.mule.runtime.api.meta.model.parameter.ParameterGroupModel.DEFAULT_GROUP_NAME;
 import static org.mule.runtime.extension.api.util.NameUtils.sanitizeName;
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.TLS_ATTRIBUTE_NAME;
 import static org.mule.runtime.module.extension.internal.capability.xml.schema.builder.ObjectTypeSchemaDelegate.getAbstractElementName;
 import static org.mule.runtime.module.extension.internal.util.ExtensionMetadataTypeUtils.getId;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.ATTRIBUTE_NAME_VALUE;
+import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.MAX_ONE;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.MULE_ABSTRACT_RECONNECTION_STRATEGY;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.MULE_EXTENSION_NAMESPACE;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.MULE_EXTENSION_OPERATION_TRANSACTIONAL_ACTION_TYPE;
@@ -29,8 +33,9 @@ import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.SPR
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.SPRING_FRAMEWORK_SCHEMA_LOCATION;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.STRING;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.TLS_CONTEXT_TYPE;
+import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.USE_OPTIONAL;
+import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.USE_REQUIRED;
 import static org.mule.runtime.module.extension.internal.xml.SchemaConstants.XML_NAMESPACE;
-
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.annotation.EnumAnnotation;
 import org.mule.metadata.api.model.ArrayType;
@@ -66,7 +71,6 @@ import org.mule.runtime.module.extension.internal.capability.xml.schema.model.Do
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.ExplicitGroup;
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.ExtensionType;
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.FormChoice;
-import org.mule.runtime.module.extension.internal.capability.xml.schema.model.Group;
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.Import;
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.LocalComplexType;
 import org.mule.runtime.module.extension.internal.capability.xml.schema.model.LocalSimpleType;
@@ -84,8 +88,10 @@ import org.mule.runtime.module.extension.internal.xml.SchemaConstants;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -103,16 +109,15 @@ public final class SchemaBuilder {
   private static final String GLOBAL_ABSTRACT_ELEMENT_MASK = "global-%s";
 
   private final Set<StringType> registeredEnums = new LinkedHashSet<>();
-
   private final ObjectFactory objectFactory = new ObjectFactory();
   private final ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
-  private final ConfigurationSchemaDelegate configurationSchemaDelegate = new ConfigurationSchemaDelegate(this);
-  private final ConnectionProviderSchemaDelegate connectionProviderSchemaDelegate = new ConnectionProviderSchemaDelegate(this);
-  private final OperationSchemaDelegate operationSchemaDelegate = new OperationSchemaDelegate(this);
-  private final SourceSchemaDelegate sourceSchemaDelegate = new SourceSchemaDelegate(this);
-  private final CollectionSchemaDelegate collectionDelegate = new CollectionSchemaDelegate(this);
-  private final ObjectTypeSchemaDelegate objectTypeDelegate = new ObjectTypeSchemaDelegate(this);
-  private final MapSchemaDelegate mapDelegate = new MapSchemaDelegate(this);
+  //private final ConfigurationSchemaDelegate configurationSchemaDelegate = new ConfigurationSchemaDelegate(this);
+  //private final ConnectionProviderSchemaDelegate connectionProviderSchemaDelegate = new ConnectionProviderSchemaDelegate(this);
+  //private final OperationSchemaDelegate operationSchemaDelegate = new OperationSchemaDelegate(this);
+  //private final SourceSchemaDelegate sourceSchemaDelegate = new SourceSchemaDelegate(this);
+  //private final CollectionSchemaDelegate collectionDelegate = new CollectionSchemaDelegate(this);
+  //private final ObjectTypeSchemaDelegate objectTypeDelegate = new ObjectTypeSchemaDelegate(this);
+  //private final MapSchemaDelegate mapDelegate = new MapSchemaDelegate(this);
 
   private Schema schema;
   private boolean requiresTls = false;
@@ -122,6 +127,13 @@ public final class SchemaBuilder {
   private SubTypesMappingContainer subTypesMapping;
   private Set<ImportedTypeModel> importedTypes;
   private DslResolvingContext dslExtensionContext;
+  private ConfigurationSchemaDelegate configurationSchemaDelegate;
+  private ConnectionProviderSchemaDelegate connectionProviderSchemaDelegate;
+  private OperationSchemaDelegate operationSchemaDelegate;
+  private SourceSchemaDelegate sourceSchemaDelegate;
+  private CollectionSchemaDelegate collectionDelegate;
+  private ObjectTypeSchemaDelegate objectTypeDelegate;
+  private MapSchemaDelegate mapDelegate;
 
   public static SchemaBuilder newSchema(ExtensionModel extensionModel, XmlDslModel xmlDslModel,
                                         DslResolvingContext dslContext) {
@@ -138,12 +150,23 @@ public final class SchemaBuilder {
         .importMuleNamespace()
         .importMuleExtensionNamespace();
 
-    builder.withImportedTypes(extensionModel.getImportedTypes());
+    builder.initialiseDelegates();
 
+    builder.withImportedTypes(extensionModel.getImportedTypes());
     builder.withTypeMapping(extensionModel.getSubTypes());
     builder.withTypes(extensionModel.getTypes());
 
     return builder;
+  }
+
+  private void initialiseDelegates() {
+    configurationSchemaDelegate = new ConfigurationSchemaDelegate(this);
+    connectionProviderSchemaDelegate = new ConnectionProviderSchemaDelegate(this);
+    operationSchemaDelegate = new OperationSchemaDelegate(this);
+    sourceSchemaDelegate = new SourceSchemaDelegate(this);
+    collectionDelegate = new CollectionSchemaDelegate(this);
+    objectTypeDelegate = new ObjectTypeSchemaDelegate(this);
+    mapDelegate = new MapSchemaDelegate(this);
   }
 
   private SchemaBuilder withDslSyntaxResolver(ExtensionModel model, DslResolvingContext dslContext) {
@@ -257,14 +280,18 @@ public final class SchemaBuilder {
     return this;
   }
 
-  void registerParameters(ExtensionType type, ExplicitGroup choice, Collection<ParameterModel> parameterModels) {
+  //void registerParameters(ExtensionType type, ExplicitGroup choice, Collection<ParameterModel> parameterModels) {
+  Map<String, TopLevelElement> registerParameters(ExtensionType type, Collection<ParameterModel> parameterModels) {
+    LinkedHashMap<String, TopLevelElement> all = new LinkedHashMap<>();
     for (final ParameterModel parameterModel : getSortedParameterModels(parameterModels)) {
-      declareAsParameter(parameterModel.getType(), type, choice, parameterModel);
+      //declareAsParameter(parameterModel.getType(), type, choice, parameterModel);
+      DslElementSyntax paramDsl = dslResolver.resolve(parameterModel);
+      declareAsParameter(parameterModel.getType(), type, parameterModel, paramDsl, all);
     }
-
-    if (!choice.getParticle().isEmpty()) {
-      type.setSequence(choice);
-    }
+    return all;
+    //if (!choice.getParticle().isEmpty()) {
+    //  type.setSequence(choice);
+    //}
   }
 
   /**
@@ -353,10 +380,10 @@ public final class SchemaBuilder {
   private Attribute createAttribute(final String name, String description, final MetadataType type, Object defaultValue,
                                     boolean required, final ExpressionSupport expressionSupport) {
     final Attribute attribute = new Attribute();
-    attribute.setUse(required ? SchemaConstants.USE_REQUIRED : SchemaConstants.USE_OPTIONAL);
+    attribute.setUse(required ? USE_REQUIRED : USE_OPTIONAL);
     attribute.setAnnotation(createDocAnnotation(description));
 
-    if (defaultValue instanceof String && StringUtils.isNotBlank(defaultValue.toString())) {
+    if (defaultValue instanceof String && isNotBlank(defaultValue.toString())) {
       attribute.setDefault(defaultValue.toString());
     }
 
@@ -407,17 +434,17 @@ public final class SchemaBuilder {
    * support only local declarations as childs.
    * <p/>
    * For example, a resulting choice group for a type of name {@code TypeName} will look like:
-   *
+   * <p>
    * <xs:complexType>
-   *  <xs:choice minOccurs="1" maxOccurs="1">
-   *    <xs:element minOccurs="0" maxOccurs="1" ref="ns:abstract-type-name"></xs:element>
-   *    <xs:element minOccurs="0" maxOccurs="1" ref="ns:global-abstract-type-name"></xs:element>
-   *  </xs:choice>
+   * <xs:choice minOccurs="1" maxOccurs="1">
+   * <xs:element minOccurs="0" maxOccurs="1" ref="ns:abstract-type-name"></xs:element>
+   * <xs:element minOccurs="0" maxOccurs="1" ref="ns:global-abstract-type-name"></xs:element>
+   * </xs:choice>
    * </xs:complexType>
    * <p/>
    *
-   * @param typeDsl {@link DslElementSyntax} of the referenced type
-   * @param type the {@link MetadataType type} of the base element that will be referenced
+   * @param typeDsl   {@link DslElementSyntax} of the referenced type
+   * @param type      the {@link MetadataType type} of the base element that will be referenced
    * @param minOccurs {@link BigInteger#ZERO} if the {@code group} is optional or {@link BigInteger#ONE} if required
    * @param maxOccurs the maximum number of occurrences for this group
    * @return a {@link ExplicitGroup Choice} group with the necessary options for this case
@@ -451,9 +478,7 @@ public final class SchemaBuilder {
 
   boolean isImported(MetadataType type) {
     return importedTypes.stream()
-        .filter(t -> Objects.equals(getTypeId(t.getImportedType()), getTypeId(type)))
-        .findFirst()
-        .isPresent();
+        .anyMatch(t -> Objects.equals(getTypeId(t.getImportedType()), getTypeId(type)));
   }
 
   private String getTypeId(MetadataType type) {
@@ -466,18 +491,18 @@ public final class SchemaBuilder {
    * the referenced abstract-element
    * <p/>
    * For example, if we create this ref element to the type of name {@code TypeName}:
-   *
+   * <p>
    * <xs:element minOccurs="0" maxOccurs="1" ref="ns:abstract-type-name"></xs:element>
-   *
+   * <p>
    * <p/>
    * Then, any of the following elements are allowed to be used where the ref exists:
-   *
+   * <p>
    * <xs:element type="ns:org.mule.test.SomeType" substitutionGroup="ns:abstract-type-name" name="some-type"></xs:element>
-   *
+   * <p>
    * <xs:element type="ns:org.mule.test.OtherType" substitutionGroup="ns:abstract-type-name" name="other-type"></xs:element>
    *
-   * @param typeDsl {@link DslElementSyntax} of the referenced {@code type}
-   * @param type {@link MetadataType} of the referenced {@code type}
+   * @param typeDsl    {@link DslElementSyntax} of the referenced {@code type}
+   * @param type       {@link MetadataType} of the referenced {@code type}
    * @param isRequired whether or not the element element is required
    * @return the {@link TopLevelElement element} representing the reference
    */
@@ -494,25 +519,30 @@ public final class SchemaBuilder {
     return createRefElement(refQName, isRequired);
   }
 
-  void declareAsParameter(MetadataType type, ExtensionType extensionType, ExplicitGroup all, ParameterModel parameterModel) {
+  void declareAsParameter(MetadataType type, ExtensionType extensionType, ParameterModel parameterModel,
+                          DslElementSyntax paramDsl, Map<String, TopLevelElement> childElements) {
+
     if (ExtensionModelUtils.isContent(parameterModel) || TypeUtils.isContent(type)) {
-      DslElementSyntax paramDsl = dslResolver.resolve(parameterModel);
-      generateTextElement(paramDsl, parameterModel.getDescription(), parameterModel.isRequired(), all);
+      childElements.put(paramDsl.getElementName(),
+                        generateTextElement(paramDsl, parameterModel.getDescription(), parameterModel.isRequired()));
     } else {
-      type.accept(getParameterDeclarationVisitor(extensionType, all, parameterModel));
+      type.accept(getParameterDeclarationVisitor(extensionType, childElements, parameterModel));
     }
   }
 
-  private MetadataTypeVisitor getParameterDeclarationVisitor(final ExtensionType extensionType, final ExplicitGroup all,
+  private MetadataTypeVisitor getParameterDeclarationVisitor(final ExtensionType extensionType,
+                                                             final Map<String, TopLevelElement> childElements,
                                                              final ParameterModel parameterModel) {
     final DslElementSyntax paramDsl = dslResolver.resolve(parameterModel);
-    return getParameterDeclarationVisitor(extensionType, all, parameterModel.getName(), parameterModel.getDescription(),
+    return getParameterDeclarationVisitor(extensionType, childElements,
+                                          parameterModel.getName(), parameterModel.getDescription(),
                                           parameterModel.getExpressionSupport(), parameterModel.isRequired(),
                                           parameterModel.getDefaultValue(), paramDsl,
                                           parameterModel.getDslModel());
   }
 
-  private MetadataTypeVisitor getParameterDeclarationVisitor(final ExtensionType extensionType, final ExplicitGroup all,
+  private MetadataTypeVisitor getParameterDeclarationVisitor(final ExtensionType extensionType,
+                                                             final Map<String, TopLevelElement> childElements,
                                                              final String name, final String description,
                                                              ExpressionSupport expressionSupport, boolean required,
                                                              Object defaultValue, DslElementSyntax paramDsl,
@@ -525,7 +555,9 @@ public final class SchemaBuilder {
       public void visitArrayType(ArrayType arrayType) {
         defaultVisit(arrayType);
         if (paramDsl.supportsChildDeclaration()) {
-          collectionDelegate.generateCollectionElement(arrayType, paramDsl, description, false, all);
+          collectionDelegate.generateCollectionElement(arrayType, paramDsl, description,
+                                                       !paramDsl.supportsAttributeDeclaration(),
+                                                       childElements);
         }
       }
 
@@ -533,7 +565,9 @@ public final class SchemaBuilder {
       public void visitDictionary(DictionaryType dictionaryType) {
         defaultVisit(dictionaryType);
         if (paramDsl.supportsChildDeclaration()) {
-          mapDelegate.generateMapElement(dictionaryType, paramDsl, description, false, all);
+          mapDelegate.generateMapElement(dictionaryType, paramDsl, description,
+                                         !paramDsl.supportsAttributeDeclaration(),
+                                         childElements);
         }
       }
 
@@ -541,18 +575,19 @@ public final class SchemaBuilder {
       public void visitObject(ObjectType objectType) {
         final String id = getId(objectType);
         if (id.equals(TlsContextFactory.class.getName())) {
-          addTlsSupport(extensionType, all);
+          addTlsSupport(extensionType, childElements);
           return;
         }
 
         defaultVisit(objectType);
-        objectTypeDelegate.generatePojoElement(objectType, paramDsl, dslModel, description, all);
+        objectTypeDelegate.generatePojoElement(objectType, paramDsl, dslModel, description, childElements);
       }
 
       @Override
       public void visitString(StringType stringType) {
         if (paramDsl.supportsChildDeclaration()) {
-          generateTextElement(paramDsl, description, isRequired(forceOptional, required), all);
+          childElements.put(paramDsl.getElementName(),
+                            generateTextElement(paramDsl, description, isRequired(forceOptional, required)));
         } else {
           defaultVisit(stringType);
         }
@@ -560,8 +595,11 @@ public final class SchemaBuilder {
 
       @Override
       protected void defaultVisit(MetadataType metadataType) {
-        extensionType.getAttributeOrAttributeGroup().add(createAttribute(name, description, metadataType, defaultValue,
-                                                                         isRequired(forceOptional, required), expressionSupport));
+        if (paramDsl.supportsAttributeDeclaration()) {
+          extensionType.getAttributeOrAttributeGroup().add(createAttribute(name, description, metadataType, defaultValue,
+                                                                           isRequired(forceOptional, required),
+                                                                           expressionSupport));
+        }
       }
 
       private boolean isRequired(boolean forceOptional, boolean required) {
@@ -582,35 +620,36 @@ public final class SchemaBuilder {
     return languageModel;
   }
 
-  private void addTlsSupport(ExtensionType extensionType, ExplicitGroup all) {
+  private void addTlsSupport(ExtensionType extensionType, Map<String, TopLevelElement> childElements) {
     if (!requiresTls) {
       importTlsNamespace();
       requiresTls = true;
     }
 
-    addAttributeAndElement(extensionType, all, TLS_ATTRIBUTE_NAME, TLS_CONTEXT_TYPE);
+    addAttributeAndElement(extensionType, childElements, TLS_ATTRIBUTE_NAME, TLS_CONTEXT_TYPE);
   }
 
-  private void addAttributeAndElement(ExtensionType extensionType, ExplicitGroup all, String attributeName, QName elementRef) {
+  private void addAttributeAndElement(ExtensionType extensionType, Map<String, TopLevelElement> childElements,
+                                      String attributeName, QName elementRef) {
 
     extensionType.getAttributeOrAttributeGroup()
         .add(createAttribute(attributeName, load(String.class), false, ExpressionSupport.NOT_SUPPORTED));
 
-    all.getParticle().add(objectFactory.createElement(createRefElement(elementRef, false)));
+    childElements.put(elementRef.getLocalPart(), createRefElement(elementRef, false));
   }
 
   TopLevelElement createRefElement(QName elementRef, boolean isRequired) {
     TopLevelElement element = new TopLevelElement();
     element.setRef(elementRef);
     element.setMinOccurs(isRequired ? ONE : ZERO);
-    element.setMaxOccurs("1");
+    element.setMaxOccurs(MAX_ONE);
     return element;
   }
 
   Attribute createAttribute(String name, String description, boolean optional, QName type) {
     Attribute attr = new Attribute();
     attr.setName(name);
-    attr.setUse(optional ? SchemaConstants.USE_OPTIONAL : SchemaConstants.USE_REQUIRED);
+    attr.setUse(optional ? USE_OPTIONAL : USE_REQUIRED);
     attr.setType(type);
 
     if (description != null) {
@@ -659,11 +698,35 @@ public final class SchemaBuilder {
     return extensionModel;
   }
 
-  private void generateTextElement(DslElementSyntax paramDsl, String description, boolean isRequired, Group all) {
-    TopLevelElement textElement = createTopLevelElement(paramDsl.getElementName(), isRequired ? ONE : ZERO, "1");
+  private TopLevelElement generateTextElement(DslElementSyntax paramDsl, String description, boolean isRequired) {
+    TopLevelElement textElement = createTopLevelElement(paramDsl.getElementName(), isRequired ? ONE : ZERO, MAX_ONE);
     textElement.setAnnotation(createDocAnnotation(description));
     textElement.setType(STRING);
 
-    all.getParticle().add(objectFactory.createElement(textElement));
+    return textElement;
+  }
+
+  boolean isRequired(TopLevelElement element) {
+    return element.getMinOccurs().equals(ONE);
+  }
+
+  void addOrderedParameterGroupsToSequence(Map<String, Map<String, TopLevelElement>> groups, ExplicitGroup sequence) {
+    // General parameters first
+    groups.getOrDefault(DEFAULT_GROUP_NAME, emptyMap())
+        .forEach((name, parameter) -> {
+          sequence.getParticle().add(objectFactory.createElement(parameter));
+          if (isRequired(parameter)) {
+            sequence.setMinOccurs(ONE);
+          }
+        });
+
+    // Other groups later
+    groups.keySet().stream().filter(name -> !name.equals(DEFAULT_GROUP_NAME))
+        .forEach(group -> groups.get(group).forEach((name, parameter) -> {
+          sequence.getParticle().add(objectFactory.createElement(parameter));
+          if (isRequired(parameter)) {
+            sequence.setMinOccurs(ONE);
+          }
+        }));
   }
 }

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/SchemaBuilder.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/builder/SchemaBuilder.java
@@ -111,14 +111,6 @@ public final class SchemaBuilder {
   private final Set<StringType> registeredEnums = new LinkedHashSet<>();
   private final ObjectFactory objectFactory = new ObjectFactory();
   private final ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
-  //private final ConfigurationSchemaDelegate configurationSchemaDelegate = new ConfigurationSchemaDelegate(this);
-  //private final ConnectionProviderSchemaDelegate connectionProviderSchemaDelegate = new ConnectionProviderSchemaDelegate(this);
-  //private final OperationSchemaDelegate operationSchemaDelegate = new OperationSchemaDelegate(this);
-  //private final SourceSchemaDelegate sourceSchemaDelegate = new SourceSchemaDelegate(this);
-  //private final CollectionSchemaDelegate collectionDelegate = new CollectionSchemaDelegate(this);
-  //private final ObjectTypeSchemaDelegate objectTypeDelegate = new ObjectTypeSchemaDelegate(this);
-  //private final MapSchemaDelegate mapDelegate = new MapSchemaDelegate(this);
-
   private Schema schema;
   private boolean requiresTls = false;
 
@@ -280,18 +272,13 @@ public final class SchemaBuilder {
     return this;
   }
 
-  //void registerParameters(ExtensionType type, ExplicitGroup choice, Collection<ParameterModel> parameterModels) {
   Map<String, TopLevelElement> registerParameters(ExtensionType type, Collection<ParameterModel> parameterModels) {
     LinkedHashMap<String, TopLevelElement> all = new LinkedHashMap<>();
     for (final ParameterModel parameterModel : getSortedParameterModels(parameterModels)) {
-      //declareAsParameter(parameterModel.getType(), type, choice, parameterModel);
       DslElementSyntax paramDsl = dslResolver.resolve(parameterModel);
       declareAsParameter(parameterModel.getType(), type, parameterModel, paramDsl, all);
     }
     return all;
-    //if (!choice.getParticle().isEmpty()) {
-    //  type.setSequence(choice);
-    //}
   }
 
   /**

--- a/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/capability/xml/SchemaGeneratorTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/capability/xml/SchemaGeneratorTestCase.java
@@ -83,17 +83,17 @@ public class SchemaGeneratorTestCase extends AbstractMuleTestCase {
     final Map<Class<?>, String> extensions = new LinkedHashMap<Class<?>, String>() {
 
       {
-        put(HeisenbergExtension.class, "heisenberg.xsd");
-        put(TestConnector.class, "basic.xsd");
-        put(GlobalPojoConnector.class, "global-pojo.xsd");
-        put(GlobalInnerPojoConnector.class, "global-inner-pojo.xsd");
         put(MapConnector.class, "map.xsd");
         put(ListConnector.class, "list.xsd");
+        put(TestConnector.class, "basic.xsd");
         put(StringListConnector.class, "string-list.xsd");
+        put(GlobalPojoConnector.class, "global-pojo.xsd");
+        put(GlobalInnerPojoConnector.class, "global-inner-pojo.xsd");
         put(VeganExtension.class, "vegan.xsd");
-        put(SubTypesMappingConnector.class, "subtypes.xsd");
         put(PetStoreConnector.class, "petstore.xsd");
         put(MetadataExtension.class, "metadata.xsd");
+        put(HeisenbergExtension.class, "heisenberg.xsd");
+        put(SubTypesMappingConnector.class, "subtypes.xsd");
       }
     };
 

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-config.xml
@@ -29,17 +29,15 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
-        <heisenberg:ricin-packs>
-            <heisenberg:ricin microgramsPerKilo="22">
-                <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
-            </heisenberg:ricin>
-        </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-                <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
+        <heisenberg:monthly-incomes>
+            <heisenberg:monthly-income value="12000"/>
+            <heisenberg:monthly-income value="500"/>
+        </heisenberg:monthly-incomes>
+        <heisenberg:recipes>
+            <heisenberg:recipe key="methylamine" value="75"/>
+            <heisenberg:recipe key="pseudoephedrine" value="0"/>
+            <heisenberg:recipe key="P2P" value="25"/>
+        </heisenberg:recipes>
         <heisenberg:deaths-by-seasons>
             <heisenberg:deaths-by-season key="s01">
                 <heisenberg:deaths-by-season-item value="emilio"/>
@@ -48,22 +46,6 @@
             <heisenberg:deaths-by-season key="s02" value="#[['some', 'other']]"/>
             <heisenberg:deaths-by-season key="s02" value="#[['tuco', 'tortuga']]"/>
         </heisenberg:deaths-by-seasons>
-        <heisenberg:labeled-ricins>
-            <heisenberg:labeled-ricin key="pojo">
-                <heisenberg:ricin microgramsPerKilo="22">
-                    <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
-                </heisenberg:ricin>
-            </heisenberg:labeled-ricin>
-        </heisenberg:labeled-ricins>
-        <heisenberg:recipes>
-            <heisenberg:recipe key="methylamine" value="75"/>
-            <heisenberg:recipe key="pseudoephedrine" value="0"/>
-            <heisenberg:recipe key="P2P" value="25"/>
-        </heisenberg:recipes>
-        <heisenberg:monthly-incomes>
-            <heisenberg:monthly-income value="12000"/>
-            <heisenberg:monthly-income value="500"/>
-        </heisenberg:monthly-incomes>
         <heisenberg:weapon-value-maps>
             <heisenberg:weapon-value-map key="first">
                 <heisenberg:ricin microgramsPerKilo="22">
@@ -83,6 +65,21 @@
             <heisenberg:health-progression value="CANCER"/>
             <heisenberg:health-progression value="DEAD"/>
         </heisenberg:health-progressions>
+        <heisenberg:labeled-ricins>
+            <heisenberg:labeled-ricin key="pojo">
+                <heisenberg:ricin microgramsPerKilo="22">
+                    <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
+                </heisenberg:ricin>
+            </heisenberg:labeled-ricin>
+        </heisenberg:labeled-ricins>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
+        <heisenberg:ricin-packs>
+            <heisenberg:ricin microgramsPerKilo="22">
+                <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
+            </heisenberg:ricin>
+        </heisenberg:ricin-packs>
     </heisenberg:config>
 
     <heisenberg:config name="heisenbergWithPlaceHolders"
@@ -104,19 +101,19 @@
             <heisenberg:enemy value="${fring}"/>
             <heisenberg:enemy value="${hank}"/>
         </heisenberg:enemies>
-        <heisenberg:ricin-packs>
-            <heisenberg:ricin microgramsPerKilo="${microgramsPerKilo}">
-                <heisenberg:destination victim="${lidia}" address="${steviaCoffeShop}"/>
-            </heisenberg:ricin>
-        </heisenberg:ricin-packs>
-        <heisenberg:next-door address="${pollosHermanos}" victim="${fring}">
-                <heisenberg:previous victim="${krazy8}" address="${jesseAddress}"/>
-        </heisenberg:next-door>
         <heisenberg:monthly-incomes>
             <heisenberg:monthly-income value="12000"/>
             <heisenberg:monthly-income value="500"/>
         </heisenberg:monthly-incomes>
         <heisenberg:first-endevour><![CDATA[Gray Matter Technologies]]></heisenberg:first-endevour>
+        <heisenberg:next-door address="${pollosHermanos}" victim="${fring}">
+            <heisenberg:previous victim="${krazy8}" address="${jesseAddress}"/>
+        </heisenberg:next-door>
+        <heisenberg:ricin-packs>
+            <heisenberg:ricin microgramsPerKilo="${microgramsPerKilo}">
+                <heisenberg:destination victim="${lidia}" address="${steviaCoffeShop}"/>
+            </heisenberg:ricin>
+        </heisenberg:ricin-packs>
     </heisenberg:config>
 
     <heisenberg:config name="heisenbergByRef"
@@ -160,15 +157,15 @@
             <heisenberg:enemy value="#[gustavoFring]"/>
             <heisenberg:enemy value="#[hank]"/>
         </heisenberg:enemies>
+        <heisenberg:first-endevour><![CDATA[Gray Matter Technologies]]></heisenberg:first-endevour>
+        <heisenberg:next-door address="#[pollosHermanos]" victim="#[gustavoFring]">
+            <heisenberg:previous victim="#[krazy8]" address="#[jesses]"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="#[microgramsPerKilo]">
                 <heisenberg:destination victim="#[lidia]" address="#[steviaCoffeShop]"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="#[pollosHermanos]" victim="#[gustavoFring]">
-            <heisenberg:previous victim="#[krazy8]" address="#[jesses]"/>
-        </heisenberg:next-door>
-        <heisenberg:first-endevour><![CDATA[Gray Matter Technologies]]></heisenberg:first-endevour>
     </heisenberg:config>
 
     <heisenberg:config name="expressionHeisenbergByRef"

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-default-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-default-config.xml
@@ -22,14 +22,14 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
     </heisenberg:config>
 
     <flow name="sayMyName">

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-default-illegal-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-default-illegal-config.xml
@@ -25,14 +25,14 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
     </heisenberg:config>
 
     <heisenberg:config name="heisenberg2"
@@ -51,14 +51,14 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
     </heisenberg:config>
 
     <flow name="sayMyName">

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-injected.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-injected.xml
@@ -18,14 +18,14 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
     </heisenberg:config>
 
     <heisenberg:config name="dynamicAgeHeisenberg"
@@ -41,17 +41,17 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:monthly-incomes>
+            <heisenberg:monthly-income value="12000"/>
+            <heisenberg:monthly-income value="500"/>
+        </heisenberg:monthly-incomes>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
-        <heisenberg:monthly-incomes>
-            <heisenberg:monthly-income value="12000"/>
-            <heisenberg:monthly-income value="500"/>
-        </heisenberg:monthly-incomes>
     </heisenberg:config>
 </mule>

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-operation-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-operation-config.xml
@@ -29,18 +29,18 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:monthly-incomes>
+            <heisenberg:monthly-income value="12000"/>
+            <heisenberg:monthly-income value="500"/>
+        </heisenberg:monthly-incomes>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
-        <heisenberg:monthly-incomes>
-            <heisenberg:monthly-income value="12000"/>
-            <heisenberg:monthly-income value="500"/>
-        </heisenberg:monthly-incomes>
     </heisenberg:config>
 
     <flow name="sayMyName">

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-operation-error-handling-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-operation-error-handling-config.xml
@@ -21,18 +21,18 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:monthly-incomes>
+            <heisenberg:monthly-income value="12000"/>
+            <heisenberg:monthly-income value="500"/>
+        </heisenberg:monthly-incomes>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
-        <heisenberg:monthly-incomes>
-            <heisenberg:monthly-income value="12000"/>
-            <heisenberg:monthly-income value="500"/>
-        </heisenberg:monthly-incomes>
     </heisenberg:config>
 
     <flow name="cureCancer">

--- a/modules/extensions-spring-support/src/test/resources/operation-with-expression-config-ref.xml
+++ b/modules/extensions-spring-support/src/test/resources/operation-with-expression-config-ref.xml
@@ -21,14 +21,14 @@
             <heisenberg:enemy value="Gustavo Fring"/>
             <heisenberg:enemy value="Hank"/>
         </heisenberg:enemies>
+        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
+            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
+        </heisenberg:next-door>
         <heisenberg:ricin-packs>
             <heisenberg:ricin microgramsPerKilo="22">
                 <heisenberg:destination victim="Lidia" address="Stevia coffe shop"/>
             </heisenberg:ricin>
         </heisenberg:ricin-packs>
-        <heisenberg:next-door address="pollos hermanos" victim="Gustavo Fring">
-            <heisenberg:previous victim="Krazy-8" address="Jesse's"/>
-        </heisenberg:next-door>
     </heisenberg:config>
 
     <flow name="sayMyName">

--- a/modules/extensions-spring-support/src/test/resources/petstore-exclusive-parameters-operation.xml
+++ b/modules/extensions-spring-support/src/test/resources/petstore-exclusive-parameters-operation.xml
@@ -5,7 +5,9 @@
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
                http://www.mulesoft.org/schema/mule/petstore http://www.mulesoft.org/schema/mule/petstore/current/mule-petstore.xsd">
 
-    <petstore:config name="config" cashierName="cashierName"/>
+    <petstore:config name="config" cashierName="cashierName">
+        <petstore:connection username="someUSer" password="somePass"/>
+    </petstore:config>
 
     <flow name="getBreederOperation">
         <petstore:get-breeder mammals="Primate" birds="Owl"/>

--- a/modules/extensions-spring-support/src/test/resources/schemas/basic.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/basic.xsd
@@ -12,7 +12,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:sequence minOccurs="1" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="1" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="required-pojo-default">
@@ -89,7 +89,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                     </xs:sequence>
                     <xs:attribute xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="mule:expressionString" use="required" name="connectionProviderRequiredFieldDefault"></xs:attribute>

--- a/modules/extensions-spring-support/src/test/resources/schemas/global-inner-pojo.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/global-inner-pojo.xsd
@@ -12,7 +12,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="required-pojo-default">
                             <xs:complexType>

--- a/modules/extensions-spring-support/src/test/resources/schemas/global-pojo.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/global-pojo.xsd
@@ -12,7 +12,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="required-extensible-pojo">
                             <xs:complexType>

--- a/modules/extensions-spring-support/src/test/resources/schemas/heisenberg.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/heisenberg.xsd
@@ -26,7 +26,7 @@
     <xs:complexType name="org.mule.test.heisenberg.extension.model.KnockeableDoor">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="previous">
                         <xs:complexType>
                             <xs:complexContent>
@@ -44,7 +44,7 @@
     <xs:complexType name="org.mule.test.heisenberg.extension.model.Ricin">
         <xs:complexContent>
             <xs:extension xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg" base="heisenberg:org.mule.test.heisenberg.extension.model.Weapon">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="destination">
                         <xs:complexType>
                             <xs:complexContent>
@@ -105,7 +105,7 @@
     <xs:complexType name="org.mule.test.heisenberg.extension.model.Investment">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+             <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="discarded-investments">
                         <xs:complexType>
                             <xs:sequence>
@@ -162,7 +162,7 @@
     <xs:complexType name="org.mule.test.heisenberg.extension.model.RecursivePojo">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="next">
                         <xs:complexType>
                             <xs:complexContent>
@@ -212,7 +212,7 @@
     <xs:complexType name="org.mule.test.heisenberg.extension.model.RecursiveChainA">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+                <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="chain-b">
                         <xs:complexType>
                             <xs:complexContent>
@@ -247,7 +247,7 @@
     <xs:complexType name="org.mule.test.heisenberg.extension.model.RecursiveChainB">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="chain-a">
                         <xs:complexType>
                             <xs:complexContent>
@@ -276,38 +276,9 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                      <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
-                        <xs:element minOccurs="0" maxOccurs="1" name="labeled-ricins">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element minOccurs="0" maxOccurs="unbounded" name="labeled-ricin">
-                                        <xs:complexType>
-                                            <xs:sequence maxOccurs="1">
-                                                <xs:element xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg" minOccurs="0" maxOccurs="1" ref="heisenberg:abstract-ricin"></xs:element>
-                                            </xs:sequence>
-                                            <xs:attribute type="mule:expressionString" use="required" name="key"></xs:attribute>
-                                            <xs:attribute type="xs:string" use="optional" name="value"></xs:attribute>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element minOccurs="0" maxOccurs="1" name="next-door">
-                            <xs:complexType>
-                                <xs:complexContent>
-                                    <xs:extension xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg" base="heisenberg:org.mule.test.heisenberg.extension.model.KnockeableDoor"></xs:extension>
-                                </xs:complexContent>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element minOccurs="0" maxOccurs="1" name="ricin-packs">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg" minOccurs="0" maxOccurs="unbounded" ref="heisenberg:abstract-ricin"></xs:element>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="family-informations">
                             <xs:complexType>
                                 <xs:sequence>
@@ -429,6 +400,46 @@
                                 </xs:sequence>
                             </xs:complexType>
                         </xs:element>
+                        <xs:element minOccurs="0" maxOccurs="1" name="known-addresses">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element minOccurs="0" maxOccurs="unbounded" name="known-address">
+                                <xs:complexType>
+                                  <xs:attribute type="mule:expressionString" use="required" name="value"></xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element minOccurs="0" maxOccurs="1" name="labeled-ricins">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element minOccurs="0" maxOccurs="unbounded" name="labeled-ricin">
+                                <xs:complexType>
+                                  <xs:sequence maxOccurs="1">
+                                    <xs:element xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg" minOccurs="0" maxOccurs="1" ref="heisenberg:abstract-ricin"></xs:element>
+                                  </xs:sequence>
+                                  <xs:attribute type="mule:expressionString" use="required" name="key"></xs:attribute>
+                                  <xs:attribute type="xs:string" use="optional" name="value"></xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element minOccurs="0" maxOccurs="1" name="next-door">
+                          <xs:complexType>
+                            <xs:complexContent>
+                              <xs:extension xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg" base="heisenberg:org.mule.test.heisenberg.extension.model.KnockeableDoor"></xs:extension>
+                            </xs:complexContent>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element minOccurs="0" maxOccurs="1" name="ricin-packs">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg" minOccurs="0" maxOccurs="unbounded" ref="heisenberg:abstract-ricin"></xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
                     </xs:sequence>
                     <xs:attribute type="xs:string" use="required" name="name"></xs:attribute>
                     <xs:attribute type="mule:expressionString" use="optional" default="Heisenberg" name="myName"></xs:attribute>
@@ -437,6 +448,7 @@
                     <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfBirth"></xs:attribute>
                     <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfDeath"></xs:attribute>
                     <xs:attribute type="mule:substitutableDateTime" use="optional" name="dateOfGraduation"></xs:attribute>
+                    <xs:attribute type="mule:expressionList" use="optional" name="knownAddresses"></xs:attribute>
                     <xs:attribute type="mule:expressionMap" use="optional" name="labeledRicin"></xs:attribute>
                     <xs:attribute type="xs:string" use="optional" name="nextDoor"></xs:attribute>
                     <xs:attribute type="mule:expressionList" use="optional" name="ricinPacks"></xs:attribute>
@@ -465,12 +477,26 @@
     <xs:complexType name="org.mule.test.heisenberg.extension.model.PersonalInfo">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
+                <xs:sequence minOccurs="0" maxOccurs="1">
+                  <xs:element minOccurs="0" maxOccurs="1" name="known-addresses">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element minOccurs="0" maxOccurs="unbounded" name="known-address">
+                          <xs:complexType>
+                            <xs:attribute type="mule:expressionString" use="required" name="value"></xs:attribute>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
                 <xs:attribute type="mule:expressionString" use="optional" default="Heisenberg" name="myName"></xs:attribute>
                 <xs:attribute type="mule:expressionInt" use="optional" default="50" name="age"></xs:attribute>
                 <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfConception"></xs:attribute>
                 <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfBirth"></xs:attribute>
                 <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfDeath"></xs:attribute>
                 <xs:attribute type="mule:substitutableDateTime" use="optional" name="dateOfGraduation"></xs:attribute>
+                <xs:attribute type="mule:expressionList" use="optional" name="knownAddresses"></xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -486,7 +512,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                         <xs:element xmlns:tls="http://www.mulesoft.org/schema/mule/tls" minOccurs="0" maxOccurs="1" ref="tls:context"></xs:element>
                     </xs:sequence>
@@ -668,12 +694,26 @@
     <xs:complexType name="AliasType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+                  <xs:element minOccurs="0" maxOccurs="1" name="known-addresses">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element minOccurs="0" maxOccurs="unbounded" name="known-address">
+                          <xs:complexType>
+                            <xs:attribute type="mule:expressionString" use="required" name="value"></xs:attribute>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
                 <xs:attribute type="mule:expressionString" use="optional" default="Heisenberg" name="myName"></xs:attribute>
                 <xs:attribute type="mule:expressionInt" use="optional" default="50" name="age"></xs:attribute>
                 <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfConception"></xs:attribute>
                 <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfBirth"></xs:attribute>
                 <xs:attribute type="mule:expressionDateTime" use="optional" name="dateOfDeath"></xs:attribute>
                 <xs:attribute type="mule:substitutableDateTime" use="optional" name="dateOfGraduation"></xs:attribute>
+                <xs:attribute type="mule:expressionList" use="optional" name="knownAddresses"></xs:attribute>
                 <xs:attribute type="mule:expressionString" use="required" name="greeting"></xs:attribute>
                 <xs:attribute type="xs:string" use="optional" name="target">
                     <xs:annotation>
@@ -687,7 +727,7 @@
     <xs:complexType name="ApproveType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="investment">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -798,7 +838,7 @@
     <xs:complexType name="GetGramsInStorageType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="grams">
                         <xs:complexType>
                             <xs:sequence>
@@ -836,7 +876,7 @@
     <xs:complexType name="GetMedicalHistoryType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                 <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="health-by-years">
                         <xs:complexType>
                             <xs:sequence>
@@ -894,7 +934,7 @@
     <xs:complexType name="KillManyType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="1" maxOccurs="1">
                     <xs:element minOccurs="1" maxOccurs="unbounded" name="kill-operations">
                         <xs:complexType>
                             <xs:group xmlns="http://www.mulesoft.org/schema/mule/heisenberg" minOccurs="1" maxOccurs="unbounded" ref="heisenberg-empire-group"></xs:group>
@@ -914,7 +954,7 @@
     <xs:complexType name="KillOneType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="1" maxOccurs="1">
                     <xs:element minOccurs="1" maxOccurs="1" name="kill-operation">
                         <xs:complexType>
                             <xs:group xmlns="http://www.mulesoft.org/schema/mule/heisenberg" minOccurs="1" maxOccurs="1" ref="heisenberg-empire-group"></xs:group>
@@ -948,7 +988,7 @@
     <xs:complexType name="KillWithMultipleWildCardWeaponsType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="wild-card-weapons">
                         <xs:complexType>
                             <xs:sequence>
@@ -973,7 +1013,7 @@
     <xs:complexType name="KillWithMultiplesWeaponsType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                 <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="weapons">
                         <xs:complexType>
                             <xs:sequence>
@@ -998,7 +1038,7 @@
     <xs:complexType name="KillWithRicinsType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="ricins">
                         <xs:complexType>
                             <xs:sequence>
@@ -1027,7 +1067,7 @@
     <xs:complexType name="KillWithWeaponType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                 <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="weapon">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -1059,7 +1099,7 @@
     <xs:complexType name="KnockType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="knocked-door">
                         <xs:complexType>
                             <xs:complexContent>
@@ -1081,7 +1121,7 @@
     <xs:complexType name="KnockManyType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="doors">
                         <xs:complexType>
                             <xs:sequence>
@@ -1149,7 +1189,7 @@
     <xs:complexType name="ProcessSaleType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="sales">
                         <xs:complexType>
                             <xs:sequence>
@@ -1179,7 +1219,7 @@
     <xs:complexType name="ProcessWeaponType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="weapon">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -1202,7 +1242,7 @@
     <xs:complexType name="ProcessWeaponWithDefaultValueType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="weapon">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">

--- a/modules/extensions-spring-support/src/test/resources/schemas/list.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/list.xsd
@@ -12,7 +12,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                        <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="required-list-defaults">
                             <xs:complexType>

--- a/modules/extensions-spring-support/src/test/resources/schemas/map.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/map.xsd
@@ -12,7 +12,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="required-map-defaults">
                             <xs:complexType>

--- a/modules/extensions-spring-support/src/test/resources/schemas/metadata.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/metadata.xsd
@@ -134,7 +134,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                      <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                     </xs:sequence>
@@ -149,7 +149,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                   <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                     </xs:sequence>
                 </xs:extension>
@@ -234,7 +234,7 @@
     <xs:complexType name="ContentAndOutputMetadataWithoutKeyIdType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -254,7 +254,7 @@
     <xs:complexType name="ContentMetadataWithKeyIdType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+             <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -359,7 +359,7 @@
     <xs:complexType name="FailWithResolvingExceptionType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                         <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -412,7 +412,7 @@
     <xs:complexType name="MetadataKeyWithDefaultValueType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -471,7 +471,7 @@
     <xs:complexType name="OutputMetadataWithKeyIdType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -492,7 +492,7 @@
     <xs:complexType name="OutputMetadataWithoutKeyIdType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -548,7 +548,7 @@
     <xs:complexType name="ShouldInheritExtensionResolversType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -564,7 +564,7 @@
     <xs:complexType name="ShouldInheritOperationParentResolversType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -580,7 +580,7 @@
     <xs:complexType name="ShouldInheritOperationResolversType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:substitutableName" use="optional" name="config-ref">
@@ -636,7 +636,7 @@
     <xs:complexType name="ContentParameterShouldNotGenerateListChildElementType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="contents">
                         <xs:complexType>
                             <xs:sequence>
@@ -657,7 +657,7 @@
     <xs:complexType name="ContentParameterShouldNotGenerateMapChildElementType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="map-content"></xs:element>
                 </xs:sequence>
             </xs:extension>
@@ -667,7 +667,7 @@
     <xs:complexType name="ContentParameterShouldNotGeneratePojoChildElementType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="animal-content">
                         <xs:complexType>
                             <xs:complexContent>
@@ -684,7 +684,7 @@
     <xs:complexType name="DoQueryType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="query"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="xs:string" use="optional" name="target">
@@ -749,7 +749,7 @@
     <xs:complexType name="PagedOperationMetadataType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="animal">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -799,7 +799,7 @@
     <xs:complexType name="TypeWithDeclaredSubtypesMetadataType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="plain-shape">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">

--- a/modules/extensions-spring-support/src/test/resources/schemas/petstore.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/petstore.xsd
@@ -13,7 +13,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:sequence minOccurs="1" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="1" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element xmlns:tls="http://www.mulesoft.org/schema/mule/tls" minOccurs="0" maxOccurs="1" ref="tls:context"></xs:element>
@@ -60,7 +60,7 @@
     <xs:complexType name="org.mule.test.petstore.extension.PetCage">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="birds">
                         <xs:complexType>
                             <xs:sequence>
@@ -104,7 +104,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                  <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                         <xs:element xmlns:tls="http://www.mulesoft.org/schema/mule/tls" minOccurs="0" maxOccurs="1" ref="tls:context"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="closed-for-holidays">
@@ -145,7 +145,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                     <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:pooling-profile"></xs:element>
                         <xs:element xmlns:tls="http://www.mulesoft.org/schema/mule/tls" minOccurs="0" maxOccurs="1" ref="tls:context"></xs:element>
@@ -187,7 +187,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                      <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                         <xs:element xmlns:tls="http://www.mulesoft.org/schema/mule/tls" minOccurs="0" maxOccurs="1" ref="tls:context"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="closed-for-holidays">
@@ -340,7 +340,7 @@
     <xs:complexType name="GetForbiddenPetsType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                 <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="forbidden-pets">
                         <xs:complexType>
                             <xs:sequence>

--- a/modules/extensions-spring-support/src/test/resources/schemas/string-list.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/string-list.xsd
@@ -12,7 +12,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="required-list-defaults">
                             <xs:complexType>

--- a/modules/extensions-spring-support/src/test/resources/schemas/subtypes.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/subtypes.xsd
@@ -124,7 +124,7 @@
                     <xs:annotation>
                         <xs:documentation>Default configuration</xs:documentation>
                     </xs:annotation>
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                     <xs:sequence minOccurs="1" maxOccurs="1">
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="1" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="abstract-shape">
@@ -262,7 +262,7 @@
     <xs:complexType name="org.mule.test.subtypes.extension.ExtensiblePojo">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+                <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="numbers">
                         <xs:complexType>
                             <xs:sequence>
@@ -309,7 +309,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                 <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="abstract-shape">
                             <xs:complexType>
@@ -383,7 +383,7 @@
     <xs:complexType name="SubtypesSourceType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractMessageSourceType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="door-param">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -399,11 +399,21 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+  <xs:element xmlns="http://www.mulesoft.org/schema/mule/subtypes" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="ContentDoorsType" substitutionGroup="mule:abstract-operator" name="content-doors"></xs:element>
+  <xs:complexType name="ContentDoorsType">
+    <xs:complexContent>
+      <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+          <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="content-map"></xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
     <xs:element xmlns="http://www.mulesoft.org/schema/mule/subtypes" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="DoorRetrieverType" substitutionGroup="mule:abstract-operator" name="door-retriever"></xs:element>
     <xs:complexType name="DoorRetrieverType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="door">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -439,7 +449,7 @@
     <xs:complexType name="ProcessDoorType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+              <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="door">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -475,11 +485,27 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+      <xs:element xmlns="http://www.mulesoft.org/schema/mule/subtypes" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="RequiredChildType" substitutionGroup="mule:abstract-operator" name="required-child"></xs:element>
+      <xs:complexType name="RequiredChildType">
+        <xs:complexContent>
+          <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
+            <xs:sequence minOccurs="1" maxOccurs="1">
+              <xs:element minOccurs="1" maxOccurs="1" name="required-child-only-pojo">
+                <xs:complexType>
+                  <xs:complexContent>
+                    <xs:extension xmlns:subtypes="http://www.mulesoft.org/schema/mule/subtypes" base="subtypes:org.mule.test.subtypes.extension.FinalPojo"></xs:extension>
+                  </xs:complexContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
     <xs:element xmlns="http://www.mulesoft.org/schema/mule/subtypes" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="ShapeRetrieverType" substitutionGroup="mule:abstract-operator" name="shape-retriever"></xs:element>
     <xs:complexType name="ShapeRetrieverType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="shape">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">
@@ -510,7 +536,7 @@
     <xs:complexType name="SubtypedAndConcreteParametersType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+               <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="base-shape">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">

--- a/modules/extensions-spring-support/src/test/resources/schemas/vegan.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/vegan.xsd
@@ -51,8 +51,8 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="mule:abstractExtensionType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="1" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
+          <xs:sequence minOccurs="0" maxOccurs="1">
+                        <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                         <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:dynamic-config-policy"></xs:element>
                         <xs:element minOccurs="0" maxOccurs="1" name="cook-book">
                             <xs:complexType>
@@ -73,7 +73,7 @@
     <xs:complexType name="org.mule.test.vegan.extension.VeganCookBook">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractExtensionType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="recipes">
                         <xs:complexType>
                             <xs:sequence>
@@ -105,7 +105,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                     </xs:sequence>
                 </xs:extension>
@@ -185,8 +185,8 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="mule:abstractExtensionType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="1" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
+                    <xs:sequence minOccurs="0" maxOccurs="1">
+                      <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                     </xs:sequence>
                     <xs:attribute type="xs:string" use="required" name="name"></xs:attribute>
                 </xs:extension>
@@ -197,7 +197,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                     </xs:sequence>
                     <xs:attribute xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="mule:expressionString" use="optional" default="Ecuador" name="originCountry"></xs:attribute>
@@ -295,8 +295,8 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="mule:abstractExtensionType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="1" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
+                    <xs:sequence minOccurs="0" maxOccurs="1">
+                       <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                     </xs:sequence>
                     <xs:attribute type="xs:string" use="required" name="name"></xs:attribute>
                 </xs:extension>
@@ -307,7 +307,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                  <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                     </xs:sequence>
                 </xs:extension>
@@ -335,8 +335,8 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="mule:abstractExtensionType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="1" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
+                    <xs:sequence minOccurs="0" maxOccurs="1">
+                      <xs:element xmlns:extension="http://www.mulesoft.org/schema/mule/extension" minOccurs="0" maxOccurs="1" ref="extension:abstractConnectionProvider"></xs:element>
                     </xs:sequence>
                     <xs:attribute type="xs:string" use="required" name="name"></xs:attribute>
                 </xs:extension>
@@ -347,7 +347,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="extension:abstractConnectionProviderType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                   <xs:sequence minOccurs="0" maxOccurs="1">
                         <xs:element xmlns:mule="http://www.mulesoft.org/schema/mule/core" minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
                     </xs:sequence>
                 </xs:extension>
@@ -381,7 +381,7 @@
     <xs:complexType name="ApplyPolicyType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                 <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="policy">
                         <xs:complexType>
                             <xs:complexContent>
@@ -424,7 +424,7 @@
     <xs:complexType name="EatWatermelonType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="fruit">
                         <xs:complexType>
                             <xs:complexContent>
@@ -446,7 +446,7 @@
     <xs:complexType name="GetAllApplesType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+        <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element type="xs:string" minOccurs="0" maxOccurs="1" name="apples"></xs:element>
                 </xs:sequence>
                 <xs:attribute type="mule:expressionString" use="optional" name="key"></xs:attribute>
@@ -462,7 +462,7 @@
     <xs:complexType name="GetProductionType">
         <xs:complexContent>
             <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
-                <xs:sequence>
+                <xs:sequence minOccurs="0" maxOccurs="1">
                     <xs:element minOccurs="0" maxOccurs="1" name="food">
                         <xs:complexType>
                             <xs:choice minOccurs="1" maxOccurs="1">

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/xml/SchemaConstants.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/xml/SchemaConstants.java
@@ -94,6 +94,7 @@ public final class SchemaConstants {
   public static final String ENUM_TYPE_SUFFIX = "EnumType";
   public static final String TYPE_SUFFIX = "Type";
   public static final String UNBOUNDED = "unbounded";
+  public static final String MAX_ONE = "1";
   public static final String ATTRIBUTE_NAME_NAME = "name";
   public static final String XSD_EXTENSION = ".xsd";
   public static final String DISABLE_VALIDATION = "disableValidation";

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/AnnotationsBasedDescriberTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/AnnotationsBasedDescriberTestCase.java
@@ -36,11 +36,6 @@ import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.o
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.toMetadataType;
 import static org.mule.test.vegan.extension.VeganExtension.APPLE;
 import static org.mule.test.vegan.extension.VeganExtension.BANANA;
-import com.google.common.reflect.TypeToken;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mule.metadata.api.model.AnyType;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.VoidType;
@@ -98,6 +93,8 @@ import org.mule.test.vegan.extension.PaulMcCartneySource;
 import org.mule.test.vegan.extension.VeganAttributes;
 import org.mule.test.vegan.extension.VeganExtension;
 
+import com.google.common.reflect.TypeToken;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Calendar;
@@ -107,6 +104,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
@@ -199,7 +201,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
     ConfigurationDeclaration configuration = extensionDeclaration.getConfigurations().get(1);
     assertThat(configuration, is(notNullValue()));
     assertThat(configuration.getName(), equalTo(EXTENDED_CONFIG_NAME));
-    assertThat(configuration.getAllParameters(), hasSize(29));
+    assertThat(configuration.getAllParameters(), hasSize(30));
     assertParameter(configuration.getAllParameters(), "extendedProperty", "", toMetadataType(String.class), true, SUPPORTED,
                     null);
   }
@@ -339,7 +341,7 @@ public class AnnotationsBasedDescriberTestCase extends AbstractAnnotationsBasedD
     assertThat(conf.getName(), equalTo(DEFAULT_CONFIG_NAME));
 
     List<ParameterDeclaration> parameters = conf.getAllParameters();
-    assertThat(parameters, hasSize(28));
+    assertThat(parameters, hasSize(29));
 
     assertParameter(parameters, "myName", "", toMetadataType(String.class), false, SUPPORTED, HEISENBERG);
     assertParameter(parameters, "age", "", toMetadataType(Integer.class), false, SUPPORTED, AGE);

--- a/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/HeisenbergExtension.java
+++ b/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/HeisenbergExtension.java
@@ -46,12 +46,13 @@ import org.mule.test.heisenberg.extension.model.Ricin;
 import org.mule.test.heisenberg.extension.model.Weapon;
 import org.mule.test.heisenberg.extension.model.types.WeaponType;
 
-import javax.inject.Inject;
 import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+
+import javax.inject.Inject;
 
 @Extension(name = HeisenbergExtension.HEISENBERG, description = HeisenbergExtension.EXTENSION_DESCRIPTION, category = SELECT,
     minMuleVersion = "4.1")
@@ -91,9 +92,6 @@ public class HeisenbergExtension implements Lifecycle, MuleContextAware {
   @ConfigName
   private String configName;
 
-  @ParameterGroup(PERSONAL_INFORMATION_GROUP_NAME)
-  private PersonalInfo personalInfo = new PersonalInfo();
-
   @Parameter
   @Optional
   private List<PersonalInfo> familyInformations;
@@ -117,6 +115,9 @@ public class HeisenbergExtension implements Lifecycle, MuleContextAware {
 
   @ParameterGroup(RICIN_GROUP_NAME)
   private RicinGroup ricinGroup;
+
+  @ParameterGroup(PERSONAL_INFORMATION_GROUP_NAME)
+  private PersonalInfo personalInfo = new PersonalInfo();
 
   @Parameter
   private BigDecimal money;

--- a/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/model/PersonalInfo.java
+++ b/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/model/PersonalInfo.java
@@ -20,6 +20,7 @@ import org.mule.runtime.extension.api.annotation.param.display.Placement;
 import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 public class PersonalInfo {
 
@@ -55,6 +56,14 @@ public class PersonalInfo {
   @Expression(NOT_SUPPORTED)
   @Placement(order = 6)
   private Calendar dateOfGraduation;
+
+  @Parameter
+  @Placement(order = 7)
+  private List<String> knownAddresses;
+
+  public List<String> getKnownAddresses() {
+    return knownAddresses;
+  }
 
   public PersonalInfo() {}
 

--- a/tests/test-extensions/subtypes-extension/src/main/java/org/mule/test/subtypes/extension/SubTypesTestOperations.java
+++ b/tests/test-extensions/subtypes-extension/src/main/java/org/mule/test/subtypes/extension/SubTypesTestOperations.java
@@ -7,18 +7,20 @@
 package org.mule.test.subtypes.extension;
 
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
+import org.mule.runtime.extension.api.annotation.Expression;
 import org.mule.runtime.extension.api.annotation.dsl.xml.XmlHints;
 import org.mule.runtime.extension.api.annotation.metadata.MetadataScope;
 import org.mule.runtime.extension.api.annotation.param.Connection;
+import org.mule.runtime.extension.api.annotation.param.Content;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.UseConfig;
 import org.mule.test.vegan.extension.VeganCookBook;
 
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonMap;
 
 @MetadataScope(outputResolver = SubtypesOutputResolver.class)
 public class SubTypesTestOperations {
@@ -51,5 +53,13 @@ public class SubTypesTestOperations {
 
   public Map<Door, Map<String, Door>> processDoor(Door door, @Optional Map<String, Door> doorRegistry) {
     return singletonMap(door, doorRegistry);
+  }
+
+  public void contentDoors(@Content Map<String, Door> contentMap) {
+
+  }
+
+  public void requiredChild(@XmlHints(allowReferences = false) @Expression(NOT_SUPPORTED) FinalPojo requiredChildOnlyPojo) {
+
   }
 }


### PR DESCRIPTION
* Improve validation of required/optional elements
* Order parameters: 
- First any custom/prefixed element like "reconnection"
- Then the parameters of the "Generic" group
- Finally the parameters from other groups, sorted by how they were declared in the group 
(no extra sorting, just taking the order provided by the model)