### PR TITLE
MULE-10366: Code formatter improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,7 @@
         <jetty.maven.plugin.version>9.2.10.v20150310</jetty.maven.plugin.version>
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
+        <formatterGoal>validate</formatterGoal>
     </properties>
 
     <dependencies>
@@ -1580,9 +1581,10 @@
                     </configuration>
                     <executions>
                         <execution>
+                            <id>apply-format</id>
                             <phase>compile</phase>
                             <goals>
-                                <goal>validate</goal>
+                                <goal>${formatterGoal}</goal>
                             </goals>
                             <configuration>
                                 <skipFormatting>${skipVerifications}</skipFormatting>


### PR DESCRIPTION
Extract formatter goal to a property to be able to use the 'format' goal in place of the 'validate' goal and format the code while compiling.