### PR TITLE
MULE-11362: ArtifactClassLoaderRunner - Should avoid including servic…

### DIFF
--- a/modules/extensions-xml-support/src/test/java/org/mule/test/functional/AbstractXmlExtensionMuleArtifactFunctionalTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/test/functional/AbstractXmlExtensionMuleArtifactFunctionalTestCase.java
@@ -29,7 +29,8 @@ import java.util.Map;
  * @since 4.0
  */
 @ArtifactClassLoaderRunnerConfig(
-    plugins = {"org.mule.modules:mule-module-http-ext", "org.mule.modules:mule-module-sockets"})
+    plugins = {"org.mule.modules:mule-module-http-ext", "org.mule.modules:mule-module-sockets"},
+    providedInclusions = "org.mule.modules:mule-module-sockets")
 public abstract class AbstractXmlExtensionMuleArtifactFunctionalTestCase extends MuleArtifactFunctionalTestCase {
 
   /**

--- a/tests/performance/pom.xml
+++ b/tests/performance/pom.xml
@@ -53,6 +53,7 @@
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-file-extension-common</artifactId>
             <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -90,12 +91,14 @@
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-file</artifactId>
             <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-ftp</artifactId>
             <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/performance/src/test/java/org/mule/test/performance/util/AbstractIsolatedFunctionalPerformanceTestCase.java
+++ b/tests/performance/src/test/java/org/mule/test/performance/util/AbstractIsolatedFunctionalPerformanceTestCase.java
@@ -15,7 +15,8 @@ import org.junit.Rule;
 
 @ArtifactClassLoaderRunnerConfig(
     plugins = {"org.mule.modules:mule-module-ftp", "org.mule.modules:mule-module-file", "org.mule.modules:mule-module-http-ext",
-        "org.mule.modules:mule-module-sockets"})
+        "org.mule.modules:mule-module-sockets"},
+    providedInclusions = "org.mule.modules:mule-module-sockets")
 public abstract class AbstractIsolatedFunctionalPerformanceTestCase extends MuleArtifactFunctionalTestCase {
 
   @Rule


### PR DESCRIPTION
…es/plugins classified in Container CL
* Aether filtering logic excludes the artifact but not its transitive dependencies, it is by each artifact that the filter is called. So, changed logic on Container classification to avoid adding plugins/services that were already classified in the list of direct dependencies for the provided dependencies. This will work as plugins should come from transitive dependencies.
* Fixed tests that were not adding sockets (is still required the jar as mule-module) as provided inclusion.