### PR TITLE
MULE-11255: Add support to use artifact plugins on policies

### DIFF
--- a/modules/artifact/pom.xml
+++ b/modules/artifact/pom.xml
@@ -23,6 +23,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-util</artifactId>
+            <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-api</artifactId>
+            <version>${aetherVersion}</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptorUtils.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptorUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.descriptor;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+
+import org.eclipse.aether.util.version.GenericVersionScheme;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.eclipse.aether.version.Version;
+
+/**
+ * Utilities to work with {@link BundleDescriptor}
+ */
+public class BundleDescriptorUtils {
+
+  private BundleDescriptorUtils() {}
+
+  /**
+   * Determines if a version is compatible with another one
+   *
+   * @param availableVersion version that is available to use. Non empty
+   * @param expectedVersion version that is expected. Non empty
+   * @return true if versions are compatible, false otherwise
+   */
+  public static boolean isCompatibleVersion(String availableVersion, String expectedVersion) {
+    checkArgument(!isEmpty(availableVersion), "availableVersion cannot be empty");
+    checkArgument(!isEmpty(expectedVersion), "expectedVersion cannot be empty");
+
+    if (availableVersion.equals(expectedVersion)) {
+      return true;
+    }
+
+    Version available = getBundleVersion(availableVersion);
+    Version expected = getBundleVersion(expectedVersion);
+
+    if (available.compareTo(expected) >= 0) {
+      String availableMajorVersion = getMajorVersion(availableVersion);
+      String expectedMajorVersion = getMajorVersion(expectedVersion);
+
+      return availableMajorVersion.equals(expectedMajorVersion);
+    }
+
+    return false;
+  }
+
+  private static String getMajorVersion(String version) {
+    int index = version.indexOf(".");
+    if (index < 0) {
+      return version;
+    } else {
+      return version.substring(0, index);
+    }
+  }
+
+  private static Version getBundleVersion(String version) {
+    try {
+      return new GenericVersionScheme().parseVersion(version);
+    } catch (InvalidVersionSpecificationException e) {
+      throw new InvalidDependencyVersionException("Unable to parse bundle version: " + version);
+    }
+  }
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/InvalidDependencyVersionException.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/InvalidDependencyVersionException.java
@@ -5,7 +5,7 @@
  * LICENSE.txt file.
  */
 
-package org.mule.runtime.deployment.model.api.artifact;
+package org.mule.runtime.module.artifact.descriptor;
 
 /**
  * Thrown to indicate that a given bundle dependency version is not well formed.

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptorUtilsTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptorUtilsTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.descriptor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mule.runtime.module.artifact.descriptor.BundleDescriptorUtils.isCompatibleVersion;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import org.junit.Test;
+
+@SmallTest
+public class BundleDescriptorUtilsTestCase extends AbstractMuleTestCase {
+
+  @Test
+  public void detectsCompatibleBugFixVersion() throws Exception {
+    assertThat(isCompatibleVersion("1.0.1", "1.0.0"), is(true));
+  }
+
+  @Test
+  public void detectsCompatibleMinorVersion() throws Exception {
+    assertThat(isCompatibleVersion("1.1.0", "1.0.0"), is(true));
+  }
+
+  @Test
+  public void detectsIncompatibleBugFixVersion() throws Exception {
+    assertThat(isCompatibleVersion("1.0.0", "1.0.1"), is(false));
+  }
+
+  @Test
+  public void detectsIncompatibleMinorVersion() throws Exception {
+    assertThat(isCompatibleVersion("1.0.0", "1.1.0"), is(false));
+  }
+
+  @Test
+  public void detectsCompatibleMinorVersionWithNoBugFix() throws Exception {
+    assertThat(isCompatibleVersion("1.1", "1.0"), is(true));
+  }
+
+  @Test
+  public void detectsIncompatibleMinorVersionWithNoBugFix() throws Exception {
+    assertThat(isCompatibleVersion("1.0", "1.1"), is(false));
+  }
+
+  @Test
+  public void detectsIncompatibleMajorVersion() throws Exception {
+    assertThat(isCompatibleVersion("2.0.0", "1.0.0"), is(false));
+  }
+
+  @Test
+  public void detectsIncompatibleMajorVersionWithNoMinor() throws Exception {
+    assertThat(isCompatibleVersion("2", "1"), is(false));
+  }
+
+  @Test
+  public void detectsIncompatibleMajorVersionWithNoBugFix() throws Exception {
+    assertThat(isCompatibleVersion("2.0", "1.0"), is(false));
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/MuleArtifactResourcesRegistry.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/MuleArtifactResourcesRegistry.java
@@ -108,8 +108,8 @@ public class MuleArtifactResourcesRegistry {
     domainFactory = new DefaultDomainFactory(this.domainClassLoaderFactory, domainManager, containerClassLoader,
                                              artifactClassLoaderManager, serviceManager);
 
-    ArtifactClassLoaderFactory<PolicyTemplateDescriptor> policyClassLoaderFactory =
-        trackArtifactClassLoaderFactory(new PolicyTemplateClassLoaderFactory());
+    DeployableArtifactClassLoaderFactory<PolicyTemplateDescriptor> policyClassLoaderFactory =
+        trackDeployableArtifactClassLoaderFactory(new PolicyTemplateClassLoaderFactory());
     PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory =
         new ApplicationPolicyTemplateClassLoaderBuilderFactory(policyClassLoaderFactory, artifactPluginRepository,
                                                                artifactPluginClassLoaderFactory,

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
@@ -121,7 +121,8 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
                                           new DefaultPolicyTemplateFactory(policyTemplateClassLoaderBuilderFactory),
                                           new DefaultPolicyInstanceProviderFactory(
                                                                                    serviceRepository,
-                                                                                   classLoaderRepository));
+                                                                                   classLoaderRepository,
+                                                                                   extensionModelLoaderRepository));
     DefaultMuleApplication delegate =
         new DefaultMuleApplication(descriptor, applicationClassLoader, artifactPlugins, domainRepository,
                                    serviceRepository, extensionModelLoaderRepository, descriptor.getArtifactLocation(),

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProvider.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProvider.java
@@ -67,8 +67,7 @@ public class MuleApplicationPolicyProvider implements ApplicationPolicyProvider,
         .findAny();
 
     if (!registeredPolicyTemplate.isPresent()) {
-      PolicyTemplate policyTemplate =
-          policyTemplateFactory.createArtifact(policyTemplateDescriptor, application.getRegionClassLoader());
+      PolicyTemplate policyTemplate = policyTemplateFactory.createArtifact(application, policyTemplateDescriptor);
       registeredPolicyTemplate = of(new RegisteredPolicyTemplate(policyTemplate));
       registeredPolicyTemplates.add(registeredPolicyTemplate.get());
     }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ArtifactExtensionManagerConfigurationBuilder.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ArtifactExtensionManagerConfigurationBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.deployment.impl.internal.artifact;
+
+import static org.mule.runtime.api.util.Preconditions.checkNotNull;
+import org.mule.runtime.core.DefaultMuleContext;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.config.ConfigurationBuilder;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.core.config.builders.AbstractConfigurationBuilder;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
+import org.mule.runtime.module.extension.internal.manager.ExtensionManagerFactory;
+
+import java.util.List;
+
+/**
+ * Implementation of {@link ConfigurationBuilder} that registers a {@link ExtensionManager}
+ *
+ * @since 4.0
+ */
+public class ArtifactExtensionManagerConfigurationBuilder extends AbstractConfigurationBuilder {
+
+  public static final String META_INF_FOLDER = "META-INF";
+
+  private final List<ArtifactPlugin> artifactPlugins;
+  private final ExtensionManagerFactory extensionManagerFactory;
+
+  /**
+   * Creates an instance of the configuration builder.
+   *
+   * @param artifactPlugins {@link List} of {@link ArtifactPlugin ArtifactPlugins} to be registered.
+   * @param extensionManagerFactory creates the extension manager for this artifact. Non null.
+   */
+  public ArtifactExtensionManagerConfigurationBuilder(List<ArtifactPlugin> artifactPlugins,
+                                                      ExtensionManagerFactory extensionManagerFactory) {
+    checkNotNull(artifactPlugins, "artifactPlugins cannot be null");
+    checkNotNull(extensionManagerFactory, "extensionManagerFactory cannot be null");
+
+    this.artifactPlugins = artifactPlugins;
+    this.extensionManagerFactory = extensionManagerFactory;
+  }
+
+  @Override
+  protected void doConfigure(MuleContext muleContext) throws Exception {
+    ExtensionManager extensionManager = extensionManagerFactory.create(muleContext);
+
+    ((DefaultMuleContext) muleContext).setExtensionManager(extensionManager);
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ApplicationPolicyTemplateClassLoaderBuilderFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ApplicationPolicyTemplateClassLoaderBuilderFactory.java
@@ -11,13 +11,14 @@ import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginRepository;
 import org.mule.runtime.deployment.model.internal.plugin.PluginDependenciesResolver;
 import org.mule.runtime.deployment.model.internal.policy.PolicyTemplateClassLoaderBuilder;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
+import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
 
 /**
  * Creates {@link PolicyTemplateClassLoaderBuilder} for application artifacts.
  */
 public class ApplicationPolicyTemplateClassLoaderBuilderFactory implements PolicyTemplateClassLoaderBuilderFactory {
 
-  private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
+  private final DeployableArtifactClassLoaderFactory artifactClassLoaderFactory;
   private final ArtifactPluginRepository artifactPluginRepository;
   private final ArtifactClassLoaderFactory artifactPluginClassLoaderFactory;
   private final PluginDependenciesResolver pluginDependenciesResolver;
@@ -31,7 +32,7 @@ public class ApplicationPolicyTemplateClassLoaderBuilderFactory implements Polic
    * @param artifactPluginClassLoaderFactory factory to create class loaders for each used plugin. Non be not null.
    * @param pluginDependenciesResolver resolves artifact plugin dependencies. Non null
    */
-  public ApplicationPolicyTemplateClassLoaderBuilderFactory(ArtifactClassLoaderFactory artifactClassLoaderFactory,
+  public ApplicationPolicyTemplateClassLoaderBuilderFactory(DeployableArtifactClassLoaderFactory artifactClassLoaderFactory,
                                                             ArtifactPluginRepository artifactPluginRepository,
                                                             ArtifactClassLoaderFactory artifactPluginClassLoaderFactory,
                                                             PluginDependenciesResolver pluginDependenciesResolver) {

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ArtifactExtensionManagerFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ArtifactExtensionManagerFactory.java
@@ -4,29 +4,26 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.module.deployment.impl.internal.application;
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
 
 import static java.lang.String.format;
-import static org.mule.runtime.api.util.Preconditions.checkNotNull;
+import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactExtensionManagerConfigurationBuilder.META_INF_FOLDER;
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.EXTENSION_MANIFEST_FILE_NAME;
 import static org.mule.runtime.module.extension.internal.loader.java.JavaExtensionModelLoader.TYPE_PROPERTY_NAME;
 import static org.mule.runtime.module.extension.internal.loader.java.JavaExtensionModelLoader.VERSION;
 import static org.slf4j.LoggerFactory.getLogger;
-
 import org.mule.runtime.api.deployment.meta.MulePluginModel;
-import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.core.DefaultMuleContext;
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.extension.ExtensionManager;
-import org.mule.runtime.core.config.builders.AbstractConfigurationBuilder;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.extension.api.loader.ExtensionModelLoader;
 import org.mule.runtime.extension.api.manifest.ExtensionManifest;
 import org.mule.runtime.module.extension.internal.loader.ExtensionModelLoaderRepository;
 import org.mule.runtime.module.extension.internal.loader.java.JavaExtensionModelLoader;
-import org.mule.runtime.module.extension.internal.manager.DefaultExtensionManagerAdapterFactory;
 import org.mule.runtime.module.extension.internal.manager.ExtensionManagerFactory;
 
 import java.net.URL;
@@ -37,51 +34,33 @@ import java.util.Map;
 import org.slf4j.Logger;
 
 /**
- * Implementation of {@link ConfigurationBuilder} that registers a {@link ExtensionManager}
- *
- * @since 4.0
+ * Creates {@link ExtensionManager} for mule artifacts that own a {@link MuleContext}
  */
-public class ApplicationExtensionsManagerConfigurationBuilder extends AbstractConfigurationBuilder {
+public class ArtifactExtensionManagerFactory implements ExtensionManagerFactory {
 
-  public static final String META_INF_FOLDER = "META-INF";
-  private static Logger LOGGER = getLogger(ApplicationExtensionsManagerConfigurationBuilder.class);
+  private static Logger LOGGER = getLogger(ArtifactExtensionManagerFactory.class);
 
-  private final ExtensionManagerFactory extensionManagerFactory;
-  private final List<ArtifactPlugin> artifactPlugins;
   private final ExtensionModelLoaderRepository extensionModelLoaderRepository;
+  private final List<ArtifactPlugin> artifactPlugins;
+  private final ExtensionManagerFactory extensionManagerFactory;
 
   /**
-   * Creates an instance of the configuration builder that uses the {@link DefaultExtensionManagerAdapterFactory}.
+   * Creates a extensionManager factory
    *
-   * @param artifactPlugins {@link List} of {@link ArtifactPlugin ArtifactPlugins} to be registered.
-   * @param extensionModelLoaderRepository {@link ExtensionModelLoaderRepository} with the available extension loaders.
+   * @param artifactPlugins artifact plugins deployed inside the artifact. Non null.
+   * @param extensionModelLoaderRepository {@link ExtensionModelLoaderRepository} with the available extension loaders. Non null.
+   * @param extensionManagerFactory creates the {@link ExtensionManager} for the artifact. Non null
    */
-  public ApplicationExtensionsManagerConfigurationBuilder(List<ArtifactPlugin> artifactPlugins,
-                                                          ExtensionModelLoaderRepository extensionModelLoaderRepository) {
-    this(artifactPlugins, new DefaultExtensionManagerAdapterFactory(), extensionModelLoaderRepository);
-  }
-
-  /**
-   * Creates an instance of the configuration builder.
-   *
-   * @param artifactPlugins {@link List} of {@link ArtifactPlugin ArtifactPlugins} to be registered.
-   * @param extensionManagerFactory {@link ExtensionManagerFactory} in order to create the {@link ExtensionManager}.
-   * @param extensionModelLoaderRepository {@link ExtensionModelLoaderRepository} with the available extension loaders.
-   */
-  public ApplicationExtensionsManagerConfigurationBuilder(List<ArtifactPlugin> artifactPlugins,
-                                                          ExtensionManagerFactory extensionManagerAdapterFactory,
-                                                          ExtensionModelLoaderRepository extensionModelLoaderRepository) {
-    checkNotNull(artifactPlugins, "artifactPlugins cannot be null");
-    checkNotNull(extensionManagerAdapterFactory, "extensionManagerFactory cannot be null");
-    checkNotNull(extensionModelLoaderRepository, "extensionModelLoaderRepository cannot be null");
-
+  public ArtifactExtensionManagerFactory(List<ArtifactPlugin> artifactPlugins,
+                                         ExtensionModelLoaderRepository extensionModelLoaderRepository,
+                                         ExtensionManagerFactory extensionManagerFactory) {
     this.artifactPlugins = artifactPlugins;
-    this.extensionManagerFactory = extensionManagerAdapterFactory;
     this.extensionModelLoaderRepository = extensionModelLoaderRepository;
+    this.extensionManagerFactory = extensionManagerFactory;
   }
 
   @Override
-  protected void doConfigure(MuleContext muleContext) throws Exception {
+  public ExtensionManager create(MuleContext muleContext) {
     final ExtensionManager extensionManager = createExtensionManager(muleContext);
 
     for (ArtifactPlugin artifactPlugin : artifactPlugins) {
@@ -105,12 +84,14 @@ public class ApplicationExtensionsManagerConfigurationBuilder extends AbstractCo
         discoverExtensionThroughJsonDescriber(artifactPlugin, extensionManager);
       }
     }
+
+    return extensionManager;
   }
 
   /**
    * Looks for an extension using the {@link ArtifactPluginDescriptor#MULE_PLUGIN_JSON} file, where if available it will parse it
-   * using the {@link ExtensionModelLoader} which {@link ExtensionModelLoader#getId() id} matches the plugin's
-   * descriptor id.
+   * using the {@link ExtensionModelLoader} which {@link ExtensionModelLoader#getId() ID} matches the plugin's
+   * descriptor ID.
    *
    * @param artifactPlugin   to introspect for the {@link ArtifactPluginDescriptor#MULE_PLUGIN_JSON} and further resources from its {@link ClassLoader}
    * @param extensionManager object to store the generated {@link ExtensionModel} if exists
@@ -130,12 +111,11 @@ public class ApplicationExtensionsManagerConfigurationBuilder extends AbstractCo
     });
   }
 
-  private ExtensionManager createExtensionManager(MuleContext muleContext) throws InitialisationException {
-    try {
-      return extensionManagerFactory.createExtensionManager(muleContext);
-    } catch (Exception e) {
-      throw new InitialisationException(e, muleContext);
-    }
-  }
+  private ExtensionManager createExtensionManager(MuleContext muleContext) {
+    ExtensionManager extensionManager = extensionManagerFactory.create(muleContext);
 
+    ((DefaultMuleContext) muleContext).setExtensionManager(extensionManager);
+
+    return extensionManager;
+  }
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ArtifactExtensionManagerFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/ArtifactExtensionManagerFactory.java
@@ -15,7 +15,6 @@ import static org.mule.runtime.module.extension.internal.loader.java.JavaExtensi
 import static org.slf4j.LoggerFactory.getLogger;
 import org.mule.runtime.api.deployment.meta.MulePluginModel;
 import org.mule.runtime.api.meta.model.ExtensionModel;
-import org.mule.runtime.core.DefaultMuleContext;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
@@ -61,7 +60,7 @@ public class ArtifactExtensionManagerFactory implements ExtensionManagerFactory 
 
   @Override
   public ExtensionManager create(MuleContext muleContext) {
-    final ExtensionManager extensionManager = createExtensionManager(muleContext);
+    final ExtensionManager extensionManager = extensionManagerFactory.create(muleContext);
 
     for (ArtifactPlugin artifactPlugin : artifactPlugins) {
       URL manifestUrl =
@@ -109,13 +108,5 @@ public class ArtifactExtensionManagerFactory implements ExtensionManagerFactory 
           .loadExtensionModel(artifactPlugin.getArtifactClassLoader().getClassLoader(), descriptorProperty.getAttributes());
       extensionManager.registerExtension(extensionModel);
     });
-  }
-
-  private ExtensionManager createExtensionManager(MuleContext muleContext) {
-    ExtensionManager extensionManager = extensionManagerFactory.create(muleContext);
-
-    ((DefaultMuleContext) muleContext).setExtensionManager(extensionManager);
-
-    return extensionManager;
   }
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/CompositeArtifactExtensionManager.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/CompositeArtifactExtensionManager.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static java.lang.String.format;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.core.api.Event;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.extension.api.manifest.ExtensionManifest;
+import org.mule.runtime.extension.api.runtime.ConfigurationInstance;
+import org.mule.runtime.extension.api.runtime.ConfigurationProvider;
+
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Composes {@link ExtensionManager} from a child and a parent artifacts, so child artifact can access extensions provided by the
+ * parent.
+ */
+public class CompositeArtifactExtensionManager implements ExtensionManager {
+
+  private final ExtensionManager parentExtensionManager;
+  private final ExtensionManager childExtensionManager;
+  private final Set<ExtensionModel> extensionModels;
+
+  /**
+   * Creates a composed extension manager
+   *
+   * @param parentExtensionManager extension manager for the parent artifact. Non null
+   * @param childExtensionManager extension manager for the child artifact. Non null
+   */
+  public CompositeArtifactExtensionManager(ExtensionManager parentExtensionManager,
+                                           ExtensionManager childExtensionManager) {
+    checkArgument(parentExtensionManager != null, "parentExtensionManager cannot be null");
+    checkArgument(childExtensionManager != null, "childExtensionManager cannot be null");
+
+    this.parentExtensionManager = parentExtensionManager;
+    this.childExtensionManager = childExtensionManager;
+
+    extensionModels = new HashSet<>();
+    extensionModels.addAll(parentExtensionManager.getExtensions());
+    extensionModels.addAll(childExtensionManager.getExtensions());
+  }
+
+  @Override
+  public void registerExtension(ExtensionModel extensionModel) {
+    throw new UnsupportedOperationException("Composite extension manager cannot register extensions");
+  }
+
+  @Override
+  public Set<ExtensionModel> getExtensions() {
+    return extensionModels;
+  }
+
+  @Override
+  public Optional<ExtensionModel> getExtension(String extensionName) {
+    return extensionModels.stream().filter(extensionModel -> extensionModel.getName().equals(extensionName)).findFirst();
+  }
+
+  @Override
+  public ConfigurationInstance getConfiguration(String configurationProviderName, Event event) {
+    return getConfigurationProvider(configurationProviderName).map(provider -> provider.get(event))
+        .orElseThrow(() -> new IllegalArgumentException(
+                                                        format(
+                                                               "There is no registered configurationProvider under name '%s'",
+                                                               configurationProviderName)));
+  }
+
+  @Override
+  public ConfigurationInstance getConfiguration(ExtensionModel extensionModel, Event event) {
+
+    Optional<ConfigurationProvider> provider = getConfigurationProvider(extensionModel);
+    if (provider.isPresent()) {
+      return provider.get().get(event);
+    }
+
+    throw new IllegalArgumentException(format(
+                                              "There is no registered configuration provider for extension '%s'",
+                                              extensionModel.getName()));
+  }
+
+  @Override
+  public Optional<ConfigurationProvider> getConfigurationProvider(ExtensionModel extensionModel) {
+    Optional<ConfigurationProvider> configurationProvider = childExtensionManager.getConfigurationProvider(extensionModel);
+
+    if (!configurationProvider.isPresent()) {
+      configurationProvider = parentExtensionManager.getConfigurationProvider(extensionModel);
+    }
+
+    return configurationProvider;
+  }
+
+  @Override
+  public Optional<ConfigurationProvider> getConfigurationProvider(String configurationProviderName) {
+    Optional<ConfigurationProvider> configurationProvider =
+        childExtensionManager.getConfigurationProvider(configurationProviderName);
+
+    if (!configurationProvider.isPresent()) {
+      configurationProvider = parentExtensionManager.getConfigurationProvider(configurationProviderName);
+    }
+
+    return configurationProvider;
+  }
+
+  @Override
+  public void registerConfigurationProvider(ConfigurationProvider configurationProvider) {
+    throw new UnsupportedOperationException("Composite extension manager cannot register extension providers");
+  }
+
+  @Override
+  public ExtensionManifest parseExtensionManifestXml(URL manifestUrl) {
+    throw new UnsupportedOperationException("Composite extension manager cannot parse extension manifests");
+  }
+
+  public ExtensionManager getParentExtensionManager() {
+    return parentExtensionManager;
+  }
+
+  public ExtensionManager getChildExtensionManager() {
+    return childExtensionManager;
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstanceProviderFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyInstanceProviderFactory.java
@@ -12,6 +12,7 @@ import org.mule.runtime.core.policy.PolicyParametrization;
 import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+import org.mule.runtime.module.extension.internal.loader.ExtensionModelLoaderRepository;
 import org.mule.runtime.module.service.ServiceRepository;
 
 /**
@@ -21,16 +22,21 @@ public class DefaultPolicyInstanceProviderFactory implements PolicyInstanceProvi
 
   private final ServiceRepository serviceRepository;
   private final ClassLoaderRepository classLoaderRepository;
+  private final ExtensionModelLoaderRepository extensionModelLoaderRepository;
 
   /**
    * Creates a new factory
    *
    * @param serviceRepository contains available service instances. Non null.
    * @param classLoaderRepository contains the registered classloaders that can be used to load serialized classes. Non null.
+   * @param extensionModelLoaderRepository {@link ExtensionModelLoaderRepository} with the available extension loaders. Non null.
    */
-  public DefaultPolicyInstanceProviderFactory(ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository) {
+  public DefaultPolicyInstanceProviderFactory(ServiceRepository serviceRepository, ClassLoaderRepository classLoaderRepository,
+                                              ExtensionModelLoaderRepository extensionModelLoaderRepository) {
+    this.extensionModelLoaderRepository = extensionModelLoaderRepository;
     checkArgument(serviceRepository != null, "serviceRepository cannot be null");
     checkArgument(classLoaderRepository != null, "classLoaderRepository cannot be null");
+    checkArgument(extensionModelLoaderRepository != null, "extensionModelLoaderRepository cannot be null");
 
     this.serviceRepository = serviceRepository;
     this.classLoaderRepository = classLoaderRepository;
@@ -40,7 +46,8 @@ public class DefaultPolicyInstanceProviderFactory implements PolicyInstanceProvi
   public ApplicationPolicyInstance create(Application application, PolicyTemplate policyTemplate,
                                           PolicyParametrization parametrization) {
     return new DefaultApplicationPolicyInstance(application, policyTemplate, parametrization, serviceRepository,
-                                                classLoaderRepository);
+                                                classLoaderRepository, policyTemplate.getArtifactPlugins(),
+                                                extensionModelLoaderRepository);
   }
 
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplate.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplate.java
@@ -7,11 +7,15 @@
 
 package org.mule.runtime.module.deployment.impl.internal.policy;
 
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Default implementation of {@link PolicyTemplate}
@@ -21,6 +25,7 @@ public class DefaultPolicyTemplate implements PolicyTemplate {
   private final String artifactId;
   private final PolicyTemplateDescriptor descriptor;
   private final ArtifactClassLoader policyClassLoader;
+  private final List<ArtifactPlugin> artifactPlugins;
 
   /**
    * Creates a new policy template artifact
@@ -28,11 +33,19 @@ public class DefaultPolicyTemplate implements PolicyTemplate {
    * @param artifactId artifact unique ID. Non empty.
    * @param descriptor describes the policy to create. Non null.
    * @param policyClassLoader classloader to use on this policy. Non null.
+   * @param artifactPlugins artifact plugins deployed inside the policy. Non null.
    */
-  public DefaultPolicyTemplate(String artifactId, PolicyTemplateDescriptor descriptor, ArtifactClassLoader policyClassLoader) {
+  public DefaultPolicyTemplate(String artifactId, PolicyTemplateDescriptor descriptor, ArtifactClassLoader policyClassLoader,
+                               List<ArtifactPlugin> artifactPlugins) {
+    checkArgument(!isEmpty(artifactId), "artifactId cannot be empty");
+    checkArgument(descriptor != null, "descriptor cannot be null");
+    checkArgument(policyClassLoader != null, "policyClassLoader cannot be null");
+    checkArgument(artifactPlugins != null, "artifactPlugins cannot be null");
+
     this.artifactId = artifactId;
     this.descriptor = descriptor;
     this.policyClassLoader = policyClassLoader;
+    this.artifactPlugins = artifactPlugins;
   }
 
   @Override
@@ -65,4 +78,7 @@ public class DefaultPolicyTemplate implements PolicyTemplate {
     policyClassLoader.dispose();
   }
 
+  public List<ArtifactPlugin> getArtifactPlugins() {
+    return artifactPlugins;
+  }
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplateFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/DefaultPolicyTemplateFactory.java
@@ -8,14 +8,25 @@
 package org.mule.runtime.module.deployment.impl.internal.policy;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import static org.mule.runtime.deployment.model.internal.AbstractArtifactClassLoaderBuilder.getArtifactPluginId;
 import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.NULL_CLASSLOADER_FILTER;
+import static org.mule.runtime.module.artifact.descriptor.BundleDescriptorUtils.isCompatibleVersion;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
-import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
-import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
+import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
+import org.mule.runtime.module.deployment.impl.internal.plugin.DefaultArtifactPlugin;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Creates {@link DefaultPolicyTemplate} instances.
@@ -27,7 +38,8 @@ public class DefaultPolicyTemplateFactory implements PolicyTemplateFactory {
   /**
    * Creates a new factory
    *
-   * @param policyTemplateClassLoaderBuilderFactory creates class loader builders to create the class loaders for the created policy templates. Non null.
+   * @param policyTemplateClassLoaderBuilderFactory creates class loader builders to create the class loaders for the created
+   *        policy templates. Non null.
    */
   public DefaultPolicyTemplateFactory(PolicyTemplateClassLoaderBuilderFactory policyTemplateClassLoaderBuilderFactory) {
     checkArgument(policyTemplateClassLoaderBuilderFactory != null, "policyTemplateClassLoaderBuilderFactory cannot be null");
@@ -36,20 +48,70 @@ public class DefaultPolicyTemplateFactory implements PolicyTemplateFactory {
   }
 
   @Override
-  public PolicyTemplate createArtifact(PolicyTemplateDescriptor descriptor, RegionClassLoader regionClassLoader) {
-    ArtifactClassLoader policyClassLoader;
+  public PolicyTemplate createArtifact(Application application, PolicyTemplateDescriptor descriptor) {
+    MuleDeployableArtifactClassLoader policyClassLoader;
+    ArtifactPluginDescriptor[] artifactPluginDescriptors =
+        getArtifactPluginDescriptors(application.getDescriptor().getPlugins(), descriptor);
     try {
       policyClassLoader = policyTemplateClassLoaderBuilderFactory.createArtifactClassLoaderBuilder()
-          .setParentClassLoader(regionClassLoader).setArtifactDescriptor(descriptor).build();
+          .addArtifactPluginDescriptors(artifactPluginDescriptors)
+          .setParentClassLoader(application.getRegionClassLoader()).setArtifactDescriptor(descriptor).build();
     } catch (IOException e) {
       throw new PolicyTemplateCreationException(createPolicyTemplateCreationErrorMessage(descriptor.getName()), e);
     }
-    regionClassLoader.addClassLoader(policyClassLoader, NULL_CLASSLOADER_FILTER);
+    application.getRegionClassLoader().addClassLoader(policyClassLoader, NULL_CLASSLOADER_FILTER);
+
+    List<ArtifactPlugin> artifactPlugins = createArtifactPluginList(policyClassLoader, Arrays.asList(artifactPluginDescriptors));
 
     DefaultPolicyTemplate policy =
-        new DefaultPolicyTemplate(policyClassLoader.getArtifactId(), descriptor, policyClassLoader);
+        new DefaultPolicyTemplate(policyClassLoader.getArtifactId(), descriptor, policyClassLoader, artifactPlugins);
 
     return policy;
+  }
+
+  private ArtifactPluginDescriptor[] getArtifactPluginDescriptors(Set<ArtifactPluginDescriptor> appPlugins,
+                                                                  PolicyTemplateDescriptor descriptor) {
+    List<ArtifactPluginDescriptor> artifactPluginDescriptors = new ArrayList<>();
+    for (ArtifactPluginDescriptor policyPluginDescriptor : descriptor.getPlugins()) {
+      ArtifactPluginDescriptor appPluginDescriptor = findPlugin(appPlugins, policyPluginDescriptor.getBundleDescriptor());
+      if (appPluginDescriptor == null) {
+        artifactPluginDescriptors.add(policyPluginDescriptor);
+      } else if (!isCompatibleVersion(appPluginDescriptor.getBundleDescriptor().getVersion(),
+                                      policyPluginDescriptor.getBundleDescriptor().getVersion())) {
+        throw new IllegalStateException(
+                                        format("Incompatible version of plugin '%s' found. Policy requires version'%s' but application provides version'%s'",
+                                               policyPluginDescriptor.getName(),
+                                               policyPluginDescriptor.getBundleDescriptor().getVersion(),
+                                               appPluginDescriptor.getBundleDescriptor().getVersion()));
+      }
+    }
+
+    return artifactPluginDescriptors.toArray(new ArtifactPluginDescriptor[0]);
+  }
+
+  private ArtifactPluginDescriptor findPlugin(Set<ArtifactPluginDescriptor> appPlugins, BundleDescriptor bundleDescriptor) {
+    for (ArtifactPluginDescriptor appPlugin : appPlugins) {
+      if (appPlugin.getBundleDescriptor().getArtifactId().equals(bundleDescriptor.getArtifactId())
+          && appPlugin.getBundleDescriptor().getGroupId().equals(bundleDescriptor.getGroupId())) {
+        return appPlugin;
+      }
+    }
+
+    return null;
+  }
+
+  private List<ArtifactPlugin> createArtifactPluginList(MuleDeployableArtifactClassLoader policyClassLoader,
+                                                        List<ArtifactPluginDescriptor> plugins) {
+    return plugins.stream()
+        .map(artifactPluginDescriptor -> new DefaultArtifactPlugin(getArtifactPluginId(policyClassLoader.getArtifactId(),
+                                                                                       artifactPluginDescriptor.getName()),
+                                                                   artifactPluginDescriptor, policyClassLoader
+                                                                       .getArtifactPluginClassLoaders().stream()
+                                                                       .filter(artifactClassLoader -> artifactClassLoader
+                                                                           .getArtifactId()
+                                                                           .endsWith(artifactPluginDescriptor.getName()))
+                                                                       .findFirst().get()))
+        .collect(toList());
   }
 
   /**

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateExtensionManagerFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateExtensionManagerFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
+import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
+import org.mule.runtime.module.extension.internal.loader.ExtensionModelLoaderRepository;
+import org.mule.runtime.module.extension.internal.manager.ExtensionManagerFactory;
+
+import java.util.List;
+
+/**
+ * Creates extension managers for {@link PolicyTemplate} artifacts
+ */
+public class PolicyTemplateExtensionManagerFactory extends ArtifactExtensionManagerFactory {
+
+  private final Application application;
+
+  /**
+   * Creates a new factory
+   *
+   * @param application application on which the policies are applied. Non null.
+   * @param extensionModelLoaderRepository {@link ExtensionModelLoaderRepository} with the available extension loaders. Non null.
+   * @param artifactPlugins artifact plugins deployed inside the artifact. Non null.
+   * @param extensionManagerFactory creates the {@link ExtensionManager} for the artifact. Non null
+   */
+  public PolicyTemplateExtensionManagerFactory(Application application,
+                                               ExtensionModelLoaderRepository extensionModelLoaderRepository,
+                                               List<ArtifactPlugin> artifactPlugins,
+                                               ExtensionManagerFactory extensionManagerFactory) {
+    super(artifactPlugins, extensionModelLoaderRepository, extensionManagerFactory);
+
+    checkArgument(application != null, "application cannot be null");
+    this.application = application;
+  }
+
+  @Override
+  public ExtensionManager create(MuleContext muleContext) {
+    ExtensionManager policyExtensionManager = super.create(muleContext);
+
+    ExtensionManager applicationExtensionManager = application.getMuleContext().getExtensionManager();
+
+    return new CompositeArtifactExtensionManager(applicationExtensionManager, policyExtensionManager);
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateFactory.java
@@ -7,9 +7,9 @@
 
 package org.mule.runtime.module.deployment.impl.internal.policy;
 
+import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplate;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
-import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 
 /**
  * Creates {@link PolicyTemplate} instances
@@ -19,10 +19,10 @@ public interface PolicyTemplateFactory {
   /**
    * Creates a new policy template artifact
    *
+   * @param application class loader where the policy template's class loader will be included. Non null.
    * @param descriptor describes how to build a policy template artifact. Non null
-   * @param regionClassLoader class loader where the policy template's class loader will be included. Non null.
    * @return a {@link PolicyTemplate} artifact from the provided descriptor as a member of the region.
    * @throws PolicyTemplateCreationException when the artifact cannot be created
    */
-  PolicyTemplate createArtifact(PolicyTemplateDescriptor descriptor, RegionClassLoader regionClassLoader);
+  PolicyTemplate createArtifact(Application application, PolicyTemplateDescriptor descriptor);
 }

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProviderTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/MuleApplicationPolicyProviderTestCase.java
@@ -81,7 +81,7 @@ public class MuleApplicationPolicyProviderTestCase extends AbstractMuleTestCase 
     policyClassLoader = null;
     when(policyTemplate.getArtifactClassLoader()).thenReturn(policyClassLoader);
 
-    when(policyTemplateFactory.createArtifact(policyTemplateDescriptor, regionClassLoader)).thenReturn(policyTemplate);
+    when(policyTemplateFactory.createArtifact(application, policyTemplateDescriptor)).thenReturn(policyTemplate);
     when(applicationPolicyInstance1.getPointcut()).thenReturn(pointcut);
     when(applicationPolicyInstance1.getOrder()).thenReturn(ORDER_POLICY1);
     when(applicationPolicyInstance1.getOperationPolicy()).thenReturn(of(policy1));
@@ -311,7 +311,7 @@ public class MuleApplicationPolicyProviderTestCase extends AbstractMuleTestCase 
     policyProvider.addPolicy(policyTemplateDescriptor, parametrization1);
     policyProvider.addPolicy(policyTemplateDescriptor, parametrization2);
 
-    verify(policyTemplateFactory).createArtifact(policyTemplateDescriptor, regionClassLoader);
+    verify(policyTemplateFactory).createArtifact(application, policyTemplateDescriptor);
   }
 
   @Test

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/PolicyFileBuilder.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/PolicyFileBuilder.java
@@ -94,6 +94,20 @@ public class PolicyFileBuilder extends AbstractArtifactFileBuilder<PolicyFileBui
   }
 
   /**
+   * Adds an application plugin to the policy template.
+   *
+   * @param plugin builder defining the plugin. Non null.
+   * @return the same builder instance
+   */
+  public PolicyFileBuilder containingPlugin(ArtifactPluginFileBuilder plugin) {
+    checkImmutable();
+    checkArgument(plugin != null, "Plugin cannot be null");
+    this.plugins.add(plugin);
+
+    return this;
+  }
+
+  /**
    * Adds a dependency against another plugin
    *
    * @param pluginName name of the plugin to be dependent. Non empty.

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/CompositeArtifactExtensionManagerTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/CompositeArtifactExtensionManagerTestCase.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.junit.rules.ExpectedException.none;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.core.api.Event;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.extension.api.runtime.ConfigurationInstance;
+import org.mule.runtime.extension.api.runtime.ConfigurationProvider;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@SmallTest
+public class CompositeArtifactExtensionManagerTestCase extends AbstractMuleTestCase {
+
+  public static final String PROVIDER_NAME = "providerName";
+
+  private final ExtensionManager parentExtensionManager = mock(ExtensionManager.class);
+  private final ExtensionManager childExtensionManager = mock(ExtensionManager.class);
+
+  @Rule
+  public ExpectedException expectedException = none();
+
+  @Test
+  public void providesComposedExtensions() throws Exception {
+    ExtensionModel parentExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> parentExtensions = singleton(parentExtension);
+    when(parentExtensionManager.getExtensions()).thenReturn(parentExtensions);
+
+    ExtensionModel childExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> childExtensions = singleton(childExtension);
+    when(childExtensionManager.getExtensions()).thenReturn(childExtensions);
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+
+    Set<ExtensionModel> extensions = extensionManager.getExtensions();
+    assertThat(extensions.size(), equalTo(2));
+    assertThat(extensions, hasItem(parentExtension));
+    assertThat(extensions, hasItem(childExtension));
+  }
+
+  @Test
+  public void providesRegisteredExtension() throws Exception {
+    ExtensionModel parentExtension = mock(ExtensionModel.class);
+    when(parentExtension.getName()).thenReturn("testExtension");
+    Set<ExtensionModel> parentExtensions = singleton(parentExtension);
+    when(parentExtensionManager.getExtensions()).thenReturn(parentExtensions);
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+
+    Optional<ExtensionModel> extension = extensionManager.getExtension("testExtension");
+    assertThat(extension.get(), is(parentExtension));
+  }
+
+  @Test
+  public void returnsEmptyExtensionWhenNonRegistered() throws Exception {
+    ExtensionModel parentExtension = mock(ExtensionModel.class);
+    when(parentExtension.getName()).thenReturn("testExtension");
+    Set<ExtensionModel> parentExtensions = singleton(parentExtension);
+    when(parentExtensionManager.getExtensions()).thenReturn(parentExtensions);
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+
+    Optional<ExtensionModel> extension = extensionManager.getExtension("fooExtension");
+    assertThat(extension.isPresent(), is(false));
+  }
+
+  @Test
+  public void returnsChildConfigurationProviderFromModel() throws Exception {
+
+    ExtensionModel childExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> childExtensions = singleton(childExtension);
+    when(childExtensionManager.getExtensions()).thenReturn(childExtensions);
+    when(parentExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
+    when(childExtensionManager.getConfigurationProvider(childExtension)).thenReturn(of(childConfigurationProvider));
+    when(parentExtensionManager.getConfigurationProvider(childExtension)).thenReturn(empty());
+
+    Optional<ConfigurationProvider> configurationProvider = extensionManager.getConfigurationProvider(childExtension);
+
+    assertThat(configurationProvider.get(), is(childConfigurationProvider));
+  }
+
+  @Test
+  public void returnsParentConfigurationProviderFromModel() throws Exception {
+
+    ExtensionModel parentExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> parentExtensions = singleton(parentExtension);
+    when(parentExtensionManager.getExtensions()).thenReturn(parentExtensions);
+    when(childExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    ConfigurationProvider parentConfigurationProvider = mock(ConfigurationProvider.class);
+    when(parentExtensionManager.getConfigurationProvider(parentExtension)).thenReturn(of(parentConfigurationProvider));
+    when(childExtensionManager.getConfigurationProvider(parentExtension)).thenReturn(empty());
+
+    Optional<ConfigurationProvider> configurationProvider = extensionManager.getConfigurationProvider(parentExtension);
+
+    assertThat(configurationProvider.get(), is(parentConfigurationProvider));
+  }
+
+  @Test
+  public void returnsChildConfigurationProviderFromProviderName() throws Exception {
+    ExtensionModel childExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> childExtensions = singleton(childExtension);
+    when(childExtensionManager.getExtensions()).thenReturn(childExtensions);
+    when(parentExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
+    when(childExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(of(childConfigurationProvider));
+    when(parentExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(empty());
+
+    Optional<ConfigurationProvider> configurationProvider = extensionManager.getConfigurationProvider(PROVIDER_NAME);
+
+    assertThat(configurationProvider.get(), is(childConfigurationProvider));
+  }
+
+  @Test
+  public void returnsParentConfigurationProviderFromProviderName() throws Exception {
+    ExtensionModel parentExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> parentExtensions = singleton(parentExtension);
+    when(parentExtensionManager.getExtensions()).thenReturn(parentExtensions);
+    when(childExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    ConfigurationProvider parentConfigurationProvider = mock(ConfigurationProvider.class);
+    when(parentExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(of(parentConfigurationProvider));
+    when(childExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(empty());
+
+    Optional<ConfigurationProvider> configurationProvider = extensionManager.getConfigurationProvider(PROVIDER_NAME);
+
+    assertThat(configurationProvider.get(), is(parentConfigurationProvider));
+  }
+
+  @Test
+  public void returnsConfigurationFromProviderName() throws Exception {
+    ExtensionModel childExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> childExtensions = singleton(childExtension);
+    when(childExtensionManager.getExtensions()).thenReturn(childExtensions);
+    when(parentExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    Event event = mock(Event.class);
+
+    ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
+    ConfigurationInstance configurationInstance = mock(ConfigurationInstance.class);
+    when(childConfigurationProvider.get(event)).thenReturn(configurationInstance);
+    when(childExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(of(childConfigurationProvider));
+    when(parentExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(empty());
+
+    ConfigurationInstance configuration = extensionManager.getConfiguration(PROVIDER_NAME, event);
+
+    assertThat(configuration, is(configurationInstance));
+  }
+
+  @Test
+  public void failsToObtainMissingConfigurationFromProviderName() throws Exception {
+    ExtensionModel childExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> childExtensions = singleton(childExtension);
+    when(childExtensionManager.getExtensions()).thenReturn(childExtensions);
+    when(parentExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    Event event = mock(Event.class);
+
+    ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
+    ConfigurationInstance configurationInstance = mock(ConfigurationInstance.class);
+    when(childConfigurationProvider.get(event)).thenReturn(configurationInstance);
+    when(childExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(empty());
+    when(parentExtensionManager.getConfigurationProvider(PROVIDER_NAME)).thenReturn(empty());
+
+    expectedException.expect(IllegalArgumentException.class);
+    extensionManager.getConfiguration(PROVIDER_NAME, event);
+  }
+
+  @Test
+  public void returnsConfigurationFromModel() throws Exception {
+    ExtensionModel childExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> childExtensions = singleton(childExtension);
+    when(childExtensionManager.getExtensions()).thenReturn(childExtensions);
+    when(parentExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    Event event = mock(Event.class);
+
+    ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
+    ConfigurationInstance configurationInstance = mock(ConfigurationInstance.class);
+    when(childConfigurationProvider.get(event)).thenReturn(configurationInstance);
+    when(childExtensionManager.getConfigurationProvider(childExtension)).thenReturn(of(childConfigurationProvider));
+    when(parentExtensionManager.getConfigurationProvider(childExtension)).thenReturn(empty());
+
+    ConfigurationInstance configuration = extensionManager.getConfiguration(childExtension, event);
+
+    assertThat(configuration, is(configurationInstance));
+  }
+
+  @Test
+  public void failsToObtainMissingConfigurationFromModel() throws Exception {
+    ExtensionModel childExtension = mock(ExtensionModel.class);
+    Set<ExtensionModel> childExtensions = singleton(childExtension);
+    when(childExtensionManager.getExtensions()).thenReturn(childExtensions);
+    when(parentExtensionManager.getExtensions()).thenReturn(emptySet());
+
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+    Event event = mock(Event.class);
+
+    ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
+    ConfigurationInstance configurationInstance = mock(ConfigurationInstance.class);
+    when(childConfigurationProvider.get(event)).thenReturn(configurationInstance);
+    when(childExtensionManager.getConfigurationProvider(childExtension)).thenReturn(empty());
+    when(parentExtensionManager.getConfigurationProvider(childExtension)).thenReturn(empty());
+
+    expectedException.expect(IllegalArgumentException.class);
+    extensionManager.getConfiguration(childExtension, event);
+  }
+
+  @Test
+  public void doesNotRegisterExtension() throws Exception {
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+
+    expectedException.expect(UnsupportedOperationException.class);
+    extensionManager.registerExtension(mock(ExtensionModel.class));
+  }
+
+  @Test
+  public void doesNotParsesExtensionManifestXml() throws Exception {
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+
+    expectedException.expect(UnsupportedOperationException.class);
+    extensionManager.parseExtensionManifestXml(null);
+  }
+
+  @Test
+  public void doesNotRegisterConfigurationProviders() throws Exception {
+    CompositeArtifactExtensionManager extensionManager = new CompositeArtifactExtensionManager(parentExtensionManager,
+                                                                                               childExtensionManager);
+
+    expectedException.expect(UnsupportedOperationException.class);
+    extensionManager.registerConfigurationProvider(mock(ConfigurationProvider.class));
+  }
+}

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateExtensionManagerFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateExtensionManagerFactoryTestCase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.policy;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mule.runtime.core.DefaultMuleContext;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.module.extension.internal.loader.ExtensionModelLoaderRepository;
+import org.mule.runtime.module.extension.internal.manager.ExtensionManagerFactory;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import org.junit.Test;
+
+@SmallTest
+public class PolicyTemplateExtensionManagerFactoryTestCase extends AbstractMuleTestCase {
+
+  @Test
+  public void createsCompositeExtensionManager() throws Exception {
+
+    Application application = mock(Application.class, RETURNS_DEEP_STUBS);
+    ExtensionManager applicationExtensionManager = mock(ExtensionManager.class);
+    when(application.getMuleContext().getExtensionManager()).thenReturn(applicationExtensionManager);
+
+    ExtensionModelLoaderRepository extensionModelLoaderRepository = mock(ExtensionModelLoaderRepository.class);
+
+    ExtensionManagerFactory extensionManagerFactory = mock(ExtensionManagerFactory.class);
+    PolicyTemplateExtensionManagerFactory factory = new PolicyTemplateExtensionManagerFactory(application,
+                                                                                              extensionModelLoaderRepository,
+                                                                                              emptyList(),
+                                                                                              extensionManagerFactory);
+
+    ExtensionManager policyExtensionManager = mock(ExtensionManager.class);
+    MuleContext muleContext = mock(DefaultMuleContext.class);
+    when(extensionManagerFactory.create(muleContext)).thenReturn(policyExtensionManager);
+
+    ExtensionManager extensionManager = factory.create(muleContext);
+
+    assertThat(extensionManager, instanceOf(CompositeArtifactExtensionManager.class));
+    CompositeArtifactExtensionManager compositeArtifactExtensionManager = (CompositeArtifactExtensionManager) extensionManager;
+    assertThat(compositeArtifactExtensionManager.getParentExtensionManager(), equalTo(applicationExtensionManager));
+    assertThat(compositeArtifactExtensionManager.getChildExtensionManager(), equalTo(policyExtensionManager));
+  }
+}

--- a/modules/deployment-model/pom.xml
+++ b/modules/deployment-model/pom.xml
@@ -40,16 +40,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-util</artifactId>
-            <version>${aetherVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-api</artifactId>
-            <version>${aetherVersion}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-artifact</artifactId>
             <version>${project.version}</version>

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplate.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplate.java
@@ -7,7 +7,10 @@
 
 package org.mule.runtime.deployment.model.api.policy;
 
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPlugin;
 import org.mule.runtime.module.artifact.Artifact;
+
+import java.util.List;
 
 /**
  * Represents a policy template artifact.
@@ -20,4 +23,9 @@ public interface PolicyTemplate extends Artifact<PolicyTemplateDescriptor> {
    * Disposes the artifact releasing any held resources
    */
   void dispose();
+
+  /**
+   * @return plugins deployed inside the policy template
+   */
+  List<ArtifactPlugin> getArtifactPlugins();
 }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptor.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptor.java
@@ -7,10 +7,12 @@
 
 package org.mule.runtime.deployment.model.api.policy;
 
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
 
 import java.io.File;
-
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Describes how to create a {@link PolicyTemplate} artifact
@@ -24,6 +26,7 @@ public class PolicyTemplateDescriptor extends ArtifactDescriptor {
   public static final String MULE_POLICY_JSON = "mule-policy.json";
 
   private File[] configResourceFiles;
+  private Set<ArtifactPluginDescriptor> plugins = new HashSet<>(0);
 
   /**
    * Creates a new descriptor for a named artifact
@@ -40,5 +43,13 @@ public class PolicyTemplateDescriptor extends ArtifactDescriptor {
 
   public void setConfigResourceFiles(File[] configResourceFiles) {
     this.configResourceFiles = configResourceFiles;
+  }
+
+  public Set<ArtifactPluginDescriptor> getPlugins() {
+    return plugins;
+  }
+
+  public void setPlugins(Set<ArtifactPluginDescriptor> plugins) {
+    this.plugins = plugins;
   }
 }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
@@ -8,9 +8,9 @@
 package org.mule.runtime.deployment.model.internal.plugin;
 
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
+import static org.mule.runtime.module.artifact.descriptor.BundleDescriptorUtils.isCompatibleVersion;
 import org.mule.runtime.deployment.model.api.artifact.DependenciesProvider;
 import org.mule.runtime.deployment.model.api.artifact.DependencyNotFoundException;
-import org.mule.runtime.deployment.model.api.artifact.InvalidDependencyVersionException;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorFactory;
 import org.mule.runtime.module.artifact.descriptor.BundleDependency;
@@ -26,10 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.eclipse.aether.util.version.GenericVersionScheme;
-import org.eclipse.aether.version.InvalidVersionSpecificationException;
-import org.eclipse.aether.version.Version;
 
 /**
  * Resolves plugin dependencies considering the plugin name only.
@@ -216,32 +212,6 @@ public class BundlePluginDependenciesResolver implements PluginDependenciesResol
     return availableBundleDescriptor.getArtifactId().equals(expectedBundleDescriptor.getArtifactId()) &&
         availableBundleDescriptor.getGroupId().equals(expectedBundleDescriptor.getGroupId()) &&
         isCompatibleVersion(availableBundleDescriptor.getVersion(), expectedBundleDescriptor.getVersion());
-  }
-
-  private static boolean isCompatibleVersion(String availableVersion, String expectedVersion) {
-    if (availableVersion.equals(expectedVersion)) {
-      return true;
-    }
-
-    Version available = getBundleVersion(availableVersion);
-    Version expected = getBundleVersion(expectedVersion);
-
-    if (available.compareTo(expected) >= 0) {
-      String availableMajorVersion = availableVersion.substring(0, availableVersion.indexOf("."));
-      String expectedMajorVersion = expectedVersion.substring(0, expectedVersion.indexOf("."));
-
-      return availableMajorVersion.equals(expectedMajorVersion);
-    }
-
-    return false;
-  }
-
-  private static Version getBundleVersion(String version) {
-    try {
-      return new GenericVersionScheme().parseVersion(version);
-    } catch (InvalidVersionSpecificationException e) {
-      throw new InvalidDependencyVersionException("Unable to parse bundle version: " + version);
-    }
   }
 
   private boolean hasPluginDependenciesResolved(Set<BundleDependency> pluginDependencies,

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderBuilder.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderBuilder.java
@@ -14,15 +14,19 @@ import org.mule.runtime.deployment.model.internal.AbstractArtifactClassLoaderBui
 import org.mule.runtime.deployment.model.internal.plugin.PluginDependenciesResolver;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
+import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
+import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.RegionClassLoader;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+
+import java.io.IOException;
 
 /**
  * Builds the class loader to use on a {@link org.mule.runtime.deployment.model.api.policy.PolicyTemplate}
  */
-public class PolicyTemplateClassLoaderBuilder extends AbstractArtifactClassLoaderBuilder {
+public class PolicyTemplateClassLoaderBuilder extends AbstractArtifactClassLoaderBuilder<PolicyTemplateClassLoaderBuilder> {
 
-  private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
+  private final DeployableArtifactClassLoaderFactory artifactClassLoaderFactory;
   private ArtifactClassLoader parentClassLoader;
 
   /**
@@ -34,7 +38,7 @@ public class PolicyTemplateClassLoaderBuilder extends AbstractArtifactClassLoade
    * @param artifactPluginClassLoaderFactory factory to create class loaders for each used plugin. Non be not null.
    * @param pluginDependenciesResolver resolves artifact plugin dependencies. Non null
    */
-  public PolicyTemplateClassLoaderBuilder(ArtifactClassLoaderFactory artifactClassLoaderFactory,
+  public PolicyTemplateClassLoaderBuilder(DeployableArtifactClassLoaderFactory artifactClassLoaderFactory,
                                           ArtifactPluginRepository artifactPluginRepository,
                                           ArtifactClassLoaderFactory artifactPluginClassLoaderFactory,
                                           PluginDependenciesResolver pluginDependenciesResolver) {
@@ -45,12 +49,17 @@ public class PolicyTemplateClassLoaderBuilder extends AbstractArtifactClassLoade
 
   @Override
   protected ArtifactClassLoader createArtifactClassLoader(String artifactId, RegionClassLoader regionClassLoader) {
-    return artifactClassLoaderFactory.create(artifactId, regionClassLoader, artifactDescriptor);
+    return artifactClassLoaderFactory.create(artifactId, regionClassLoader, artifactDescriptor, artifactPluginClassLoaders);
   }
 
   @Override
   protected ArtifactClassLoader getParentClassLoader() {
     return parentClassLoader;
+  }
+
+  @Override
+  public MuleDeployableArtifactClassLoader build() throws IOException {
+    return (MuleDeployableArtifactClassLoader) super.build();
   }
 
   public PolicyTemplateClassLoaderBuilder setParentClassLoader(ArtifactClassLoader parentClassLoader) {

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderFactory.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/policy/PolicyTemplateClassLoaderFactory.java
@@ -9,19 +9,21 @@ package org.mule.runtime.deployment.model.internal.policy;
 
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
-import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFactory;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderLookupPolicy;
-import org.mule.runtime.module.artifact.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.classloader.DeployableArtifactClassLoaderFactory;
+import org.mule.runtime.module.artifact.classloader.MuleDeployableArtifactClassLoader;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Creates {@link ArtifactClassLoader} for policy templates artifact.
  */
-public class PolicyTemplateClassLoaderFactory implements ArtifactClassLoaderFactory<PolicyTemplateDescriptor> {
+public class PolicyTemplateClassLoaderFactory implements DeployableArtifactClassLoaderFactory<PolicyTemplateDescriptor> {
 
   @Override
-  public ArtifactClassLoader create(String artifactId, ArtifactClassLoader parent, PolicyTemplateDescriptor descriptor) {
+  public ArtifactClassLoader create(String artifactId, ArtifactClassLoader parent, PolicyTemplateDescriptor descriptor,
+                                    List<ArtifactClassLoader> artifactPluginClassLoaders) {
     File rootFolder = descriptor.getRootFolder();
     if (rootFolder == null || !rootFolder.exists()) {
       throw new IllegalArgumentException("Policy folder does not exists: " + (rootFolder != null ? rootFolder.getName() : null));
@@ -29,9 +31,11 @@ public class PolicyTemplateClassLoaderFactory implements ArtifactClassLoaderFact
 
     final ClassLoaderLookupPolicy classLoaderLookupPolicy = parent.getClassLoaderLookupPolicy();
 
-    return new MuleArtifactClassLoader(artifactId, descriptor,
-                                       descriptor.getClassLoaderModel().getUrls(),
-                                       parent.getClassLoader(),
-                                       classLoaderLookupPolicy);
+    MuleDeployableArtifactClassLoader deployableArtifactClassLoader =
+        new MuleDeployableArtifactClassLoader(artifactId, descriptor, descriptor.getClassLoaderModel().getUrls(),
+                                              parent.getClassLoader(),
+                                              classLoaderLookupPolicy, artifactPluginClassLoaders);
+
+    return deployableArtifactClassLoader;
   }
 }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestPolicyManager.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestPolicyManager.java
@@ -36,17 +36,20 @@ public class TestPolicyManager implements DeploymentListener {
   private final DeploymentService deploymentService;
   private final Map<String, List<AppPolicyParametrization>> registeredPolicies = new HashMap<>();
   private final List<PolicyTemplateDescriptor> policyTemplateDescriptors = new ArrayList<>();
-  private final PolicyTemplateDescriptorFactory policyTemplateDescriptorFactory = new PolicyTemplateDescriptorFactory();
+  private final PolicyTemplateDescriptorFactory policyTemplateDescriptorFactory;
 
   /**
    * Creates a new manager
    *
    * @param deploymentService service that deploys applications in the container. Non null.
+   * @param policyTemplateDescriptorFactory  creates descriptors for the policy templates. Non null
    */
-  public TestPolicyManager(DeploymentService deploymentService) {
+  public TestPolicyManager(DeploymentService deploymentService, PolicyTemplateDescriptorFactory policyTemplateDescriptorFactory) {
     checkArgument(deploymentService != null, "deploymentService cannot be null");
+    checkArgument(policyTemplateDescriptorFactory != null, "policyTemplateDescriptorFactory cannot be null");
 
     this.deploymentService = deploymentService;
+    this.policyTemplateDescriptorFactory = policyTemplateDescriptorFactory;
   }
 
   @Override

--- a/modules/deployment/src/test/resources/app-with-simple-extension-config.xml
+++ b/modules/deployment/src/test/resources/app-with-simple-extension-config.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns="http://www.mulesoft.org/schema/mule/core"
-      xmlns:hello="http://www.mulesoft.org/schema/mule/hello"
+      xmlns:simple="http://www.mulesoft.org/schema/mule/simple"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-      http://www.mulesoft.org/schema/mule/hello http://www.mulesoft.org/schema/mule/hello/current/mule-hello.xsd">
-
-    <hello:config name="default" message="Hello from app!!!"/>
+      http://www.mulesoft.org/schema/mule/simple http://www.mulesoft.org/schema/mule/simple/current/mule-simple.xsd">
 
     <flow name="main">
-        <poll frequency="1000">
+        <poll frequency="10000">
             <set-payload value=""/>
         </poll>
 
-        <hello:print-message/>
+        <simple:print-message/>
+        <echo-component/>
     </flow>
 </mule>

--- a/modules/deployment/src/test/resources/appPluginPolicy.xml
+++ b/modules/deployment/src/test/resources/appPluginPolicy.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test-policy="http://www.mulesoft.org/schema/mule/test-policy"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:hello="http://www.mulesoft.org/schema/mule/hello"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/test-policy http://www.mulesoft.org/schema/mule/test-policy/current/mule-test-policy.xsd
+               http://www.mulesoft.org/schema/mule/hello http://www.mulesoft.org/schema/mule/hello/current/mule-hello.xsd">
+
+    <hello:config name="default" message="Hello from policy!!!"/>
+
+    <test-policy:proxy>
+        <test-policy:operation>
+            <hello:print-message/>
+
+            <component class="org.mule.runtime.module.deployment.internal.DeploymentServiceTestCase$TestPolicyComponent" />
+
+            <test-policy:execute-next/>
+        </test-policy:operation>
+    </test-policy:proxy>
+</mule>

--- a/modules/deployment/src/test/resources/org/foo/simple/SimpleExtension.java
+++ b/modules/deployment/src/test/resources/org/foo/simple/SimpleExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.foo.hello;
+
+import org.mule.runtime.extension.api.annotation.Extension;
+import org.mule.runtime.extension.api.annotation.Operations;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.service.test.FooService;
+
+import javax.inject.Inject;
+
+@Extension(
+    name = "Simple",
+    description = "Extension for testing purposes")
+@Operations({SimpleOperation.class})
+public class SimpleExtension {
+
+  public SimpleExtension() {}
+
+  public String getMessage() {
+    return "Simplicity is better!!";
+  }
+}

--- a/modules/deployment/src/test/resources/org/foo/simple/SimpleOperation.java
+++ b/modules/deployment/src/test/resources/org/foo/simple/SimpleOperation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.foo.hello;
+
+import org.mule.runtime.extension.api.annotation.param.UseConfig;
+
+public class SimpleOperation {
+
+  public SimpleOperation() {}
+
+  public String printMessage(@UseConfig SimpleExtension config) {
+    System.out.println("Simple extension says: " + config.getMessage());
+    return config.getMessage();
+  }
+}

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/manager/DefaultExtensionManagerFactory.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/manager/DefaultExtensionManagerFactory.java
@@ -17,17 +17,17 @@ import org.mule.runtime.core.api.extension.ExtensionManager;
 
 /**
  * Default implementation of {@link ExtensionManagerFactory} which creates instances of
- * {@link DefaultExtensionManagerAdapterFactory} and sets them into the owning {@link MuleContext}
+ * {@link DefaultExtensionManager} and sets them into the owning {@link MuleContext}
  *
  * @since 4.0
  */
-public class DefaultExtensionManagerAdapterFactory implements ExtensionManagerFactory {
+public class DefaultExtensionManagerFactory implements ExtensionManagerFactory {
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public ExtensionManager createExtensionManager(MuleContext muleContext) {
+  public ExtensionManager create(MuleContext muleContext) {
     ExtensionManager extensionManager = new DefaultExtensionManager();
     ((DefaultMuleContext) muleContext).setExtensionManager(extensionManager);
     try {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/manager/ExtensionManagerFactory.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/manager/ExtensionManagerFactory.java
@@ -22,5 +22,5 @@ public interface ExtensionManagerFactory {
    * @param muleContext the owning {@link MuleContext}
    * @return a non {@code null} {@link ExtensionManager}
    */
-  ExtensionManager createExtensionManager(MuleContext muleContext);
+  ExtensionManager create(MuleContext muleContext);
 }


### PR DESCRIPTION
_ Adding ExtensionManagerFactory interface+ implementations
_ Converting ApplicationExtensionManagerConfigurationBuilder into ArtifactExtensionManagerConfigurationBuilder
_ Adding basic composite extension manager for policies
_ Adding plugins to DefaultPolicyTemplate
_ Adding plugins to PolicyTemplate
_ Making PolicyTemplateClassLoaderBuilder to return a  MuleDeployableArtifactClassLoader class loader
_ Changing ArtifactClassLoaderFactory to DeployableArtifactClassLoaderFactory on policy factory
_ Updating PolicyFileBuilder to include plugins
_ Adding plugins to PolicyTemplate
_ Making PolicyTemplateClassLoaderBuilder to return a  MuleDeployableArtifactClassLoader class loader
_ Extracting code into BundleDescriptorUtils
_ Adding integration tests