### PR TITLE
MULE-11285: Fix DateTimeDateTestCase and DateTimeTestCase plusWeeks t…

### DIFF
--- a/core/src/test/java/org/mule/el/datetime/DateTimeDateTestCase.java
+++ b/core/src/test/java/org/mule/el/datetime/DateTimeDateTestCase.java
@@ -81,7 +81,7 @@ public class DateTimeDateTestCase extends AbstractMuleTestCase
     @Test
     public void plusWeeks()
     {
-        assertEquals((currentCalendar.get(WEEK_OF_YEAR) % currentCalendar.getWeeksInWeekYear()) + 1, now.plusWeeks(1).plusYears(-1).getWeekOfYear());
+        assertEquals((currentCalendar.get(WEEK_OF_YEAR) % currentCalendar.getWeeksInWeekYear()) + 1, now.plusWeeks(1).getWeekOfYear());
     }
 
     @Test


### PR DESCRIPTION
…ests to work with years with 53 weeks.

Remove 'plusYears(-1)' in the 'plusWeeks()' test which was left by mistake after checking the test was working in different scenarios.