### PR TITLE
MULE-11348 Migrate non-blocking approach used to use a single stream.…

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/processor/strategy/AbstractProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/processor/strategy/AbstractProcessingStrategyTestCase.java
@@ -103,6 +103,7 @@ public abstract class AbstractProcessingStrategyTestCase extends AbstractReactiv
 
   @After
   public void after() {
+    flow.dispose();
     cpuLight.shutdownNow();
     blocking.shutdownNow();
     cpuIntensive.shutdownNow();
@@ -142,7 +143,6 @@ public abstract class AbstractProcessingStrategyTestCase extends AbstractReactiv
       assertThat(latchedProcessor.getSecondCalledLatch().await(BLOCK_TIMEOUT, MILLISECONDS), is(true));
     }
 
-    flow.dispose();
   }
 
   @Test

--- a/tests/unit/src/main/java/org/mule/tck/MuleTestUtils.java
+++ b/tests/unit/src/main/java/org/mule/tck/MuleTestUtils.java
@@ -23,6 +23,7 @@ import org.mule.runtime.core.api.Injector;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.rx.Exceptions.EventDroppedException;
+import org.mule.runtime.core.processor.strategy.LegacySynchronousProcessingStrategyFactory;
 
 import java.util.function.Function;
 
@@ -56,7 +57,9 @@ public final class MuleTestUtils {
   }
 
   public static Flow getTestFlow(MuleContext context) throws MuleException {
-    final Flow flow = builder(APPLE_FLOW, context).build();
+    // Use simple processing strategy given flow used in test event is not used for processing.
+    final Flow flow =
+        builder(APPLE_FLOW, context).processingStrategyFactory(new LegacySynchronousProcessingStrategyFactory()).build();
     if (context.getRegistry() != null) {
       context.getRegistry().registerFlowConstruct(flow);
     }


### PR DESCRIPTION
… Don't create ring-buffers for test events/