### PR TITLE
MULE-11191: Fix: FTP reconnect Notifier is not working

### DIFF
--- a/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
+++ b/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
@@ -32,7 +32,6 @@ import org.apache.commons.logging.LogFactory;
 public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, MuleContextAware
 {
     protected RetryNotifier notifier = new ConnectNotifier();
-    
     /** This data will be made available to the RetryPolicy via the RetryContext. */
     private Map<Object, Object> metaInfo;
 
@@ -49,10 +48,9 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
     {
         PolicyStatus status = null;
         RetryPolicy policy = createRetryInstance();
-        DefaultRetryContext context = new DefaultRetryContext(callback.getWorkDescription(), 
+        DefaultRetryContext context = new DefaultRetryContext(callback.getWorkDescription(),
             metaInfo);
         context.setMuleContext(muleContext);
-
         try
         {
             Exception cause = null;

--- a/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionNotifierTestCase.java
+++ b/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionNotifierTestCase.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.ftp;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import org.mule.api.retry.RetryContext;
+import org.mule.api.retry.RetryNotifier;
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.api.transport.Connector;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.tck.junit4.rule.SystemProperty;
+import org.mule.tck.probe.JUnitProbe;
+import org.mule.tck.probe.PollingProber;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ftpserver.FtpServer;
+import org.apache.ftpserver.FtpServerFactory;
+import org.apache.ftpserver.ftplet.Authority;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.listener.ListenerFactory;
+import org.apache.ftpserver.usermanager.PropertiesUserManagerFactory;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+import org.apache.ftpserver.usermanager.impl.WritePermission;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class FtpReconnectionNotifierTestCase extends FunctionalTestCase
+{
+
+    private final static Integer RECONNECTION_ATTEMPTS = 2;
+    private final static Integer POLLING_FREQUENCY = 100;
+
+    @Rule
+    public SystemProperty countSystemProperty = new SystemProperty("count", RECONNECTION_ATTEMPTS.toString());
+
+    @Rule
+    public SystemProperty pollingFrequencySystemProperty = new SystemProperty("pollingFrequency", POLLING_FREQUENCY.toString());
+
+    @Rule
+    public DynamicPort ftpPort = new DynamicPort("port");
+
+    private TestReconnectNotifier notifier = null;
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "ftp-reconnection-notifier-fails-config.xml";
+    }
+
+    @Test
+    public void testNotificationOnReconnectionAttempts() throws Exception
+    {
+        notifier = mock(TestReconnectNotifier.class);
+        Connector c = muleContext.getRegistry().lookupConnector("FTP");
+        RetryPolicyTemplate rpf = c.getRetryPolicyTemplate();
+        rpf.setNotifier(notifier);
+        MuleFtpServer server = new MuleFtpServer(ftpPort.getNumber(), 1);
+        server.start();
+        serverConnected();
+        server.stop();
+        serverDisconnected();
+    }
+
+    private void verifyOnSuccessNotification()
+    {
+        PollingProber pollingProber = new PollingProber(RECEIVE_TIMEOUT, POLLING_FREQUENCY);
+        pollingProber.check(new JUnitProbe()
+        {
+            @Override
+            protected boolean test()
+            {
+                verify(notifier).onSuccess(any(RetryContext.class));
+                return true;
+            }
+
+            @Override
+            public String describeFailure()
+            {
+                return "Success notification wasn't triggered";
+            }
+        });
+    }
+
+    private void verifyOnFailureNotification()
+    {
+        PollingProber pollingProber = new PollingProber(RECEIVE_TIMEOUT, POLLING_FREQUENCY);
+        pollingProber.check(new JUnitProbe()
+        {
+            @Override
+            protected boolean test()
+            {
+                verify(notifier, times(3)).onFailure(any(RetryContext.class), any(Throwable.class));
+                return true;
+            }
+
+            @Override
+            public String describeFailure()
+            {
+                return "Failure notification wasn't triggered";
+            }
+        });
+    }
+
+    private void serverConnected() throws Exception
+    {
+        runFlow("main-test");
+        verifyOnSuccessNotification();
+    }
+
+    private void serverDisconnected()
+    {
+        try
+        {
+            runFlow("main-test");
+            fail("ConnectException wasn't caught.");
+        }
+        catch (Exception e)
+        {
+            verifyOnFailureNotification();
+        }
+    }
+
+    public static class MuleFtpServer
+    {
+
+        private final FtpServer server;
+        private final FtpServerFactory serverFactory;
+        private final ListenerFactory factory;
+
+        public MuleFtpServer(int port, long delay)
+        {
+            serverFactory = new FtpServerFactory();
+            factory = new ListenerFactory();
+            factory.setPort(port);
+            serverFactory.addListener("default", factory.createListener());
+            PropertiesUserManagerFactory userManagerFactory = new PropertiesUserManagerFactory();
+            serverFactory.setUserManager(userManagerFactory.createUserManager());
+            BaseUser user = new BaseUser();
+            user.setName("mule-test");
+            user.setPassword("mule-test");
+            List<Authority> authorities = new ArrayList<Authority>();
+            authorities.add(new WritePermission());
+            user.setAuthorities(authorities);
+            try
+            {
+                serverFactory.getUserManager().save(user);
+            }
+            catch (FtpException e)
+            {
+                throw new RuntimeException(e);
+            }
+            server = serverFactory.createServer();
+        }
+
+        public void start()
+        {
+            try
+            {
+                server.start();
+            }
+            catch (FtpException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void stop()
+        {
+            try
+            {
+                server.stop();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class TestReconnectNotifier implements RetryNotifier
+    {
+
+        public static volatile int fails = 0;
+        public static volatile int successes = 0;
+
+        @Override
+        public void onFailure(RetryContext retryContext, Throwable throwable)
+        {
+            fails++;
+        }
+
+        @Override
+        public void onSuccess(RetryContext retryContext)
+        {
+            successes++;
+        }
+
+    }
+}
+

--- a/transports/ftp/src/test/resources/ftp-reconnection-notifier-fails-config.xml
+++ b/transports/ftp/src/test/resources/ftp-reconnection-notifier-fails-config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ftp="http://www.mulesoft.org/schema/mule/ftp"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/ftp http://www.mulesoft.org/schema/mule/ftp/current/mule-ftp.xsd">
+
+    <ftp:connector name="FTP" validateConnections="true">
+        <reconnect frequency="${pollingFrequency}" count="${count}">
+            <reconnect-custom-notifier class="org.mule.transport.ftp.FtpReconnectionNotifierTestCase$TestReconnectNotifier"/>
+        </reconnect>
+    </ftp:connector>
+    <flow name="main-test">
+        <ftp:outbound-endpoint host="localhost" port="${port}" path="~" user="mule-test" password="mule-test"
+                               connector-ref="FTP"/>
+    </flow>
+</mule>


### PR DESCRIPTION
SimpleRetryPolicy and FtpConnector and FtpMessageReceiver was modified.
FtpReconnectionNotifierTestCase and ftp-reconnection-notifier-fails-config.xml were added.