### PR TITLE
MULE-10979: Remove System Properties Configuration

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/config/DefaultMuleConfiguration.java
+++ b/core/src/main/java/org/mule/runtime/core/config/DefaultMuleConfiguration.java
@@ -239,15 +239,6 @@ public class DefaultMuleConfiguration implements MuleConfiguration, MuleContextA
     if (p != null) {
       systemModelType = p;
     }
-    p = System.getProperty(MuleProperties.SYSTEM_PROPERTY_PREFIX + "timeout.synchronous");
-    if (p != null) {
-      responseTimeout = NumberUtils.toInt(p);
-    }
-    p = System.getProperty(MuleProperties.SYSTEM_PROPERTY_PREFIX + "timeout.transaction");
-    if (p != null) {
-      defaultTransactionTimeout = NumberUtils.toInt(p);
-    }
-
     p = System.getProperty(MuleProperties.SYSTEM_PROPERTY_PREFIX + "workingDirectory");
     if (p != null) {
       workingDirectory = p;

--- a/distributions/standalone/src/main/resources/conf/wrapper.conf
+++ b/distributions/standalone/src/main/resources/conf/wrapper.conf
@@ -83,8 +83,6 @@ wrapper.java.additional.15=-Dorg.quartz.scheduler.skipUpdateCheck=true
 #wrapper.java.additional.<n>=-Dmule.encoding=UTF-8
 #wrapper.java.additional.<n>=-Dmule.endpoints.synchronous=false
 #wrapper.java.additional.<n>=-Dmule.remoteSync=false
-#wrapper.java.additional.<n>=-Dmule.timeout.synchronous=10000
-#wrapper.java.additional.<n>=-Dmule.timeout.transaction=30000
 #wrapper.java.additional.<n>=-Dmule.systemModelType=seda
 #wrapper.java.additional.<n>=-Dmule.clientMode=false
 

--- a/tests/integration/src/test/java/org/mule/test/config/MuleConfigurationTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/config/MuleConfigurationTestCase.java
@@ -121,8 +121,6 @@ public class MuleConfigurationTestCase extends AbstractMuleTestCase {
     // These are OK to change after init but before start
     mutableConfig.setDefaultSynchronousEndpoints(true);
     mutableConfig.setSystemModelType("direct");
-    mutableConfig.setDefaultResponseTimeout(30000);
-    mutableConfig.setDefaultTransactionTimeout(60000);
     mutableConfig.setClientMode(true);
 
     // These are not OK to change after init
@@ -135,8 +133,6 @@ public class MuleConfigurationTestCase extends AbstractMuleTestCase {
 
     // These are OK to change after init but before start
     assertEquals("direct", config.getSystemModelType());
-    assertEquals(30000, config.getDefaultResponseTimeout());
-    assertEquals(60000, config.getDefaultTransactionTimeout());
     assertTrue(config.isClientMode());
 
     // These are not OK to change after init
@@ -156,14 +152,10 @@ public class MuleConfigurationTestCase extends AbstractMuleTestCase {
     DefaultMuleConfiguration mutableConfig = ((DefaultMuleConfiguration) muleContext.getConfiguration());
     mutableConfig.setDefaultSynchronousEndpoints(true);
     mutableConfig.setSystemModelType("direct");
-    mutableConfig.setDefaultResponseTimeout(30000);
-    mutableConfig.setDefaultTransactionTimeout(60000);
     mutableConfig.setClientMode(true);
 
     MuleConfiguration config = muleContext.getConfiguration();
     assertFalse("direct".equals(config.getSystemModelType()));
-    assertFalse(30000 == config.getDefaultResponseTimeout());
-    assertFalse(60000 == config.getDefaultTransactionTimeout());
     assertFalse(config.isClientMode());
   }
 
@@ -171,8 +163,6 @@ public class MuleConfigurationTestCase extends AbstractMuleTestCase {
     MuleConfiguration config = muleContext.getConfiguration();
     assertEquals("UTF-16", config.getDefaultEncoding());
     assertEquals("direct", config.getSystemModelType());
-    assertEquals(30000, config.getDefaultResponseTimeout());
-    assertEquals(60000, config.getDefaultTransactionTimeout());
     // on windows this ends up with a c:/ in it
     assertTrue(config.getWorkingDirectory().indexOf(workingDirectory) != -1);
     assertTrue(config.isClientMode());


### PR DESCRIPTION
Two properties were deleted in applySystemProperties method: defaultTransactionTimeout and responseTimeout. They were overwritten in XML configuration.
MuleConfigurationTestCase was cleaned up.

Conflicts:
	core/src/main/java/org/mule/config/DefaultMuleConfiguration.java
	tests/integration/src/test/java/org/mule/test/config/MuleConfigurationTestCase.java