### PR TITLE
Mule 11298: Fix: wsconsumer ignores proxy when retrieving wsdl in initialization phase

### DIFF
--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/ProxyWsdlRetrieverStrategy.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/ProxyWsdlRetrieverStrategy.java
@@ -103,7 +103,7 @@ public class ProxyWsdlRetrieverStrategy extends AbstractInputStreamStrategy
         }
         catch (Exception e)
         {
-            throw new WSDLException("Exception retrieving wsdl for url : %s", url.toString(), e);
+            throw new WSDLException("Exception retrieving WSDL for URL: %s", url.toString(), e);
         }
     }
 

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/ProxyWsdlRetrieverStrategy.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/ProxyWsdlRetrieverStrategy.java
@@ -7,9 +7,9 @@
 
 package org.mule.module.ws.consumer;
 
+import static java.lang.String.format;
 import static org.mule.module.http.internal.request.HttpAuthenticationType.BASIC;
 import static org.mule.util.concurrent.ThreadNameHelper.getPrefix;
-import static java.lang.String.format;
 
 import org.mule.api.MuleContext;
 import org.mule.module.http.api.requester.proxy.ProxyConfig;
@@ -64,54 +64,47 @@ public class ProxyWsdlRetrieverStrategy extends AbstractInputStreamStrategy
     }
 
     @Override
-    public Definition retrieveWsdlFrom(URL url) throws Exception
+    public Definition retrieveWsdlFrom(URL url) throws WSDLException
     {
-        Definition wsdlDefinition = null;
-        InputStream responseStream = null;
-        String threadNamePrefix = format(THREAD_NAME_PREFIX_PATTERN, getPrefix(context), WSDL_RETRIEVER);
-
-        HttpClientConfiguration configuration = new HttpClientConfiguration.Builder()
-                                                                                     .setTlsContextFactory(tlsContextFactory)
-                                                                                     .setProxyConfig(proxyConfig)
-                                                                                     .setClientSocketProperties(socketProperties)
-                                                                                     .setMaxConnections(DEFAULT_CONNECTIONS)
-                                                                                     .setUsePersistentConnections(DEFAULT_USE_PERSISTENT_CONNECTION)
-                                                                                     .setConnectionIdleTimeout(DEFAULT_CONNECTION_IDLE_TIMEOUT)
-                                                                                     .setThreadNamePrefix(threadNamePrefix)
-                                                                                     .setOwnerName(WSDL_RETRIEVER)
-                                                                                     .setMaxWorkerPoolSize(MINIMUM_WORKER_MAX_POOL_SIZE)
-                                                                                     .setWorkerCoreSize(MINIMUM_WORKER_CORE_SIZE)
-                                                                                     .setMaxKernelPoolSize(MINIMUM_KERNEL_MAX_POOL_SIZE)
-                                                                                     .setKernelCoreSize(MINIMUM_KERNEL_CORE_SIZE)
-                                                                                     .build();
-
-        GrizzlyHttpClient httpClient = new GrizzlyHttpClient(configuration);
-        httpClient.start();
-
-        HttpRequest request = new DefaultHttpRequest(url.toString(), null, HTTP_METHOD_WSDL_RETRIEVAL, new ParameterMap(),
-                new ParameterMap(), null);
-        responseStream = httpClient.sendAndReceiveInputStream(request, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_FOLLOW_REDIRECTS,
-                basicAuthentication);
-
         try
         {
+            Definition wsdlDefinition = null;
+            InputStream responseStream = null;
+            String threadNamePrefix = format(THREAD_NAME_PREFIX_PATTERN, getPrefix(context), WSDL_RETRIEVER);
+
+            HttpClientConfiguration configuration = new HttpClientConfiguration.Builder()
+                                                                                         .setTlsContextFactory(tlsContextFactory)
+                                                                                         .setProxyConfig(proxyConfig)
+                                                                                         .setClientSocketProperties(socketProperties)
+                                                                                         .setMaxConnections(DEFAULT_CONNECTIONS)
+                                                                                         .setUsePersistentConnections(DEFAULT_USE_PERSISTENT_CONNECTION)
+                                                                                         .setConnectionIdleTimeout(DEFAULT_CONNECTION_IDLE_TIMEOUT)
+                                                                                         .setThreadNamePrefix(threadNamePrefix)
+                                                                                         .setOwnerName(WSDL_RETRIEVER)
+                                                                                         .setMaxWorkerPoolSize(MINIMUM_WORKER_MAX_POOL_SIZE)
+                                                                                         .setWorkerCoreSize(MINIMUM_WORKER_CORE_SIZE)
+                                                                                         .setMaxKernelPoolSize(MINIMUM_KERNEL_MAX_POOL_SIZE)
+                                                                                         .setKernelCoreSize(MINIMUM_KERNEL_CORE_SIZE)
+                                                                                         .build();
+
+            GrizzlyHttpClient httpClient = new GrizzlyHttpClient(configuration);
+            httpClient.start();
+
+            HttpRequest request = new DefaultHttpRequest(url.toString(), null, HTTP_METHOD_WSDL_RETRIEVAL, new ParameterMap(),
+                    new ParameterMap(), null);
+            responseStream = httpClient.sendAndReceiveInputStream(request, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_FOLLOW_REDIRECTS,
+                    basicAuthentication);
+
             wsdlDefinition = getWsdlDefinition(url, responseStream);
-        }
-        finally
-        {
             httpClient.stop();
-            try
-            {
-                responseStream.close();
-            }
-            catch (Exception e)
-            {
-                throw new WSDLException("Exception closing input stream for url: %s", url.toString(), e);
-            }
+            responseStream.close();
+
+            return wsdlDefinition;
         }
-
-        return wsdlDefinition;
-
+        catch (Exception e)
+        {
+            throw new WSDLException("Exception retrieving wsdl for url : %s", url.toString(), e);
+        }
     }
 
 }

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/URLRetrieverStrategy.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/URLRetrieverStrategy.java
@@ -46,7 +46,7 @@ public class URLRetrieverStrategy extends AbstractInputStreamStrategy
         }
         catch (Exception e)
         {
-            throw new WSDLException("Exception retrieving wsdl for url : %s", url.toString(), e);
+            throw new WSDLException("Exception retrieving WSDL for URL: %s", url.toString(), e);
         }
     }
 

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/URLRetrieverStrategy.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/URLRetrieverStrategy.java
@@ -24,37 +24,30 @@ public class URLRetrieverStrategy extends AbstractInputStreamStrategy
 {
 
     @Override
-    public Definition retrieveWsdlFrom(URL url) throws Exception
+    public Definition retrieveWsdlFrom(URL url) throws WSDLException
     {
-        InputStream responseStream = null;
-        Definition wsdlDefinition = null;
-
-        URLConnection urlConnection = url.openConnection();
-
-        if (url.getUserInfo() != null)
-        {
-            urlConnection.setRequestProperty("Authorization", "Basic " + encodeBytes(url.getUserInfo().getBytes()));
-        }
-
-        responseStream = urlConnection.getInputStream();
-
         try
         {
-            wsdlDefinition = getWsdlDefinition(url, responseStream);
-        }
-        finally
-        {
-            try
-            {
-                responseStream.close();
-            }
-            catch (Exception e)
-            {
-                throw new WSDLException("Exception closing streaming for url: %s", url.toString(), e);
-            }
-        }
+            InputStream responseStream = null;
+            Definition wsdlDefinition = null;
 
-        return wsdlDefinition;
+            URLConnection urlConnection = url.openConnection();
+
+            if (url.getUserInfo() != null)
+            {
+                urlConnection.setRequestProperty("Authorization", "Basic " + encodeBytes(url.getUserInfo().getBytes()));
+            }
+
+            responseStream = urlConnection.getInputStream();
+
+            wsdlDefinition = getWsdlDefinition(url, responseStream);
+            responseStream.close();
+            return wsdlDefinition;
+        }
+        catch (Exception e)
+        {
+            throw new WSDLException("Exception retrieving wsdl for url : %s", url.toString(), e);
+        }
     }
 
 }

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/WSConsumer.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/WSConsumer.java
@@ -372,7 +372,7 @@ public class WSConsumer implements MessageProcessor, Initialisable, MuleContextA
         }
         catch (Exception e)
         {
-            throw new InitialisationException(MessageFactory.createStaticMessage("Couldn't retrieve wsdl at %s", config.getWsdlLocation()), e, this);
+            throw new InitialisationException(e, this);
         }
 
         Service service = wsdlDefinition.getService(new QName(wsdlDefinition.getTargetNamespace(), config.getService()));

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/WsdlRetrieverStrategy.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/WsdlRetrieverStrategy.java
@@ -10,6 +10,7 @@ package org.mule.module.ws.consumer;
 import java.net.URL;
 
 import javax.wsdl.Definition;
+import javax.wsdl.WSDLException;
 
 /**
  * A strategy to retrieve the wsdl from the url defined
@@ -18,5 +19,5 @@ import javax.wsdl.Definition;
  */
 public interface WsdlRetrieverStrategy 
 {
-	Definition retrieveWsdlFrom(URL url) throws Exception;
+	Definition retrieveWsdlFrom(URL url) throws WSDLException;
 }


### PR DESCRIPTION
Changes due to sonar were requested in [MULE-11298](https://www.mulesoft.org/jira/browse/MULE-11298):

1) Do not use "throws Exception" in WsdlRetrieverStrategy because
a) Sonar does not like it: https://sonarqube.com/coding_rules#rule_key=squid%3AS00112
b) No receiver can react on new exceptions thrown as everybody just implements (catch (Exception e) ...)
Better use
throws WSDLException
and wrap all other exceptions coming in ProxyWsdlRetrieverStrategy.retrieveWsdlFrom into a WSDLException with speaking reason or add a second Exception to interface 
e.g. throws WSDLException,IOException
2) Do not throw exception in finally block, as it will hide the original exception.
(ProxyWsdlRetrieverStrategy and URLRetrieverStrategy.java)
See https://sonarqube.com/coding_rules#rule_key=squid%3AS1143