### PR TITLE
MULE-11270: Classloading: mule-extensions-maven-plugin must package t…

### DIFF
--- a/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
+++ b/modules/repository/src/main/java/org/mule/runtime/module/repository/internal/DefaultRepositoryService.java
@@ -69,7 +69,7 @@ public class DefaultRepositoryService implements RepositoryService {
 
   private DefaultArtifact toArtifact(BundleDependency bundleDependency) {
     return new DefaultArtifact(bundleDependency.getDescriptor().getGroupId(), bundleDependency.getDescriptor().getArtifactId(),
-                               bundleDependency.getDescriptor().getClassifier().get(),
+                               bundleDependency.getDescriptor().getClassifier().orElse(null),
                                bundleDependency.getDescriptor().getType(),
                                bundleDependency.getDescriptor().getVersion());
   }


### PR DESCRIPTION
…he pom and the minimal repository when bundling extensions - Handle null optional classifier
* Mistake when getting optional classifier, Aether Artifact supports null values on this field. 