### PR TITLE
MULE-11465: plugins generates only jar files

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -166,7 +166,7 @@
 /mule-standalone-${productVersion}/plugins
 /mule-standalone-${productVersion}/plugins/mule-module-db-${productVersion}-mule-plugin.jar
 /mule-standalone-${productVersion}/plugins/mule-module-email-${productVersion}-mule-plugin.jar
-/mule-standalone-${productVersion}/plugins/mule-module-file-extension-common-${productVersion}.zip
+/mule-standalone-${productVersion}/plugins/mule-module-file-extension-common-${productVersion}-mule-plugin.jar
 /mule-standalone-${productVersion}/plugins/mule-module-file-${productVersion}-mule-plugin.jar
 /mule-standalone-${productVersion}/plugins/mule-module-ftp-${productVersion}-mule-plugin.jar
 /mule-standalone-${productVersion}/plugins/mule-module-sockets-${productVersion}-mule-plugin.jar

--- a/distributions/standalone/pom.xml
+++ b/distributions/standalone/pom.xml
@@ -190,7 +190,7 @@
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-file-extension-common</artifactId>
             <version>${project.version}</version>
-            <type>zip</type>
+            <classifier>mule-plugin</classifier>
         </dependency>
 
         <!-- Include DataWeave Plugin -->

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactory.java
@@ -108,7 +108,7 @@ public class ArtifactPluginDescriptorFactory implements ArtifactDescriptorFactor
   }
 
   /**
-   * Given a {@code pluginFolder} as a starting point, it will add a /classes and every JAR file {@link URL}s into the
+   * Given a {@code pluginFolder} as a starting point, it will add a the root folder of it and every JAR file {@link URL}s into the
    * {@link ClassLoaderModelBuilder}.
    *
    * @param pluginFolder plugin's location
@@ -116,7 +116,7 @@ public class ArtifactPluginDescriptorFactory implements ArtifactDescriptorFactor
    */
   private void loadUrlsToClassLoaderModelBuilder(File pluginFolder, ClassLoaderModelBuilder classLoaderModelBuilder) {
     try {
-      classLoaderModelBuilder.containing(new File(pluginFolder, "classes").toURI().toURL());
+      classLoaderModelBuilder.containing(pluginFolder.toURI().toURL());
       final File libDir = new File(pluginFolder, "lib");
       if (libDir.exists()) {
         final File[] jars = libDir.listFiles((FilenameFilter) new SuffixFileFilter(".jar"));

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/ArtifactPluginFileBuilder.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/ArtifactPluginFileBuilder.java
@@ -99,7 +99,7 @@ public class ArtifactPluginFileBuilder extends AbstractArtifactFileBuilder<Artif
   }
 
   /**
-   * Adds a resource file to the application classes folder.
+   * Adds a resource file to the plugin root folder.
    *
    * @param resourceFile resource file from a external file or test resource.
    * @return the same builder instance
@@ -107,21 +107,23 @@ public class ArtifactPluginFileBuilder extends AbstractArtifactFileBuilder<Artif
   public ArtifactPluginFileBuilder containingResource(String resourceFile, String alias) {
     checkImmutable();
     checkArgument(!isEmpty(resourceFile), "Resource file cannot be empty");
-    resources.add(new ZipResource(resourceFile, "classes/" + alias));
+    resources.add(new ZipResource(resourceFile, alias));
     return this;
   }
 
   /**
-   * Adds a resource file to the artifact folder.
+   * Adds a class file to the artifact classes folder.
    *
-   * @param resourceFile resource file from a external file or test resource.
+   * @param classFile class file to include. Non null.
+   * @param alias path where the file must be added inside the app file
    * @return the same builder instance
    */
-  public ArtifactPluginFileBuilder containingRootResource(String resourceFile, String alias) {
+  @Override
+  public ArtifactPluginFileBuilder containingClass(File classFile, String alias) {
     checkImmutable();
-    checkArgument(!isEmpty(resourceFile), "Resource file cannot be empty");
-    resources.add(new ZipResource(resourceFile, alias));
-    return this;
+    checkArgument(classFile != null, "Class file cannot be null");
+    resources.add(new ZipResource(classFile.getAbsolutePath(), alias));
+    return getThis();
   }
 
   /**

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
@@ -76,6 +76,15 @@ import static org.mule.runtime.module.deployment.internal.MuleDeploymentService.
 import static org.mule.runtime.module.deployment.internal.TestApplicationFactory.createTestApplicationFactory;
 import static org.mule.runtime.module.service.ServiceDescriptorFactory.SERVICE_PROVIDER_CLASS_NAME;
 import static org.mule.tck.junit4.AbstractMuleContextTestCase.TEST_MESSAGE;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.verification.VerificationMode;
 import org.mule.runtime.api.deployment.meta.MuleArtifactLoaderDescriptor;
 import org.mule.runtime.api.deployment.meta.MulePluginModel.MulePluginModelBuilder;
 import org.mule.runtime.api.deployment.meta.MulePolicyModel.MulePolicyModelBuilder;
@@ -147,16 +156,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.mockito.verification.VerificationMode;
 
 @RunWith(Parameterized.class)
 public class DeploymentServiceTestCase extends AbstractMuleTestCase {
@@ -1639,7 +1638,7 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
     builder.withBundleDescriptorLoader(createPolicyBundleDescriptorLoader(extensionName, MULE_EXTENSION_CLASSIFIER, MAVEN));
 
     final ArtifactPluginFileBuilder byeXmlExtensionPlugin = new ArtifactPluginFileBuilder(extensionName)
-        .containingRootResource("module-byeSource.xml", moduleDestination)
+        .containingResource("module-byeSource.xml", moduleDestination)
         .containingMuleArtifactResource("module-bye-pom.xml", "pom.xml")
         .describedBy(builder.build());
 
@@ -1673,7 +1672,7 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
     builder.withBundleDescriptorLoader(createPolicyBundleDescriptorLoader(extensionName, MULE_EXTENSION_CLASSIFIER, MAVEN));
 
     final ArtifactPluginFileBuilder byeXmlExtensionPlugin = new ArtifactPluginFileBuilder(extensionName)
-        .containingRootResource("module-using-javaSource.xml", moduleDestination)
+        .containingResource("module-using-javaSource.xml", moduleDestination)
         .containingMuleArtifactResource("module-using-java-pom.xml", "pom.xml")
         .containingRepositoryResource(echoTestJarFile.getAbsolutePath(), "org/foo/echo-test/1.0/echo-test-1.0.jar")
         .containingRepositoryResource("echo-test-pom.xml", "org/foo/echo-test/1.0/echo-test-1.0.pom")

--- a/modules/file-extension-common/pom.xml
+++ b/modules/file-extension-common/pom.xml
@@ -66,28 +66,6 @@
 
     <build>
         <plugins>
-            <!--TODO (MULE-10540) parent pom for mule plugins -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>mule-plugin</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>mule-plugin</classifier>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.mule.plugins</groupId>
                 <artifactId>mule-app-plugins-maven-plugin</artifactId>


### PR DESCRIPTION
Do not merge until https://github.com/mulesoft/mule-extensions-maven-plugin/pull/40 is in.

All plugins, except for DW, generate a JAR file with its `mule-plugin` classifier.