### PR TITLE
MULE-10929:  Support policy packaging and deployment

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/DefaultMuleContext.java
+++ b/core/src/main/java/org/mule/runtime/core/DefaultMuleContext.java
@@ -43,7 +43,6 @@ import static org.mule.runtime.core.context.notification.MuleContextNotification
 import static org.mule.runtime.core.util.ExceptionUtils.getRootCauseException;
 import static org.mule.runtime.core.util.JdkVersionUtils.getSupportedJdks;
 import static reactor.core.Exceptions.unwrap;
-
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.lifecycle.Disposable;
@@ -103,7 +102,6 @@ import org.mule.runtime.core.exception.MessagingException;
 import org.mule.runtime.core.lifecycle.MuleContextLifecycleManager;
 import org.mule.runtime.core.management.stats.AllStatistics;
 import org.mule.runtime.core.management.stats.ProcessingTimeWatcher;
-import org.mule.runtime.core.policy.PolicyManager;
 import org.mule.runtime.core.registry.DefaultRegistryBroker;
 import org.mule.runtime.core.registry.MuleRegistryHelper;
 import org.mule.runtime.core.util.ApplicationShutdownSplashScreen;
@@ -116,7 +114,6 @@ import org.mule.runtime.core.util.UUID;
 import org.mule.runtime.core.util.concurrent.Latch;
 import org.mule.runtime.core.util.lock.LockFactory;
 import org.mule.runtime.core.util.queue.QueueManager;
-import org.mule.runtime.core.util.rx.Exceptions;
 import org.mule.runtime.core.util.rx.Exceptions.EventDroppedException;
 import org.mule.runtime.extension.api.ExtensionManager;
 
@@ -132,7 +129,6 @@ import javax.xml.namespace.QName;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import reactor.core.publisher.Hooks;
 
 public class DefaultMuleContext implements MuleContext {
@@ -259,8 +255,6 @@ public class DefaultMuleContext implements MuleContext {
       }
     });
   }
-
-  private PolicyManager policyManager;
 
   /**
    * @deprecated Use empty constructor instead and use setter for dependencies.

--- a/core/src/main/java/org/mule/runtime/core/api/config/MuleProperties.java
+++ b/core/src/main/java/org/mule/runtime/core/api/config/MuleProperties.java
@@ -168,6 +168,7 @@ public class MuleProperties {
   public static final String OBJECT_CONNECTIVITY_TESTING_SERVICE = "_muleConnectivityTestingService";
   public static final String OBJECT_CONFIGURATION_COMPONENT_LOCATOR = "_muleConfigurationComponentLocator";
   public static final String OBJECT_POLICY_MANAGER = "_mulePolicyManager";
+  public static final String OBJECT_POLICY_PROVIDER = "_mulePolicyProvider";
   public static final String OBJECT_POLICY_MANAGER_STATE_HANDLER = "_mulePolicyStateHandler";
   public static final String DEFAULT_TLS_CONTEXT_FACTORY_REGISTRY_KEY = "_muleDefaultTlsContextFactory";
   public static final String DEFAULT_TLS_CONTEXT_FACTORY_BUILDER_REGISTRY_KEY = "_muleDefaultTlsContextFactoryBuilder";

--- a/core/src/main/java/org/mule/runtime/core/policy/OperationPolicyProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/policy/OperationPolicyProcessor.java
@@ -8,13 +8,10 @@ package org.mule.runtime.core.policy;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
-import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.DefaultMuleException;
 import org.mule.runtime.core.api.Event;
-import org.mule.runtime.core.api.policy.OperationPolicyParametersTransformer;
 import org.mule.runtime.core.api.processor.Processor;
 
-import java.util.Map;
 import java.util.Optional;
 
 /**

--- a/core/src/main/java/org/mule/runtime/core/policy/PolicyParametrization.java
+++ b/core/src/main/java/org/mule/runtime/core/policy/PolicyParametrization.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.core.policy;
+
+import static java.util.Collections.unmodifiableMap;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+
+import java.util.Map;
+
+/**
+ * Parametrizes a policy template
+ * <p/>
+ * A policy template is a Mule artifact consistent of a context with dependencies deployed inside
+ * a Mule application.
+ *
+ * @since 4.0
+ */
+public class PolicyParametrization {
+
+  private final String id;
+  private final PolicyPointcut pointcut;
+  private final Map<String, Object> parameters;
+
+  /**
+   * Creates a new parametrization
+   *
+   * @param id parametrization identifier. Non empty.
+   * @param pointcut used to determine if the policy must be applied on a given request. Non null
+   * @param parameters parameters for the policy template on which the parametrization is based on. Non null.
+   */
+  public PolicyParametrization(String id, PolicyPointcut pointcut, Map<String, Object> parameters) {
+    checkArgument(!isEmpty(id), "id cannot be null");
+    checkArgument(pointcut != null, "pointcut cannot be null");
+    checkArgument(parameters != null, "parameters cannot be null");
+
+    this.id = id;
+    this.pointcut = pointcut;
+    this.parameters = unmodifiableMap(parameters);
+  }
+
+  /**
+   * @return parametrization identifier
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * @return pointcut to evaluate whether the policy must be applied or not.
+   */
+  public PolicyPointcut getPointcut() {
+    return pointcut;
+  }
+
+  /**
+   * @return parameters to configure the policy template
+   */
+  public Map<String, Object> getParameters() {
+    return parameters;
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/policy/PolicyPointcut.java
+++ b/core/src/main/java/org/mule/runtime/core/policy/PolicyPointcut.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.core.policy;
+
+/**
+ * Provides a way to select which policies must be applied based on a given request.
+ *
+ * @since 4.0
+ */
+public interface PolicyPointcut {
+
+  /**
+   * Determines whether or not a policy must be applied on a given request
+   *
+   * @param parameters parameters used to evaluate the pointcut created using the current request. Non null.
+   * @return true if the policy must be applied, false otherwise.
+   */
+  boolean matches(PolicyPointcutParameters parameters);
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/RegionOwnerArtifact.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/classloader/RegionOwnerArtifact.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.classloader;
+
+/**
+ * Indicates that an artifact is the owner of a region where other artifact are included as members.
+ */
+public interface RegionOwnerArtifact {
+
+  /**
+   * @return the {@link RegionClassLoader} that represents the region that is owned by an artifact
+   * @throws IllegalStateException if the artifact's class loader does not represent a region
+   */
+  RegionClassLoader getRegionClassLoader();
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectOutputStream.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/serializer/ArtifactClassLoaderObjectOutputStream.java
@@ -28,7 +28,7 @@ public class ArtifactClassLoaderObjectOutputStream extends ObjectOutputStream {
   /**
    * Creates a new output stream.
    *
-   * @param classLoaderRepository
+   * @param classLoaderRepository contains the registered classloaders that can be used to load serialized classes. Non null.
    * @param out output stream to write to
    * @throws IOException if an I/O error occurs while writing stream header
    */

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/MuleArtifactResourcesRegistry.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/MuleArtifactResourcesRegistry.java
@@ -12,12 +12,16 @@ import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
 import org.mule.runtime.deployment.model.api.domain.DomainDescriptor;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginClassLoaderFactory;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
+import org.mule.runtime.deployment.model.internal.policy.PolicyTemplateClassLoaderFactory;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
 import org.mule.runtime.deployment.model.internal.application.MuleApplicationClassLoaderFactory;
 import org.mule.runtime.deployment.model.internal.artifact.DefaultDependenciesProvider;
 import org.mule.runtime.deployment.model.internal.domain.DomainClassLoaderFactory;
 import org.mule.runtime.deployment.model.internal.nativelib.DefaultNativeLibraryFinderFactory;
 import org.mule.runtime.deployment.model.internal.plugin.BundlePluginDependenciesResolver;
 import org.mule.runtime.deployment.model.internal.plugin.PluginDependenciesResolver;
+import org.mule.runtime.module.deployment.impl.internal.policy.ApplicationPolicyTemplateClassLoaderBuilderFactory;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateClassLoaderBuilderFactory;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
@@ -100,14 +104,23 @@ public class MuleArtifactResourcesRegistry {
 
     domainFactory = new DefaultDomainFactory(this.domainClassLoaderFactory, domainManager, containerClassLoader,
                                              artifactClassLoaderManager, serviceManager);
+
+    ArtifactClassLoaderFactory<PolicyTemplateDescriptor> policyClassLoaderFactory =
+        trackArtifactClassLoaderFactory(new PolicyTemplateClassLoaderFactory());
+    PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory =
+        new ApplicationPolicyTemplateClassLoaderBuilderFactory(policyClassLoaderFactory, artifactPluginRepository,
+                                                               artifactPluginClassLoaderFactory,
+                                                               pluginDependenciesResolver);
+
     applicationFactory = new DefaultApplicationFactory(applicationClassLoaderBuilderFactory, applicationDescriptorFactory,
                                                        artifactPluginRepository, domainManager, serviceManager,
-                                                       artifactClassLoaderManager);
+                                                       artifactClassLoaderManager, policyTemplateClassLoaderBuilderFactory);
     temporaryApplicationFactory = new TemporaryApplicationFactory(applicationClassLoaderBuilderFactory,
                                                                   new TemporaryApplicationDescriptorFactory(artifactPluginDescriptorLoader,
                                                                                                             artifactPluginRepository),
                                                                   artifactPluginRepository, domainManager, serviceManager,
-                                                                  artifactClassLoaderManager);
+                                                                  artifactClassLoaderManager,
+                                                                  policyTemplateClassLoaderBuilderFactory);
 
     temporaryArtifactClassLoaderBuilderFactory =
         new TemporaryArtifactClassLoaderBuilderFactory(artifactPluginClassLoaderFactory,

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationPolicyProvider.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationPolicyProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.application;
+
+import org.mule.runtime.core.policy.PolicyProvider;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.application.ApplicationPolicyManager;
+
+/**
+ * Provides and manages policies for an {@link Application}
+ *
+ * @since 4.0
+ *
+ */
+public interface ApplicationPolicyProvider extends ApplicationPolicyManager, PolicyProvider {
+
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationWrapper.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationWrapper.java
@@ -9,10 +9,12 @@ package org.mule.runtime.module.deployment.impl.internal.application;
 import org.mule.runtime.api.metadata.MetadataService;
 import org.mule.runtime.core.api.connectivity.ConnectivityTestingService;
 import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
+import org.mule.runtime.deployment.model.api.application.ApplicationPolicyManager;
 import org.mule.runtime.deployment.model.api.application.ApplicationStatus;
 import org.mule.runtime.deployment.model.api.domain.Domain;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 import org.mule.runtime.module.deployment.impl.internal.artifact.DeployableArtifactWrapper;
-import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,6 +42,16 @@ public class ApplicationWrapper extends DeployableArtifactWrapper<Application, A
   @Override
   public ApplicationStatus getStatus() {
     return getDelegate().getStatus();
+  }
+
+  @Override
+  public RegionClassLoader getRegionClassLoader() {
+    return getDelegate().getRegionClassLoader();
+  }
+
+  @Override
+  public ApplicationPolicyManager getPolicyManager() {
+    return getDelegate().getPolicyManager();
   }
 
   @Override

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
@@ -19,15 +19,15 @@ import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
-import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateClassLoaderBuilderFactory;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactFactory;
 import org.mule.runtime.module.deployment.impl.internal.artifact.MuleContextListenerFactory;
 import org.mule.runtime.module.deployment.impl.internal.domain.DomainRepository;
 import org.mule.runtime.module.deployment.impl.internal.plugin.DefaultArtifactPlugin;
-import org.mule.runtime.module.deployment.impl.internal.policy.DefaultPolicyInstanceFactory;
+import org.mule.runtime.module.deployment.impl.internal.policy.DefaultPolicyInstanceProviderFactory;
 import org.mule.runtime.module.deployment.impl.internal.policy.DefaultPolicyTemplateFactory;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateClassLoaderBuilderFactory;
 import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
 import org.mule.runtime.module.service.ServiceRepository;
 
@@ -114,9 +114,9 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
     MuleApplicationPolicyProvider applicationPolicyProvider =
         new MuleApplicationPolicyProvider(
                                           new DefaultPolicyTemplateFactory(policyTemplateClassLoaderBuilderFactory),
-                                          new DefaultPolicyInstanceFactory(
-                                                                           serviceRepository,
-                                                                           classLoaderRepository));
+                                          new DefaultPolicyInstanceProviderFactory(
+                                                                                   serviceRepository,
+                                                                                   classLoaderRepository));
     DefaultMuleApplication delegate =
         new DefaultMuleApplication(descriptor, applicationClassLoader, artifactPlugins, domainRepository,
                                    serviceRepository, descriptor.getArtifactLocation(), classLoaderRepository,

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
@@ -19,12 +19,15 @@ import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateClassLoaderBuilderFactory;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactFactory;
 import org.mule.runtime.module.deployment.impl.internal.artifact.MuleContextListenerFactory;
 import org.mule.runtime.module.deployment.impl.internal.domain.DomainRepository;
 import org.mule.runtime.module.deployment.impl.internal.plugin.DefaultArtifactPlugin;
+import org.mule.runtime.module.deployment.impl.internal.policy.DefaultPolicyInstanceFactory;
+import org.mule.runtime.module.deployment.impl.internal.policy.DefaultPolicyTemplateFactory;
 import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
 import org.mule.runtime.module.service.ServiceRepository;
 
@@ -43,25 +46,30 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
   private final ArtifactPluginRepository artifactPluginRepository;
   private final ServiceRepository serviceRepository;
   private final ClassLoaderRepository classLoaderRepository;
+  private final PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory;
   private MuleContextListenerFactory muleContextListenerFactory;
 
   public DefaultApplicationFactory(ApplicationClassLoaderBuilderFactory applicationClassLoaderBuilderFactory,
                                    ApplicationDescriptorFactory applicationDescriptorFactory,
                                    ArtifactPluginRepository artifactPluginRepository, DomainRepository domainRepository,
                                    ServiceRepository serviceRepository,
-                                   ClassLoaderRepository classLoaderRepository) {
-    this.classLoaderRepository = classLoaderRepository;
+                                   ClassLoaderRepository classLoaderRepository,
+                                   PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory) {
     checkArgument(applicationClassLoaderBuilderFactory != null, "Application classloader builder factory cannot be null");
     checkArgument(applicationDescriptorFactory != null, "Application descriptor factory cannot be null");
     checkArgument(artifactPluginRepository != null, "Artifact plugin repository cannot be null");
     checkArgument(domainRepository != null, "Domain repository cannot be null");
     checkArgument(serviceRepository != null, "Service repository cannot be null");
+    checkArgument(classLoaderRepository != null, "classLoaderRepository cannot be null");
+    checkArgument(policyTemplateClassLoaderBuilderFactory != null, "policyClassLoaderBuilderFactory cannot be null");
 
+    this.classLoaderRepository = classLoaderRepository;
     this.applicationClassLoaderBuilderFactory = applicationClassLoaderBuilderFactory;
     this.applicationDescriptorFactory = applicationDescriptorFactory;
     this.artifactPluginRepository = artifactPluginRepository;
     this.domainRepository = domainRepository;
     this.serviceRepository = serviceRepository;
+    this.policyTemplateClassLoaderBuilderFactory = policyTemplateClassLoaderBuilderFactory;
   }
 
   public void setMuleContextListenerFactory(MuleContextListenerFactory muleContextListenerFactory) {
@@ -103,9 +111,18 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
 
     List<ArtifactPlugin> artifactPlugins = createArtifactPluginList(applicationClassLoader, applicationPluginDescriptors);
 
+    MuleApplicationPolicyProvider applicationPolicyProvider =
+        new MuleApplicationPolicyProvider(
+                                          new DefaultPolicyTemplateFactory(policyTemplateClassLoaderBuilderFactory),
+                                          new DefaultPolicyInstanceFactory(
+                                                                           serviceRepository,
+                                                                           classLoaderRepository));
     DefaultMuleApplication delegate =
         new DefaultMuleApplication(descriptor, applicationClassLoader, artifactPlugins, domainRepository,
-                                   serviceRepository, descriptor.getArtifactLocation(), classLoaderRepository);
+                                   serviceRepository, descriptor.getArtifactLocation(), classLoaderRepository,
+                                   applicationPolicyProvider);
+
+    applicationPolicyProvider.setApplication(delegate);
 
     if (muleContextListenerFactory != null) {
       delegate.setMuleContextListener(muleContextListenerFactory.create(descriptor.getName()));

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProvider.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.application;
+
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.api.lifecycle.Disposable;
+import org.mule.runtime.core.policy.PolicyParametrization;
+import org.mule.runtime.core.policy.PolicyPointcutParameters;
+import org.mule.runtime.core.policy.PolicyProvider;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstance;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstanceFactory;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Provides policy management and provision for Mule applications
+ */
+public class MuleApplicationPolicyProvider implements ApplicationPolicyProvider, PolicyProvider, Disposable {
+
+  private final PolicyTemplateFactory policyTemplateFactory;
+  private final PolicyInstanceFactory policyInstanceFactory;
+  private final List<PolicyTemplate> registeredPolicyTemplates = new LinkedList<>();
+  private final List<PolicyInstance> registeredPolicyInstances = new LinkedList<>();
+  private Application application;
+
+  /**
+   * Creates a new provider
+   *
+   * @param policyTemplateFactory used to create the policy templates for the application. Non null.
+   * @param policyInstanceFactory used to create the policy instances for the application. Non null.
+   */
+  public MuleApplicationPolicyProvider(PolicyTemplateFactory policyTemplateFactory, PolicyInstanceFactory policyInstanceFactory) {
+    this.policyTemplateFactory = policyTemplateFactory;
+    this.policyInstanceFactory = policyInstanceFactory;
+  }
+
+  @Override
+  public void addPolicy(PolicyTemplateDescriptor policyTemplateDescriptor, PolicyParametrization parametrization) {
+    checkArgument(application != null, "application was not configured on the policy provider");
+
+    PolicyTemplate policyTemplate =
+        policyTemplateFactory.createArtifact(policyTemplateDescriptor, application.getRegionClassLoader());
+    registeredPolicyTemplates.add(policyTemplate);
+
+    PolicyInstance policyInstance = policyInstanceFactory.create(application, policyTemplate, parametrization);
+    registeredPolicyInstances.add(policyInstance);
+  }
+
+  @Override
+  public List<org.mule.runtime.core.policy.Policy> findSourceParameterizedPolicies(
+                                                                                   PolicyPointcutParameters policyPointcutParameters) {
+    List<org.mule.runtime.core.policy.Policy> policies = new ArrayList<>();
+
+    if (!registeredPolicyInstances.isEmpty()) {
+      for (PolicyInstance policyInstance : registeredPolicyInstances) {
+        if (policyInstance.getPointcut().matches(policyPointcutParameters)) {
+          policies.addAll(policyInstance.findSourceParameterizedPolicies(policyPointcutParameters));
+        }
+      }
+    }
+
+    return policies;
+  }
+
+  @Override
+  public List<org.mule.runtime.core.policy.Policy> findOperationParameterizedPolicies(
+
+                                                                                      PolicyPointcutParameters policyPointcutParameters) {
+    List<org.mule.runtime.core.policy.Policy> policies = new ArrayList<>();
+
+    if (!registeredPolicyInstances.isEmpty()) {
+      for (PolicyInstance policyInstance : registeredPolicyInstances) {
+        if (policyInstance.getPointcut().matches(policyPointcutParameters)) {
+          policies.addAll(policyInstance.findOperationParameterizedPolicies(policyPointcutParameters));
+        }
+      }
+    }
+
+    return policies;
+  }
+
+  @Override
+  public void dispose() {
+
+    for (PolicyInstance registeredPolicyInstance : registeredPolicyInstances) {
+      registeredPolicyInstance.dispose();
+    }
+
+    for (PolicyTemplate registeredPolicyTemplate : registeredPolicyTemplates) {
+      try {
+        registeredPolicyTemplate.dispose();
+      } catch (RuntimeException e) {
+        // Ignore and continue
+      }
+
+      registeredPolicyTemplates.clear();
+    }
+  }
+
+  public void setApplication(Application application) {
+    this.application = application;
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/TemporaryApplicationFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/TemporaryApplicationFactory.java
@@ -8,6 +8,7 @@
 package org.mule.runtime.module.deployment.impl.internal.application;
 
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateClassLoaderBuilderFactory;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.deployment.impl.internal.domain.DomainRepository;
 import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
@@ -26,9 +27,10 @@ public class TemporaryApplicationFactory extends DefaultApplicationFactory {
                                      ApplicationDescriptorFactory applicationDescriptorFactory,
                                      ArtifactPluginRepository artifactPluginRepository, DomainRepository domainRepository,
                                      ServiceRepository serviceRepository,
-                                     ClassLoaderRepository classLoaderRepository) {
+                                     ClassLoaderRepository classLoaderRepository,
+                                     PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory) {
     super(applicationClassLoaderBuilderFactory, applicationDescriptorFactory, artifactPluginRepository, domainRepository,
-          serviceRepository, classLoaderRepository);
+          serviceRepository, classLoaderRepository, policyTemplateClassLoaderBuilderFactory);
   }
 
   @Override

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ApplicationPolicyTemplateClassLoaderBuilderFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ApplicationPolicyTemplateClassLoaderBuilderFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
+import org.mule.runtime.deployment.model.internal.plugin.PluginDependenciesResolver;
+import org.mule.runtime.deployment.model.internal.policy.PolicyTemplateClassLoaderBuilder;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
+
+/**
+ * Creates {@link PolicyTemplateClassLoaderBuilder} for application artifacts.
+ */
+public class ApplicationPolicyTemplateClassLoaderBuilderFactory implements PolicyTemplateClassLoaderBuilderFactory {
+
+  private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
+  private final ArtifactPluginRepository artifactPluginRepository;
+  private final ArtifactClassLoaderFactory artifactPluginClassLoaderFactory;
+  private final PluginDependenciesResolver pluginDependenciesResolver;
+
+  /**
+   * Creates a new factory instance
+   *
+   * @param artifactClassLoaderFactory factory for the classloader specific to the artifact resource and classes. Must be not
+   *        null.
+   * @param artifactPluginRepository repository of plugins contained by the runtime. Must be not null.
+   * @param artifactPluginClassLoaderFactory factory to create class loaders for each used plugin. Non be not null.
+   * @param pluginDependenciesResolver resolves artifact plugin dependencies. Non null
+   */
+  public ApplicationPolicyTemplateClassLoaderBuilderFactory(ArtifactClassLoaderFactory artifactClassLoaderFactory,
+                                                            ArtifactPluginRepository artifactPluginRepository,
+                                                            ArtifactClassLoaderFactory artifactPluginClassLoaderFactory,
+                                                            PluginDependenciesResolver pluginDependenciesResolver) {
+    this.artifactClassLoaderFactory = artifactClassLoaderFactory;
+    this.artifactPluginRepository = artifactPluginRepository;
+    this.artifactPluginClassLoaderFactory = artifactPluginClassLoaderFactory;
+    this.pluginDependenciesResolver = pluginDependenciesResolver;
+  }
+
+  @Override
+  public PolicyTemplateClassLoaderBuilder createArtifactClassLoaderBuilder() {
+    return new PolicyTemplateClassLoaderBuilder(artifactClassLoaderFactory, artifactPluginRepository,
+                                                artifactPluginClassLoaderFactory,
+                                                pluginDependenciesResolver);
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstance.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstance.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.mule.runtime.core.config.bootstrap.ArtifactType.APP;
+import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.newBuilder;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.core.api.config.MuleProperties;
+import org.mule.runtime.core.api.registry.RegistrationException;
+import org.mule.runtime.core.policy.Policy;
+import org.mule.runtime.core.policy.PolicyParametrization;
+import org.mule.runtime.core.policy.PolicyPointcut;
+import org.mule.runtime.core.policy.PolicyPointcutParameters;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.artifact.ArtifactContext;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+import org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder;
+import org.mule.runtime.module.service.ServiceRepository;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Default implementation of {@link PolicyInstance} that depends on a {@link PolicyTemplate} artifact.
+ */
+public class DefaultPolicyInstance implements PolicyInstance {
+
+  private ArtifactContext policyContext;
+  private final Application application;
+  private final PolicyTemplate template;
+  private final PolicyParametrization parametrization;
+  private final ServiceRepository serviceRepository;
+  private final ClassLoaderRepository classLoaderRepository;
+  private org.mule.runtime.core.policy.PolicyInstance policyInstance;
+
+  /**
+   * Creates a new policy instance
+   *
+   * @param application application artifact owning the created policy. Non null
+   * @param template policy template from which the instance will be created. Non null
+   * @param parametrization parameters used to configure the created instance. Non null
+   * @param serviceRepository repository of available services. Non null.
+   * @param classLoaderRepository contains the registered classloaders that can be used to load serialized classes. Non null.
+   */
+  public DefaultPolicyInstance(Application application, PolicyTemplate template,
+                               PolicyParametrization parametrization, ServiceRepository serviceRepository,
+                               ClassLoaderRepository classLoaderRepository) {
+    this.application = application;
+    this.template = template;
+    this.parametrization = parametrization;
+    this.serviceRepository = serviceRepository;
+    this.classLoaderRepository = classLoaderRepository;
+  }
+
+  private void initPolicyContext() {
+    if (policyContext == null) {
+      ArtifactContextBuilder artifactBuilder =
+          newBuilder().setArtifactType(APP)
+              .setArtifactName(parametrization.getId())
+              .setConfigurationFiles(getResourcePaths(template.getDescriptor().getConfigResourceFiles()))
+              .setExecutionClassloader(template.getArtifactClassLoader().getClassLoader())
+              .setServiceRepository(serviceRepository)
+              .setClassLoaderRepository(classLoaderRepository);
+
+      artifactBuilder.withServiceConfigurator(customizationService -> customizationService
+          .overrideDefaultServiceImpl(MuleProperties.OBJECT_POLICY_MANAGER_STATE_HANDLER,
+                                      application.getMuleContext().getRegistry()
+                                          .lookupObject(MuleProperties.OBJECT_POLICY_MANAGER_STATE_HANDLER)));
+
+      try {
+        policyContext = artifactBuilder.build();
+        policyContext.getMuleContext().start();
+      } catch (MuleException e) {
+        throw new IllegalStateException("Cannot create artifact context for the policy instance", e);
+      }
+    }
+  }
+
+  private String[] getResourcePaths(File[] configResourceFiles) {
+    List<String> paths = new ArrayList<>();
+    for (File configResourceFile : configResourceFiles) {
+      paths.add(configResourceFile.getAbsolutePath());
+    }
+
+    return paths.toArray(new String[0]);
+  }
+
+  @Override
+  public List<Policy> findSourceParameterizedPolicies(
+                                                      PolicyPointcutParameters policyPointcutParameters) {
+
+    initPolicyInstance();
+
+    return policyInstance.getSourcePolicyChain()
+        .map(operationChain -> asList(new Policy(operationChain, parametrization.getId())))
+        .orElse(emptyList());
+  }
+
+  private void initPolicyInstance() {
+
+    if (policyInstance == null) {
+      synchronized (this) {
+        initPolicyContext();
+
+        try {
+          policyInstance = policyContext.getMuleContext().getRegistry().lookupObject(
+                                                                                     org.mule.runtime.core.policy.DefaultPolicyInstance.class);
+        } catch (RegistrationException e) {
+          throw new IllegalStateException(String.format("More than one %s found on context", PolicyInstance.class), e);
+        }
+
+        try {
+          policyInstance.initialise();
+          policyInstance.start();
+        } catch (Exception e) {
+          throw new IllegalStateException("Unable to apply lifecycle to policy instance", e);
+        }
+      }
+    }
+  }
+
+  @Override
+  public List<Policy> findOperationParameterizedPolicies(
+                                                         PolicyPointcutParameters policyPointcutParameters) {
+    initPolicyInstance();
+
+    return policyInstance.getOperationPolicyChain()
+        .map(operationChain -> asList(new Policy(operationChain, parametrization.getId())))
+        .orElse(emptyList());
+  }
+
+  @Override
+  public PolicyPointcut getPointcut() {
+    return parametrization.getPointcut();
+  }
+
+  @Override
+  public void dispose() {
+    if (policyContext != null) {
+      try {
+        policyContext.getMuleContext().stop();
+      } catch (MuleException e) {
+        // Ignore, try to dispose it anyway
+      }
+      policyContext.getMuleContext().dispose();
+    }
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstanceFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstanceFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.core.policy.PolicyParametrization;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+import org.mule.runtime.module.service.ServiceRepository;
+
+/**
+ * Creates instances of {@link DefaultPolicyInstance}
+ */
+public class DefaultPolicyInstanceFactory implements PolicyInstanceFactory {
+
+  private final ServiceRepository serviceRepository;
+  private final ClassLoaderRepository classLoaderRepository;
+
+  /**
+   * Creates a new factory
+   *
+   * @param serviceRepository contains available service instances. Non null.
+   * @param classLoaderRepository contains the registered classloaders that can be used to load serialized classes. Non null.
+   */
+  public DefaultPolicyInstanceFactory(ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository) {
+    checkArgument(serviceRepository != null, "serviceRepository cannot be null");
+    checkArgument(classLoaderRepository != null, "classLoaderRepository cannot be null");
+
+    this.serviceRepository = serviceRepository;
+    this.classLoaderRepository = classLoaderRepository;
+  }
+
+  @Override
+  public PolicyInstance create(Application application, PolicyTemplate policyTemplate,
+                               PolicyParametrization parametrization) {
+    return new DefaultPolicyInstance(application, policyTemplate, parametrization, serviceRepository, classLoaderRepository);
+  }
+
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstanceProviderFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstanceProviderFactory.java
@@ -15,9 +15,9 @@ import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.service.ServiceRepository;
 
 /**
- * Creates instances of {@link DefaultPolicyInstance}
+ * Creates instances of {@link DefaultPolicyInstanceProvider}
  */
-public class DefaultPolicyInstanceFactory implements PolicyInstanceFactory {
+public class DefaultPolicyInstanceProviderFactory implements PolicyInstanceProviderFactory {
 
   private final ServiceRepository serviceRepository;
   private final ClassLoaderRepository classLoaderRepository;
@@ -28,7 +28,7 @@ public class DefaultPolicyInstanceFactory implements PolicyInstanceFactory {
    * @param serviceRepository contains available service instances. Non null.
    * @param classLoaderRepository contains the registered classloaders that can be used to load serialized classes. Non null.
    */
-  public DefaultPolicyInstanceFactory(ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository) {
+  public DefaultPolicyInstanceProviderFactory(ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository) {
     checkArgument(serviceRepository != null, "serviceRepository cannot be null");
     checkArgument(classLoaderRepository != null, "classLoaderRepository cannot be null");
 
@@ -37,9 +37,10 @@ public class DefaultPolicyInstanceFactory implements PolicyInstanceFactory {
   }
 
   @Override
-  public PolicyInstance create(Application application, PolicyTemplate policyTemplate,
-                               PolicyParametrization parametrization) {
-    return new DefaultPolicyInstance(application, policyTemplate, parametrization, serviceRepository, classLoaderRepository);
+  public PolicyInstanceProvider create(Application application, PolicyTemplate policyTemplate,
+                                       PolicyParametrization parametrization) {
+    return new DefaultPolicyInstanceProvider(application, policyTemplate, parametrization, serviceRepository,
+                                             classLoaderRepository);
   }
 
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplate.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplate.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+
+import java.io.File;
+
+/**
+ * Default implementation of {@link PolicyTemplate}
+ */
+public class DefaultPolicyTemplate implements PolicyTemplate {
+
+  private final String artifactId;
+  private final PolicyTemplateDescriptor descriptor;
+  private final ArtifactClassLoader policyClassLoader;
+
+  /**
+   * Creates a new policy template artifact
+   *
+   * @param artifactId artifact unique ID. Non empty.
+   * @param descriptor describes the policy to create. Non null.
+   * @param policyClassLoader classloader to use on this policy. Non null.
+   */
+  public DefaultPolicyTemplate(String artifactId, PolicyTemplateDescriptor descriptor, ArtifactClassLoader policyClassLoader) {
+    this.artifactId = artifactId;
+    this.descriptor = descriptor;
+    this.policyClassLoader = policyClassLoader;
+  }
+
+  @Override
+  public String getArtifactName() {
+    return descriptor.getName();
+  }
+
+  @Override
+  public String getArtifactId() {
+    return artifactId;
+  }
+
+  @Override
+  public PolicyTemplateDescriptor getDescriptor() {
+    return descriptor;
+  }
+
+  @Override
+  public File[] getResourceFiles() {
+    return descriptor.getConfigResourceFiles();
+  }
+
+  @Override
+  public ArtifactClassLoader getArtifactClassLoader() {
+    return policyClassLoader;
+  }
+
+  @Override
+  public void dispose() {
+    policyClassLoader.dispose();
+  }
+
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplateFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplateFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static java.lang.String.format;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.NULL_CLASSLOADER_FILTER;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
+
+import java.io.IOException;
+
+/**
+ * Creates {@link DefaultPolicyTemplate} instances.
+ */
+public class DefaultPolicyTemplateFactory implements PolicyTemplateFactory {
+
+  private final PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory;
+
+  /**
+   * Creates a new factory
+   *
+   * @param policyTemplateClassLoaderBuilderFactory creates class loader builders to create the class loaders for the created policy templates. Non null.
+   */
+  public DefaultPolicyTemplateFactory(PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory) {
+    checkArgument(policyTemplateClassLoaderBuilderFactory != null, "policyTemplateClassLoaderBuilderFactory cannot be null");
+
+    this.policyTemplateClassLoaderBuilderFactory = policyTemplateClassLoaderBuilderFactory;
+  }
+
+  @Override
+  public PolicyTemplate createArtifact(PolicyTemplateDescriptor descriptor, RegionClassLoader regionClassLoader) {
+    ArtifactClassLoader policyClassLoader;
+    try {
+      policyClassLoader = policyTemplateClassLoaderBuilderFactory.createArtifactClassLoaderBuilder()
+          .setParentClassLoader(regionClassLoader).setArtifactDescriptor(descriptor).build();
+    } catch (IOException e) {
+      throw new PolicyTemplateCreationException(createPolicyTemplateCreationErrorMessage(descriptor.getName()), e);
+    }
+    regionClassLoader.addClassLoader(policyClassLoader, NULL_CLASSLOADER_FILTER);
+
+    DefaultPolicyTemplate policy =
+        new DefaultPolicyTemplate(policyClassLoader.getArtifactId(), descriptor, policyClassLoader);
+
+    return policy;
+  }
+
+  /**
+   * @param policyName name of the policy that cannot be created
+   * @return the error message to indicate policy creation failure
+   */
+  static String createPolicyTemplateCreationErrorMessage(String policyName) {
+    return format("Cannot create policy template '%s'", policyName);
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstance.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstance.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import org.mule.runtime.core.policy.PolicyPointcut;
+import org.mule.runtime.core.policy.PolicyProvider;
+
+/**
+ * Defines a policy provider for a given parametrized policy
+ */
+public interface PolicyInstance extends PolicyProvider {
+
+  /**
+   * @return the policy's pointcut used to determine whether to apply or ignore the policy when a request arrives. No null.
+   */
+  PolicyPointcut getPointcut();
+
+  /**
+   * Disposes the instance releasing any held resources
+   */
+  void dispose();
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstanceFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstanceFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import org.mule.runtime.core.policy.PolicyParametrization;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+
+/**
+ * Creates {@link PolicyInstance} instances
+ */
+public interface PolicyInstanceFactory {
+
+  /**
+   * Creates a new policy
+   *
+   * @param application application when the policy is applied. Non null
+   * @param policyTemplate template of the policy being applied. Non null.
+   * @param parametrization parameters used to configure the template. Non null/
+   * @return
+   */
+  PolicyInstance create(Application application, PolicyTemplate policyTemplate, PolicyParametrization parametrization);
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstanceProvider.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstanceProvider.java
@@ -13,7 +13,7 @@ import org.mule.runtime.core.policy.PolicyProvider;
 /**
  * Defines a policy provider for a given parametrized policy
  */
-public interface PolicyInstance extends PolicyProvider {
+public interface PolicyInstanceProvider extends PolicyProvider {
 
   /**
    * @return the policy's pointcut used to determine whether to apply or ignore the policy when a request arrives. No null.

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstanceProviderFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyInstanceProviderFactory.java
@@ -12,9 +12,9 @@ import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
 
 /**
- * Creates {@link PolicyInstance} instances
+ * Creates {@link PolicyInstanceProvider} instances
  */
-public interface PolicyInstanceFactory {
+public interface PolicyInstanceProviderFactory {
 
   /**
    * Creates a new policy
@@ -24,5 +24,5 @@ public interface PolicyInstanceFactory {
    * @param parametrization parameters used to configure the template. Non null/
    * @return
    */
-  PolicyInstance create(Application application, PolicyTemplate policyTemplate, PolicyParametrization parametrization);
+  PolicyInstanceProvider create(Application application, PolicyTemplate policyTemplate, PolicyParametrization parametrization);
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateClassLoaderBuilderFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateClassLoaderBuilderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import org.mule.runtime.deployment.model.internal.policy.PolicyTemplateClassLoaderBuilder;
+
+/**
+ * Creates instances of {@link PolicyTemplateClassLoaderBuilder}
+ */
+public interface PolicyTemplateClassLoaderBuilderFactory {
+
+  /**
+   * Creates a new builder
+   *
+   * @return a new builder instance.
+   */
+  PolicyTemplateClassLoaderBuilder createArtifactClassLoaderBuilder();
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateCreationException.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateCreationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+
+/**
+ * Thrown to indicate that an error was found while attempting to create a {@link PolicyTemplate} artifact.
+ */
+public class PolicyTemplateCreationException extends RuntimeException {
+
+  /**
+   * {@inheritDoc}
+   */
+  public PolicyTemplateCreationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.DEFAULT_POLICY_CONFIGURATION_RESOURCE;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorFactory;
+import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Properties;
+
+import org.apache.commons.io.filefilter.SuffixFileFilter;
+
+/**
+ * Creates descriptors for policy templates
+ */
+public class PolicyTemplateDescriptorFactory implements ArtifactDescriptorFactory<PolicyTemplateDescriptor> {
+
+  protected static final String CLASSES_DIR = "classes";
+  protected static final String LIB_DIR = "lib";
+  private static final String JAR_FILE = ".jar";
+
+  public static final String POLICY_PROPERTIES = "policy.properties";
+  public static final String MISSING_POLICY_PROPERTIES_FILE = "Policy must contain a " + POLICY_PROPERTIES + " file";
+  public static final String POLICY_PROPERTIES_FILE_READ_ERROR = "Cannot read " + POLICY_PROPERTIES + " file";
+
+  @Override
+  public PolicyTemplateDescriptor create(File artifactFolder) throws ArtifactDescriptorCreateException {
+    final String pluginName = artifactFolder.getName();
+    final PolicyTemplateDescriptor descriptor = new PolicyTemplateDescriptor(pluginName);
+
+    final File policyPropsFile = new File(artifactFolder, POLICY_PROPERTIES);
+    if (!policyPropsFile.exists()) {
+      throw new ArtifactDescriptorCreateException(MISSING_POLICY_PROPERTIES_FILE);
+    }
+    Properties props = new Properties();
+    try {
+      props.load(new FileReader(policyPropsFile));
+    } catch (IOException e) {
+      throw new ArtifactDescriptorCreateException(POLICY_PROPERTIES_FILE_READ_ERROR, e);
+    }
+
+    ClassLoaderModel.ClassLoaderModelBuilder classLoaderModelBuilder = new ClassLoaderModel.ClassLoaderModelBuilder();
+    try {
+      classLoaderModelBuilder.containing(new File(artifactFolder, CLASSES_DIR).toURI().toURL());
+      final File libDir = new File(artifactFolder, LIB_DIR);
+      if (libDir.exists()) {
+        final File[] jars = libDir.listFiles((FilenameFilter) new SuffixFileFilter(JAR_FILE));
+        for (int i = 0; i < jars.length; i++) {
+          classLoaderModelBuilder.containing(jars[i].toURI().toURL());
+        }
+      }
+    } catch (MalformedURLException e) {
+      throw new ArtifactDescriptorCreateException("Failed to create plugin descriptor " + artifactFolder);
+    }
+    descriptor.setClassLoaderModel(classLoaderModelBuilder.build());
+    descriptor.setConfigResourceFiles(new File[] {new File(artifactFolder, DEFAULT_POLICY_CONFIGURATION_RESOURCE)});
+    descriptor.setRootFolder(artifactFolder);
+
+    return descriptor;
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
+
+/**
+ * Creates {@link PolicyTemplate} instances
+ */
+public interface PolicyTemplateFactory {
+
+  /**
+   * Creates a new policy template artifact
+   *
+   * @param descriptor describes how to build a policy template artifact. Non null
+   * @param regionClassLoader class loader where the policy template's class loader will be included. Non null.
+   * @return a {@link PolicyTemplate} artifact from the provided descriptor as a member of the region.
+   * @throws PolicyTemplateCreationException when the artifact cannot be created
+   */
+  PolicyTemplate createArtifact(PolicyTemplateDescriptor descriptor, RegionClassLoader regionClassLoader);
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/temporary/TemporaryArtifactClassLoaderBuilder.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/temporary/TemporaryArtifactClassLoaderBuilder.java
@@ -14,6 +14,7 @@ import org.mule.runtime.deployment.model.internal.plugin.PluginDependenciesResol
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel.ClassLoaderModelBuilder;
 import org.mule.runtime.module.artifact.util.FileJarExplorer;
@@ -49,8 +50,12 @@ public class TemporaryArtifactClassLoaderBuilder extends AbstractArtifactClassLo
   public TemporaryArtifactClassLoaderBuilder(ArtifactPluginRepository artifactPluginRepository,
                                              ArtifactClassLoaderFactory<ArtifactPluginDescriptor> artifactPluginClassLoaderFactory,
                                              PluginDependenciesResolver pluginDependenciesResolver) {
-    super(new TemporaryArtifactClassLoaderFactory(), artifactPluginRepository,
-          artifactPluginClassLoaderFactory, pluginDependenciesResolver);
+    super(artifactPluginRepository, artifactPluginClassLoaderFactory, pluginDependenciesResolver);
+  }
+
+  @Override
+  protected ArtifactClassLoader createArtifactClassLoader(String artifactId, RegionClassLoader regionClassLoader) {
+    return artifactPluginClassLoaderFactory.create(artifactId, regionClassLoader, artifactDescriptor);
   }
 
   /**

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactoryTestCase.java
@@ -27,11 +27,10 @@ import org.mule.runtime.deployment.model.internal.application.ApplicationClassLo
 import org.mule.runtime.deployment.model.internal.application.MuleApplicationClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
-import org.mule.runtime.module.deployment.impl.internal.application.ApplicationClassLoaderBuilderFactory;
-import org.mule.runtime.module.deployment.impl.internal.application.ApplicationDescriptorFactory;
-import org.mule.runtime.module.deployment.impl.internal.application.DefaultApplicationFactory;
 import org.mule.runtime.module.deployment.impl.internal.domain.DomainRepository;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateClassLoaderBuilderFactory;
 import org.mule.runtime.module.service.ServiceRepository;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.junit4.rule.SystemPropertyTemporaryFolder;
@@ -59,9 +58,13 @@ public class DefaultApplicationFactoryTestCase extends AbstractMuleTestCase {
   private final ArtifactPluginRepository applicationPluginRepository = mock(ArtifactPluginRepository.class);
   private final ApplicationDescriptorFactory applicationDescriptorFactory = mock(ApplicationDescriptorFactory.class);
   private final ServiceRepository serviceRepository = mock(ServiceRepository.class);
+  private final ClassLoaderRepository classLoaderRepository = mock(ClassLoaderRepository.class);
+  private final PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory =
+      mock(PolicyTemplateClassLoaderBuilderFactory.class);
   private final DefaultApplicationFactory applicationFactory =
       new DefaultApplicationFactory(applicationClassLoaderBuilderFactory, applicationDescriptorFactory,
-                                    applicationPluginRepository, domainRepository, serviceRepository, null);
+                                    applicationPluginRepository, domainRepository, serviceRepository, classLoaderRepository,
+                                    policyTemplateClassLoaderBuilderFactory);
 
   @Rule
   public TemporaryFolder muleHome = new SystemPropertyTemporaryFolder(MuleProperties.MULE_HOME_DIRECTORY_PROPERTY);

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultMuleApplicationStatusTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultMuleApplicationStatusTestCase.java
@@ -20,7 +20,6 @@ import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
 import org.mule.runtime.deployment.model.api.application.ApplicationStatus;
 import org.mule.runtime.deployment.model.api.artifact.ArtifactContext;
 import org.mule.runtime.deployment.model.internal.application.MuleApplicationClassLoader;
-import org.mule.runtime.module.deployment.impl.internal.application.DefaultMuleApplication;
 import org.mule.runtime.module.service.ServiceRepository;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.probe.JUnitProbe;
@@ -49,7 +48,7 @@ public class DefaultMuleApplicationStatusTestCase extends AbstractMuleContextTes
     when(mockArtifactContext.getMuleContext()).thenReturn(muleContext);
     application = new DefaultMuleApplication(null, parentArtifactClassLoader, emptyList(),
                                              null, mock(ServiceRepository.class), appLocation,
-                                             null);
+                                             null, null);
     application.setArtifactContext(mockArtifactContext);
   }
 
@@ -92,7 +91,7 @@ public class DefaultMuleApplicationStatusTestCase extends AbstractMuleContextTes
 
     DefaultMuleApplication application =
         new DefaultMuleApplication(descriptor, mock(MuleApplicationClassLoader.class), emptyList(), null,
-                                   null, appLocation, null);
+                                   null, appLocation, null, null);
     application.install();
     assertThat(application.deploymentClassLoader, is(notNullValue()));
     application.dispose();

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProviderTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProviderTestCase.java
@@ -20,8 +20,8 @@ import org.mule.runtime.core.policy.PolicyPointcutParameters;
 import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
-import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstance;
-import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstanceFactory;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstanceProvider;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstanceProviderFactory;
 import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateFactory;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -36,17 +36,17 @@ import org.junit.Test;
 public class MuleApplicationPolicyProviderTestCase extends AbstractMuleTestCase {
 
 
-  private final PolicyInstanceFactory policyInstanceFactory = mock(PolicyInstanceFactory.class);
+  private final PolicyInstanceProviderFactory policyInstanceProviderFactory = mock(PolicyInstanceProviderFactory.class);
   private final PolicyTemplateFactory policyTemplateFactory = mock(PolicyTemplateFactory.class);
   private final MuleApplicationPolicyProvider policyProvider =
-      new MuleApplicationPolicyProvider(policyTemplateFactory, policyInstanceFactory);
+      new MuleApplicationPolicyProvider(policyTemplateFactory, policyInstanceProviderFactory);
   private final Application application = mock(Application.class);
   private final PolicyPointcut pointcut = mock(PolicyPointcut.class);
   private final PolicyParametrization parametrization = new PolicyParametrization("policyId", pointcut, emptyMap());
   private final PolicyTemplateDescriptor policyTemplateDescriptor = new PolicyTemplateDescriptor("testPolicy");
   private final PolicyPointcutParameters policyPointcutParameters = mock(PolicyPointcutParameters.class);
   private PolicyTemplate policyTemplate = mock(PolicyTemplate.class);
-  private final PolicyInstance policyInstance = mock(PolicyInstance.class);
+  private final PolicyInstanceProvider policyInstanceProvider = mock(PolicyInstanceProvider.class);
   private final Policy policy1 = mock(Policy.class);
   private final Policy policy2 = mock(Policy.class);
   private final List<Policy> policiesToApply = new ArrayList<>();
@@ -55,10 +55,10 @@ public class MuleApplicationPolicyProviderTestCase extends AbstractMuleTestCase 
   public void setUp() throws Exception {
     policyProvider.setApplication(application);
     when(policyTemplateFactory.createArtifact(policyTemplateDescriptor, null)).thenReturn(policyTemplate);
-    when(policyInstance.getPointcut()).thenReturn(pointcut);
-    when(policyInstance.findOperationParameterizedPolicies(policyPointcutParameters)).thenReturn(policiesToApply);
-    when(policyInstance.findSourceParameterizedPolicies(policyPointcutParameters)).thenReturn(policiesToApply);
-    when(policyInstanceFactory.create(application, policyTemplate, parametrization)).thenReturn(policyInstance);
+    when(policyInstanceProvider.getPointcut()).thenReturn(pointcut);
+    when(policyInstanceProvider.findOperationParameterizedPolicies(policyPointcutParameters)).thenReturn(policiesToApply);
+    when(policyInstanceProvider.findSourceParameterizedPolicies(policyPointcutParameters)).thenReturn(policiesToApply);
+    when(policyInstanceProviderFactory.create(application, policyTemplate, parametrization)).thenReturn(policyInstanceProvider);
   }
 
   @Test

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProviderTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProviderTestCase.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.application;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mule.runtime.core.policy.Policy;
+import org.mule.runtime.core.policy.PolicyParametrization;
+import org.mule.runtime.core.policy.PolicyPointcut;
+import org.mule.runtime.core.policy.PolicyPointcutParameters;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstance;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyInstanceFactory;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateFactory;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+@SmallTest
+public class MuleApplicationPolicyProviderTestCase extends AbstractMuleTestCase {
+
+
+  private final PolicyInstanceFactory policyInstanceFactory = mock(PolicyInstanceFactory.class);
+  private final PolicyTemplateFactory policyTemplateFactory = mock(PolicyTemplateFactory.class);
+  private final MuleApplicationPolicyProvider policyProvider =
+      new MuleApplicationPolicyProvider(policyTemplateFactory, policyInstanceFactory);
+  private final Application application = mock(Application.class);
+  private final PolicyPointcut pointcut = mock(PolicyPointcut.class);
+  private final PolicyParametrization parametrization = new PolicyParametrization("policyId", pointcut, emptyMap());
+  private final PolicyTemplateDescriptor policyTemplateDescriptor = new PolicyTemplateDescriptor("testPolicy");
+  private final PolicyPointcutParameters policyPointcutParameters = mock(PolicyPointcutParameters.class);
+  private PolicyTemplate policyTemplate = mock(PolicyTemplate.class);
+  private final PolicyInstance policyInstance = mock(PolicyInstance.class);
+  private final Policy policy1 = mock(Policy.class);
+  private final Policy policy2 = mock(Policy.class);
+  private final List<Policy> policiesToApply = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    policyProvider.setApplication(application);
+    when(policyTemplateFactory.createArtifact(policyTemplateDescriptor, null)).thenReturn(policyTemplate);
+    when(policyInstance.getPointcut()).thenReturn(pointcut);
+    when(policyInstance.findOperationParameterizedPolicies(policyPointcutParameters)).thenReturn(policiesToApply);
+    when(policyInstance.findSourceParameterizedPolicies(policyPointcutParameters)).thenReturn(policiesToApply);
+    when(policyInstanceFactory.create(application, policyTemplate, parametrization)).thenReturn(policyInstance);
+  }
+
+  @Test
+  public void addsOperationPoliciesFromSinglePolicyInstance() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(true);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findOperationParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(2));
+    assertThat(parameterizedPolicies.get(0), is(policy1));
+    assertThat(parameterizedPolicies.get(1), is(policy2));
+  }
+
+  @Test
+  public void addsOperationPoliciesFromSinglePolicyInstanceApplyingPointCut() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(false);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findOperationParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(0));
+  }
+
+  @Test
+  public void addsOperationPoliciesFromMultiplePolicyInstances() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(true).thenReturn(true);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findOperationParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(4));
+    assertThat(parameterizedPolicies.get(0), is(policy1));
+    assertThat(parameterizedPolicies.get(1), is(policy2));
+    assertThat(parameterizedPolicies.get(2), is(policy1));
+    assertThat(parameterizedPolicies.get(3), is(policy2));
+  }
+
+  @Test
+  public void addsOperationPoliciesFromFirstPolicyInstance() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(true).thenReturn(false);
+    doMultipleOperationPoliciesPoincutRejectionTest();
+  }
+
+  @Test
+  public void addsOperationPoliciesFromSecondPolicyInstance() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(false).thenReturn(true);
+    doMultipleOperationPoliciesPoincutRejectionTest();
+  }
+
+  private void doMultipleOperationPoliciesPoincutRejectionTest() {
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findOperationParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(2));
+    assertThat(parameterizedPolicies.get(0), is(policy1));
+    assertThat(parameterizedPolicies.get(1), is(policy2));
+  }
+
+
+  @Test
+  public void addsOperationPoliciesFromMultiplePolicyInstancesApplyingPointCuts() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(false).thenReturn(false);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findOperationParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(0));
+  }
+
+  @Test
+  public void addsSourcePoliciesFromSinglePolicyInstance() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(true);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findSourceParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(2));
+    assertThat(parameterizedPolicies.get(0), is(policy1));
+    assertThat(parameterizedPolicies.get(1), is(policy2));
+  }
+
+  @Test
+  public void addsSourcePoliciesFromSinglePolicyInstanceApplyingPointCut() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(false);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findSourceParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(0));
+  }
+
+  @Test
+  public void addsSourcePoliciesFromMultiplePolicyInstances() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(true).thenReturn(true);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findSourceParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(4));
+    assertThat(parameterizedPolicies.get(0), is(policy1));
+    assertThat(parameterizedPolicies.get(1), is(policy2));
+    assertThat(parameterizedPolicies.get(2), is(policy1));
+    assertThat(parameterizedPolicies.get(3), is(policy2));
+  }
+
+  @Test
+  public void addsSourcePoliciesFromFirstPolicyInstance() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(true).thenReturn(false);
+    doMultipleSourcePoliciesPoincutRejectionTest();
+  }
+
+  @Test
+  public void addsSourcePoliciesFromSecondPolicyInstance() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(false).thenReturn(true);
+    doMultipleSourcePoliciesPoincutRejectionTest();
+  }
+
+  private void doMultipleSourcePoliciesPoincutRejectionTest() {
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findSourceParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(2));
+    assertThat(parameterizedPolicies.get(0), is(policy1));
+    assertThat(parameterizedPolicies.get(1), is(policy2));
+  }
+
+  @Test
+  public void addsSourcePoliciesFromMultiplePolicyInstancesApplyingPointCuts() throws Exception {
+    when(pointcut.matches(policyPointcutParameters)).thenReturn(false).thenReturn(false);
+
+    policiesToApply.add(policy1);
+    policiesToApply.add(policy2);
+
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+    policyProvider.addPolicy(policyTemplateDescriptor, parametrization);
+
+    List<Policy> parameterizedPolicies = policyProvider.findSourceParameterizedPolicies(policyPointcutParameters);
+
+    assertThat(parameterizedPolicies.size(), equalTo(0));
+  }
+}

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/artifact/ArtifactContextBuilderTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/artifact/ArtifactContextBuilderTestCase.java
@@ -18,6 +18,7 @@ import static org.mule.runtime.module.deployment.impl.internal.artifact.Artifact
 import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.INSTALLATION_DIRECTORY_MUST_BE_A_DIRECTORY;
 import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.MULE_CONTEXT_ARTIFACT_PROPERTIES_CANNOT_BE_NULL;
 import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.ONLY_APPLICATIONS_ARE_ALLOWED_TO_HAVE_A_PARENT_CONTEXT;
+import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.SERVICE_CONFIGURATOR_CANNOT_BE_NULL;
 import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.SERVICE_REPOSITORY_CANNOT_BE_NULL;
 import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.newBuilder;
 
@@ -67,6 +68,12 @@ public class ArtifactContextBuilderTestCase extends AbstractMuleTestCase {
   public void setNullClassLoaderRepository() throws Exception {
     expectedException.expectMessage(CLASS_LOADER_REPOSITORY_CANNOT_BE_NULL);
     newBuilder().setClassLoaderRepository(null);
+  }
+
+  @Test
+  public void setNullServiceConfigurator() throws Exception {
+    expectedException.expectMessage(SERVICE_CONFIGURATOR_CANNOT_BE_NULL);
+    newBuilder().withServiceConfigurator(null);
   }
 
   @Test

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/PolicyFileBuilder.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/PolicyFileBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.builder;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.DEFAULT_POLICY_CONFIGURATION_RESOURCE;
+import static org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorFactory.PLUGIN_DEPENDENCIES;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateDescriptorFactory.POLICY_PROPERTIES;
+import org.mule.runtime.core.util.StringUtils;
+import org.mule.runtime.module.artifact.builder.AbstractArtifactFileBuilder;
+import org.mule.tck.ZipUtils;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Creates Mule Application Policy files.
+ */
+public class PolicyFileBuilder extends AbstractArtifactFileBuilder<PolicyFileBuilder> {
+
+  private List<ArtifactPluginFileBuilder> plugins = new LinkedList<>();
+  private Properties properties = new Properties();
+
+  public PolicyFileBuilder(String id) {
+    super(id);
+  }
+
+  @Override
+  public String getConfigFile() {
+    return DEFAULT_POLICY_CONFIGURATION_RESOURCE;
+  }
+
+  @Override
+  protected PolicyFileBuilder getThis() {
+    return this;
+  }
+
+  @Override
+  protected List<ZipUtils.ZipResource> getCustomResources() {
+    final List<ZipUtils.ZipResource> customResources = new LinkedList<>();
+
+    for (ArtifactPluginFileBuilder plugin : plugins) {
+      customResources
+          .add(new ZipUtils.ZipResource(plugin.getArtifactFile().getAbsolutePath(),
+                                        "plugins/" + plugin.getArtifactFile().getName()));
+    }
+
+    if (!properties.isEmpty()) {
+      final File applicationPropertiesFile = new File(getTempFolder(), POLICY_PROPERTIES);
+      applicationPropertiesFile.deleteOnExit();
+      createPropertiesFile(applicationPropertiesFile, properties);
+
+      customResources.add(new ZipUtils.ZipResource(applicationPropertiesFile.getAbsolutePath(), POLICY_PROPERTIES));
+    }
+
+    return customResources;
+  }
+
+  /**
+   * Adds a dependency against another plugin
+   *
+   * @param pluginName name of the plugin to be dependent. Non empty.
+   * @return the same builder instance
+   */
+  public PolicyFileBuilder dependingOn(String pluginName) {
+    checkImmutable();
+    checkArgument(!isEmpty(pluginName), "Plugin name cannot be empty");
+    String plugins = properties.getProperty(PLUGIN_DEPENDENCIES);
+    if (isEmpty(plugins)) {
+      plugins = pluginName;
+    } else {
+      plugins = plugins + ", " + pluginName;
+    }
+
+    properties.setProperty(PLUGIN_DEPENDENCIES, plugins);
+
+    return this;
+  }
+
+  /**
+   * Sets the configuration file used for the policy.
+   *
+   * @param configFile policy configuration from a external file or test resource. Non empty.
+   * @return the same builder instance
+   */
+  public PolicyFileBuilder definedBy(String configFile) {
+    checkImmutable();
+    checkArgument(!StringUtils.isEmpty(configFile), "Config file cannot be empty");
+    this.resources.add(new ZipUtils.ZipResource(configFile, DEFAULT_POLICY_CONFIGURATION_RESOURCE));
+
+    return this;
+  }
+
+  /**
+   * Adds a resource file to the artifact classes folder.
+   *
+   * @param resourceFile class file from a external file or test resource. Non empty.
+   * @param targetFile name to use on the added resource. Non empty.
+   * @return the same builder instance
+   */
+  public PolicyFileBuilder usingResource(String resourceFile, String targetFile) {
+    checkImmutable();
+    checkArgument(!isEmpty(resourceFile), "Resource file cannot be empty");
+    resources.add(new ZipUtils.ZipResource(resourceFile, "classes/" + targetFile));
+
+    return getThis();
+  }
+
+  /**
+   * Adds a property into the policy properties file.
+   *
+   * @param propertyName name fo the property to add. Non empty
+   * @param propertyValue value of the property to add. Non null.
+   * @return the same builder instance
+   */
+  public PolicyFileBuilder configuredWith(String propertyName, String propertyValue) {
+    checkImmutable();
+    checkArgument(!isEmpty(propertyName), "Property name cannot be empty");
+    checkArgument(propertyValue != null, "Property value cannot be null");
+    properties.put(propertyName, propertyValue);
+
+    return this;
+  }
+}

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplateFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplateFactoryTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.NULL_CLASSLOADER_FILTER;
+import static org.mule.runtime.module.deployment.impl.internal.policy.DefaultPolicyTemplateFactory.createPolicyTemplateCreationErrorMessage;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.deployment.model.internal.policy.PolicyTemplateClassLoaderBuilder;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@SmallTest
+public class DefaultPolicyTemplateFactoryTestCase extends AbstractMuleTestCase {
+
+  private static final String POLICY_ID = "policyId";
+  private static final String POLICY_NAME = "testPolicy";
+
+  private final PolicyTemplateClassLoaderBuilderFactory classLoaderBuilderFactory =
+      mock(PolicyTemplateClassLoaderBuilderFactory.class);
+  private final PolicyTemplateFactory policyTemplateFactory = new DefaultPolicyTemplateFactory(classLoaderBuilderFactory);
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+  private final PolicyTemplateDescriptor descriptor = new PolicyTemplateDescriptor(POLICY_NAME);
+
+  @Test
+  public void createsPolicyTemplate() throws Exception {
+
+    RegionClassLoader regionClassLoader = createRegionClassLoader();
+    PolicyTemplateClassLoaderBuilder policyTemplateClassLoaderBuilder = createPolicyTemplateClassLoaderBuilder(regionClassLoader);
+
+    ArtifactClassLoader policyClassLoader = mock(ArtifactClassLoader.class);
+    when(policyClassLoader.getArtifactId()).thenReturn(POLICY_ID);
+    when(policyTemplateClassLoaderBuilder.build()).thenReturn(policyClassLoader);
+    when(classLoaderBuilderFactory.createArtifactClassLoaderBuilder()).thenReturn(policyTemplateClassLoaderBuilder);
+
+    PolicyTemplate policyTemplate = policyTemplateFactory.createArtifact(descriptor, regionClassLoader);
+
+    assertThat(policyTemplate.getArtifactClassLoader(), is(policyClassLoader));
+    assertThat(policyTemplate.getDescriptor(), is(descriptor));
+    assertThat(policyTemplate.getArtifactId(), is(POLICY_ID));
+    assertThat(regionClassLoader.getArtifactPluginClassLoaders().size(), equalTo(1));
+  }
+
+  @Test
+  public void managesArtifactContextCreationFailure() throws Exception {
+    RegionClassLoader regionClassLoader = createRegionClassLoader();
+    PolicyTemplateClassLoaderBuilder policyTemplateClassLoaderBuilder = createPolicyTemplateClassLoaderBuilder(regionClassLoader);
+
+    final String errorMessage = "Error";
+    final IOException exceptionCause = new IOException(errorMessage);
+    when(policyTemplateClassLoaderBuilder.build()).thenThrow(exceptionCause);
+    when(classLoaderBuilderFactory.createArtifactClassLoaderBuilder()).thenReturn(policyTemplateClassLoaderBuilder);
+
+    this.expectedException.expect(PolicyTemplateCreationException.class);
+    this.expectedException.expectMessage(createPolicyTemplateCreationErrorMessage(POLICY_NAME));
+    this.expectedException.expectCause(equalTo(exceptionCause));
+    policyTemplateFactory.createArtifact(descriptor, regionClassLoader);
+
+    // Checks that the region was not updated
+    assertThat(regionClassLoader.getArtifactPluginClassLoaders().size(), equalTo(0));
+  }
+
+  private PolicyTemplateClassLoaderBuilder createPolicyTemplateClassLoaderBuilder(RegionClassLoader regionClassLoader) {
+    PolicyTemplateClassLoaderBuilder policyTemplateClassLoaderBuilder = mock(PolicyTemplateClassLoaderBuilder.class);
+    when(policyTemplateClassLoaderBuilder.setParentClassLoader(regionClassLoader)).thenReturn(policyTemplateClassLoaderBuilder);
+    when(policyTemplateClassLoaderBuilder.setArtifactDescriptor(descriptor)).thenReturn(policyTemplateClassLoaderBuilder);
+    return policyTemplateClassLoaderBuilder;
+  }
+
+  private RegionClassLoader createRegionClassLoader() {
+    ClassLoaderLookupPolicy lookupPolicy = mock(ClassLoaderLookupPolicy.class);
+    RegionClassLoader regionClassLoader =
+        new RegionClassLoader(descriptor.getName(), descriptor, this.getClass().getClassLoader(),
+                              lookupPolicy);
+
+    // Adds the owner of the region
+    ArtifactClassLoader regionOwnerClassLoader = mock(ArtifactClassLoader.class);
+    regionClassLoader.addClassLoader(regionOwnerClassLoader, NULL_CLASSLOADER_FILTER);
+
+    return regionClassLoader;
+  }
+}

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactoryTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static java.io.File.createTempFile;
+import static java.io.File.separator;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.util.FileUtils.unzip;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateDescriptorFactory.CLASSES_DIR;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateDescriptorFactory.LIB_DIR;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateDescriptorFactory.MISSING_POLICY_PROPERTIES_FILE;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
+import org.mule.runtime.module.deployment.impl.internal.builder.PolicyFileBuilder;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+import org.mule.tck.util.CompilerUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@SmallTest
+public class PolicyTemplateDescriptorFactoryTestCase extends AbstractMuleTestCase {
+
+  public static final String POLICY_NAME = "testPolicy";
+  public static final String JAR_FILE_NAME = "test.jar";
+
+  private static final File echoTestJarFile =
+      new CompilerUtils.JarCompiler().compiling(getResourceFile("/org/foo/EchoTest.java"))
+          .compile(JAR_FILE_NAME);
+
+  private static File getResourceFile(String resource) {
+    return new File(PolicyTemplateDescriptorFactoryTestCase.class.getResource(resource).getFile());
+  }
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private ArtifactPluginRepository applicationPluginRepository;
+
+  @Before
+  public void setUp() throws Exception {
+    applicationPluginRepository = mock(ArtifactPluginRepository.class);
+    when(applicationPluginRepository.getContainerArtifactPluginDescriptors()).thenReturn(emptyList());
+  }
+
+  @Test
+  public void verifiesThatPolicyDescriptorIsPresent() throws Exception {
+    PolicyFileBuilder policyFileBuilder = new PolicyFileBuilder(POLICY_NAME).usingLibrary(echoTestJarFile.getAbsolutePath());
+    File tempFolder = createTempFolder();
+    unzip(policyFileBuilder.getArtifactFile(), tempFolder);
+
+    PolicyTemplateDescriptorFactory descriptorFactory = new PolicyTemplateDescriptorFactory();
+
+    expectedException.expect(ArtifactDescriptorCreateException.class);
+    expectedException.expectMessage(MISSING_POLICY_PROPERTIES_FILE);
+    descriptorFactory.create(tempFolder);
+  }
+
+  @Test
+  public void readsRuntimeLibs() throws Exception {
+    PolicyFileBuilder policyFileBuilder = new PolicyFileBuilder(POLICY_NAME).configuredWith("policy.name", POLICY_NAME)
+        .usingLibrary(echoTestJarFile.getAbsolutePath());
+    File tempFolder = createTempFolder();
+    unzip(policyFileBuilder.getArtifactFile(), tempFolder);
+
+    PolicyTemplateDescriptorFactory descriptorFactory = new PolicyTemplateDescriptorFactory();
+    PolicyTemplateDescriptor desc = descriptorFactory.create(tempFolder);
+
+    assertThat(desc.getClassLoaderModel().getUrls().length, equalTo(2));
+    assertThat(desc.getClassLoaderModel().getUrls()[0].getFile(), equalTo(new File(tempFolder, CLASSES_DIR).toString()));
+    assertThat(desc.getClassLoaderModel().getUrls()[1].getFile(),
+               equalTo(new File(tempFolder, LIB_DIR + separator + JAR_FILE_NAME).toString()));
+  }
+
+  private File createTempFolder() throws IOException {
+    File tempFolder = createTempFile("tempPolicy", null);
+    assertThat(tempFolder.delete(), is(true));
+    assertThat(tempFolder.mkdir(), is(true));
+    return tempFolder;
+  }
+}

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/application/Application.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/application/Application.java
@@ -7,10 +7,11 @@
 package org.mule.runtime.deployment.model.api.application;
 
 import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.module.artifact.classloader.RegionOwnerArtifact;
 import org.mule.runtime.deployment.model.api.DeployableArtifact;
 import org.mule.runtime.deployment.model.api.domain.Domain;
 
-public interface Application extends DeployableArtifact<ApplicationDescriptor> {
+public interface Application extends DeployableArtifact<ApplicationDescriptor>, RegionOwnerArtifact {
 
   MuleContext getMuleContext();
 
@@ -24,4 +25,8 @@ public interface Application extends DeployableArtifact<ApplicationDescriptor> {
    */
   ApplicationStatus getStatus();
 
+  /**
+   * @return the policy manager for the application
+   */
+  ApplicationPolicyManager getPolicyManager();
 }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/application/ApplicationPolicyManager.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/application/ApplicationPolicyManager.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.api.application;
+
+import org.mule.runtime.core.policy.PolicyParametrization;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+
+/**
+ * Manages the policies that must be applied to a given application
+ */
+public interface ApplicationPolicyManager {
+
+  /**
+   * Add a new policy
+   *
+   * @param policyTemplateDescriptor describes how to create the policy template. Non null
+   * @param parametrization parametrization used to instantiate the policy. Non null
+   */
+  void addPolicy(PolicyTemplateDescriptor policyTemplateDescriptor, PolicyParametrization parametrization);
+}

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplate.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplate.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.api.policy;
+
+import org.mule.runtime.module.artifact.Artifact;
+
+/**
+ * Represents a policy template artifact.
+ *
+ * @since 4.0
+ */
+public interface PolicyTemplate extends Artifact<PolicyTemplateDescriptor> {
+
+  /**
+   * Disposes the artifact releasing any held resources
+   */
+  void dispose();
+}

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptor.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.api.policy;
+
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+
+import java.io.File;
+
+
+/**
+ * Describes how to create a {@link PolicyTemplate} artifact
+ *
+ * @since 4.0
+ */
+public class PolicyTemplateDescriptor extends ArtifactDescriptor {
+
+  public static final String DEFAULT_POLICY_CONFIGURATION_RESOURCE = "policy.xml";
+
+  private File[] configResourceFiles;
+
+  /**
+   * Creates a new descriptor for a named artifact
+   *
+   * @param name artifact name. Non empty.
+   */
+  public PolicyTemplateDescriptor(String name) {
+    super(name);
+  }
+
+  public File[] getConfigResourceFiles() {
+    return configResourceFiles;
+  }
+
+  public void setConfigResourceFiles(File[] configResourceFiles) {
+    this.configResourceFiles = configResourceFiles;
+  }
+}

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/application/ApplicationClassLoaderBuilder.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/application/ApplicationClassLoaderBuilder.java
@@ -20,6 +20,7 @@ import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.io.IOException;
  */
 public class ApplicationClassLoaderBuilder extends AbstractArtifactClassLoaderBuilder<ApplicationClassLoaderBuilder> {
 
+  private final DeployableArtifactClassLoaderFactory artifactClassLoaderFactory;
   private Domain domain;
 
   /**
@@ -48,8 +50,9 @@ public class ApplicationClassLoaderBuilder extends AbstractArtifactClassLoaderBu
                                        ArtifactPluginRepository artifactPluginRepository,
                                        ArtifactClassLoaderFactory<ArtifactPluginDescriptor> artifactPluginClassLoaderFactory,
                                        PluginDependenciesResolver pluginDependenciesResolver) {
-    super(artifactClassLoaderFactory, artifactPluginRepository, artifactPluginClassLoaderFactory,
-          pluginDependenciesResolver);
+    super(artifactPluginRepository, artifactPluginClassLoaderFactory, pluginDependenciesResolver);
+
+    this.artifactClassLoaderFactory = artifactClassLoaderFactory;
   }
 
   /**
@@ -63,6 +66,11 @@ public class ApplicationClassLoaderBuilder extends AbstractArtifactClassLoaderBu
     checkState(domain != null, "Domain cannot be null");
 
     return (MuleDeployableArtifactClassLoader) super.build();
+  }
+
+  @Override
+  protected ArtifactClassLoader createArtifactClassLoader(String artifactId, RegionClassLoader regionClassLoader) {
+    return artifactClassLoaderFactory.create(artifactId, regionClassLoader, artifactDescriptor, artifactPluginClassLoaders);
   }
 
   @Override

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderBuilder.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.internal.policy;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
+import org.mule.runtime.deployment.model.internal.AbstractArtifactClassLoaderBuilder;
+import org.mule.runtime.deployment.model.internal.plugin.PluginDependenciesResolver;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
+import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+
+/**
+ * Builds the class loader to use on a {@link org.mule.runtime.deployment.model.api.policy.PolicyTemplate}
+ */
+public class PolicyTemplateClassLoaderBuilder extends AbstractArtifactClassLoaderBuilder {
+
+  private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
+  private ArtifactClassLoader parentClassLoader;
+
+  /**
+   * Creates an {@link AbstractArtifactClassLoaderBuilder}.
+   * 
+   * @param artifactClassLoaderFactory factory for the classloader specific to the artifact resource and classes. Must be not
+   *        null.
+   * @param artifactPluginRepository repository of plugins contained by the runtime. Must be not null.
+   * @param artifactPluginClassLoaderFactory factory to create class loaders for each used plugin. Non be not null.
+   * @param pluginDependenciesResolver resolves artifact plugin dependencies. Non null
+   */
+  public PolicyTemplateClassLoaderBuilder(ArtifactClassLoaderFactory artifactClassLoaderFactory,
+                                          ArtifactPluginRepository artifactPluginRepository,
+                                          ArtifactClassLoaderFactory artifactPluginClassLoaderFactory,
+                                          PluginDependenciesResolver pluginDependenciesResolver) {
+    super(artifactPluginRepository, artifactPluginClassLoaderFactory, pluginDependenciesResolver);
+    this.artifactClassLoaderFactory = artifactClassLoaderFactory;
+  }
+
+
+  @Override
+  protected ArtifactClassLoader createArtifactClassLoader(String artifactId, RegionClassLoader regionClassLoader) {
+    return artifactClassLoaderFactory.create(artifactId, regionClassLoader, artifactDescriptor);
+  }
+
+  @Override
+  protected ArtifactClassLoader getParentClassLoader() {
+    return parentClassLoader;
+  }
+
+  public PolicyTemplateClassLoaderBuilder setParentClassLoader(ArtifactClassLoader parentClassLoader) {
+    this.parentClassLoader = parentClassLoader;
+
+    return this;
+  }
+
+  @Override
+  protected String getArtifactId(ArtifactDescriptor artifactDescriptor) {
+    return getPolicyId(artifactDescriptor.getName());
+  }
+
+  public String getPolicyId(String policyName) {
+    checkArgument(!isEmpty(policyName), "policyName cannot be empty");
+
+    return parentClassLoader.getArtifactId() + "/policy/" + policyName;
+  }
+}

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderFactory.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.internal.policy;
+
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
+
+import java.io.File;
+
+/**
+ * Creates {@link ArtifactClassLoader} for policy templates artifact.
+ */
+public class PolicyTemplateClassLoaderFactory implements ArtifactClassLoaderFactory<PolicyTemplateDescriptor> {
+
+  @Override
+  public ArtifactClassLoader create(String artifactId, ArtifactClassLoader parent, PolicyTemplateDescriptor descriptor) {
+    File rootFolder = descriptor.getRootFolder();
+    if (rootFolder == null || !rootFolder.exists()) {
+      throw new IllegalArgumentException("Policy folder does not exists: " + (rootFolder != null ? rootFolder.getName() : null));
+    }
+
+    final ClassLoaderLookupPolicy classLoaderLookupPolicy = parent.getClassLoaderLookupPolicy();
+
+    return new MuleArtifactClassLoader(artifactId, descriptor,
+                                       descriptor.getClassLoaderModel().getUrls(),
+                                       parent.getClassLoader(),
+                                       classLoaderLookupPolicy);
+  }
+}

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/tooling/ToolingPluginClassLoaderBuilder.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/tooling/ToolingPluginClassLoaderBuilder.java
@@ -40,6 +40,7 @@ import java.net.URL;
 public class ToolingPluginClassLoaderBuilder extends AbstractArtifactClassLoaderBuilder<ToolingPluginClassLoaderBuilder> {
 
   private static final String TOOLING_EXTENSION_MODEL = "tooling-extension-model";
+  private final DeployableArtifactClassLoaderFactory artifactClassLoaderFactory;
   private ArtifactPluginDescriptor artifactPluginDescriptor;
 
   private ArtifactClassLoader parentClassLoader;
@@ -56,10 +57,14 @@ public class ToolingPluginClassLoaderBuilder extends AbstractArtifactClassLoader
                                          ArtifactClassLoaderFactory<ArtifactPluginDescriptor> artifactPluginClassLoaderFactory,
                                          ArtifactPluginDescriptor artifactPluginDescriptor,
                                          PluginDependenciesResolver pluginDependenciesResolver) {
-    super(artifactClassLoaderFactory, artifactPluginRepository,
-          artifactPluginClassLoaderFactory,
-          pluginDependenciesResolver);
+    super(artifactPluginRepository, artifactPluginClassLoaderFactory, pluginDependenciesResolver);
     this.artifactPluginDescriptor = artifactPluginDescriptor;
+    this.artifactClassLoaderFactory = artifactClassLoaderFactory;
+  }
+
+  @Override
+  protected ArtifactClassLoader createArtifactClassLoader(String artifactId, RegionClassLoader regionClassLoader) {
+    return artifactClassLoaderFactory.create(artifactId, regionClassLoader, artifactDescriptor, artifactPluginClassLoaders);
   }
 
   /**

--- a/modules/deployment-model/src/main/resources/META-INF/mule-module.properties
+++ b/modules/deployment-model/src/main/resources/META-INF/mule-module.properties
@@ -4,5 +4,6 @@ artifact.export.classPackages=org.mule.runtime.deployment.model.api,\
                               org.mule.runtime.deployment.model.api.application,\
                               org.mule.runtime.deployment.model.api.artifact,\
                               org.mule.runtime.deployment.model.api.domain,\
-                              org.mule.runtime.deployment.model.api.plugin
+                              org.mule.runtime.deployment.model.api.plugin,\
+                              org.mule.runtime.deployment.model.api.policy
 

--- a/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderFactoryTestCase.java
+++ b/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderFactoryTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.internal.policy;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.module.artifact.classloader.ClassLoaderLookupStrategy.PARENT_FIRST;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.io.File;
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+@SmallTest
+public class PolicyTemplateClassLoaderFactoryTestCase extends AbstractMuleTestCase {
+
+  private static final String POLICY_ID = "policy/policyId";
+
+  private final ClassLoaderLookupPolicy lookupPolicy = mock(ClassLoaderLookupPolicy.class);
+  @Rule
+  public TemporaryFolder policyFolder = new TemporaryFolder();
+  private PolicyTemplateClassLoaderFactory factory = new PolicyTemplateClassLoaderFactory();
+  private PolicyTemplateDescriptor descriptor;
+  private ArtifactClassLoader parentClassLoader;
+
+  @Before
+  public void setUp() throws Exception {
+    descriptor = new PolicyTemplateDescriptor("testPolicy");
+    descriptor.setRootFolder(policyFolder.getRoot());
+
+    parentClassLoader = mock(ArtifactClassLoader.class);
+    when(parentClassLoader.getClassLoader()).thenReturn(getClass().getClassLoader());
+    when(lookupPolicy.getLookupStrategy(anyString())).thenReturn(PARENT_FIRST);
+    when(parentClassLoader.getClassLoaderLookupPolicy()).thenReturn(lookupPolicy);
+  }
+
+  @Test
+  public void createsEmptyClassLoader() throws Exception {
+    final ArtifactClassLoader artifactClassLoader = factory.create(POLICY_ID, parentClassLoader, descriptor);
+    final MuleArtifactClassLoader classLoader = (MuleArtifactClassLoader) artifactClassLoader.getClassLoader();
+    assertThat(classLoader.getURLs(), equalTo(new URL[0]));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void validatesPolicyFolder() throws Exception {
+    File fakePolicyFolder = new File("./fake/folder/for/test");
+    descriptor.setRootFolder(fakePolicyFolder);
+    factory.create(POLICY_ID, null, descriptor);
+  }
+
+  @Test
+  public void usesClassLoaderLookupPolicy() throws Exception {
+    final ArtifactClassLoader artifactClassLoader = factory.create(POLICY_ID, parentClassLoader, descriptor);
+    final MuleArtifactClassLoader classLoader = (MuleArtifactClassLoader) artifactClassLoader.getClassLoader();
+
+    final String className = "com.dummy.Foo";
+    try {
+      classLoader.loadClass(className);
+      fail("Able to load an un-existent class");
+    } catch (ClassNotFoundException e) {
+      // Expected
+    }
+
+    verify(lookupPolicy).getLookupStrategy(className);
+  }
+}

--- a/modules/deployment/pom.xml
+++ b/modules/deployment/pom.xml
@@ -90,6 +90,12 @@
             <type>test-jar</type>
         </dependency>
         <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-module-test-policy</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-artifact</artifactId>
             <version>${project.version}</version>

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestApplicationFactory.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestApplicationFactory.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.deployment.internal;
 
+import static org.mockito.Mockito.mock;
 import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginClassLoaderFactory;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
@@ -14,6 +15,7 @@ import org.mule.runtime.deployment.model.internal.application.MuleApplicationCla
 import org.mule.runtime.deployment.model.internal.artifact.DefaultDependenciesProvider;
 import org.mule.runtime.deployment.model.internal.plugin.BundlePluginDependenciesResolver;
 import org.mule.runtime.deployment.model.internal.plugin.PluginDependenciesResolver;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateClassLoaderBuilderFactory;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.classloader.TrackingArtifactClassLoaderFactory;
 import org.mule.runtime.module.deployment.impl.internal.application.ApplicationClassLoaderBuilderFactory;
@@ -44,9 +46,10 @@ public class TestApplicationFactory extends DefaultApplicationFactory {
   public TestApplicationFactory(ApplicationClassLoaderBuilderFactory applicationClassLoaderBuilderFactory,
                                 ApplicationDescriptorFactory applicationDescriptorFactory,
                                 ArtifactPluginRepository artifactPluginRepository, DomainRepository domainRepository,
-                                ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository) {
+                                ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository,
+                                PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory) {
     super(applicationClassLoaderBuilderFactory, applicationDescriptorFactory, artifactPluginRepository, domainRepository,
-          serviceRepository, classLoaderRepository);
+          serviceRepository, classLoaderRepository, policyTemplateClassLoaderBuilderFactory);
   }
 
   public static TestApplicationFactory createTestApplicationFactory(MuleApplicationClassLoaderFactory applicationClassLoaderFactory,
@@ -68,8 +71,10 @@ public class TestApplicationFactory extends DefaultApplicationFactory {
                                                  new TrackingArtifactClassLoaderFactory<>(artifactClassLoaderManager,
                                                                                           new ArtifactPluginClassLoaderFactory()),
                                                  pluginDependenciesResolver);
+
     return new TestApplicationFactory(applicationClassLoaderBuilderFactory, applicationDescriptorFactory,
-                                      applicationPluginRepository, domainManager, serviceRepository, artifactClassLoaderManager);
+                                      applicationPluginRepository, domainManager, serviceRepository, artifactClassLoaderManager,
+                                      mock(PolicyTemplateClassLoaderBuilderFactory.class));
   }
 
   @Override

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestPolicyManager.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestPolicyManager.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.internal;
+
+import static org.apache.commons.io.FilenameUtils.getBaseName;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import static org.mule.runtime.container.api.MuleFoldersUtil.getExecutionFolder;
+import static org.mule.runtime.core.util.FileUtils.unzip;
+import org.mule.runtime.core.policy.PolicyParametrization;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.application.ApplicationPolicyManager;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.module.deployment.api.DeploymentListener;
+import org.mule.runtime.module.deployment.api.DeploymentService;
+import org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateDescriptorFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Applies policies to each deployed application to simulate the real manager provided by API Gateway.
+ */
+public class TestPolicyManager implements DeploymentListener {
+
+  private final DeploymentService deploymentService;
+  private final Map<String, List<AppPolicyParametrization>> registeredPolicies = new HashMap<>();
+  private final List<PolicyTemplateDescriptor> policyTemplateDescriptors = new ArrayList<>();
+  private final PolicyTemplateDescriptorFactory policyTemplateDescriptorFactory = new PolicyTemplateDescriptorFactory();
+
+  /**
+   * Creates a new manager
+   *
+   * @param deploymentService service that deploys applications in the container. Non null.
+   */
+  public TestPolicyManager(DeploymentService deploymentService) {
+    checkArgument(deploymentService != null, "deploymentService cannot be null");
+
+    this.deploymentService = deploymentService;
+  }
+
+  @Override
+  public void onDeploymentSuccess(String artifactName) {
+    List<AppPolicyParametrization> appPolicyParametrizations = registeredPolicies.get(artifactName);
+
+    if (appPolicyParametrizations == null) {
+      return;
+    }
+
+    Application application = deploymentService.findApplication(artifactName);
+    ApplicationPolicyManager policyManager = application.getPolicyManager();
+
+    for (AppPolicyParametrization appPolicyParametrization : appPolicyParametrizations) {
+      policyManager.addPolicy(appPolicyParametrization.policyTemplateDescriptor, appPolicyParametrization.policyParametrization);
+    }
+  }
+
+  /**
+   * Registers a policy template that can be later used to register a parameterized policy
+   *
+   * @param policyTemplate policy artifact file. Non null.
+   */
+  public void registerPolicyTemplate(File policyTemplate) {
+    final File tempFolder = new File(getPoliciesTempFolder(), getBaseName(policyTemplate.getName()));
+    try {
+      unzip(policyTemplate, tempFolder);
+    } catch (IOException e) {
+      throw new IllegalStateException("Error processing policy ZIP file: " + policyTemplate, e);
+    }
+
+    final PolicyTemplateDescriptor policyTemplateDescriptor = policyTemplateDescriptorFactory.create(tempFolder);
+    policyTemplateDescriptors.add(policyTemplateDescriptor);
+  }
+
+  /**
+   * Adds a parameterized policy
+   *
+   * @param appName application where the policy must be applied. Non empty.
+   * @param policyTemplateName template that must be used to instantiate the parametrized policy. Non empty.
+   * @param policyParametrization parametrization to instantiate the policy. Non null.
+   */
+  public void addPolicy(String appName, String policyTemplateName, PolicyParametrization policyParametrization) {
+
+    checkArgument(isEmpty(appName), "appName cannot be empty");
+    checkArgument(isEmpty(policyTemplateName), "policyTemplateName cannot be empty");
+    checkArgument(policyParametrization != null, "policyParametrization cannot be ull");
+
+    Optional<PolicyTemplateDescriptor> policyTemplateDescriptor =
+        policyTemplateDescriptors.stream().filter(template -> template.getName().equals(policyTemplateName)).findFirst();
+
+    if (!policyTemplateDescriptor.isPresent()) {
+      throw new IllegalStateException("Cannot find policy template descriptor with name: " + policyTemplateName);
+    }
+
+    List<AppPolicyParametrization> appPolicyParametrizations = registeredPolicies.get(appName);
+
+    if (appPolicyParametrizations == null) {
+      appPolicyParametrizations = new ArrayList<>();
+      registeredPolicies.put(appName, appPolicyParametrizations);
+    }
+
+    appPolicyParametrizations.add(new AppPolicyParametrization(policyTemplateDescriptor.get(), policyParametrization));
+  }
+
+  private File getPoliciesTempFolder() {
+    return new File(getExecutionFolder(), "policies");
+  }
+
+  private static class AppPolicyParametrization {
+
+    private final PolicyTemplateDescriptor policyTemplateDescriptor;
+    private final PolicyParametrization policyParametrization;
+
+    private AppPolicyParametrization(PolicyTemplateDescriptor policyTemplateDescriptor,
+                                     PolicyParametrization policyParametrization) {
+      this.policyTemplateDescriptor = policyTemplateDescriptor;
+      this.policyParametrization = policyParametrization;
+    }
+  }
+}

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestPolicyManager.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestPolicyManager.java
@@ -91,8 +91,8 @@ public class TestPolicyManager implements DeploymentListener {
    */
   public void addPolicy(String appName, String policyTemplateName, PolicyParametrization policyParametrization) {
 
-    checkArgument(isEmpty(appName), "appName cannot be empty");
-    checkArgument(isEmpty(policyTemplateName), "policyTemplateName cannot be empty");
+    checkArgument(!isEmpty(appName), "appName cannot be empty");
+    checkArgument(!isEmpty(policyTemplateName), "policyTemplateName cannot be empty");
     checkArgument(policyParametrization != null, "policyParametrization cannot be ull");
 
     Optional<PolicyTemplateDescriptor> policyTemplateDescriptor =

--- a/modules/deployment/src/test/resources/fooPolicy.xml
+++ b/modules/deployment/src/test/resources/fooPolicy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test-policy="http://www.mulesoft.org/schema/mule/test-policy"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/test-policy http://www.mulesoft.org/schema/mule/test-policy/current/mule-test-policy.xsd">
+
+    <test-policy:proxy>
+        <test-policy:operation>
+            <logger level="ERROR" message="Test policy operation"/>
+            <component class="org.mule.runtime.module.deployment.internal.DeploymentServiceTestCase$TestPolicyComponent" />
+            <test-policy:execute-next/>
+        </test-policy:operation>
+    </test-policy:proxy>
+</mule>


### PR DESCRIPTION
_ Adding PolicyParametrization to parameterize policy templates
_ Adding PolicyPointcut to provide a way to decide whether a policy must be applied on given a request
_ Adding RegionOwnerArtifact to provide access to the region classloader where policies are included
_ Adding TestPolicyManager to simulate API gateway
_ Adding ApplicationPolicyManager to manage policies per application.
_Adding a applicationPolicyManager to applications
_ Adding PolicyTemplateDescriptor and PolicyTemplate (and related factories and builders) to represent policy template artifacts
_ Refactoring AbstractArtifactClassLoaderBuilder to receive a PluginDependenciesResolver instead of the values needed to create it
_ Refactoring AbstractArtifactClassLoaderBuilder to let subclases to define how to createArtifactClassLoader
_ Adding ApplicationPolicyProvider to manage and provide application policies
_ Adding PolicyInstance (and related factories/builders) to represent instances of polices applied to applications
_ Adding PolicyFileBuilder to create policy file for testing purposes
_ Adding deployment test with policies