### PR TITLE
MULE-11334: Migrate old MuleClient uses

### DIFF
--- a/compatibility/modules/cxf/pom.xml
+++ b/compatibility/modules/cxf/pom.xml
@@ -764,6 +764,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-http</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
         <!--  for dynamic client -->
         <dependency>
             <groupId>org.apache.ant</groupId>

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBackToBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBackToBlockingTestCase.java
@@ -9,6 +9,7 @@ package org.mule.compatibility.module.cxf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mule.compatibility.module.cxf.CxfBasicTestCase.APP_SOAP_XML;
+import static org.mule.runtime.api.metadata.MediaType.XML;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import org.mule.runtime.core.util.IOUtils;
@@ -22,6 +23,7 @@ import org.mule.tck.SensingNullRequestResponseMessageProcessor;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.transform.TransformerFactoryConfigurationError;
 
@@ -69,7 +71,7 @@ public class CxfBackToBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
     HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
     String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
     assertTrue(payload.contains("Hello!"));
-    assertEquals("text/xml; charset=UTF-8", response.getHeaderValueIgnoreCase(CONTENT_TYPE));
+    assertEquals(XML.withCharset(StandardCharsets.UTF_8), response.getHeaderValueIgnoreCase(CONTENT_TYPE));
     muleContext.getRegistry().lookupObject(SensingNullRequestResponseMessageProcessor.class).assertRequestResponseThreadsSame();
   }
 

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBackToBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBackToBlockingTestCase.java
@@ -38,7 +38,7 @@ public class CxfBackToBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBackToBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBackToBlockingTestCase.java
@@ -7,14 +7,10 @@
 package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mule.compatibility.module.cxf.CxfBasicTestCase.APP_SOAP_XML;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
-import org.mule.runtime.core.api.client.MuleClient;
-import org.mule.runtime.core.api.message.InternalMessage;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.runtime.module.xml.util.XMLUtils;
 import org.mule.service.http.api.domain.ParameterMap;
@@ -66,14 +62,14 @@ public class CxfBackToBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
     InputStream xml = getClass().getResourceAsStream("/direct/direct-request.xml");
 
     ParameterMap headersMap = new ParameterMap();
-    headersMap.put("content-type", APP_SOAP_XML.toRfcString());
+    headersMap.put(CONTENT_TYPE, APP_SOAP_XML.toRfcString());
     HttpRequest request = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/services/Echo")
         .setMethod(POST.name()).setEntity(new InputStreamHttpEntity(xml)).setHeaders(headersMap).build();
 
     HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
     String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
     assertTrue(payload.contains("Hello!"));
-    assertEquals("text/xml; charset=UTF-8", response.getHeaderValue("content-type"));
+    assertEquals("text/xml; charset=UTF-8", response.getHeaderValueIgnoreCase(CONTENT_TYPE));
     muleContext.getRegistry().lookupObject(SensingNullRequestResponseMessageProcessor.class).assertRequestResponseThreadsSame();
   }
 

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBadSoapRequestTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBadSoapRequestTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertEquals;
+import static org.mule.runtime.api.metadata.MediaType.XML;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import org.mule.runtime.core.util.IOUtils;
@@ -17,6 +18,7 @@ import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.dom4j.Document;
@@ -50,7 +52,7 @@ public class CxfBadSoapRequestTestCase extends AbstractCxfOverHttpExtensionTestC
 
     HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
 
-    assertEquals("text/xml; charset=UTF-8", response.getHeaderValueIgnoreCase(CONTENT_TYPE));
+    assertEquals(XML.withCharset(StandardCharsets.UTF_8), response.getHeaderValueIgnoreCase(CONTENT_TYPE));
     String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
 
     Document document = DocumentHelper.parseText(payload);

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBadSoapRequestTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBadSoapRequestTestCase.java
@@ -8,7 +8,7 @@ package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertEquals;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-import org.mule.runtime.core.api.client.MuleClient;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
@@ -50,7 +50,7 @@ public class CxfBadSoapRequestTestCase extends AbstractCxfOverHttpExtensionTestC
 
     HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
 
-    assertEquals("text/xml; charset=UTF-8", response.getHeaderValue("content-type"));
+    assertEquals("text/xml; charset=UTF-8", response.getHeaderValueIgnoreCase(CONTENT_TYPE));
     String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
 
     Document document = DocumentHelper.parseText(payload);

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBadSoapRequestTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBadSoapRequestTestCase.java
@@ -31,7 +31,7 @@ public class CxfBadSoapRequestTestCase extends AbstractCxfOverHttpExtensionTestC
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBasicTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBasicTestCase.java
@@ -35,7 +35,7 @@ public class CxfBasicTestCase extends AbstractCxfOverHttpExtensionTestCase {
   private String echoWsdl;
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBasicTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfBasicTestCase.java
@@ -9,6 +9,7 @@ package org.mule.compatibility.module.cxf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.core.util.IOUtils;
@@ -62,14 +63,14 @@ public class CxfBasicTestCase extends AbstractCxfOverHttpExtensionTestCase {
 
     HttpRequest request =
         HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/services/Echo").setMethod(POST.name())
-            .setEntity(new InputStreamHttpEntity(xml)).addHeader("content-type", APP_SOAP_XML.toRfcString()).build();
+            .setEntity(new InputStreamHttpEntity(xml)).addHeader(CONTENT_TYPE, APP_SOAP_XML.toRfcString()).build();
 
     HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
 
     String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
 
     assertTrue(payload.contains("Hello!"));
-    assertEquals("text/xml; charset=UTF-8", response.getHeaderValue("content-type"));
+    assertEquals("text/xml; charset=UTF-8", response.getHeaderValueIgnoreCase(CONTENT_TYPE));
   }
 
   @Test

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfComponentExceptionStrategyTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfComponentExceptionStrategyTestCase.java
@@ -8,14 +8,13 @@ package org.mule.compatibility.module.cxf;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.service.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -44,7 +43,7 @@ public class CxfComponentExceptionStrategyTestCase extends AbstractCxfOverHttpEx
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfCustomHttpHeaderTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfCustomHttpHeaderTestCase.java
@@ -52,7 +52,7 @@ public class CxfCustomHttpHeaderTestCase extends AbstractCxfOverHttpExtensionTes
   private List<Message> notificationMsgList = new ArrayList<>();
   private Latch latch = new Latch();
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfCustomHttpHeaderTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfCustomHttpHeaderTestCase.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_IGNORE_METHOD_PROPERTY;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_METHOD_PROPERTY;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_USER_PROPERTY;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
 import org.mule.extension.http.api.HttpRequestAttributes;

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfErrorBehaviorTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfErrorBehaviorTestCase.java
@@ -48,7 +48,7 @@ public class CxfErrorBehaviorTestCase extends AbstractCxfOverHttpExtensionTestCa
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfErrorBehaviorTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/CxfErrorBehaviorTestCase.java
@@ -6,25 +6,23 @@
  */
 package org.mule.compatibility.module.cxf;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mule.functional.junit4.matchers.ThrowableCauseMatcher.hasCause;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-import static org.mule.runtime.module.http.api.HttpConstants.ResponseProperties.HTTP_STATUS_PROPERTY;
 
-import org.mule.runtime.core.api.client.MuleClient;
-import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.config.i18n.CoreMessages;
 import org.mule.runtime.core.exception.MessagingException;
 import org.mule.runtime.core.transformer.AbstractTransformer;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import java.nio.charset.Charset;
@@ -49,9 +47,8 @@ public class CxfErrorBehaviorTestCase extends AbstractCxfOverHttpExtensionTestCa
   public DynamicPort dynamicPort = new DynamicPort("port1");
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
-
-  public static final HttpRequestOptions HTTP_REQUEST_OPTIONS =
-      newOptions().method(POST.name()).disableStatusCodeValidation().build();
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
 
   @Override
   protected String getConfigFile() {
@@ -60,54 +57,53 @@ public class CxfErrorBehaviorTestCase extends AbstractCxfOverHttpExtensionTestCa
 
   @Test
   public void testFaultInCxfService() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestFaultPayload).build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage response =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/testServiceWithFault", request, HTTP_REQUEST_OPTIONS)
-            .getRight();
-    assertNotNull(response);
-    assertTrue(getPayloadAsString(response).contains("<faultstring>"));
-    assertEquals(String.valueOf(INTERNAL_SERVER_ERROR.getStatusCode()),
-                 response.getInboundProperty(HTTP_STATUS_PROPERTY).toString());
+    HttpRequest request = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/testServiceWithFault")
+        .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestFaultPayload.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+
+    assertTrue(payload.contains("<faultstring>"));
+    assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
   }
 
   @Test
   public void testFaultInCxfSimpleService() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestPayload).build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage response =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/testSimpleServiceWithFault", request, HTTP_REQUEST_OPTIONS)
-            .getRight();
-    assertNotNull(response);
-    assertTrue(getPayloadAsString(response).contains("<faultstring>"));
-    assertEquals(String.valueOf(INTERNAL_SERVER_ERROR.getStatusCode()),
-                 response.getInboundProperty(HTTP_STATUS_PROPERTY).toString());
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/testSimpleServiceWithFault")
+            .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+
+    assertTrue(payload.contains("<faultstring>"));
+    assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
   }
 
   @Test
   public void testExceptionThrownInTransformer() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestPayload).build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage response =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/testTransformerException", request, HTTP_REQUEST_OPTIONS)
-            .getRight();
-    assertNotNull(response);
-    assertTrue(getPayloadAsString(response).contains("<faultstring>"));
-    assertEquals(String.valueOf(INTERNAL_SERVER_ERROR.getStatusCode()),
-                 response.getInboundProperty(HTTP_STATUS_PROPERTY).toString());
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/testTransformerException")
+            .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+
+    assertTrue(payload.contains("<faultstring>"));
+    assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
   }
 
   @Test
   public void testUnwrapException() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestPayload).build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage response =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/testUnwrapException", request, HTTP_REQUEST_OPTIONS)
-            .getRight();
-    assertNotNull(response);
-    assertTrue(getPayloadAsString(response).contains("Illegal argument!!"));
-    assertEquals(String.valueOf(INTERNAL_SERVER_ERROR.getStatusCode()),
-                 response.getInboundProperty(HTTP_STATUS_PROPERTY).toString());
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/testUnwrapException")
+            .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+
+    assertTrue(payload.contains("Illegal argument!!"));
+    assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
   }
 
   @Test
@@ -124,38 +120,41 @@ public class CxfErrorBehaviorTestCase extends AbstractCxfOverHttpExtensionTestCa
 
   @Test
   public void testServerClientProxyWithFault() throws Exception {
-    MuleClient client = muleContext.getClient();
-    InternalMessage result = client.send("http://localhost:" + dynamicPort.getNumber() + "/testProxyWithFault",
-                                         InternalMessage.of(requestFaultPayload), HTTP_REQUEST_OPTIONS)
-        .getRight();
-    String resString = getPayloadAsString(result);
-    assertThat(resString, containsString("<faultstring>Cxf Exception Message</faultstring>"));
-    assertEquals(String.valueOf(INTERNAL_SERVER_ERROR.getStatusCode()),
-                 result.getInboundProperty(HTTP_STATUS_PROPERTY).toString());
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/testProxyWithFault")
+            .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestFaultPayload.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+
+    assertTrue(payload.contains("<faultstring>Cxf Exception Message</faultstring>"));
+    assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
   }
 
   @Test
   public void testServerClientProxyWithTransformerException() throws Exception {
-    MuleClient client = muleContext.getClient();
-    InternalMessage result = client.send("http://localhost:" + dynamicPort.getNumber() + "/testProxyWithTransformerException",
-                                         InternalMessage.of(requestPayload), HTTP_REQUEST_OPTIONS)
-        .getRight();
-    String resString = getPayloadAsString(result);
-    assertTrue(resString.contains("TransformerException"));
-    assertEquals(String.valueOf(INTERNAL_SERVER_ERROR.getStatusCode()),
-                 result.getInboundProperty(HTTP_STATUS_PROPERTY).toString());
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/testProxyWithTransformerException")
+            .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+
+    assertTrue(payload.contains("TransformerException"));
+    assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
   }
 
   @Test
   public void testServerClientJaxwsWithUnwrapFault() throws Exception {
-    MuleClient client = muleContext.getClient();
-    InternalMessage result = client.send("http://localhost:" + dynamicPort.getNumber() + "/testUnwrapProxyFault",
-                                         InternalMessage.of(requestPayload), HTTP_REQUEST_OPTIONS)
-        .getRight();
-    String resString = getPayloadAsString(result);
-    assertThat(resString, containsString("Illegal argument!!"));
-    assertEquals(String.valueOf(INTERNAL_SERVER_ERROR.getStatusCode()),
-                 result.getInboundProperty(HTTP_STATUS_PROPERTY).toString());
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/testUnwrapProxyFault")
+            .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+
+    assertTrue(payload.contains("Illegal argument!!"));
+    assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatusCode());
   }
 
   public static class CxfTransformerThrowsExceptions extends AbstractTransformer {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/DatabindingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/DatabindingTestCase.java
@@ -8,13 +8,12 @@ package org.mule.compatibility.module.cxf;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertNotNull;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.service.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -28,7 +27,7 @@ public class DatabindingTestCase extends AbstractCxfOverHttpExtensionTestCase {
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ExceptionStrategyTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ExceptionStrategyTestCase.java
@@ -56,7 +56,7 @@ public class ExceptionStrategyTestCase extends AbstractCxfOverHttpExtensionTestC
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/GZIPEncodingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/GZIPEncodingTestCase.java
@@ -49,7 +49,7 @@ public class GZIPEncodingTestCase extends AbstractCxfOverHttpExtensionTestCase {
   private String getAllRequest;
   private String getAllResponse;
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   @Before

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/GZIPEncodingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/GZIPEncodingTestCase.java
@@ -11,6 +11,7 @@ package org.mule.compatibility.module.cxf;
 import static org.custommonkey.xmlunit.XMLUnit.compareXML;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mule.extension.http.api.HttpHeaders.Names.CONTENT_ENCODING;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
 import org.mule.runtime.core.util.IOUtils;

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/GZIPEncodingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/GZIPEncodingTestCase.java
@@ -11,24 +11,22 @@ package org.mule.compatibility.module.cxf;
 import static org.custommonkey.xmlunit.XMLUnit.compareXML;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_ENCODING;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
-import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.util.IOUtils;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
+import org.mule.service.http.api.domain.ParameterMap;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Serializable;
 import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -38,8 +36,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class GZIPEncodingTestCase extends AbstractCxfOverHttpExtensionTestCase {
-
-  private static final HttpRequestOptions HTTP_REQUEST_OPTIONS = newOptions().method(POST.name()).build();
 
   private static final String GZIP = "gzip";
 
@@ -51,6 +47,8 @@ public class GZIPEncodingTestCase extends AbstractCxfOverHttpExtensionTestCase {
 
   private String getAllRequest;
   private String getAllResponse;
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
 
   @Override
   @Before
@@ -67,27 +65,36 @@ public class GZIPEncodingTestCase extends AbstractCxfOverHttpExtensionTestCase {
 
   @Test
   public void proxyWithGZIPResponse() throws Exception {
-    InternalMessage response = muleContext.getClient().send("http://localhost:" + httpPortProxy.getNumber() + "/proxy",
-                                                            InternalMessage.of(getAllRequest), HTTP_REQUEST_OPTIONS)
-        .getRight();
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + httpPortProxy.getNumber() + "/proxy")
+            .setMethod(POST.name())
+            .setEntity(new ByteArrayHttpEntity(getAllRequest.getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
     validateResponse(response);
   }
 
   @Test
   public void proxyWithGZIPRequestAndResponse() throws Exception {
-    Map<String, Serializable> properties = new HashMap<>();
-    properties.put(CONTENT_ENCODING, "gzip,deflate");
-    InternalMessage response = muleContext.getClient()
-        .send("http://localhost:" + httpPortProxy.getNumber() + "/proxy",
-              InternalMessage.builder().payload(gzip(getAllRequest)).outboundProperties(properties).build(), HTTP_REQUEST_OPTIONS)
-        .getRight();
+    ParameterMap headersMap = new ParameterMap();
+    headersMap.put(CONTENT_ENCODING, "gzip,deflate");
+
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + httpPortProxy.getNumber() + "/proxy")
+            .setMethod(POST.name())
+            .setHeaders(headersMap)
+            .setEntity(new ByteArrayHttpEntity(gzip(getAllRequest))).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
     validateResponse(response);
   }
 
-  private void validateResponse(InternalMessage response) throws Exception {
-    String unzipped = unzip(new ByteArrayInputStream(getPayloadAsBytes(response)));
+  private void validateResponse(HttpResponse response) throws Exception {
+    String unzipped = unzip(((InputStreamHttpEntity) response.getEntity()).getInputStream());
     assertThat(unzipped, compareXML(getAllResponse, unzipped).identical(), is(true));
-    assertThat(response.getInboundProperty(CONTENT_ENCODING), is(GZIP));
+    assertThat(response.getHeaderValue("content-encoding"), is(GZIP));
   }
 
   private String unzip(InputStream input) throws IOException {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/HolderNonBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/HolderNonBlockingTestCase.java
@@ -7,18 +7,18 @@
 package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
-import org.mule.runtime.core.api.client.MuleClient;
-import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.transformer.AbstractTransformer;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.SensingNullRequestResponseMessageProcessor;
 import org.mule.tck.junit4.rule.DynamicPort;
 
-import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.nio.charset.Charset;
 
@@ -34,6 +34,9 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
+
   @Override
   protected String getConfigFile() {
     return "holder-conf-httpn-nb.xml";
@@ -42,13 +45,14 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Test
   @Ignore("MULE-10618")
   public void testClientEchoHolder() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("TEST").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/echoClient", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    assertNotNull(received);
-    Object[] payload = deserializeResponse(received);
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echoClient")
+            .setMethod(POST.name())
+            .setEntity(new ByteArrayHttpEntity("TEST".getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    Object[] payload = deserializeResponse(response);
     assertEquals("one-response", payload[0]);
     assertEquals(null, payload[1]);
     assertEquals("one-holder1", ((Holder) payload[2]).value);
@@ -59,13 +63,14 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Test
   @Ignore("MULE-10618")
   public void testClientProxyEchoHolder() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("TEST").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/echoClientProxy", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    assertNotNull(received);
-    Object[] payload = deserializeResponse(received);
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echoClientProxy")
+            .setMethod(POST.name())
+            .setEntity(new ByteArrayHttpEntity("TEST".getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    Object[] payload = deserializeResponse(response);
     assertEquals("one-response", payload[0]);
     assertEquals("one-holder1", ((Holder) payload[1]).value);
     assertEquals("one-holder2", ((Holder) payload[2]).value);
@@ -75,13 +80,14 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Test
   @Ignore("MULE-10618")
   public void testClientEcho2Holder() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("TEST").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/echo2Client", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    assertNotNull(received);
-    Object[] payload = deserializeResponse(received);
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echo2Client")
+            .setMethod(POST.name())
+            .setEntity(new ByteArrayHttpEntity("TEST".getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    Object[] payload = deserializeResponse(response);
     assertEquals("one-response", payload[0]);
     assertEquals(null, payload[1]);
     assertEquals("two-holder", ((Holder) payload[2]).value);
@@ -91,13 +97,14 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Test
   @Ignore("MULE-10618")
   public void testClientProxyEcho2Holder() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("TEST").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/echo2ClientProxy", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    assertNotNull(received);
-    Object[] payload = deserializeResponse(received);
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echo2ClientProxy")
+            .setMethod(POST.name())
+            .setEntity(new ByteArrayHttpEntity("TEST".getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    Object[] payload = deserializeResponse(response);
     assertEquals("one-response", payload[0]);
     assertEquals("two-holder", ((Holder) payload[1]).value);
     getSensingInstance("sensingRequestResponseProcessorEchoProxy2").assertRequestResponseThreadsSame();
@@ -106,13 +113,15 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Test
   @Ignore("MULE-10618")
   public void testClientEcho3Holder() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("TEST").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/echo3Client", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    assertNotNull(received);
-    Object[] payload = deserializeResponse(received);
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echo3Client")
+            .setMethod(POST.name())
+            .setEntity(new ByteArrayHttpEntity("TEST".getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    Object[] payload = deserializeResponse(response);
+
     assertEquals(null, payload[0]);
     assertEquals("one", ((Holder) payload[1]).value);
     getSensingInstance("sensingRequestResponseProcessorEcho3").assertRequestResponseThreadsDifferent();
@@ -121,13 +130,14 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   @Test
   @Ignore("MULE-10618")
   public void testClientProxyEcho3Holder() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("TEST").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/echo3ClientProxy", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    assertNotNull(received);
-    Object[] payload = deserializeResponse(received);
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echo3ClientProxy")
+            .setMethod(POST.name())
+            .setEntity(new ByteArrayHttpEntity("TEST".getBytes())).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    Object[] payload = deserializeResponse(response);
     assertEquals(null, payload[0]);
     assertEquals("one", ((Holder) payload[1]).value);
     getSensingInstance("sensingRequestResponseProcessorEchoProxy3").assertRequestResponseThreadsSame();
@@ -137,8 +147,8 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
     return ((SensingNullRequestResponseMessageProcessor) muleContext.getRegistry().lookupObject(instanceBeanName));
   }
 
-  private static <T> T deserializeResponse(InternalMessage received) throws Exception {
-    ObjectInputStream objectInputStream = new ObjectInputStream((InputStream) received.getPayload().getValue());
+  private static <T> T deserializeResponse(HttpResponse received) throws Exception {
+    ObjectInputStream objectInputStream = new ObjectInputStream(((InputStreamHttpEntity) received.getEntity()).getInputStream());
     Object objectPayload = objectInputStream.readObject();
     return (T) objectPayload;
   }

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/HolderNonBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/HolderNonBlockingTestCase.java
@@ -35,7 +35,7 @@ public class HolderNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestC
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/OnErrorContinueTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/OnErrorContinueTestCase.java
@@ -67,7 +67,7 @@ public class OnErrorContinueTestCase extends AbstractCxfOverHttpExtensionTestCas
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/OnErrorContinueTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/OnErrorContinueTestCase.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mule.service.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.mule.service.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyNonBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyNonBlockingTestCase.java
@@ -8,14 +8,13 @@ package org.mule.compatibility.module.cxf;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.service.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.tck.SensingNullRequestResponseMessageProcessor;
 import org.mule.tck.junit4.rule.DynamicPort;
 
@@ -41,7 +40,7 @@ public class ProxyNonBlockingTestCase extends AbstractCxfOverHttpExtensionTestCa
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyRPCBindingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyRPCBindingTestCase.java
@@ -34,7 +34,7 @@ public class ProxyRPCBindingTestCase extends AbstractCxfOverHttpExtensionTestCas
   private String getAllRequest;
   private String getAllResponse;
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxySoapVersionTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxySoapVersionTestCase.java
@@ -7,14 +7,13 @@
 package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertTrue;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.service.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -38,7 +37,7 @@ public class ProxySoapVersionTestCase extends AbstractCxfOverHttpExtensionTestCa
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyTestCase.java
@@ -57,7 +57,7 @@ public class ProxyTestCase extends AbstractCxfOverHttpExtensionTestCase {
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyTestCase.java
@@ -17,7 +17,6 @@ import static org.mule.compatibility.module.cxf.SoapConstants.SOAP_ACTION_PROPER
 import static org.mule.service.http.api.HttpConstants.HttpStatus.ACCEPTED;
 import static org.mule.service.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.compatibility.module.cxf.testmodels.AsyncService;
 import org.mule.compatibility.module.cxf.testmodels.AsyncServiceWithSoapAction;
 import org.mule.functional.functional.FunctionalTestComponent;
@@ -32,7 +31,9 @@ import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyValidationComparisonTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyValidationComparisonTestCase.java
@@ -36,7 +36,7 @@ public class ProxyValidationComparisonTestCase extends AbstractCxfOverHttpExtens
   public final DynamicPort httpPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWSDLRewriteAddressTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWSDLRewriteAddressTestCase.java
@@ -8,13 +8,12 @@
 package org.mule.compatibility.module.cxf;
 
 import static junit.framework.Assert.assertEquals;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.service.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import java.io.StringReader;
@@ -36,7 +35,7 @@ public class ProxyWSDLRewriteAddressTestCase extends AbstractCxfOverHttpExtensio
   @Rule
   public final DynamicPort httpPort = new DynamicPort("port1");
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWSDLRewriteSchemaLocationsTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWSDLRewriteSchemaLocationsTestCase.java
@@ -45,7 +45,7 @@ public class ProxyWSDLRewriteSchemaLocationsTestCase extends AbstractCxfOverHttp
   public final DynamicPort httpPortMockServer = new DynamicPort("portMockServer");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   private MuleContext mockServerContext;
 

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWithValidationTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWithValidationTestCase.java
@@ -7,14 +7,13 @@
 package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertTrue;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.service.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -29,7 +28,7 @@ public class ProxyWithValidationTestCase extends AbstractCxfOverHttpExtensionTes
   @Rule
   public final DynamicPort httpPort = new DynamicPort("port1");
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWithValidationTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/ProxyWithValidationTestCase.java
@@ -7,11 +7,14 @@
 package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
-import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -19,15 +22,14 @@ import org.junit.Test;
 
 public class ProxyWithValidationTestCase extends AbstractCxfOverHttpExtensionTestCase {
 
-  private static final HttpRequestOptions HTTP_REQUEST_OPTIONS =
-      newOptions().method(POST.name()).disableStatusCodeValidation().build();
-
   public static final String SAMPLE_REQUEST = "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">"
       + "<soap:Body> " + "<echo xmlns=\"http://www.muleumo.org\">" + "  <echo><![CDATA[bla]]></echo>" + "</echo>" + "</soap:Body>"
       + "</soap:Envelope>";
 
   @Rule
   public final DynamicPort httpPort = new DynamicPort("port1");
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
 
   @Override
   protected String getConfigFile() {
@@ -36,10 +38,11 @@ public class ProxyWithValidationTestCase extends AbstractCxfOverHttpExtensionTes
 
   @Test
   public void acceptsRequestWithCData() throws Exception {
-    InternalMessage response = muleContext.getClient().send("http://localhost:" + httpPort.getNumber() + "/services/Echo",
-                                                            InternalMessage.of(SAMPLE_REQUEST), HTTP_REQUEST_OPTIONS)
-        .getRight();
+    HttpRequest request = HttpRequest.builder().setUri("http://localhost:" + httpPort.getNumber() + "/services/Echo")
+        .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(SAMPLE_REQUEST.getBytes())).build();
 
-    assertTrue(getPayloadAsString(response).contains("bla"));
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+    assertTrue(payload.contains("bla"));
   }
 }

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/SoapRequestNoMethodParamTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/SoapRequestNoMethodParamTestCase.java
@@ -7,14 +7,13 @@
 package org.mule.compatibility.module.cxf;
 
 import static org.junit.Assert.assertEquals;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
 import org.mule.service.http.api.domain.message.request.HttpRequest;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
 import org.mule.services.http.TestHttpClient;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -31,7 +30,7 @@ public class SoapRequestNoMethodParamTestCase extends AbstractCxfOverHttpExtensi
   public DynamicPort port1 = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/UsernameTokenProxyWithoutMustUnderstandTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/UsernameTokenProxyWithoutMustUnderstandTestCase.java
@@ -30,7 +30,7 @@ public class UsernameTokenProxyWithoutMustUnderstandTestCase extends AbstractCxf
   public final DynamicPort httpPortProxy = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   private String request;
   private String response;

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeNonBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeNonBlockingTestCase.java
@@ -8,12 +8,13 @@ package org.mule.compatibility.module.cxf.functional;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
-import org.mule.runtime.core.api.client.MuleClient;
-import org.mule.runtime.core.api.message.InternalMessage;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.SensingNullRequestResponseMessageProcessor;
 import org.mule.tck.junit4.rule.DynamicPort;
 
@@ -31,6 +32,9 @@ public class CxfContentTypeNonBlockingTestCase extends AbstractCxfOverHttpExtens
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
+
   @Override
   protected String getConfigFile() {
     return "cxf-echo-service-conf-httpn-nb.xml";
@@ -39,26 +43,28 @@ public class CxfContentTypeNonBlockingTestCase extends AbstractCxfOverHttpExtens
   @Test
   @Ignore("MULE-10618")
   public void testCxfService() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestPayload).build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/hello", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    String contentType = received.getPayload().getDataType().getMediaType().toRfcString();
-    assertNotNull(contentType);
+    HttpRequest httpRequest =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/hello")
+            .setEntity(new ByteArrayHttpEntity(requestPayload.getBytes()))
+            .setMethod(POST.name()).build();
+
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    String contentType = httpResponse.getHeaderValue("content-type");
     assertTrue(contentType.contains("charset"));
   }
 
   @Test
   @Ignore("MULE-10618")
   public void testCxfClient() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("hello").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/helloClient", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    String contentType = received.getInboundProperty("contentType");
-    assertNotNull(contentType);
+    HttpRequest httpRequest =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/helloClient")
+            .setEntity(new ByteArrayHttpEntity("hello".getBytes()))
+            .setMethod(POST.name()).build();
+
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    String contentType = httpResponse.getHeaderValue("content-type");
     assertTrue(contentType.contains("charset"));
     getSensingInstance("sensingRequestResponseProcessor").assertRequestResponseThreadsDifferent();
   }
@@ -66,12 +72,14 @@ public class CxfContentTypeNonBlockingTestCase extends AbstractCxfOverHttpExtens
   @Test
   @Ignore("MULE-10618")
   public void testCxfClientProxy() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload("hello").build();
-    MuleClient client = muleContext.getClient();
-    InternalMessage received = client.send("http://localhost:" + dynamicPort.getNumber() + "/helloClientProxy", request,
-                                           newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    String contentType = received.getInboundProperty("contentType");
+    HttpRequest httpRequest =
+        HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/helloClientProxy")
+            .setEntity(new ByteArrayHttpEntity("hello".getBytes()))
+            .setMethod(POST.name()).build();
+
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    String contentType = httpResponse.getHeaderValue("content-type");
     assertNotNull(contentType);
     assertTrue(contentType.contains("charset"));
     getSensingInstance("sensingRequestResponseProcessorProxy").assertRequestResponseThreadsDifferent();

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeNonBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeNonBlockingTestCase.java
@@ -34,7 +34,7 @@ public class CxfContentTypeNonBlockingTestCase extends AbstractCxfOverHttpExtens
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeNonBlockingTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeNonBlockingTestCase.java
@@ -9,6 +9,7 @@ package org.mule.compatibility.module.cxf.functional;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
 import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
@@ -50,7 +51,7 @@ public class CxfContentTypeNonBlockingTestCase extends AbstractCxfOverHttpExtens
 
     HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    String contentType = httpResponse.getHeaderValue("content-type");
+    String contentType = httpResponse.getHeaderValueIgnoreCase(CONTENT_TYPE);
     assertTrue(contentType.contains("charset"));
   }
 
@@ -64,7 +65,7 @@ public class CxfContentTypeNonBlockingTestCase extends AbstractCxfOverHttpExtens
 
     HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    String contentType = httpResponse.getHeaderValue("content-type");
+    String contentType = httpResponse.getHeaderValueIgnoreCase(CONTENT_TYPE);
     assertTrue(contentType.contains("charset"));
     getSensingInstance("sensingRequestResponseProcessor").assertRequestResponseThreadsDifferent();
   }
@@ -79,7 +80,7 @@ public class CxfContentTypeNonBlockingTestCase extends AbstractCxfOverHttpExtens
 
     HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    String contentType = httpResponse.getHeaderValue("content-type");
+    String contentType = httpResponse.getHeaderValueIgnoreCase(CONTENT_TYPE);
     assertNotNull(contentType);
     assertTrue(contentType.contains("charset"));
     getSensingInstance("sensingRequestResponseProcessorProxy").assertRequestResponseThreadsDifferent();

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeTestCase.java
@@ -9,6 +9,7 @@ package org.mule.compatibility.module.cxf.functional;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
 import org.mule.runtime.core.api.message.InternalMessage;
@@ -47,7 +48,7 @@ public class CxfContentTypeTestCase extends AbstractCxfOverHttpExtensionTestCase
 
     HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    String contentType = httpResponse.getHeaderValue("content-type");
+    String contentType = httpResponse.getHeaderValueIgnoreCase(CONTENT_TYPE);
     assertTrue(contentType.contains("charset"));
   }
 

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfContentTypeTestCase.java
@@ -32,7 +32,7 @@ public class CxfContentTypeTestCase extends AbstractCxfOverHttpExtensionTestCase
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfDataTypeTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfDataTypeTestCase.java
@@ -8,21 +8,26 @@ package org.mule.compatibility.module.cxf.functional;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
 import static org.mule.compatibility.module.cxf.CxfBasicTestCase.APP_SOAP_XML;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.core.api.MuleEventContext;
-import org.mule.runtime.core.api.client.MuleClient;
 import org.mule.runtime.core.api.lifecycle.Callable;
 import org.mule.runtime.core.api.message.InternalMessage;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.domain.ParameterMap;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -35,6 +40,9 @@ public class CxfDataTypeTestCase extends AbstractCxfOverHttpExtensionTestCase {
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
+
   @Override
   protected String getConfigFile() {
     return "cxf-datatype-conf.xml";
@@ -42,45 +50,50 @@ public class CxfDataTypeTestCase extends AbstractCxfOverHttpExtensionTestCase {
 
   @Test
   public void testCxfService() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestPayload).build();
-    InternalMessage received = muleContext.getClient().send("http://localhost:" + dynamicPort.getNumber() + "/hello", request,
-                                                            newOptions().method(POST.name()).disableStatusCodeValidation()
-                                                                .build())
-        .getRight();
-    Assert.assertThat(getPayloadAsString(received), not(containsString("Fault")));
+    HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/hello")
+        .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
+
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertThat(payload, not(containsString("Fault")));
   }
 
   @Test
   public void testCxfClient() throws Exception {
     InternalMessage received = flowRunner("helloServiceClient").withPayload("hello").run().getMessage();
-    Assert.assertThat(getPayloadAsString(received), not(containsString("Fault")));
+    assertThat(getPayloadAsString(received), not(containsString("Fault")));
   }
 
   @Test
   public void testCxfProxy() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestPayload).build();
-    InternalMessage received =
-        muleContext.getClient().send("http://localhost:" + dynamicPort.getNumber() + "/hello-proxy", request,
-                                     newOptions().method(POST.name()).disableStatusCodeValidation().build())
-            .getRight();
-    Assert.assertThat(getPayloadAsString(received), not(containsString("Fault")));
+    HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/hello-proxy")
+        .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
+
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertThat(payload, not(containsString("Fault")));
   }
 
   @Test
   public void testCxfSimpleService() throws Exception {
-    MuleClient client = muleContext.getClient();
     InputStream xml = getClass().getResourceAsStream("/direct/direct-request.xml");
-    InternalMessage result = client.send("http://localhost:" + dynamicPort.getNumber() + "/echo",
-                                         InternalMessage.builder().payload(xml).mediaType(APP_SOAP_XML).build(),
-                                         newOptions().method(POST.name()).disableStatusCodeValidation().build())
-        .getRight();
-    Assert.assertThat(getPayloadAsString(result), not(containsString("Fault")));
+    ParameterMap headersMap = new ParameterMap();
+    headersMap.put("content-type", APP_SOAP_XML.toRfcString());
+
+    HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echo")
+        .setMethod(POST.name()).setEntity(new InputStreamHttpEntity(xml)).setHeaders(headersMap).build();
+
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertThat(payload, not(containsString("Fault")));
   }
 
   @Test
   public void testCxfSimpleClient() throws Exception {
     InternalMessage received = flowRunner("helloServiceClient").withPayload("hello").run().getMessage();
-    Assert.assertThat(getPayloadAsString(received), not(containsString("Fault")));
+    assertThat(getPayloadAsString(received), not(containsString("Fault")));
   }
 
   public static class EnsureXmlDataType extends EnsureDataType {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfDataTypeTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfDataTypeTestCase.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mule.compatibility.module.cxf.CxfBasicTestCase.APP_SOAP_XML;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
 import org.mule.runtime.api.metadata.MediaType;
@@ -79,7 +80,7 @@ public class CxfDataTypeTestCase extends AbstractCxfOverHttpExtensionTestCase {
   public void testCxfSimpleService() throws Exception {
     InputStream xml = getClass().getResourceAsStream("/direct/direct-request.xml");
     ParameterMap headersMap = new ParameterMap();
-    headersMap.put("content-type", APP_SOAP_XML.toRfcString());
+    headersMap.put(CONTENT_TYPE, APP_SOAP_XML.toRfcString());
 
     HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/echo")
         .setMethod(POST.name()).setEntity(new InputStreamHttpEntity(xml)).setHeaders(headersMap).build();

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfDataTypeTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfDataTypeTestCase.java
@@ -42,7 +42,7 @@ public class CxfDataTypeTestCase extends AbstractCxfOverHttpExtensionTestCase {
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
 import org.mule.runtime.core.util.IOUtils;
@@ -67,7 +68,7 @@ public class CxfJaxWsServiceAndClientTestCase extends AbstractCxfOverHttpExtensi
 
     HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    assertThat(httpResponse.getHeaderValue("content-type"),
+    assertThat(httpResponse.getHeaderValueIgnoreCase(CONTENT_TYPE),
                allOf(startsWith("multipart/related; charset=UTF-8; boundary=\"uuid:"),
                      endsWith("\"; start=\"<root.message@cxf.apache.org>\"; type=\"application/xop+xml\"; start-info=\"text/xml\"")));
 

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
@@ -9,30 +9,25 @@ package org.mule.compatibility.module.cxf.functional;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
-import org.mule.runtime.api.message.MultiPartPayload;
-import org.mule.runtime.core.api.client.MuleClient;
-import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
 import org.junit.Test;
 
 public class CxfJaxWsServiceAndClientTestCase extends AbstractCxfOverHttpExtensionTestCase {
-
-  @Rule
-  public DynamicPort port = new DynamicPort("port");
-
-  private static final HttpRequestOptions HTTP_REQUEST_OPTIONS = newOptions().method(POST.name()).build();
 
   private static final String REQUEST_PAYLOAD =
       "<soap:Envelope \n" + "           xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"\n"
@@ -43,6 +38,12 @@ public class CxfJaxWsServiceAndClientTestCase extends AbstractCxfOverHttpExtensi
       + "<soap:Body>" + "<ns2:sayHiResponse xmlns:ns2=\"http://example.cxf.module.compatibility.mule.org/\">" + "<return>"
       + "Hello\u2297 Test Message" + "</return>" + "</ns2:sayHiResponse>" + "</soap:Body>" + "</soap:Envelope>";
 
+  @Rule
+  public DynamicPort port = new DynamicPort("port");
+
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
+
   @Override
   protected String getConfigFile() {
     return "cxf-jaxws-service-and-client-config-httpn.xml";
@@ -50,26 +51,27 @@ public class CxfJaxWsServiceAndClientTestCase extends AbstractCxfOverHttpExtensi
 
   @Test
   public void jaxWsClientReadsMuleMethodPropertySetByJaxWsService() throws Exception {
-    String url = "http://localhost:" + port.getNumber() + "/hello";
-    MuleClient client = muleContext.getClient();
+    HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + port.getNumber() + "/hello")
+        .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(REQUEST_PAYLOAD.getBytes())).build();
 
-    InternalMessage result = client.send(url, InternalMessage.of(REQUEST_PAYLOAD), HTTP_REQUEST_OPTIONS).getRight();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    assertEquals(RESPONSE_PAYLOAD, getPayloadAsString(result));
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertEquals(RESPONSE_PAYLOAD, payload);
   }
 
   @Test
   public void jaxWsServerWithMtoMServiceHasCorrectContentType() throws Exception {
-    String url = "http://localhost:" + port.getNumber() + "/helloMtoM";
-    MuleClient client = muleContext.getClient();
+    HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + port.getNumber() + "/helloMtoM")
+        .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(REQUEST_PAYLOAD.getBytes())).build();
 
-    InternalMessage result = client.send(url, InternalMessage.of(REQUEST_PAYLOAD), HTTP_REQUEST_OPTIONS).getRight();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    assertThat(result.getPayload().getDataType().getMediaType().toRfcString(),
+    assertThat(httpResponse.getHeaderValue("content-type"),
                allOf(startsWith("multipart/related; charset=UTF-8; boundary=\"uuid:"),
                      endsWith("\"; start=\"<root.message@cxf.apache.org>\"; type=\"application/xop+xml\"; start-info=\"text/xml\"")));
-    final Object payloadValue = result.getPayload().getValue();
-    assertThat(payloadValue, instanceOf(MultiPartPayload.class));
-    assertThat(getPayloadAsString(((MultiPartPayload) payloadValue).getParts().get(0)), containsString(RESPONSE_PAYLOAD));
+
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertThat(payload, containsString(RESPONSE_PAYLOAD));
   }
 }

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/CxfJaxWsServiceAndClientTestCase.java
@@ -43,7 +43,7 @@ public class CxfJaxWsServiceAndClientTestCase extends AbstractCxfOverHttpExtensi
   public DynamicPort port = new DynamicPort("port");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/UnwrapsComponentExceptionTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/UnwrapsComponentExceptionTestCase.java
@@ -7,12 +7,16 @@
 package org.mule.compatibility.module.cxf.functional;
 
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
 import org.mule.compatibility.module.cxf.example.HelloWorld;
-import org.mule.runtime.core.api.message.InternalMessage;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import javax.jws.WebService;
@@ -31,6 +35,9 @@ public class UnwrapsComponentExceptionTestCase extends AbstractCxfOverHttpExtens
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
+
   @Override
   protected String getConfigFile() {
     return "unwraps-component-exception-config-httpn.xml";
@@ -38,14 +45,13 @@ public class UnwrapsComponentExceptionTestCase extends AbstractCxfOverHttpExtens
 
   @Test
   public void testReceivesComponentExceptionMessage() throws Exception {
-    InternalMessage request = InternalMessage.builder().payload(requestPayload).build();
+    HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/hello")
+        .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(requestPayload.getBytes())).build();
 
-    InternalMessage received = muleContext.getClient().send("http://localhost:" + dynamicPort.getNumber() + "/hello", request,
-                                                            newOptions().method(POST.name()).disableStatusCodeValidation()
-                                                                .build())
-        .getRight();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    assertTrue("Component exception was not managed", getPayloadAsString(received).contains(ERROR_MESSAGE));
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertTrue("Component exception was not managed", payload.contains(ERROR_MESSAGE));
   }
 
   @WebService(endpointInterface = "org.mule.compatibility.module.cxf.example.HelloWorld", serviceName = "HelloWorld")

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/UnwrapsComponentExceptionTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/functional/UnwrapsComponentExceptionTestCase.java
@@ -36,7 +36,7 @@ public class UnwrapsComponentExceptionTestCase extends AbstractCxfOverHttpExtens
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String getConfigFile() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/issues/ProxyMule6829TestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/issues/ProxyMule6829TestCase.java
@@ -45,7 +45,7 @@ public class ProxyMule6829TestCase extends AbstractCxfOverHttpExtensionTestCase 
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   private Latch latch;
   private TestCxfEventCallback testCxfEventCallback;

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/issues/ProxyMule6829TestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/issues/ProxyMule6829TestCase.java
@@ -10,6 +10,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mule.compatibility.module.cxf.CxfBasicTestCase.APP_SOAP_XML;
+import static org.mule.extension.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
 import org.mule.compatibility.module.cxf.AbstractCxfOverHttpExtensionTestCase;
@@ -176,7 +177,7 @@ public class ProxyMule6829TestCase extends AbstractCxfOverHttpExtensionTestCase 
       throws MuleException, IOException, TimeoutException {
     String contentType = APP_SOAP_XML.withCharset(UTF_8).toRfcString() + ";action=\"" + soapAction + "\"";
     ParameterMap headersMap = new ParameterMap();
-    headersMap.put("content-type", contentType);
+    headersMap.put(CONTENT_TYPE, contentType);
     HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/EchoService12")
         .setMethod(POST.name()).setEntity(new ByteArrayHttpEntity(msgString.getBytes())).setHeaders(headersMap).build();
 

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/wssec/UsernameTokenProxyTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/wssec/UsernameTokenProxyTestCase.java
@@ -9,9 +9,8 @@ package org.mule.compatibility.module.cxf.wssec;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import org.mule.functional.junit4.FunctionalTestCase;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-
+import org.mule.functional.junit4.FunctionalTestCase;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
@@ -34,7 +33,7 @@ public class UsernameTokenProxyTestCase extends FunctionalTestCase {
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
   @Rule
-  public TestHttpClient httpClient = new TestHttpClient();
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
 
   @Override
   protected String[] getConfigFiles() {

--- a/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/wssec/UsernameTokenProxyTestCase.java
+++ b/compatibility/modules/cxf/src/test/java/org/mule/compatibility/module/cxf/wssec/UsernameTokenProxyTestCase.java
@@ -9,16 +9,20 @@ package org.mule.compatibility.module.cxf.wssec;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
+import org.mule.functional.junit4.FunctionalTestCase;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
 
-import org.mule.functional.junit4.FunctionalTestCase;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -26,11 +30,11 @@ import org.junit.Test;
 
 public class UsernameTokenProxyTestCase extends FunctionalTestCase {
 
-  private static final HttpRequestOptions HTTP_REQUEST_OPTIONS =
-      newOptions().method(POST.name()).disableStatusCodeValidation().build();
-
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
+
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient();
 
   @Override
   protected String[] getConfigFiles() {
@@ -46,25 +50,32 @@ public class UsernameTokenProxyTestCase extends FunctionalTestCase {
   @Ignore("MULE-6926: Flaky Test")
   @Test
   public void testProxyEnvelope() throws Exception {
-    InternalMessage result = sendRequest("http://localhost:" + dynamicPort.getNumber() + "/proxy-envelope");
-    assertFalse(getPayloadAsString(result).contains("Fault"));
-    assertTrue(getPayloadAsString(result).contains("joe"));
+    HttpResponse httpResponse = sendRequest("http://localhost:" + dynamicPort.getNumber() + "/proxy-envelope");
+
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertFalse(payload.contains("Fault"));
+    assertTrue(payload.contains("joe"));
   }
 
   @Ignore("MULE-6926: Flaky Test")
   @Test
   public void testProxyBody() throws Exception {
-    InternalMessage result = sendRequest("http://localhost:" + dynamicPort.getNumber() + "/proxy-body");
+    HttpResponse httpResponse = sendRequest("http://localhost:" + dynamicPort.getNumber() + "/proxy-body");
 
-    assertFalse(getPayloadAsString(result).contains("Fault"));
-    assertFalse(getPayloadAsString(result).contains("joe"));
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    assertFalse(payload.contains("Fault"));
+    assertFalse(payload.contains("joe"));
   }
 
-  protected InternalMessage sendRequest(String url) throws MuleException {
+  protected HttpResponse sendRequest(String url) throws MuleException, IOException, TimeoutException {
     InputStream stream = getClass().getResourceAsStream(getMessageResource());
     assertNotNull(stream);
 
-    return muleContext.getClient().send(url, InternalMessage.builder().payload(stream).build(), HTTP_REQUEST_OPTIONS).getRight();
+    HttpRequest httpRequest = HttpRequest.builder().setUri(url).setEntity(new InputStreamHttpEntity(stream))
+        .setMethod(POST.name()).build();
+
+    return httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
   }
 
   protected String getMessageResource() {

--- a/compatibility/modules/cxf/src/test/resources/proxy-conf-flow-httpn.xml
+++ b/compatibility/modules/cxf/src/test/resources/proxy-conf-flow-httpn.xml
@@ -297,7 +297,9 @@
     </flow>
 
     <flow name="routeBasedOnSoapAction">
-        <httpn:listener path="/services/routeBasedOnSoapAction" config-ref="listenerConfig" allowedMethods="POST" />
+        <httpn:listener path="/services/routeBasedOnSoapAction" config-ref="listenerConfig" allowedMethods="POST" >
+            <httpn:response statusCode="#[mel:message.attributes.statusCode]"/>
+        </httpn:listener>
         <cxf:proxy-service bindingId="EchoBinding" namespace="http://new.webservice.namespace" service="EchoService" payload="body"
                            wsdlLocation="echo-11.wsdl" >
             <cxf:features>

--- a/compatibility/tests/integration-transports/pom.xml
+++ b/compatibility/tests/integration-transports/pom.xml
@@ -449,5 +449,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-http</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 </project>

--- a/compatibility/tests/integration-transports/src/test/java/org/mule/test/issues/Mule5415TestCase.java
+++ b/compatibility/tests/integration-transports/src/test/java/org/mule/test/issues/Mule5415TestCase.java
@@ -6,13 +6,17 @@
  */
 package org.mule.test.issues;
 
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mule.service.http.api.HttpConstants.HttpStatus.OK;
+import static org.mule.service.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import static org.mule.service.http.api.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
-
 import org.mule.functional.extensions.CompatibilityFunctionalTestCase;
-import org.mule.runtime.core.api.client.MuleClient;
-import org.mule.runtime.core.api.message.InternalMessage;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -24,17 +28,20 @@ public class Mule5415TestCase extends CompatibilityFunctionalTestCase {
   @Rule
   public DynamicPort port1 = new DynamicPort("port1");
 
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
+
   @Override
   protected String getConfigFile() {
     return "org/mule/issues/mule-5415-config.xml";
   }
 
   @Test
-  public void testFirstRequestDoesntFail() throws Exception {
-    MuleClient client = muleContext.getClient();
-    client.send(String.format("http://localhost:%s?param1=1&param2=3", port1.getNumber()),
-                InternalMessage.builder().payload("message").mediaType(APPLICATION_X_WWW_FORM_URLENCODED).build(),
-                newOptions().method(POST.name()).build())
-        .getRight();
+  public void testFirstRequestDoesNotFail() throws Exception {
+    HttpRequest httpRequest = HttpRequest.builder().setUri(format("http://localhost:%s?param1=1&param2=3", port1.getNumber()))
+        .addHeader(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED.toRfcString()).build();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    assertThat(httpResponse.getStatusCode(), is(OK.getStatusCode()));
   }
 }

--- a/modules/service/src/main/java/org/mule/runtime/module/service/MuleServiceManager.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/MuleServiceManager.java
@@ -75,7 +75,13 @@ public class MuleServiceManager implements ServiceManager {
   private void startServices() throws MuleException {
     for (Service service : registeredServices) {
       if (service instanceof Startable) {
-        ((Startable) service).start();
+        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+          Thread.currentThread().setContextClassLoader(service.getClass().getClassLoader());
+          ((Startable) service).start();
+        } finally {
+          Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+        }
       }
     }
   }

--- a/modules/service/src/main/java/org/mule/runtime/module/service/MuleServiceManager.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/MuleServiceManager.java
@@ -7,6 +7,7 @@
 
 package org.mule.runtime.module.service;
 
+import static java.lang.Thread.currentThread;
 import static java.util.Collections.unmodifiableList;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getServicesFolder;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
@@ -75,12 +76,12 @@ public class MuleServiceManager implements ServiceManager {
   private void startServices() throws MuleException {
     for (Service service : registeredServices) {
       if (service instanceof Startable) {
-        ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader originalContextClassLoader = currentThread().getContextClassLoader();
         try {
-          Thread.currentThread().setContextClassLoader(service.getClass().getClassLoader());
+          currentThread().setContextClassLoader(service.getClass().getClassLoader());
           ((Startable) service).start();
         } finally {
-          Thread.currentThread().setContextClassLoader(originalContextClassLoader);
+          currentThread().setContextClassLoader(originalContextClassLoader);
         }
       }
     }

--- a/services/http/pom.xml
+++ b/services/http/pom.xml
@@ -43,6 +43,19 @@
                 <version>1.0.0-SNAPSHOT</version>
                 <extensions>true</extensions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/services/http/src/test/java/org/mule/services/http/TestHttpClient.java
+++ b/services/http/src/test/java/org/mule/services/http/TestHttpClient.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.services.http;
+
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.api.tls.TlsContextFactory;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.client.HttpClientConfiguration;
+import org.mule.service.http.api.client.HttpRequestAuthentication;
+import org.mule.service.http.api.client.async.ResponseHandler;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.impl.service.HttpServiceImplementation;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.rules.ExternalResource;
+
+/**
+ * Defines a {@link org.mule.service.http.api.client.HttpClient} using a defualt implementation of {@link HttpService}
+ *
+ * <p/>
+ * This rule is intended to simplify the usage of the {@link org.mule.service.http.api.client.HttpClient} as it
+ * will be started/stopped as part of the test lifecycle.
+ */
+public class TestHttpClient extends ExternalResource implements org.mule.service.http.api.client.HttpClient {
+
+  private final TlsContextFactory tlsContextFactory;
+  private final HttpService httpService;
+  private org.mule.service.http.api.client.HttpClient httpClient;
+
+  public TestHttpClient() {
+    this(new HttpServiceImplementation(), null);
+  }
+
+  /**
+   * Creates a client using a default configuration
+   *
+   * @param httpService service instance that will be used on the client. Non null
+   */
+  public TestHttpClient(HttpService httpService) {
+    this(httpService, null);
+  }
+
+  /**
+   * Creates a custom client
+   *
+   * @param httpService service instance that will be used on the client. Non null
+   * @param tlsContextFactory the tls context factory for creating the context to secure the connection
+   */
+  public TestHttpClient(HttpService httpService, TlsContextFactory tlsContextFactory) {
+    checkArgument(httpService != null, "httpService cannot be null");
+    this.tlsContextFactory = tlsContextFactory;
+    this.httpService = httpService;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    HttpClientConfiguration.Builder builder = new HttpClientConfiguration.Builder();
+    if (tlsContextFactory != null) {
+      builder.setTlsContextFactory(tlsContextFactory);
+    }
+    HttpClientConfiguration configuration = builder.build();
+    httpClient = httpService.getClientFactory().create(configuration);
+    httpClient.start();
+  }
+
+  @Override
+  protected void after() {
+    if (httpClient != null) {
+      httpClient.stop();
+    }
+  }
+
+  @Override
+  public void start() {
+    httpClient.start();
+  }
+
+  @Override
+  public void stop() {
+    httpClient.stop();
+  }
+
+  @Override
+  public HttpResponse send(HttpRequest request, int responseTimeout, boolean followRedirects,
+                           HttpRequestAuthentication authentication)
+      throws IOException, TimeoutException {
+    return httpClient.send(request, responseTimeout, followRedirects, authentication);
+  }
+
+  @Override
+  public void send(HttpRequest request, int responseTimeout, boolean followRedirects, HttpRequestAuthentication authentication,
+                   ResponseHandler handler) {
+    httpClient.send(request, responseTimeout, followRedirects, authentication, handler);
+  }
+}

--- a/services/http/src/test/java/org/mule/services/http/TestHttpClient.java
+++ b/services/http/src/test/java/org/mule/services/http/TestHttpClient.java
@@ -31,32 +31,16 @@ import org.junit.rules.ExternalResource;
  */
 public class TestHttpClient extends ExternalResource implements org.mule.service.http.api.client.HttpClient {
 
-  private final TlsContextFactory tlsContextFactory;
   private final HttpService httpService;
+  private TlsContextFactory tlsContextFactory;
   private org.mule.service.http.api.client.HttpClient httpClient;
 
-  public TestHttpClient() {
-    this(new HttpServiceImplementation(), null);
+  private TestHttpClient() {
+    this(new HttpServiceImplementation());
   }
 
-  /**
-   * Creates a client using a default configuration
-   *
-   * @param httpService service instance that will be used on the client. Non null
-   */
-  public TestHttpClient(HttpService httpService) {
-    this(httpService, null);
-  }
-
-  /**
-   * Creates a custom client
-   *
-   * @param httpService service instance that will be used on the client. Non null
-   * @param tlsContextFactory the tls context factory for creating the context to secure the connection
-   */
-  public TestHttpClient(HttpService httpService, TlsContextFactory tlsContextFactory) {
+  private TestHttpClient(HttpService httpService) {
     checkArgument(httpService != null, "httpService cannot be null");
-    this.tlsContextFactory = tlsContextFactory;
     this.httpService = httpService;
   }
 
@@ -99,5 +83,55 @@ public class TestHttpClient extends ExternalResource implements org.mule.service
   public void send(HttpRequest request, int responseTimeout, boolean followRedirects, HttpRequestAuthentication authentication,
                    ResponseHandler handler) {
     httpClient.send(request, responseTimeout, followRedirects, authentication, handler);
+  }
+
+  public static class Builder {
+
+    private final HttpService service;
+    private TlsContextFactory tlsContextFactory;
+
+    /**
+     * Creates a builder using a default {@link HttpService}
+     */
+    public Builder() {
+      this.service = null;
+    }
+
+    /**
+     * Creates a builder using a custom {@link HttpService}
+     *
+     * @param httpService httpService instance that will be used on the client. Non null
+     */
+    public Builder(HttpService httpService) {
+      this.service = httpService;
+    }
+
+    /**
+     * @param tlsContextFactory the tls context factory for creating the context to secure the connection
+     * @return same builder instance
+     */
+    public Builder tlsContextFactory(TlsContextFactory tlsContextFactory) {
+      this.tlsContextFactory = tlsContextFactory;
+
+      return this;
+    }
+
+    /**
+     * Builds the client
+     *
+     * @return a non null {@link TestHttpClient} with the provided configuration
+     */
+    public TestHttpClient build() {
+      TestHttpClient httpClient;
+      if (service == null) {
+        httpClient = new TestHttpClient();
+      } else {
+        httpClient = new TestHttpClient(service);
+      }
+
+      httpClient.tlsContextFactory = tlsContextFactory;
+
+      return httpClient;
+    }
   }
 }

--- a/services/http/src/test/java/org/mule/services/http/TestHttpClient.java
+++ b/services/http/src/test/java/org/mule/services/http/TestHttpClient.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeoutException;
 import org.junit.rules.ExternalResource;
 
 /**
- * Defines a {@link org.mule.service.http.api.client.HttpClient} using a defualt implementation of {@link HttpService}
+ * Defines a {@link org.mule.service.http.api.client.HttpClient} using a default implementation of {@link HttpService}
  *
  * <p/>
  * This rule is intended to simplify the usage of the {@link org.mule.service.http.api.client.HttpClient} as it

--- a/tests/functional/src/main/java/org/mule/functional/junit4/ArtifactFunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/ArtifactFunctionalTestCase.java
@@ -14,10 +14,8 @@ import static org.hamcrest.object.IsCompatibleType.typeCompatibleWith;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CLASSLOADER_REPOSITORY;
 import static org.mule.test.runner.utils.AnnotationUtils.getAnnotationAttributeFrom;
-
-import org.mule.runtime.module.artifact.classloader.net.MuleArtifactUrlStreamHandler;
-import org.mule.runtime.module.artifact.classloader.net.MuleUrlStreamHandlerFactory;
 import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.service.Service;
 import org.mule.runtime.config.spring.SpringXmlConfigurationBuilder;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
@@ -25,6 +23,8 @@ import org.mule.runtime.core.api.registry.RegistrationException;
 import org.mule.runtime.core.api.serialization.ObjectSerializer;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderRepository;
+import org.mule.runtime.module.artifact.classloader.net.MuleArtifactUrlStreamHandler;
+import org.mule.runtime.module.artifact.classloader.net.MuleUrlStreamHandlerFactory;
 import org.mule.runtime.module.artifact.serializer.ArtifactObjectSerializer;
 import org.mule.runtime.module.service.DefaultServiceDiscoverer;
 import org.mule.runtime.module.service.MuleServiceManager;
@@ -95,7 +95,6 @@ public abstract class ArtifactFunctionalTestCase extends FunctionalTestCase {
   private static List<ArtifactClassLoader> pluginClassLoaders;
   private static List<ArtifactClassLoader> serviceClassLoaders;
   private static ClassLoader containerClassLoader;
-
   private static MuleServiceManager serviceRepository;
   private static ClassLoaderRepository classLoaderRepository;
 
@@ -146,6 +145,7 @@ public abstract class ArtifactFunctionalTestCase extends FunctionalTestCase {
       throw new IllegalStateException("Service class loaders were already set, it cannot be set again");
     }
     serviceClassLoaders = artifactClassLoaders;
+    createServiceManager();
   }
 
   @ContainerClassLoaderAware
@@ -169,19 +169,33 @@ public abstract class ArtifactFunctionalTestCase extends FunctionalTestCase {
     return builder;
   }
 
-  protected void configureSpringXmlConfigurationBuilder(SpringXmlConfigurationBuilder builder) {
-    if (serviceRepository == null) {
-      serviceRepository =
-          new MuleServiceManager(new DefaultServiceDiscoverer(new IsolatedServiceProviderDiscoverer(serviceClassLoaders),
-                                                              new ReflectionServiceResolver(new ReflectionServiceProviderResolutionHelper())));
-      try {
-        serviceRepository.start();
-      } catch (MuleException e) {
-        throw new IllegalStateException("Couldn't start service manager", e);
-      }
-    }
+  /**
+   * Returns an instance of a given service if available
+   *
+   * @param serviceClass class of service to look for. Non null.
+   * @param <T> service class
+   * @return an instance of the provided service type if it was declared as a dependency on the test, null otherwise.
+   */
+  protected <T extends Service> T getService(Class<T> serviceClass) {
+    Optional<Service> service =
+        serviceRepository.getServices().stream().filter(s -> serviceClass.isAssignableFrom(s.getClass())).findFirst();
 
+    return service.isPresent() ? (T) service.get() : null;
+  }
+
+  protected void configureSpringXmlConfigurationBuilder(SpringXmlConfigurationBuilder builder) {
     builder.addServiceConfigurator(new TestServicesMuleContextConfigurator(serviceRepository));
+  }
+
+  private static void createServiceManager() {
+    serviceRepository =
+        new MuleServiceManager(new DefaultServiceDiscoverer(new IsolatedServiceProviderDiscoverer(serviceClassLoaders),
+                                                            new ReflectionServiceResolver(new ReflectionServiceProviderResolutionHelper())));
+    try {
+      serviceRepository.start();
+    } catch (MuleException e) {
+      throw new IllegalStateException("Couldn't start service manager", e);
+    }
   }
 
   /**

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -371,5 +371,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-http</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 </project>

--- a/tests/integration/src/test/java/org/mule/issues/HttpReturnsJaxbObject5531TestCase.java
+++ b/tests/integration/src/test/java/org/mule/issues/HttpReturnsJaxbObject5531TestCase.java
@@ -7,18 +7,18 @@
 package org.mule.issues;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
-
-import org.mule.test.AbstractIntegrationTestCase;
 import org.mule.runtime.core.api.MuleEventContext;
-import org.mule.runtime.core.api.client.MuleClient;
 import org.mule.runtime.core.api.lifecycle.Callable;
-import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.core.internal.transformer.simple.ObjectToString;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.test.AbstractIntegrationTestCase;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -40,6 +40,9 @@ public class HttpReturnsJaxbObject5531TestCase extends AbstractIntegrationTestCa
   @Rule
   public DynamicPort port1 = new DynamicPort("port1");
 
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
+
   @Override
   protected String getConfigFile() {
     return "org/mule/issues/http-returns-jaxb-object-mule-5531-test.xml";
@@ -47,12 +50,12 @@ public class HttpReturnsJaxbObject5531TestCase extends AbstractIntegrationTestCa
 
   @Test
   public void testGetWeather() throws Exception {
-    String testUrl = "http://localhost:" + port1.getNumber() + "/test";
-    MuleClient client = muleContext.getClient();
-    Object response = client.send(testUrl, InternalMessage.of("hello"), newOptions().method(POST.name()).build());
-    assertNotNull(response);
-    String stringResponse = (String) new ObjectToString().transform(response, UTF_8);
-    assertTrue(stringResponse.contains("<Success>true</Success>"));
+    HttpRequest request =
+        HttpRequest.builder().setUri("http://localhost:" + port1.getNumber() + "/test").setMethod(POST.name()).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream(), UTF_8);
+    assertTrue(payload.contains("<Success>true</Success>"));
   }
 
   public static class WeatherReport implements Callable {

--- a/tests/integration/src/test/java/org/mule/test/core/context/notification/ConnectorMessageErrorNotificationTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/core/context/notification/ConnectorMessageErrorNotificationTestCase.java
@@ -8,14 +8,11 @@ package org.mule.test.core.context.notification;
 
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_ERROR_RESPONSE;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_RECEIVED;
-import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_REQUEST_BEGIN;
-import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_REQUEST_END;
-
-import org.mule.runtime.core.api.message.InternalMessage;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.context.notification.ConnectorMessageNotification;
-import org.mule.service.http.api.HttpConstants;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
-import org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -24,14 +21,13 @@ import org.junit.Test;
 public class ConnectorMessageErrorNotificationTestCase extends AbstractNotificationTestCase {
 
   private static final String FLOW_ID = "testFlow";
-  private static final String MULE_CLIENT_ID = "MuleClient";
-
   private static final int TIMEOUT = 1000;
-  private static final HttpRequestOptions GET_OPTIONS = HttpRequestOptionsBuilder.newOptions()
-      .method(HttpConstants.Methods.GET.name()).responseTimeout(TIMEOUT).disableStatusCodeValidation().build();
 
   @Rule
   public DynamicPort port = new DynamicPort("port");
+
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
 
   @Override
   protected String getConfigFile() {
@@ -40,16 +36,17 @@ public class ConnectorMessageErrorNotificationTestCase extends AbstractNotificat
 
   @Test
   public void doTest() throws Exception {
-    final String url = String.format("http://localhost:%s/path", port.getNumber());
-    muleContext.getClient().send(url, InternalMessage.of(TEST_PAYLOAD), GET_OPTIONS);
+    HttpRequest request =
+        HttpRequest.builder().setUri(String.format("http://localhost:%s/path", port.getNumber())).setMethod(POST.name()).build();
+
+    httpClient.send(request, TIMEOUT, false, null);
 
     assertNotifications();
   }
 
   @Override
   public RestrictedNode getSpecification() {
-    return new Node().parallel(new Node(ConnectorMessageNotification.class, MESSAGE_REQUEST_BEGIN, MULE_CLIENT_ID))
-        .parallel(new Node(ConnectorMessageNotification.class, MESSAGE_REQUEST_END, MULE_CLIENT_ID))
+    return new Node()
         .parallel(new Node(ConnectorMessageNotification.class, MESSAGE_RECEIVED, FLOW_ID))
         .parallel(new Node(ConnectorMessageNotification.class, MESSAGE_ERROR_RESPONSE, FLOW_ID));
   }

--- a/tests/integration/src/test/java/org/mule/test/core/context/notification/ConnectorMessageNotificationTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/core/context/notification/ConnectorMessageNotificationTestCase.java
@@ -7,15 +7,12 @@
 package org.mule.test.core.context.notification;
 
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_RECEIVED;
-import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_REQUEST_BEGIN;
-import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_REQUEST_END;
 import static org.mule.runtime.core.context.notification.ConnectorMessageNotification.MESSAGE_RESPONSE;
-
-import org.mule.runtime.core.api.message.InternalMessage;
+import static org.mule.service.http.api.HttpConstants.Methods.POST;
 import org.mule.runtime.core.context.notification.ConnectorMessageNotification;
-import org.mule.service.http.api.HttpConstants;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
-import org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 
 import org.junit.Rule;
@@ -24,14 +21,13 @@ import org.junit.Test;
 public class ConnectorMessageNotificationTestCase extends AbstractNotificationTestCase {
 
   private static final String FLOW_ID = "testFlow";
-  private static final String MULE_CLIENT_ID = "MuleClient";
-
   private static final int TIMEOUT = 1000;
-  private static final HttpRequestOptions GET_OPTIONS = HttpRequestOptionsBuilder.newOptions()
-      .method(HttpConstants.Methods.GET.name()).responseTimeout(TIMEOUT).disableStatusCodeValidation().build();
 
   @Rule
   public DynamicPort port = new DynamicPort("port");
+
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
 
   @Override
   protected String getConfigFile() {
@@ -40,16 +36,17 @@ public class ConnectorMessageNotificationTestCase extends AbstractNotificationTe
 
   @Test
   public void doTest() throws Exception {
-    final String url = String.format("http://localhost:%s/path", port.getNumber());
-    muleContext.getClient().send(url, InternalMessage.of(TEST_PAYLOAD), GET_OPTIONS);
+    HttpRequest request =
+        HttpRequest.builder().setUri(String.format("http://localhost:%s/path", port.getNumber())).setMethod(POST.name()).build();
+
+    httpClient.send(request, TIMEOUT, false, null);
 
     assertNotifications();
   }
 
   @Override
   public RestrictedNode getSpecification() {
-    return new Node().parallel(new Node(ConnectorMessageNotification.class, MESSAGE_REQUEST_BEGIN, MULE_CLIENT_ID))
-        .parallel(new Node(ConnectorMessageNotification.class, MESSAGE_REQUEST_END, MULE_CLIENT_ID))
+    return new Node()
         .parallel(new Node(ConnectorMessageNotification.class, MESSAGE_RECEIVED, FLOW_ID))
         .parallel(new Node(ConnectorMessageNotification.class, MESSAGE_RESPONSE, FLOW_ID));
   }

--- a/tests/integration/src/test/java/org/mule/test/integration/domain/http/HttpsSharePortTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/domain/http/HttpsSharePortTestCase.java
@@ -6,7 +6,7 @@
  */
 package org.mule.test.integration.domain.http;
 
-import org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder;
+import org.mule.runtime.api.tls.TlsContextFactory;
 import org.mule.runtime.module.tls.internal.DefaultTlsContextFactory;
 import org.mule.tck.junit4.rule.SystemProperty;
 
@@ -47,7 +47,7 @@ public class HttpsSharePortTestCase extends HttpSharePortTestCase {
   }
 
   @Override
-  protected HttpRequestOptionsBuilder getOptionsBuilder() {
-    return super.getOptionsBuilder().tlsContextFactory(tlsContextFactory);
+  protected TlsContextFactory getTlsContextFactory() {
+    return tlsContextFactory;
   }
 }

--- a/tests/integration/src/test/java/org/mule/test/integration/message/HttpPropertyScopeTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/message/HttpPropertyScopeTestCase.java
@@ -6,12 +6,6 @@
  */
 package org.mule.test.integration.message;
 
-import static java.lang.String.format;
-import static org.mule.service.http.api.HttpConstants.Methods.POST;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
-import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.core.api.client.MuleClient;
 import org.mule.test.IntegrationTestCaseRunnerConfig;
 
 public class HttpPropertyScopeTestCase extends AbstractPropertyScopeTestCase implements IntegrationTestCaseRunnerConfig {
@@ -21,8 +15,4 @@ public class HttpPropertyScopeTestCase extends AbstractPropertyScopeTestCase imp
     return "org/mule/test/message/http-property-scope.xml";
   }
 
-  protected InternalMessage sendRequest(MuleClient client, InternalMessage message) throws MuleException {
-    return client.send(format("http://localhost:%s/foo", port.getNumber()), message, newOptions().method(POST.name()).build())
-        .getRight();
-  }
 }

--- a/tests/integration/src/test/java/org/mule/test/integration/xml/XmlSendTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/integration/xml/XmlSendTestCase.java
@@ -6,17 +6,19 @@
  */
 package org.mule.test.integration.xml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mule.service.http.api.HttpConstants.HttpStatus.NOT_ACCEPTABLE;
+import static org.mule.service.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-import static org.mule.runtime.module.http.api.HttpConstants.ResponseProperties.HTTP_STATUS_PROPERTY;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
-
-import org.mule.runtime.core.api.client.MuleClient;
-import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 
@@ -30,7 +32,8 @@ public class XmlSendTestCase extends AbstractIntegrationTestCase {
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
-  private static final HttpRequestOptions httpOptions = newOptions().disableStatusCodeValidation().method(POST.name()).build();
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
 
   @Override
   protected String getConfigFile() {
@@ -39,70 +42,67 @@ public class XmlSendTestCase extends AbstractIntegrationTestCase {
 
   @Test
   public void testXmlFilter() throws Exception {
+    String url = "http://localhost:" + dynamicPort.getNumber() + "/xml-parse";
+
     InputStream xml = getClass().getResourceAsStream("request.xml");
+    HttpRequest request = HttpRequest.builder().setUri(url)
+        .setEntity(new InputStreamHttpEntity(xml)).setMethod(POST.name()).build();
 
-    assertNotNull(xml);
-
-    MuleClient client = muleContext.getClient();
-
-    // this will submit the xml via a POST request
-    InternalMessage message = client
-        .send("http://localhost:" + dynamicPort.getNumber() + "/xml-parse", InternalMessage.of(xml), httpOptions).getRight();
-    assertThat(200, is(message.<Integer>getInboundProperty(HTTP_STATUS_PROPERTY)));
+    HttpResponse httpResponse = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    assertThat(httpResponse.getStatusCode(), equalTo(OK.getStatusCode()));
 
     // This won't pass the filter
     xml = getClass().getResourceAsStream("validation1.xml");
-    message = client.send("http://localhost:" + dynamicPort.getNumber() + "/xml-parse", InternalMessage.of(xml), httpOptions)
-        .getRight();
-    assertThat(406, is(message.<Integer>getInboundProperty(HTTP_STATUS_PROPERTY)));
+    request = HttpRequest.builder().setUri(url).setEntity(new InputStreamHttpEntity(xml)).setMethod(POST.name()).build();
+
+    httpResponse = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+    assertThat(httpResponse.getStatusCode(), equalTo(NOT_ACCEPTABLE.getStatusCode()));
   }
 
   @Test
   public void testXmlFilterAndXslt() throws Exception {
     InputStream xml = getClass().getResourceAsStream("request.xml");
-
     assertNotNull(xml);
 
-    MuleClient client = muleContext.getClient();
+    HttpRequest request = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/xml-xslt-parse")
+        .setEntity(new InputStreamHttpEntity(xml)).setMethod(POST.name()).build();
 
-    // this will submit the xml via a POST request
-    InternalMessage message = client
-        .send("http://localhost:" + dynamicPort.getNumber() + "/xml-xslt-parse", InternalMessage.of(xml), httpOptions).getRight();
-    assertThat(200, is(message.<Integer>getInboundProperty(HTTP_STATUS_PROPERTY)));
+    HttpResponse httpResponse = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    assertThat(httpResponse.getStatusCode(), equalTo(OK.getStatusCode()));
   }
 
   @Test
   public void testXmlValidation() throws Exception {
+    String url = "http://localhost:" + dynamicPort.getNumber() + "/validate";
+
     InputStream xml = getClass().getResourceAsStream("validation1.xml");
-
-    assertNotNull(xml);
-
-    MuleClient client = muleContext.getClient();
-
-    // this will submit the xml via a POST request
-    InternalMessage message =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/validate", InternalMessage.of(xml), httpOptions).getRight();
-    assertThat(200, is(message.<Integer>getInboundProperty(HTTP_STATUS_PROPERTY)));
+    HttpRequest httpRequest = HttpRequest.builder().setUri(url)
+        .setEntity(new InputStreamHttpEntity(xml)).setMethod(POST.name()).build();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+    assertThat(httpResponse.getStatusCode(), equalTo(OK.getStatusCode()));
 
     xml = getClass().getResourceAsStream("validation2.xml");
-    message =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/validate", InternalMessage.of(xml), httpOptions).getRight();
-    assertThat(406, is(message.<Integer>getInboundProperty(HTTP_STATUS_PROPERTY)));
+    httpRequest = HttpRequest.builder().setUri(url)
+        .setEntity(new InputStreamHttpEntity(xml)).setMethod(POST.name()).build();
+    httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+    assertThat(httpResponse.getStatusCode(), equalTo(NOT_ACCEPTABLE.getStatusCode()));
 
     xml = getClass().getResourceAsStream("validation3.xml");
-    message =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/validate", InternalMessage.of(xml), httpOptions).getRight();
-    assertThat(200, is(message.<Integer>getInboundProperty(HTTP_STATUS_PROPERTY)));
+    httpRequest = HttpRequest.builder().setUri(url)
+        .setEntity(new InputStreamHttpEntity(xml)).setMethod(POST.name()).build();
+    httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+    assertThat(httpResponse.getStatusCode(), equalTo(OK.getStatusCode()));
   }
 
   @Test
   public void testExtractor() throws Exception {
     InputStream xml = getClass().getResourceAsStream("validation1.xml");
-    MuleClient client = muleContext.getClient();
+    HttpRequest httpRequest = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber() + "/extract")
+        .setEntity(new InputStreamHttpEntity(xml)).setMethod(POST.name()).build();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
 
-    // this will submit the xml via a POST request
-    InternalMessage message =
-        client.send("http://localhost:" + dynamicPort.getNumber() + "/extract", InternalMessage.of(xml), httpOptions).getRight();
-    assertThat(getPayloadAsString(message), equalTo("some"));
+    String payload = IOUtils.toString(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream(), UTF_8);
+    assertThat(payload, equalTo("some"));
   }
 }

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/SerializationOnResponseAggregatorTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/SerializationOnResponseAggregatorTestCase.java
@@ -7,19 +7,22 @@
 package org.mule.test.usecases.routing.response;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
-import org.mule.test.AbstractIntegrationTestCase;
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.message.InternalMessage;
-import org.mule.runtime.core.api.client.MuleClient;
 import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.core.api.serialization.ObjectSerializer;
 import org.mule.runtime.core.api.store.ObjectStoreException;
+import org.mule.runtime.core.util.IOUtils;
 import org.mule.runtime.core.util.store.SimpleMemoryObjectStore;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.test.AbstractIntegrationTestCase;
 
 import java.io.Serializable;
 
@@ -31,6 +34,9 @@ public class SerializationOnResponseAggregatorTestCase extends AbstractIntegrati
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port1");
 
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
+
   @Override
   protected String getConfigFile() {
     return "org/mule/test/usecases/routing/response/serialization-on-response-router-config.xml";
@@ -40,12 +46,13 @@ public class SerializationOnResponseAggregatorTestCase extends AbstractIntegrati
   public void testSyncResponse() throws Exception {
     muleContext.getRegistry().registerObject(MuleProperties.OBJECT_STORE_DEFAULT_IN_MEMORY_NAME,
                                              new TestObjectStore(muleContext));
-    MuleClient client = muleContext.getClient();
-    InternalMessage message = client.send("http://localhost:" + dynamicPort.getNumber(), InternalMessage.of("request"),
-                                          newOptions().method(POST.name()).build())
-        .getRight();
-    assertNotNull(message);
-    assertThat(new String(getPayloadAsBytes(message)), is("request processed"));
+    HttpRequest request = HttpRequest.builder().setUri("http://localhost:" + dynamicPort.getNumber())
+        .setEntity(new ByteArrayHttpEntity("request".getBytes())).setMethod(POST.name()).build();
+
+    HttpResponse response = httpClient.send(request, RECEIVE_TIMEOUT, false, null);
+
+    String payload = IOUtils.toString(((InputStreamHttpEntity) response.getEntity()).getInputStream());
+    assertThat(payload, is("request processed"));
   }
 
   private static class TestObjectStore extends SimpleMemoryObjectStore<Serializable> {

--- a/tests/integration/src/test/java/org/mule/test/usecases/sync/HttpTransformTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/sync/HttpTransformTestCase.java
@@ -6,18 +6,22 @@
  */
 package org.mule.test.usecases.sync;
 
+import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mule.service.http.api.HttpConstants.Methods.POST;
-import static org.mule.runtime.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
-
 import org.mule.runtime.api.metadata.DataType;
-import org.mule.runtime.core.api.client.MuleClient;
 import org.mule.runtime.core.api.message.InternalMessage;
 import org.mule.runtime.core.transformer.compression.GZipUncompressTransformer;
 import org.mule.runtime.core.transformer.simple.ByteArrayToSerializable;
-import org.mule.runtime.module.http.api.client.HttpRequestOptions;
+import org.mule.runtime.core.util.IOUtils;
+import org.mule.service.http.api.HttpService;
+import org.mule.service.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.service.http.api.domain.entity.InputStreamHttpEntity;
+import org.mule.service.http.api.domain.message.request.HttpRequest;
+import org.mule.service.http.api.domain.message.response.HttpResponse;
+import org.mule.services.http.TestHttpClient;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.AbstractIntegrationTestCase;
 
@@ -29,12 +33,14 @@ import org.junit.Test;
 
 public class HttpTransformTestCase extends AbstractIntegrationTestCase {
 
-  public static final HttpRequestOptions HTTP_REQUEST_OPTIONS = newOptions().method(POST.name()).build();
   @Rule
   public DynamicPort httpPort1 = new DynamicPort("port1");
 
   @Rule
   public DynamicPort httpPort2 = new DynamicPort("port2");
+
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder(getService(HttpService.class)).build();
 
   @Override
   protected String getConfigFile() {
@@ -43,34 +49,31 @@ public class HttpTransformTestCase extends AbstractIntegrationTestCase {
 
   @Test
   public void testTransform() throws Exception {
-    MuleClient client = muleContext.getClient();
-    InternalMessage message = client.send(String.format("http://localhost:%d/RemoteService", httpPort1.getNumber()),
-                                          InternalMessage.of("payload"), HTTP_REQUEST_OPTIONS)
-        .getRight();
-    assertNotNull(message);
-    GZipUncompressTransformer gu = new GZipUncompressTransformer();
-    gu.setMuleContext(muleContext);
-    gu.setReturnDataType(DataType.STRING);
-    assertNotNull(message.getPayload().getValue());
-    String result = (String) gu.transform(getPayloadAsBytes(message));
+    HttpRequest httpRequest = HttpRequest.builder().setUri(format("http://localhost:%d/RemoteService", httpPort1.getNumber()))
+        .setEntity(new ByteArrayHttpEntity("payload".getBytes())).setMethod(POST.name()).build();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    GZipUncompressTransformer transformer = new GZipUncompressTransformer();
+    transformer.setMuleContext(muleContext);
+    transformer.setReturnDataType(DataType.STRING);
+    byte[] byteArray = IOUtils.toByteArray(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    String result = (String) transformer.transform(byteArray);
     assertThat(result, is("<string>payload</string>"));
   }
 
   @Test
   public void testBinary() throws Exception {
-    MuleClient client = muleContext.getClient();
     ArrayList<Integer> payload = new ArrayList<>();
     payload.add(42);
-    InternalMessage message =
-        client.send(String.format("http://localhost:%d/RemoteService", httpPort2.getNumber()),
-                    InternalMessage.of(muleContext.getObjectSerializer().getExternalProtocol().serialize(payload)),
-                    HTTP_REQUEST_OPTIONS)
-            .getRight();
-    assertNotNull(message);
-    ByteArrayToSerializable bas = new ByteArrayToSerializable();
-    bas.setMuleContext(muleContext);
-    assertNotNull(message.getPayload().getValue());
-    Object result = bas.transform(message.getPayload().getValue());
+    HttpRequest httpRequest = HttpRequest.builder().setUri(format("http://localhost:%d/RemoteService", httpPort2.getNumber()))
+        .setEntity(new ByteArrayHttpEntity(muleContext.getObjectSerializer().getExternalProtocol().serialize(payload)))
+        .setMethod(POST.name()).build();
+    HttpResponse httpResponse = httpClient.send(httpRequest, RECEIVE_TIMEOUT, false, null);
+
+    ByteArrayToSerializable transformer = new ByteArrayToSerializable();
+    transformer.setMuleContext(muleContext);
+    byte[] byteArray = IOUtils.toByteArray(((InputStreamHttpEntity) httpResponse.getEntity()).getInputStream());
+    Object result = transformer.transform(byteArray);
     assertThat(result, is(payload));
   }
 


### PR DESCRIPTION
_ Adding TestHttpClient rule to provide access to an HttpClient that uses the Http service
_ Migrating CXF test to use TestHttpClient instead of muleClient