### PR TITLE
MULE-11107: Serialization fails if an Optional is used as a field for…

### DIFF
--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
@@ -64,7 +64,6 @@ import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.el.DefaultExpressionManager;
 import org.mule.runtime.core.el.mvel.MVELExpressionLanguage;
 import org.mule.runtime.core.policy.OperationParametersProcessor;
-import org.mule.runtime.core.policy.DefaultOperationPolicy;
 import org.mule.runtime.core.policy.OperationPolicy;
 import org.mule.runtime.dsl.api.component.ComponentIdentifier;
 import org.mule.runtime.extension.api.model.ImmutableOutputModel;
@@ -345,7 +344,7 @@ public class OperationMessageProcessorTestCase extends AbstractOperationMessageP
   public void getDSLOperationDynamicMetadata() throws Exception {
     final ObjectType objectType = BaseTypeBuilder
         .create(JAVA).objectType()
-        .with(new DescriptionAnnotation(empty(), "Some Description"))
+        .with(new DescriptionAnnotation("Some Description"))
         .build();
     setUpValueResolvers();
     final OutputTypeResolver outputTypeResolver = mock(OutputTypeResolver.class);


### PR DESCRIPTION
… a MetadataType Type Annotation