### PR TITLE
MULE-11270: Classloading: mule-extensions-maven-plugin must package t…

### DIFF
--- a/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
+++ b/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
@@ -69,6 +69,7 @@ public class DefaultRepositoryService implements RepositoryService {
 
   private DefaultArtifact toArtifact(BundleDependency bundleDependency) {
     return new DefaultArtifact(bundleDependency.getDescriptor().getGroupId(), bundleDependency.getDescriptor().getArtifactId(),
+                               bundleDependency.getDescriptor().getClassifier().get(),
                                bundleDependency.getDescriptor().getType(),
                                bundleDependency.getDescriptor().getVersion());
   }

--- a/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/DefaultConnectivityTestingServiceBuilder.java
+++ b/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/DefaultConnectivityTestingServiceBuilder.java
@@ -29,6 +29,7 @@ import java.util.List;
 class DefaultConnectivityTestingServiceBuilder implements ConnectivityTestingServiceBuilder {
 
   private static final String EXTENSION_BUNDLE_TYPE = "zip";
+  private static final String EXTENSION_BUNDLE_CLASSIFIER = "mule-plugin";
   private static final String JAR_BUNDLE_TYPE = "jar";
   private final RepositoryService repositoryService;
   private final TemporaryArtifactBuilderFactory artifactBuilderFactory;
@@ -66,7 +67,7 @@ class DefaultConnectivityTestingServiceBuilder implements ConnectivityTestingSer
   public ConnectivityTestingServiceBuilder addExtension(String groupId, String artifactId, String artifactVersion) {
     BundleDescriptor bundleDescriptor =
         new BundleDescriptor.Builder().setGroupId(groupId).setArtifactId(artifactId).setVersion(artifactVersion)
-            .setType(EXTENSION_BUNDLE_TYPE).build();
+            .setType(EXTENSION_BUNDLE_TYPE).setClassifier(EXTENSION_BUNDLE_CLASSIFIER).build();
     this.extensionsBundleDependencies
         .add(new BundleDependency.Builder().setDescriptor(bundleDescriptor).build());
     return this;


### PR DESCRIPTION
…he pom and the minimal repository when bundling extensions - Added mule-plugin classifier on ConnectivityTesting and Repository