### PR TITLE
MULE-11465: Packaging: plugins must be packaged as JAR files (no more…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1730,7 +1730,7 @@
                     <artifactId>mule-assembly-verifier</artifactId>
                     <version>${assembly.verifier.version}</version>
                     <configuration>
-                        <skip>${skipDistributions}</skip>
+                        <skip>${skipVerifications}</skip>
                     </configuration>
                     <dependencies>
                         <!--


### PR DESCRIPTION
… zips)

_ Maven assemble plugin was ignored by default and did not detected broken artifacts