### PR TITLE
MULE-11203: Improving Error Message in AsynchronousRetryTemplate.

### DIFF
--- a/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
+++ b/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
@@ -38,8 +38,8 @@ public class AsynchronousRetryTemplate implements RetryPolicyTemplate
     {
         if (workManager == null)
         {
-            throw new IllegalStateException(
-                "Cannot schedule a work till the workManager is initialized. Probably the connector hasn't been initialized yet");
+            throw new IllegalArgumentException(
+                "This component doesn't support asynchronous retry policies.");
         }
 
         RetryWorker worker = new RetryWorker(delegate, callback, workManager, startLatch);


### PR DESCRIPTION
Referencing to SE-1963 issue, in DB Connections, non-blocking retry policies aren't supported.
However, the message is unclear and has to be modified.