### PR TITLE
MULE-11203:  Add Error Message about not supported Asynchronous Retry Policies in DB Connection.

### DIFF
--- a/core/src/main/java/org/mule/api/retry/RetryPolicyTemplate.java
+++ b/core/src/main/java/org/mule/api/retry/RetryPolicyTemplate.java
@@ -30,4 +30,6 @@ public interface RetryPolicyTemplate
     void setNotifier(RetryNotifier retryNotifier);
 
     RetryContext execute(RetryCallback callback, WorkManager workManager) throws Exception;
+
+    boolean isSynchronous();
 }

--- a/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
+++ b/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
@@ -90,4 +90,10 @@ public class AsynchronousRetryTemplate implements RetryPolicyTemplate
     {
         this.startLatch = latch;
     }
+
+    @Override
+    public boolean isSynchronous()
+    {
+        return false;
+    }
 }

--- a/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
+++ b/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
@@ -138,4 +138,10 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
     {
         // ignore
     }
+
+    @Override
+    public boolean isSynchronous()
+    {
+        return true;
+    }
 }

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactory.java
@@ -30,6 +30,11 @@ public class RetryConnectionFactory extends AbstractConnectionFactory
     {
         this.retryPolicyTemplate = retryPolicyTemplate;
         this.delegate = delegate;
+
+        if (!retryPolicyTemplate.isSynchronous())
+        {
+            throw new IllegalArgumentException("This component doesn't support asynchronous retry policies.");
+        }
     }
 
     @Override

--- a/modules/db/src/test/java/org/mule/module/db/internal/domain/connection/AsynchronousPolicyTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/domain/connection/AsynchronousPolicyTestCase.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.db.internal.domain.connection;
+
+import org.junit.Test;
+
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.retry.policies.AbstractPolicyTemplate;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+
+import static org.mockito.Mockito.mock;
+
+@SmallTest
+public class AsynchronousPolicyTestCase extends AbstractMuleTestCase
+{
+
+    private final RetryPolicyTemplate retryPolicyTemplate = mock(AbstractPolicyTemplate.class);
+    private final ConnectionFactory delegate = mock(ConnectionFactory.class);
+
+    private RetryConnectionFactory connectionFactory;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAsynchronousPolicy()
+    {
+        connectionFactory = new RetryConnectionFactory(retryPolicyTemplate, delegate);
+    }
+}

--- a/modules/db/src/test/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactoryTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactoryTestCase.java
@@ -11,9 +11,11 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.junit.Before;
 import org.mule.api.context.WorkManager;
 import org.mule.api.retry.RetryCallback;
 import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.retry.policies.AbstractPolicyTemplate;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -33,8 +35,15 @@ public class RetryConnectionFactoryTestCase extends AbstractMuleTestCase
 
     private final RetryPolicyTemplate retryPolicyTemplate = mock(RetryPolicyTemplate.class);
     private final ConnectionFactory delegate = mock(ConnectionFactory.class);
-    private final RetryConnectionFactory connectionFactory = new RetryConnectionFactory(retryPolicyTemplate, delegate);
     private final DataSource dataSource = mock(DataSource.class);
+    private RetryConnectionFactory connectionFactory;
+
+    @Before
+    public void init()
+    {
+        when(retryPolicyTemplate.isSynchronous()).thenReturn(true);
+        connectionFactory = new RetryConnectionFactory(retryPolicyTemplate, delegate);
+    }
 
     @Test
     public void createsConnection() throws Exception


### PR DESCRIPTION
Referencing to SE-1963 issue, in DB Connections, non-blocking retry policies aren't supported.
Because of that, a verification was added in the RetryConnectionFactory class.
Now if the Retry Policy is not blocking, an exception is throwed.