### PR TITLE
MULE-11281 - Fix: SFTP Inbound Endpoint doesn't set the MimeType.

### DIFF
--- a/transports/sftp/src/main/java/org/mule/transport/sftp/SftpMessageReceiver.java
+++ b/transports/sftp/src/main/java/org/mule/transport/sftp/SftpMessageReceiver.java
@@ -8,6 +8,7 @@ package org.mule.transport.sftp;
 
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
+import org.mule.api.MuleException;
 import org.mule.api.MuleMessage;
 import org.mule.api.construct.FlowConstruct;
 import org.mule.api.endpoint.InboundEndpoint;
@@ -19,10 +20,12 @@ import org.mule.api.retry.RetryCallback;
 import org.mule.api.retry.RetryContext;
 import org.mule.api.transport.Connector;
 import org.mule.api.transport.PropertyScope;
+import org.mule.config.i18n.CoreMessages;
 import org.mule.construct.Flow;
 import org.mule.processor.strategy.SynchronousProcessingStrategy;
 import org.mule.transport.AbstractPollingMessageReceiver;
 import org.mule.transport.ConnectException;
+import org.mule.transport.DefaultMuleMessageFactory;
 import org.mule.transport.sftp.notification.SftpNotifier;
 import org.mule.util.ValueHolder;
 import org.mule.util.lock.LockFactory;
@@ -32,6 +35,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
+import javax.activation.MimetypesFileTypeMap;
 
 /**
  * <code>SftpMessageReceiver</code> polls and receives files from an sftp service
@@ -45,6 +49,7 @@ public class SftpMessageReceiver extends AbstractPollingMessageReceiver
     private LockFactory lockFactory;
     private boolean poolOnPrimaryInstanceOnly;
     private final AtomicBoolean connecting = new AtomicBoolean(false);
+    SFTPMessageFactory sftpMessageFactory = new SFTPMessageFactory();
 
     public SftpMessageReceiver(SftpConnector connector,
                                FlowConstruct flow,
@@ -170,6 +175,19 @@ public class SftpMessageReceiver extends AbstractPollingMessageReceiver
         return poolOnPrimaryInstanceOnly;
     }
 
+    @Override
+    public MuleMessage createMuleMessage(Object transportMessage, String encoding) throws MuleException
+    {
+        try
+        {
+            return sftpMessageFactory.create(transportMessage, encoding, endpoint.getMuleContext());
+        }
+        catch (Exception e)
+        {
+            throw new CreateException(CoreMessages.failedToCreate("MuleMessage"), e, this);
+        }
+    }
+
     protected void routeFile(final String path) throws Exception
     {
         final ValueHolder<InputStream> inputStreamReference = new ValueHolder<>();
@@ -254,7 +272,7 @@ public class SftpMessageReceiver extends AbstractPollingMessageReceiver
     /**
      * SFTP-35
      */
-    @Override 
+    @Override
     protected MuleMessage handleUnacceptedFilter(MuleMessage message) {
         logger.debug("the filter said no, now trying to close the payload stream");
         try {
@@ -266,7 +284,6 @@ public class SftpMessageReceiver extends AbstractPollingMessageReceiver
         }
         return super.handleUnacceptedFilter(message);
     }
-
 
 
     public void doConnect() throws Exception
@@ -331,5 +348,25 @@ public class SftpMessageReceiver extends AbstractPollingMessageReceiver
     protected void doDispose()
     {
         // no op
+    }
+
+    private class SFTPMessageFactory extends DefaultMuleMessageFactory
+    {
+
+        private final MimetypesFileTypeMap mimetypesFileTypeMap = new MimetypesFileTypeMap();
+
+        @Override
+        protected String getMimeType(Object transportMessage)
+        {
+            if (transportMessage instanceof SftpInputStream)
+            {
+                SftpInputStream inputStreamTransportMessage = (SftpInputStream) transportMessage;
+                return mimetypesFileTypeMap.getContentType(inputStreamTransportMessage.getFileName().toLowerCase());
+            }
+            else
+            {
+                return null;
+            }
+        }
     }
 }

--- a/transports/sftp/src/test/java/org/mule/transport/sftp/SftpMimeTypeTestCase.java
+++ b/transports/sftp/src/test/java/org/mule/transport/sftp/SftpMimeTypeTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.sftp;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mule.transformer.types.MimeTypes.TEXT;
+import org.mule.api.MuleEvent;
+import org.mule.api.processor.MessageProcessor;
+import org.mule.util.concurrent.Latch;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class SftpMimeTypeTestCase extends AbstractSftpFunctionalTestCase
+{
+
+    public static final String FILE_NAME = "file.txt";
+    private static Latch latch;
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "sftp-mime-type-config.xml";
+    }
+
+    @Override
+    protected void setUpTestData() throws IOException
+    {
+        latch = new Latch();
+    }
+
+    @Test
+    public void setsMimeType() throws Exception
+    {
+        sftpClient.storeFile(FILE_NAME, new ByteArrayInputStream(TEST_MESSAGE.getBytes()));
+        latch.await(RECEIVE_TIMEOUT, MILLISECONDS);
+        assertThat(SftpMessageProcessor.mimeType, equalTo(TEXT));
+    }
+
+    public static class SftpMessageProcessor implements MessageProcessor
+    {
+
+        private static String mimeType = null;
+
+        @Override
+        public MuleEvent process(MuleEvent event)
+        {
+            mimeType = event.getMessage().getDataType().getMimeType();
+            latch.release();
+            return event;
+        }
+    }
+}
+

--- a/transports/sftp/src/test/resources/sftp-mime-type-config.xml
+++ b/transports/sftp/src/test/resources/sftp-mime-type-config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp"
+      xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd">
+
+    <spring:beans>
+        <spring:import resource="sftp-properties.xml"/>
+    </spring:beans>
+
+    <sftp:connector name="sftpConnector" />
+    <flow name="main">
+        <sftp:inbound-endpoint address="sftp://${USER1_NAME}:${USER1_PASSWORD}@${SFTP_HOST}:${SFTP_PORT}/~/testdir"
+                               connector-ref="sftpConnector"/>
+        <custom-processor class="org.mule.transport.sftp.SftpMimeTypeTestCase$SftpMessageProcessor"/>
+    </flow>
+</mule>


### PR DESCRIPTION
SftpMimeTypeTestCase and his respective config was added.
SftpMessageReceiver was modified:
SFTP was using the DefaultMuleMessageFactory to create the MuleMessage.
The solution is to override the setMimeType abstract method, which returns null now.
In the overridden method, it is necessary to get the MimeType from the extension (imitating the FTP implementation).