### PR TITLE
MULE-10996: Content-Length header case conflicts with streaming.

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/CaseInsensitiveParameterMap.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/CaseInsensitiveParameterMap.java
@@ -21,7 +21,14 @@ public class CaseInsensitiveParameterMap extends ParameterMap
         this.paramsMap = new CaseInsensitiveMapWrapper<>(LinkedHashMap.class);
         for (String key : paramsMap.keySet())
         {
-            this.paramsMap.put(key, new LinkedList<>(paramsMap.getAll(key)));
+            LinkedList paramsMapValues = new LinkedList<>(paramsMap.getAll(key));
+
+            if(this.paramsMap.containsKey(key))
+            {
+                paramsMapValues.addAll(this.paramsMap.get(key));
+            }
+
+            this.paramsMap.put(key, paramsMapValues);
         }
     }
 }

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseBuilderTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerResponseBuilderTestCase.java
@@ -74,6 +74,9 @@ public class HttpListenerResponseBuilderTestCase extends FunctionalTestCase
     public SystemProperty headerDuplicatesResponseBuilderPath = new SystemProperty("headerDuplicatesResponseBuilderPath","headerDuplicatesResponseBuilderPath");
 
     @Rule
+    public SystemProperty headerDuplicatesAndDifferentCaseResponseBuilderPath = new SystemProperty("headerDuplicatesAndDifferentCaseResponseBuilderPath","headerDuplicatesAndDifferentCaseResponseBuilderPath");
+
+    @Rule
     public SystemProperty errorEmptyResponseBuilderPath = new SystemProperty("emptyResponseBuilderPath","emptyResponseBuilderPath");
 
     @Rule
@@ -86,7 +89,10 @@ public class HttpListenerResponseBuilderTestCase extends FunctionalTestCase
     public SystemProperty errorHeadersResponseBuilderPath = new SystemProperty("headersResponseBuilderPath","headersResponseBuilderPath");
 
     @Rule
-    public SystemProperty errorHeaderDuplicatesResponseBuilderPath = new SystemProperty("headerDuplicatesResponseBuilderPath","headerDuplicatesResponseBuilderPath");
+    public SystemProperty errorHeaderDuplicatesResponseBuilderPath = new SystemProperty("errorHeaderDuplicatesResponseBuilderPath","errorHeaderDuplicatesResponseBuilderPath");
+
+    @Rule
+    public SystemProperty errorHeaderDuplicatesAndDifferentCaseResponseBuilderPath = new SystemProperty("errorHeaderDuplicatesAndDifferentCaseResponseBuilderPath","errorHeaderDuplicatesAndDifferentCaseResponseBuilderPath");
 
     @Rule
     public SystemProperty responseBuilderAndErrorResponseBuilderNotTheSamePath = new SystemProperty("responseBuilderAndErrorResponseBuilderNotTheSamePath","responseBuilderAndErrorResponseBuilderNotTheSamePath");
@@ -174,6 +180,13 @@ public class HttpListenerResponseBuilderTestCase extends FunctionalTestCase
     }
 
     @Test
+    public void headerWithDuplicatesAndDifferentCaseResponseBuilder() throws Exception
+    {
+        final String url = getUrl(headerDuplicatesAndDifferentCaseResponseBuilderPath);
+        headersWithDuplicatesResponseBuilderTest(url);
+    }
+
+    @Test
     public void errorEmptyResponseBuilder() throws Exception
     {
         final String url = getUrl(errorEmptyResponseBuilderPath);
@@ -203,6 +216,13 @@ public class HttpListenerResponseBuilderTestCase extends FunctionalTestCase
 
     @Test
     public void errorHeaderWithDuplicatesResponseBuilder() throws Exception
+    {
+        final String url = getUrl(errorHeaderDuplicatesResponseBuilderPath);
+        headersWithDuplicatesResponseBuilderTest(url);
+    }
+
+    @Test
+    public void errorHeaderWithDuplicatesAndDifferentCaseResponseBuilder() throws Exception
     {
         final String url = getUrl(errorHeaderDuplicatesResponseBuilderPath);
         headersWithDuplicatesResponseBuilderTest(url);

--- a/modules/http/src/test/resources/http-listener-response-builder-config.xml
+++ b/modules/http/src/test/resources/http-listener-response-builder-config.xml
@@ -95,6 +95,17 @@
         <set-property propertyName="User-Agent" value="Mule 3.5.0"/>
     </flow>
 
+    <flow name="headerWithDuplicatesAndDifferentCaseResponseBuilderFlow">
+        <http:listener config-ref="listenerConfig" path="${headerDuplicatesAndDifferentCaseResponseBuilderPath}">
+            <http:response-builder>
+                <http:header headerName="USER-AGENT" value="Mule 3.6.0"/>
+                <http:header headerName="UsEr-AgEnT" value="Mule 3.7.0"/>
+                <http:headers expression="['user-agent': ['Mule 3.8.0', 'Mule 3.9.0']]"/>
+            </http:response-builder>
+        </http:listener>
+        <set-property propertyName="User-Agent" value="Mule 3.5.0"/>
+    </flow>
+
     <flow name="headersResponseBuilderFlow">
         <http:listener config-ref="listenerConfig" path="${headersResponseBuilderPath}">
             <http:response-builder>
@@ -134,6 +145,18 @@
                 <http:header headerName="User-Agent" value="Mule 3.6.0"/>
                 <http:header headerName="User-Agent" value="Mule 3.7.0"/>
                 <http:headers expression="['User-Agent': ['Mule 3.8.0', 'Mule 3.9.0']]"/>
+            </http:error-response-builder>
+        </http:listener>
+        <set-property propertyName="User-Agent" value="Mule 3.5.0"/>
+        <test:component throwException="true"/>
+    </flow>
+
+    <flow name="errorHeaderDuplicatesAndDifferentCaseResponseBuilderFlow">
+        <http:listener config-ref="listenerConfig" path="${errorHeaderDuplicatesAndDifferentCaseResponseBuilderPath}">
+            <http:error-response-builder>
+                <http:header headerName="USER-AGENT" value="Mule 3.6.0"/>
+                <http:header headerName="User-AgEnT" value="Mule 3.7.0"/>
+                <http:headers expression="['user-agent': ['Mule 3.8.0', 'Mule 3.9.0']]"/>
             </http:error-response-builder>
         </http:listener>
         <set-property propertyName="User-Agent" value="Mule 3.5.0"/>

--- a/modules/http/src/test/resources/http-request-headers-config.xml
+++ b/modules/http/src/test/resources/http-request-headers-config.xml
@@ -30,6 +30,18 @@
             <http:request-builder>
                 <http:header headerName="testName1" value="testValue1" />
                 <http:headers expression="#[headers]" />
+                <http:header headerName="testName1" value="testValue2" />
+            </http:request-builder>
+        </http:request>
+    </flow>
+
+    <flow name="headerOverrideCaseInsensitive">
+        <set-property propertyName="TESTName1" value="testValueOutboundPropertyInConfigXml"/>
+        <http:request config-ref="config" path="testPath" >
+            <http:request-builder>
+                <http:header headerName="testName1" value="testValueConfigHeader1" />
+                <http:headers expression="#[headers]" />
+                <http:header headerName="TESTName1" value="testValueConfigHeader2" />
             </http:request-builder>
         </http:request>
     </flow>

--- a/modules/http/src/test/resources/log4j2-test.xml
+++ b/modules/http/src/test/resources/log4j2-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration shutdownHook="disable">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%-5p %d [%t] %c: %m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+
+        <!-- CXF is used heavily by Mule for web services -->
+        <AsyncLogger name="org.apache.cxf" level="WARN"/>
+
+        <!-- Apache Commons tend to make a lot of noise which can clutter the log-->
+        <AsyncLogger name="org.apache" level="WARN"/>
+
+        <!-- Reduce startup noise -->
+        <AsyncLogger name="org.springframework.beans.factory" level="WARN"/>
+
+        <!-- Mule classes -->
+        <AsyncLogger name="org.mule" level="WARN"/>
+        <AsyncLogger name="org.mule.module.http" level="WARN"/>
+        <AsyncLogger name="com.mulesoft" level="WARN"/>
+
+        <AsyncRoot level="INFO">
+            <AppenderRef ref="Console"/>
+        </AsyncRoot>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
* Fix in the request builder to append the values of the headers with same name but different case.
* Added test cases to validate that the headers with same name but different case are appended fine in HttpRequestHeadersTestCase and HttpListenerResponseBuilderTestCase
* Added log4j2-test.xml file to add debug logging when needed in the HTTP tests.