### PR TITLE
MULE-11265: ArtifactClassLoaderRunner - Cannot handle classpath URLs …

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/classification/DefaultWorkspaceReader.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/classification/DefaultWorkspaceReader.java
@@ -15,6 +15,7 @@ import org.mule.test.runner.maven.MavenModelFactory;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -72,8 +73,7 @@ public class DefaultWorkspaceReader implements WorkspaceReader {
    * @return {@link File} that represents the {@link Artifact} passed or null
    */
   public static File findClassPathURL(final Artifact artifact, final File workspaceArtifactPath, final List<URL> classPath) {
-    final StringBuilder moduleFolder =
-        new StringBuilder(new File(workspaceArtifactPath.getAbsolutePath(), "target").toURI().getPath());
+    final Path moduleFolder = new File(workspaceArtifactPath.getAbsoluteFile(), "target").toPath();
 
     // Fix to handle when running test during an install phase due to maven builds the classPath pointing out to packaged files
     // instead of classes folders.
@@ -87,10 +87,10 @@ public class DefaultWorkspaceReader implements WorkspaceReader {
       packagedUrlSuffix.append("^(?!.*?(?:-tests.jar)).*.jar");
     }
     final Optional<URL> localFile = classPath.stream().filter(url -> {
-      String path = toFile(url).getAbsolutePath();
-      if (path.contains(moduleFolder)) {
-        String pathSuffix = path.substring(path.lastIndexOf(moduleFolder.toString()) + moduleFolder.length(), path.length());
-        return pathSuffix.matches(explodedUrlSuffix.toString()) || pathSuffix.matches(packagedUrlSuffix.toString());
+      Path path = toFile(url).toPath();
+      if (path.startsWith(moduleFolder)) {
+        String file = path.getFileName().toFile().getName();
+        return file.matches(explodedUrlSuffix.toString()) || file.matches(packagedUrlSuffix.toString());
       }
       return false;
     }).findFirst();


### PR DESCRIPTION
…escaped on Windows
* Use Paths instead of File.absolutePath to compare workspace artifacts