### PR TITLE
MULE-7211: Fix flaky test AbstractWSConsumerFunctionalTestCase (when …

### DIFF
--- a/modules/ws/src/test/java/org/mule/module/ws/functional/AbstractWSConsumerFunctionalTestCase.java
+++ b/modules/ws/src/test/java/org/mule/module/ws/functional/AbstractWSConsumerFunctionalTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.module.ws.functional;
 
 
+import static java.util.logging.Level.FINEST;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.assertEquals;
 import org.mule.api.MuleMessage;
@@ -19,6 +20,8 @@ import org.mule.transport.NullPayload;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -39,6 +42,7 @@ public abstract class AbstractWSConsumerFunctionalTestCase extends FunctionalTes
                                                            "<ns2:echoResponse xmlns:ns2=\"http://consumer.ws.module.mule.org/\">" +
                                                            "<text>Hello</text></ns2:echoResponse>";
 
+    private Level previousXmlLogLevel;
 
     @Parameterized.Parameter(value = 0)
     public boolean useTransportForUris;
@@ -53,12 +57,17 @@ public abstract class AbstractWSConsumerFunctionalTestCase extends FunctionalTes
     protected void doSetUpBeforeMuleContextCreation() throws Exception
     {
         System.setProperty(USE_TRANSPORT_FOR_URIS, Boolean.toString(useTransportForUris));
+
+        final Logger xmlLogger = Logger.getLogger("com.sun.xml.bind");
+        previousXmlLogLevel = xmlLogger.getLevel();
+        xmlLogger.setLevel(FINEST);
     }
 
     @Override
     protected void doTearDownAfterMuleContextDispose() throws Exception
     {
         System.clearProperty(USE_TRANSPORT_FOR_URIS);
+        Logger.getLogger("com.sun.xml.bind").setLevel(previousXmlLogLevel);
     }
 
 

--- a/modules/ws/src/test/java/org/mule/module/ws/functional/AbstractWSConsumerFunctionalTestCase.java
+++ b/modules/ws/src/test/java/org/mule/module/ws/functional/AbstractWSConsumerFunctionalTestCase.java
@@ -8,6 +8,7 @@ package org.mule.module.ws.functional;
 
 
 import static java.util.logging.Level.FINEST;
+import static java.util.logging.Logger.getLogger;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.assertEquals;
 import org.mule.api.MuleMessage;
@@ -24,6 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.junit.Rule;
+import org.junit.rules.ExternalResource;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -42,7 +44,24 @@ public abstract class AbstractWSConsumerFunctionalTestCase extends FunctionalTes
                                                            "<ns2:echoResponse xmlns:ns2=\"http://consumer.ws.module.mule.org/\">" +
                                                            "<text>Hello</text></ns2:echoResponse>";
 
-    private Level previousXmlLogLevel;
+    @Rule
+    public ExternalResource xmlLogLevel = new ExternalResource() {
+        private Level previousLevel;
+        final private Logger xmlLogger = getLogger("com.sun.xml.bind");
+
+        @Override
+        protected void before() throws Throwable
+        {
+            previousLevel = xmlLogger.getLevel();
+            xmlLogger.setLevel(FINEST);
+        }
+
+        @Override
+        protected void after()
+        {
+            xmlLogger.setLevel(previousLevel);
+        }
+    };
 
     @Parameterized.Parameter(value = 0)
     public boolean useTransportForUris;
@@ -57,17 +76,12 @@ public abstract class AbstractWSConsumerFunctionalTestCase extends FunctionalTes
     protected void doSetUpBeforeMuleContextCreation() throws Exception
     {
         System.setProperty(USE_TRANSPORT_FOR_URIS, Boolean.toString(useTransportForUris));
-
-        final Logger xmlLogger = Logger.getLogger("com.sun.xml.bind");
-        previousXmlLogLevel = xmlLogger.getLevel();
-        xmlLogger.setLevel(FINEST);
     }
 
     @Override
     protected void doTearDownAfterMuleContextDispose() throws Exception
     {
         System.clearProperty(USE_TRANSPORT_FOR_URIS);
-        Logger.getLogger("com.sun.xml.bind").setLevel(previousXmlLogLevel);
     }
 
 


### PR DESCRIPTION
…a global error counter across tests reaches 10, the expected error message is truncated; to avoid it we increase the logging level for the parser)