### PR TITLE
MULE-11476: Support maven loaders on policies

### DIFF
--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ArtifactDescriptorCreateException.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ArtifactDescriptorCreateException.java
@@ -25,4 +25,11 @@ public class ArtifactDescriptorCreateException extends RuntimeException {
   public ArtifactDescriptorCreateException(String s, Throwable throwable) {
     super(s, throwable);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  public ArtifactDescriptorCreateException(Throwable cause) {
+    super(cause);
+  }
 }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptorLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDescriptorLoader.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.descriptor;
+
+/**
+ * Loads the {@link BundleDescriptor} for Mule artifacts.
+ * <p/>
+ * Explicitly defined to enable definition of implementations using SPI.
+ */
+public interface BundleDescriptorLoader extends DescriptorLoader<BundleDescriptor> {
+
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ClassLoaderModelLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/ClassLoaderModelLoader.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.descriptor;
+
+/**
+ * Loads the {@link ClassLoaderModel} for Mule artifacts
+ * <p/>
+ * Explicitly defined to enable definition of implementations using SPI.
+ */
+public interface ClassLoaderModelLoader extends DescriptorLoader<ClassLoaderModel> {
+
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/DescriptorLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/DescriptorLoader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.descriptor;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Loads descriptors used to describe Mule artifacts
+ *
+ * @param <T> type of loaded objects
+ */
+public interface DescriptorLoader<T> {
+
+  /**
+   * @return the unique ID of the descriptor loader
+   */
+  String getId();
+
+  /**
+   * Loads a described object
+   *
+   * @param artifactFolder {@link File} where the current artifact to work with. Non null
+   * @param attributes collection of attributes describing the loader. Non null.
+   * @return a {@link T} loaded with the given attributes from the artifact folder.
+   */
+  T load(File artifactFolder, Map<String, Object> attributes);
+
+}

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/DescriptorLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/DescriptorLoader.java
@@ -28,7 +28,8 @@ public interface DescriptorLoader<T> {
    * @param artifactFolder {@link File} where the current artifact to work with. Non null
    * @param attributes collection of attributes describing the loader. Non null.
    * @return a {@link T} loaded with the given attributes from the artifact folder.
+   * @throws InvalidDescriptorLoaderException when is not possible to load the object with the provided configuration.
    */
-  T load(File artifactFolder, Map<String, Object> attributes);
+  T load(File artifactFolder, Map<String, Object> attributes) throws InvalidDescriptorLoaderException;
 
 }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/InvalidDescriptorLoaderException.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/InvalidDescriptorLoaderException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.artifact.descriptor;
+
+
+/**
+ * Thrown to indicate that is not possible to load an object from the provided descriptor configuration.
+ */
+public class InvalidDescriptorLoaderException extends Exception {
+
+  /**
+   * {@inheritDoc}
+   */
+  public InvalidDescriptorLoaderException(String message) {
+    super(message);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public InvalidDescriptorLoaderException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/DescriptorLoaderRepository.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/DescriptorLoaderRepository.java
@@ -22,8 +22,8 @@ public interface DescriptorLoaderRepository {
    * @param id identifies the loader to obtain. Non empty.
    * @param loaderClass class of {@link DescriptorLoader} to search for. No null.
    * @param <T> type of descriptor loader to return
-   * @returns an {@link Optional} loader of the given class and ID. It will be empty if there is no loader of that class
-   *          registered with that ID.
+   * @returns a non null {@link Optional} loader of the given class and ID
+   * @throws LoaderNotFoundException if there is no registered loader of type {@link T} with the provided ID.
    */
-  <T extends DescriptorLoader> Optional<T> get(String id, Class<T> loaderClass);
+  <T extends DescriptorLoader> T get(String id, Class<T> loaderClass) throws LoaderNotFoundException;
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/DescriptorLoaderRepository.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/DescriptorLoaderRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.artifact;
+
+import org.mule.runtime.module.artifact.descriptor.DescriptorLoader;
+
+import java.util.Optional;
+
+/**
+ * Maintains the registered {@link DescriptorLoader}
+ */
+public interface DescriptorLoaderRepository {
+
+  /**
+   * Gets a descriptor loader from the repository
+   *
+   * @param id identifies the loader to obtain. Non empty.
+   * @param loaderClass class of {@link DescriptorLoader} to search for. No null.
+   * @param <T> type of descriptor loader to return
+   * @returns an {@link Optional} loader of the given class and ID. It will be empty if there is no loader of that class
+   *          registered with that ID.
+   */
+  <T extends DescriptorLoader> Optional<T> get(String id, Class<T> loaderClass);
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/LoaderNotFoundException.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/LoaderNotFoundException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.artifact;
+
+/**
+ * Thrown to indicate that a loader was not found in the repository
+ */
+public class LoaderNotFoundException extends Exception {
+
+  /**
+   * {@inheritDoc}
+   */
+  public LoaderNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ServiceRegistryDescriptorLoaderRepository.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ServiceRegistryDescriptorLoaderRepository.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.artifact;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
+import org.mule.runtime.core.api.registry.ServiceRegistry;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
+import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
+import org.mule.runtime.module.artifact.descriptor.DescriptorLoader;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Provides a {@link DescriptorLoaderRepository} that uses a {@link ServiceRegistry} to detect available implementations of
+ * {@link ClassLoaderModelLoader}
+ */
+public class ServiceRegistryDescriptorLoaderRepository implements DescriptorLoaderRepository {
+
+  private final ServiceRegistry serviceRegistry;
+  private final Class[] descriptorLoaderClasses = new Class[] {ClassLoaderModelLoader.class, BundleDescriptorLoader.class};
+  private Map<Class, Map<String, DescriptorLoader>> descriptorLoaders;
+
+  /**
+   * Creates a new repository
+   *
+   * @param serviceRegistry provides access to the {@link ClassLoaderModelLoader} that must be tracked on the repository. Non null
+   */
+  public ServiceRegistryDescriptorLoaderRepository(ServiceRegistry serviceRegistry) {
+    checkArgument(serviceRegistry != null, "serviceRegistry cannot be null");
+
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  public <T extends DescriptorLoader> Optional<T> get(String id, Class<T> loaderClass) {
+    if (descriptorLoaders == null) {
+      initializeDescriptorLoaders();
+    }
+
+    DescriptorLoader descriptorLoader = null;
+    Map<String, DescriptorLoader> registeredDescriptorLoaders = descriptorLoaders.get(loaderClass);
+    if (registeredDescriptorLoaders != null) {
+      descriptorLoader = registeredDescriptorLoaders.get(id);
+    }
+
+    return ofNullable((T) descriptorLoader);
+  }
+
+  private void initializeDescriptorLoaders() {
+    synchronized (this) {
+      if (descriptorLoaders == null) {
+        descriptorLoaders = new HashMap<>();
+        for (Class descriptorLoaderClass : descriptorLoaderClasses) {
+          descriptorLoaders.put(descriptorLoaderClass, findBundleDescriptorLoaders(descriptorLoaderClass));
+        }
+      }
+    }
+  }
+
+  private Map<String, DescriptorLoader> findBundleDescriptorLoaders(Class<? extends DescriptorLoader> descriptorLoaderClass) {
+    Map<String, DescriptorLoader> descriptorLoaders = new HashMap<>();
+    Collection<? extends DescriptorLoader> providers =
+        serviceRegistry.lookupProviders(descriptorLoaderClass, this.getClass().getClassLoader());
+
+    for (DescriptorLoader loader : providers) {
+      if (descriptorLoaders.containsKey(loader.getId())) {
+        throw new IllegalStateException(format("Duplicated bundle descriptor loader ID: %s of class '%s'", loader.getId(),
+                                               descriptorLoaderClass.getName()));
+      }
+
+      descriptorLoaders.put(loader.getId(), loader);
+    }
+
+    return descriptorLoaders;
+  }
+}

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ServiceRegistryDescriptorLoaderRepository.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ServiceRegistryDescriptorLoaderRepository.java
@@ -8,7 +8,6 @@
 package org.mule.runtime.module.deployment.impl.internal.artifact;
 
 import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import org.mule.runtime.core.api.registry.ServiceRegistry;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
@@ -18,7 +17,6 @@ import org.mule.runtime.module.artifact.descriptor.DescriptorLoader;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Provides a {@link DescriptorLoaderRepository} that uses a {@link ServiceRegistry} to detect available implementations of
@@ -42,7 +40,7 @@ public class ServiceRegistryDescriptorLoaderRepository implements DescriptorLoad
   }
 
   @Override
-  public <T extends DescriptorLoader> Optional<T> get(String id, Class<T> loaderClass) {
+  public <T extends DescriptorLoader> T get(String id, Class<T> loaderClass) throws LoaderNotFoundException {
     if (descriptorLoaders == null) {
       initializeDescriptorLoaders();
     }
@@ -53,7 +51,15 @@ public class ServiceRegistryDescriptorLoaderRepository implements DescriptorLoad
       descriptorLoader = registeredDescriptorLoaders.get(id);
     }
 
-    return ofNullable((T) descriptorLoader);
+    if (descriptorLoader == null) {
+      throw new LoaderNotFoundException(noRegisteredLoaderError(id, loaderClass));
+    }
+
+    return (T) descriptorLoader;
+  }
+
+  protected static <T extends DescriptorLoader> String noRegisteredLoaderError(String id, Class<T> loaderClass) {
+    return format("There is no loader with ID='%s' and type '$s'", id, loaderClass.getName());
   }
 
   private void initializeDescriptorLoaders() {

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/MavenBundleDescriptorLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/MavenBundleDescriptorLoader.java
@@ -15,6 +15,7 @@ import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
+import org.mule.runtime.module.artifact.descriptor.InvalidDescriptorLoaderException;
 
 import java.io.File;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class MavenBundleDescriptorLoader implements BundleDescriptorLoader {
    * there's an issue while reading that file
    */
   @Override
-  public BundleDescriptor load(File artifactFolder, Map<String, Object> attributes) {
+  public BundleDescriptor load(File artifactFolder, Map<String, Object> attributes) throws InvalidDescriptorLoaderException {
     Model model = getPomModel(artifactFolder);
 
     return new BundleDescriptor.Builder()

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/MavenBundleDescriptorLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/MavenBundleDescriptorLoader.java
@@ -9,12 +9,15 @@ package org.mule.runtime.module.deployment.impl.internal.plugin;
 
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.EXTENSION_BUNDLE_TYPE;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
+import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.MAVEN;
 import static org.mule.runtime.module.deployment.impl.internal.plugin.MavenUtils.getPomModel;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
 
 import java.io.File;
+import java.util.Map;
 
 import org.apache.maven.model.Model;
 
@@ -22,20 +25,26 @@ import org.apache.maven.model.Model;
  * Loads a {@link BundleDescriptor} using Maven to extract the relevant information from a Mule artifact's
  * {@value ArtifactPluginDescriptor#MULE_PLUGIN_POM} file.
  */
-public class MavenBundleDescriptorLoader {
+public class MavenBundleDescriptorLoader implements BundleDescriptorLoader {
 
-  // TODO(pablo.kraan): MULE-11340: Add BundleDescriptorLoader and ClassLoaderModelDescriptorLoader interfaces
+  @Override
+  public String getId() {
+    return MAVEN;
+  }
+
   /**
    * Looks for the POM file within the current {@code pluginFolder} structure (under {@link ArtifactPluginDescriptor#MULE_ARTIFACT_FOLDER} folder)
    * to retrieve the plugin artifact locator.
    *
-   * @param pluginFolder {@link File} where the current plugin to work with.
+   * @param artifactFolder {@link File} where the current plugin to work with.
+   * @param attributes collection of attributes describing the loader. Non null.
    * @return a locator of the coordinates of the current plugin
    * @throws ArtifactDescriptorCreateException if the plugin is missing the {@link ArtifactPluginDescriptor#MULE_PLUGIN_POM} or
    * there's an issue while reading that file
    */
-  public BundleDescriptor loadBundleDescriptor(File pluginFolder) {
-    Model model = getPomModel(pluginFolder);
+  @Override
+  public BundleDescriptor load(File artifactFolder, Map<String, Object> attributes) {
+    Model model = getPomModel(artifactFolder);
 
     return new BundleDescriptor.Builder()
         .setArtifactId(model.getArtifactId())

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/MavenClassLoaderModelLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/MavenClassLoaderModelLoader.java
@@ -35,6 +35,7 @@ import org.mule.runtime.module.artifact.descriptor.BundleScope;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel.ClassLoaderModelBuilder;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
+import org.mule.runtime.module.artifact.descriptor.InvalidDescriptorLoaderException;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -115,8 +116,7 @@ public class MavenClassLoaderModelLoader implements ClassLoaderModelLoader {
    * @see BundlePluginDependenciesResolver#getArtifactsWithDependencies(List, Set)
    */
   @Override
-  public ClassLoaderModel load(File artifactFolder,
-                               Map<String, Object> attributes) {
+  public ClassLoaderModel load(File artifactFolder, Map<String, Object> attributes) throws InvalidDescriptorLoaderException {
     final Model model = getPomModel(artifactFolder);
     final ClassLoaderModelBuilder classLoaderModelBuilder = new ClassLoaderModelBuilder();
     classLoaderModelBuilder
@@ -173,7 +173,8 @@ public class MavenClassLoaderModelLoader implements ClassLoaderModelLoader {
         && MULE_PLUGIN_CLASSIFIER.equals(dependency.getArtifact().getClassifier());
   }
 
-  private PreorderNodeListGenerator assemblyDependenciesFromPom(File pluginFolder, Model model) {
+  private PreorderNodeListGenerator assemblyDependenciesFromPom(File pluginFolder, Model model)
+      throws InvalidDescriptorLoaderException {
 
     Artifact defaultArtifact = new DefaultArtifact(model.getGroupId(), model.getArtifactId(),
                                                    null,
@@ -201,13 +202,13 @@ public class MavenClassLoaderModelLoader implements ClassLoaderModelLoader {
     } catch (DependencyResolutionException e) {
       DependencyNode node = e.getResult().getRoot();
       logUnresolvedArtifacts(node, e);
-      throw new ArtifactDescriptorCreateException(format("There was an issue solving the dependencies for the plugin [%s]",
-                                                         pluginFolder.getAbsolutePath()),
-                                                  e);
+      throw new InvalidDescriptorLoaderException(format("There was an issue solving the dependencies for the plugin [%s]",
+                                                        pluginFolder.getAbsolutePath()),
+                                                 e);
     } catch (DependencyCollectionException e) {
-      throw new ArtifactDescriptorCreateException(format("There was an issue resolving the dependency tree for the plugin [%s]",
-                                                         pluginFolder.getAbsolutePath()),
-                                                  e);
+      throw new InvalidDescriptorLoaderException(format("There was an issue resolving the dependency tree for the plugin [%s]",
+                                                        pluginFolder.getAbsolutePath()),
+                                                 e);
     } catch (ArtifactDescriptorException e) {
       throw new ArtifactDescriptorCreateException(format("There was an issue resolving the artifact descriptor for the plugin [%s]",
                                                          pluginFolder.getAbsolutePath()),

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/FileSystemPolicyClassLoaderModelLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/FileSystemPolicyClassLoaderModelLoader.java
@@ -7,9 +7,9 @@
 
 package org.mule.runtime.module.deployment.impl.internal.policy;
 
-import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
+import org.mule.runtime.module.artifact.descriptor.InvalidDescriptorLoaderException;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -43,7 +43,7 @@ public class FileSystemPolicyClassLoaderModelLoader implements ClassLoaderModelL
    * @return a {@link ClassLoaderModel} loaded with all its dependencies and URLs
    */
   @Override
-  public ClassLoaderModel load(File artifactFolder, Map<String, Object> attributes) {
+  public ClassLoaderModel load(File artifactFolder, Map<String, Object> attributes) throws InvalidDescriptorLoaderException {
 
     final ClassLoaderModel.ClassLoaderModelBuilder classLoaderModelBuilder = new ClassLoaderModel.ClassLoaderModelBuilder();
 
@@ -52,7 +52,8 @@ public class FileSystemPolicyClassLoaderModelLoader implements ClassLoaderModelL
     return classLoaderModelBuilder.build();
   }
 
-  private void loadUrls(ClassLoaderModel.ClassLoaderModelBuilder classLoaderModelBuilder, File artifactFolder) {
+  private void loadUrls(ClassLoaderModel.ClassLoaderModelBuilder classLoaderModelBuilder, File artifactFolder)
+      throws InvalidDescriptorLoaderException {
     try {
       classLoaderModelBuilder.containing(new File(artifactFolder, CLASSES_DIR).toURI().toURL());
       final File libDir = new File(artifactFolder, LIB_DIR);
@@ -63,7 +64,7 @@ public class FileSystemPolicyClassLoaderModelLoader implements ClassLoaderModelL
         }
       }
     } catch (MalformedURLException e) {
-      throw new ArtifactDescriptorCreateException("Failed to create plugin descriptor " + artifactFolder);
+      throw new InvalidDescriptorLoaderException("Failed to create plugin descriptor " + artifactFolder);
     }
   }
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/FileSystemPolicyClassLoaderModelLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/FileSystemPolicyClassLoaderModelLoader.java
@@ -9,31 +9,41 @@ package org.mule.runtime.module.deployment.impl.internal.policy;
 
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
+import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.net.MalformedURLException;
+import java.util.Map;
 
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 
 /**
  * Creates a {@link ClassLoaderModel} from a policy's folder
  */
-public class FileSystemPolicyClassLoaderModelLoader {
+public class FileSystemPolicyClassLoaderModelLoader implements ClassLoaderModelLoader {
 
+  public static final String FILE_SYSTEM_POLICY_MODEL_LOADER_ID = "FILE_SYSTEM_POLICY_MODEL_LOADER";
   protected static final String LIB_DIR = "lib";
   public static final String CLASSES_DIR = "classes";
   private static final String JAR_FILE = ".jar";
 
+
+  @Override
+  public String getId() {
+    return FILE_SYSTEM_POLICY_MODEL_LOADER_ID;
+  }
 
   /**
    * Given a policy template's location it will build a {@link ClassLoaderModel} taking in account jars located inside the {@value LIB_DIR}
    * folder and resources located inside the {@value CLASSES_DIR} folder.
    *
    * @param artifactFolder {@link File} where the current plugin to work with.
-   * @return a {@link ClassLoaderModel} loaded with all its dependencies and URLs.
+   * @param attributes collection of attributes describing the loader. Non null.
+   * @return a {@link ClassLoaderModel} loaded with all its dependencies and URLs
    */
-  public ClassLoaderModel loadClassLoaderModel(File artifactFolder) {
+  @Override
+  public ClassLoaderModel load(File artifactFolder, Map<String, Object> attributes) {
 
     final ClassLoaderModel.ClassLoaderModelBuilder classLoaderModelBuilder = new ClassLoaderModel.ClassLoaderModelBuilder();
 

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PropertiesBundleDescriptorLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PropertiesBundleDescriptorLoader.java
@@ -9,13 +9,17 @@ package org.mule.runtime.module.deployment.impl.internal.policy;
 
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
 
+import java.io.File;
 import java.util.Map;
 
 /**
  * Loads a {@link BundleDescriptor} using properties defined in the stored descriptor loader.
  */
-public class PropertiesBundleDescriptorLoader {
+public class PropertiesBundleDescriptorLoader implements BundleDescriptorLoader {
+
+  public static final String PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID = "PROPERTIES";
 
   public static final String VERSION = "version";
   public static final String GROUP_ID = "groupId";
@@ -23,14 +27,22 @@ public class PropertiesBundleDescriptorLoader {
   public static final String CLASSIFIER = "classifier";
   public static final String TYPE = "type";
 
+  @Override
+  public String getId() {
+    return PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID;
+  }
+
   /**
    * Loads a bundle descriptor from the provided properties
    *
+   *
+   * @param artifactFolder {@link File} where the current artifact to work with. Non null
    * @param attributes attributes defined in the loader.
    * @return a locator of the coordinates of the current artifact
    * @throws ArtifactDescriptorCreateException if any bundle descriptor required property is missing on the given attributes.
    */
-  public BundleDescriptor loadBundleDescriptor(Map<String, Object> attributes) {
+  @Override
+  public BundleDescriptor load(File artifactFolder, Map<String, Object> attributes) {
     String version = (String) attributes.get(VERSION);
     String groupId = (String) attributes.get(GROUP_ID);
     String artifactId = (String) attributes.get(ARTIFACT_ID);

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PropertiesBundleDescriptorLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PropertiesBundleDescriptorLoader.java
@@ -10,6 +10,7 @@ package org.mule.runtime.module.deployment.impl.internal.policy;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
+import org.mule.runtime.module.artifact.descriptor.InvalidDescriptorLoaderException;
 
 import java.io.File;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class PropertiesBundleDescriptorLoader implements BundleDescriptorLoader 
    * @throws ArtifactDescriptorCreateException if any bundle descriptor required property is missing on the given attributes.
    */
   @Override
-  public BundleDescriptor load(File artifactFolder, Map<String, Object> attributes) {
+  public BundleDescriptor load(File artifactFolder, Map<String, Object> attributes) throws InvalidDescriptorLoaderException {
     String version = (String) attributes.get(VERSION);
     String groupId = (String) attributes.get(GROUP_ID);
     String artifactId = (String) attributes.get(ARTIFACT_ID);
@@ -52,7 +53,7 @@ public class PropertiesBundleDescriptorLoader implements BundleDescriptorLoader 
       return new BundleDescriptor.Builder().setVersion(version).setGroupId(groupId).setArtifactId(artifactId)
           .setClassifier(classifier).setType(type).build();
     } catch (IllegalArgumentException e) {
-      throw new ArtifactDescriptorCreateException("Bundle descriptor attributes are not complete", e);
+      throw new InvalidDescriptorLoaderException("Bundle descriptor attributes are not complete", e);
     }
   }
 }

--- a/modules/deployment-model-impl/src/main/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader
+++ b/modules/deployment-model-impl/src/main/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader
@@ -1,0 +1,1 @@
+org.mule.runtime.module.deployment.impl.internal.plugin.MavenBundleDescriptorLoader

--- a/modules/deployment-model-impl/src/main/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader
+++ b/modules/deployment-model-impl/src/main/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader
@@ -1,0 +1,1 @@
+org.mule.runtime.module.deployment.impl.internal.plugin.MavenClassLoaderModelLoader

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/artifact/ServiceRegistryDescriptorLoaderRepositoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/artifact/ServiceRegistryDescriptorLoaderRepositoryTestCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.module.deployment.impl.internal.artifact;
+
+import static java.util.Collections.singleton;
+import static java.util.Optional.empty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mule.runtime.core.api.registry.ServiceRegistry;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
+import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.junit.Test;
+
+@SmallTest
+public class ServiceRegistryDescriptorLoaderRepositoryTestCase extends AbstractMuleTestCase {
+
+  public static final String LOADER_ID = "loader";
+  private final ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+  private final ServiceRegistryDescriptorLoaderRepository repository =
+      new ServiceRegistryDescriptorLoaderRepository(serviceRegistry);
+
+  @Test
+  public void initializesClassLoaderModelLoadersOnce() throws Exception {
+    repository.get("any", ClassLoaderModelLoader.class);
+    repository.get("any", ClassLoaderModelLoader.class);
+
+    verify(serviceRegistry).lookupProviders(ClassLoaderModelLoader.class, getClass().getClassLoader());
+    verify(serviceRegistry).lookupProviders(BundleDescriptorLoader.class, getClass().getClassLoader());
+    verify(serviceRegistry, never()).lookupProvider(ClassLoaderModelLoader.class, getClass().getClassLoader());
+    verify(serviceRegistry, never()).lookupProvider(BundleDescriptorLoader.class, getClass().getClassLoader());
+  }
+
+  @Test
+  public void doesNotFindInvalidLoaderId() throws Exception {
+    Optional<ClassLoaderModelLoader> invalid = repository.get("invalid", ClassLoaderModelLoader.class);
+    assertThat(invalid, is(empty()));
+  }
+
+  @Test
+  public void findsLoader() throws Exception {
+    ClassLoaderModelLoader expectedClassLoaderModelLoader = mock(ClassLoaderModelLoader.class);
+    when(expectedClassLoaderModelLoader.getId()).thenReturn(LOADER_ID);
+    Collection<ClassLoaderModelLoader> classLoaderModelLoaders = singleton(expectedClassLoaderModelLoader);
+    when(serviceRegistry.lookupProviders(ClassLoaderModelLoader.class, getClass().getClassLoader()))
+        .thenReturn(classLoaderModelLoaders);
+    Optional<ClassLoaderModelLoader> classLoaderModelLoader = repository.get(LOADER_ID, ClassLoaderModelLoader.class);
+
+    assertThat(classLoaderModelLoader.get(), is(expectedClassLoaderModelLoader));
+  }
+
+  @Test
+  public void findsLoaderIdWithType() throws Exception {
+    ClassLoaderModelLoader classLoaderModelLoader = mock(ClassLoaderModelLoader.class);
+    when(classLoaderModelLoader.getId()).thenReturn(LOADER_ID);
+    Collection<ClassLoaderModelLoader> classLoaderModelLoaders = singleton(classLoaderModelLoader);
+    when(serviceRegistry.lookupProviders(ClassLoaderModelLoader.class, getClass().getClassLoader()))
+        .thenReturn(classLoaderModelLoaders);
+    Optional<BundleDescriptorLoader> bundleDescriptorLoader = repository.get(LOADER_ID, BundleDescriptorLoader.class);
+
+    assertThat(bundleDescriptorLoader, is(empty()));
+  }
+}

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactoryTestCase.java
@@ -9,8 +9,6 @@ package org.mule.runtime.module.deployment.impl.internal.plugin;
 
 import static java.io.File.createTempFile;
 import static java.util.Collections.emptySet;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -48,6 +46,7 @@ import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
 import org.mule.runtime.module.deployment.impl.internal.artifact.DescriptorLoaderRepository;
+import org.mule.runtime.module.deployment.impl.internal.artifact.LoaderNotFoundException;
 import org.mule.runtime.module.deployment.impl.internal.builder.ArtifactPluginFileBuilder;
 import org.mule.runtime.module.deployment.impl.internal.policy.FileSystemPolicyClassLoaderModelLoader;
 import org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader;
@@ -94,14 +93,14 @@ public class ArtifactPluginDescriptorFactoryTestCase extends AbstractMuleTestCas
         .thenReturn(NULL_CLASSLOADER_FILTER);
 
     when(descriptorLoaderRepository.get(FILE_SYSTEM_POLICY_MODEL_LOADER_ID, ClassLoaderModelLoader.class))
-        .thenReturn(of(new FileSystemPolicyClassLoaderModelLoader()));
+        .thenReturn(new FileSystemPolicyClassLoaderModelLoader());
     when(descriptorLoaderRepository.get(INVALID_LOADER_ID, ClassLoaderModelLoader.class))
-        .thenReturn(empty());
+        .thenThrow(new LoaderNotFoundException(INVALID_LOADER_ID));
 
     when(descriptorLoaderRepository.get(PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID, BundleDescriptorLoader.class))
-        .thenReturn(of(new PropertiesBundleDescriptorLoader()));
+        .thenReturn(new PropertiesBundleDescriptorLoader());
     when(descriptorLoaderRepository.get(INVALID_LOADER_ID, BundleDescriptorLoader.class))
-        .thenReturn(empty());
+        .thenThrow(new LoaderNotFoundException(INVALID_LOADER_ID));
   }
 
   @Test

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactoryTestCase.java
@@ -7,7 +7,10 @@
 
 package org.mule.runtime.module.deployment.impl.internal.plugin;
 
+import static java.io.File.createTempFile;
 import static java.util.Collections.emptySet;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -16,23 +19,38 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.util.FileUtils.stringToFile;
+import static org.mule.runtime.core.util.FileUtils.unzip;
 import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.EXPORTED_CLASS_PACKAGES_PROPERTY;
 import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.EXPORTED_RESOURCE_PROPERTY;
 import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.NULL_CLASSLOADER_FILTER;
 import static org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorFactory.PLUGIN_DEPENDENCIES;
 import static org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorFactory.PLUGIN_PROPERTIES;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorFactory.invalidBundleDescriptorLoaderIdError;
+import static org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorFactory.invalidClassLoaderModelIdError;
+import static org.mule.runtime.module.deployment.impl.internal.policy.FileSystemPolicyClassLoaderModelLoader.FILE_SYSTEM_POLICY_MODEL_LOADER_ID;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.ARTIFACT_ID;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.CLASSIFIER;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.GROUP_ID;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.TYPE;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.VERSION;
+import org.mule.runtime.api.deployment.meta.MuleArtifactLoaderDescriptor;
+import org.mule.runtime.api.deployment.meta.MulePluginModel;
 import org.mule.runtime.core.util.FileUtils;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoaderFilter;
 import org.mule.runtime.module.artifact.classloader.ClassLoaderFilterFactory;
 import org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter;
+import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateException;
 import org.mule.runtime.module.artifact.descriptor.BundleDependency;
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptor;
+import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
+import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
+import org.mule.runtime.module.deployment.impl.internal.artifact.DescriptorLoaderRepository;
+import org.mule.runtime.module.deployment.impl.internal.builder.ArtifactPluginFileBuilder;
+import org.mule.runtime.module.deployment.impl.internal.policy.FileSystemPolicyClassLoaderModelLoader;
+import org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import java.io.File;
@@ -40,24 +58,50 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
 public class ArtifactPluginDescriptorFactoryTestCase extends AbstractMuleTestCase {
 
-  public static final String PLUGIN_NAME = "testPlugin";
+  private static final String PLUGIN_NAME = "testPlugin";
+  private static final String INVALID_LOADER_ID = "INVALID";
+  private static final String MIN_MULE_VERSION = "4.0.0";
 
   @Rule
   public TemporaryFolder pluginsFolder = new TemporaryFolder();
 
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
   private final ClassLoaderFilterFactory classLoaderFilterFactory = mock(ClassLoaderFilterFactory.class);
-  private ArtifactPluginDescriptorFactory descriptorFactory = new ArtifactPluginDescriptorFactory();
+  private final DescriptorLoaderRepository descriptorLoaderRepository = mock(DescriptorLoaderRepository.class);
+  private ArtifactPluginDescriptorFactory descriptorFactory = new ArtifactPluginDescriptorFactory(descriptorLoaderRepository);
 
   @Before
   public void setUp() throws Exception {
     when(classLoaderFilterFactory.create(null, null))
         .thenReturn(NULL_CLASSLOADER_FILTER);
+
+    when(descriptorLoaderRepository.get(FILE_SYSTEM_POLICY_MODEL_LOADER_ID, ClassLoaderModelLoader.class))
+        .thenReturn(of(new FileSystemPolicyClassLoaderModelLoader()));
+    when(descriptorLoaderRepository.get(INVALID_LOADER_ID, ClassLoaderModelLoader.class))
+        .thenReturn(empty());
+
+    when(descriptorLoaderRepository.get(PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID, BundleDescriptorLoader.class))
+        .thenReturn(of(new PropertiesBundleDescriptorLoader()));
+    when(descriptorLoaderRepository.get(INVALID_LOADER_ID, BundleDescriptorLoader.class))
+        .thenReturn(empty());
   }
 
   @Test
@@ -178,6 +222,43 @@ public class ArtifactPluginDescriptorFactoryTestCase extends AbstractMuleTestCas
     descriptorFactory.create(pluginFolder);
   }
 
+  @Test
+  public void detectsInvalidClassLoaderModelLoaderId() throws Exception {
+    MulePluginModel.MulePluginModelBuilder pluginModelBuilder = new MulePluginModel.MulePluginModelBuilder().setName(PLUGIN_NAME)
+        .setMinMuleVersion(MIN_MULE_VERSION)
+        .withBundleDescriptorLoader(createBundleDescriptorLoader(PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID));
+    pluginModelBuilder.withClassLoaderModelDescriber().setId(INVALID_LOADER_ID);
+
+    ArtifactPluginFileBuilder pluginFileBuilder =
+        new ArtifactPluginFileBuilder(PLUGIN_NAME).describedBy(pluginModelBuilder.build());
+    File tempFolder = createTempFolder();
+    unzip(pluginFileBuilder.getArtifactFile(), tempFolder);
+
+    expectedException.expect(ArtifactDescriptorCreateException.class);
+    expectedException
+        .expectMessage(invalidClassLoaderModelIdError(tempFolder, pluginModelBuilder.getClassLoaderModelDescriptorLoader()));
+
+    descriptorFactory.create(tempFolder);
+  }
+
+  @Test
+  public void detectsInvalidBundleDescriptorModelLoaderId() throws Exception {
+    MulePluginModel.MulePluginModelBuilder pluginModelBuilder = new MulePluginModel.MulePluginModelBuilder().setName(PLUGIN_NAME)
+        .setMinMuleVersion(MIN_MULE_VERSION).withBundleDescriptorLoader(createBundleDescriptorLoader(INVALID_LOADER_ID));
+    pluginModelBuilder.withClassLoaderModelDescriber().setId(FILE_SYSTEM_POLICY_MODEL_LOADER_ID);
+
+    ArtifactPluginFileBuilder pluginFileBuilder =
+        new ArtifactPluginFileBuilder(PLUGIN_NAME).describedBy(pluginModelBuilder.build());
+    File tempFolder = createTempFolder();
+    unzip(pluginFileBuilder.getArtifactFile(), tempFolder);
+
+    expectedException.expect(ArtifactDescriptorCreateException.class);
+    expectedException
+        .expectMessage(invalidBundleDescriptorLoaderIdError(tempFolder, pluginModelBuilder.getBundleDescriptorLoader()));
+
+    descriptorFactory.create(tempFolder);
+  }
+
   private File createPluginFolder() {
     final File pluginFolder = new File(pluginsFolder.getRoot(), PLUGIN_NAME);
     assertThat(pluginFolder.mkdir(), is(true));
@@ -188,6 +269,23 @@ public class ArtifactPluginDescriptorFactoryTestCase extends AbstractMuleTestCas
     final File jar1 = new File(pluginLibFolder, child);
     FileUtils.write(jar1, "foo");
     return jar1;
+  }
+
+  private File createTempFolder() throws IOException {
+    File tempFolder = createTempFile("tempPolicy", null);
+    Assert.assertThat(tempFolder.delete(), Matchers.is(true));
+    Assert.assertThat(tempFolder.mkdir(), Matchers.is(true));
+    return tempFolder;
+  }
+
+  private MuleArtifactLoaderDescriptor createBundleDescriptorLoader(String bundleDescriptorLoaderId) {
+    Map<String, Object> attributes = new HashMap();
+    attributes.put(VERSION, "1.0");
+    attributes.put(GROUP_ID, "org.mule.test");
+    attributes.put(ARTIFACT_ID, PLUGIN_NAME);
+    attributes.put(CLASSIFIER, "mule-plugin");
+    attributes.put(TYPE, "jar");
+    return new MuleArtifactLoaderDescriptor(bundleDescriptorLoaderId, attributes);
   }
 
   private static class PluginDescriptorChecker {

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/FileSystemPolicyClassLoaderModelLoaderTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/FileSystemPolicyClassLoaderModelLoaderTestCase.java
@@ -45,7 +45,7 @@ public class FileSystemPolicyClassLoaderModelLoaderTestCase extends AbstractMule
     File file2 = new File(libFolder, "test2.jar");
     stringToFile(file2.getAbsolutePath(), "foo");
 
-    ClassLoaderModel classLoaderModel = classLoaderModelLoader.loadClassLoaderModel(policyFolder);
+    ClassLoaderModel classLoaderModel = classLoaderModelLoader.load(policyFolder, null);
 
     assertThat(classLoaderModel.getUrls().length, equalTo(3));
     assertThat(classLoaderModel.getUrls()[0], equalTo(classesFolder.toURI().toURL()));

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactoryTestCase.java
@@ -10,8 +10,6 @@ package org.mule.runtime.module.deployment.impl.internal.policy;
 import static java.io.File.createTempFile;
 import static java.io.File.separator;
 import static java.util.Collections.emptyList;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -42,6 +40,7 @@ import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorCreateExcep
 import org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader;
 import org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader;
 import org.mule.runtime.module.deployment.impl.internal.artifact.DescriptorLoaderRepository;
+import org.mule.runtime.module.deployment.impl.internal.artifact.LoaderNotFoundException;
 import org.mule.runtime.module.deployment.impl.internal.artifact.ServiceRegistryDescriptorLoaderRepository;
 import org.mule.runtime.module.deployment.impl.internal.builder.ArtifactPluginFileBuilder;
 import org.mule.runtime.module.deployment.impl.internal.builder.PolicyFileBuilder;
@@ -96,14 +95,14 @@ public class PolicyTemplateDescriptorFactoryTestCase extends AbstractMuleTestCas
     when(applicationPluginRepository.getContainerArtifactPluginDescriptors()).thenReturn(emptyList());
 
     when(descriptorLoaderRepository.get(FILE_SYSTEM_POLICY_MODEL_LOADER_ID, ClassLoaderModelLoader.class))
-        .thenReturn(of(new FileSystemPolicyClassLoaderModelLoader()));
+        .thenReturn(new FileSystemPolicyClassLoaderModelLoader());
     when(descriptorLoaderRepository.get(INVALID_LOADER_ID, ClassLoaderModelLoader.class))
-        .thenReturn(empty());
+        .thenThrow(new LoaderNotFoundException(INVALID_LOADER_ID));
 
     when(descriptorLoaderRepository.get(PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID, BundleDescriptorLoader.class))
-        .thenReturn(of(new PropertiesBundleDescriptorLoader()));
+        .thenReturn(new PropertiesBundleDescriptorLoader());
     when(descriptorLoaderRepository.get(INVALID_LOADER_ID, BundleDescriptorLoader.class))
-        .thenReturn(empty());
+        .thenThrow(new LoaderNotFoundException(INVALID_LOADER_ID));
   }
 
   @Test

--- a/modules/deployment-model-impl/src/test/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader
+++ b/modules/deployment-model-impl/src/test/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.BundleDescriptorLoader
@@ -1,0 +1,1 @@
+org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader

--- a/modules/deployment-model-impl/src/test/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader
+++ b/modules/deployment-model-impl/src/test/resources/META-INF/services/org.mule.runtime.module.artifact.descriptor.ClassLoaderModelLoader
@@ -1,0 +1,1 @@
+org.mule.runtime.module.deployment.impl.internal.policy.FileSystemPolicyClassLoaderModelLoader

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptor.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptor.java
@@ -7,8 +7,10 @@
 
 package org.mule.runtime.deployment.model.api.policy;
 
+import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptor;
+import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -23,6 +25,8 @@ public class PolicyTemplateDescriptor extends ArtifactDescriptor {
   public static final String DEFAULT_POLICY_CONFIGURATION_RESOURCE = "policy.xml";
   public static final String META_INF = "META-INF";
   public static final String MULE_POLICY_JSON = "mule-policy.json";
+  protected static final String POLICY_EXPORTED_PACKAGES_ERROR = "A policy template artifact cannot export packages";
+  protected static final String POLICY_EXPORTED_RESOURCE_ERROR = "A policy template artifact cannot export resources";
 
   private Set<ArtifactPluginDescriptor> plugins = new HashSet<>(0);
 
@@ -41,5 +45,13 @@ public class PolicyTemplateDescriptor extends ArtifactDescriptor {
 
   public void setPlugins(Set<ArtifactPluginDescriptor> plugins) {
     this.plugins = plugins;
+  }
+
+  @Override
+  public void setClassLoaderModel(ClassLoaderModel classLoaderModel) {
+    checkArgument(classLoaderModel.getExportedPackages().isEmpty(), POLICY_EXPORTED_PACKAGES_ERROR);
+    checkArgument(classLoaderModel.getExportedResources().isEmpty(), POLICY_EXPORTED_RESOURCE_ERROR);
+
+    super.setClassLoaderModel(classLoaderModel);
   }
 }

--- a/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptorTestCase.java
+++ b/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/api/policy/PolicyTemplateDescriptorTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.runtime.deployment.model.api.policy;
+
+import static org.junit.rules.ExpectedException.none;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.POLICY_EXPORTED_PACKAGES_ERROR;
+import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.POLICY_EXPORTED_RESOURCE_ERROR;
+import org.mule.runtime.module.artifact.descriptor.ClassLoaderModel;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
+
+import java.util.Collections;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@SmallTest
+public class PolicyTemplateDescriptorTestCase extends AbstractMuleTestCase {
+
+  private static final String POLICY_NAME = "policyName";
+
+  @Rule
+  public ExpectedException expectedException = none();
+
+  @Test
+  public void verifiesPolicyTemplateDoesNotExportPackages() throws Exception {
+    PolicyTemplateDescriptor policyTemplateDescriptor = new PolicyTemplateDescriptor(POLICY_NAME);
+    ClassLoaderModel classLoaderModel = mock(ClassLoaderModel.class);
+    when(classLoaderModel.getExportedPackages()).thenReturn(Collections.singleton("org.foo"));
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(POLICY_EXPORTED_PACKAGES_ERROR);
+    policyTemplateDescriptor.setClassLoaderModel(classLoaderModel);
+  }
+
+  @Test
+  public void verifiesPolicyTemplateDoesNotExportResources() throws Exception {
+    PolicyTemplateDescriptor policyTemplateDescriptor = new PolicyTemplateDescriptor(POLICY_NAME);
+    ClassLoaderModel classLoaderModel = mock(ClassLoaderModel.class);
+    when(classLoaderModel.getExportedResources()).thenReturn(Collections.singleton("META-INF/foo.xml"));
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(POLICY_EXPORTED_RESOURCE_ERROR);
+    policyTemplateDescriptor.setClassLoaderModel(classLoaderModel);
+  }
+}

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DeploymentServiceTestCase.java
@@ -64,10 +64,10 @@ import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassL
 import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.EXPORTED_RESOURCE_PROPERTY;
 import static org.mule.runtime.module.deployment.impl.internal.application.PropertiesDescriptorParser.PROPERTY_DOMAIN;
 import static org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorFactory.PLUGIN_BUNDLE;
-import static org.mule.runtime.module.deployment.impl.internal.policy.PolicyTemplateDescriptorFactory.PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.ARTIFACT_ID;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.CLASSIFIER;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.GROUP_ID;
+import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.TYPE;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.VERSION;
 import static org.mule.runtime.module.deployment.internal.DeploymentDirectoryWatcher.CHANGE_CHECK_INTERVAL_PROPERTY;
@@ -94,6 +94,7 @@ import org.mule.runtime.core.config.StartupContext;
 import org.mule.runtime.core.exception.MessagingException;
 import org.mule.runtime.core.policy.PolicyParametrization;
 import org.mule.runtime.core.policy.PolicyPointcut;
+import org.mule.runtime.core.registry.SpiServiceRegistry;
 import org.mule.runtime.core.util.FileUtils;
 import org.mule.runtime.core.util.IOUtils;
 import org.mule.runtime.core.util.StringUtils;
@@ -112,6 +113,7 @@ import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.module.deployment.impl.internal.MuleArtifactResourcesRegistry;
 import org.mule.runtime.module.deployment.impl.internal.artifact.DefaultClassLoaderManager;
+import org.mule.runtime.module.deployment.impl.internal.artifact.ServiceRegistryDescriptorLoaderRepository;
 import org.mule.runtime.module.deployment.impl.internal.builder.ApplicationFileBuilder;
 import org.mule.runtime.module.deployment.impl.internal.builder.ArtifactPluginFileBuilder;
 import org.mule.runtime.module.deployment.impl.internal.builder.DomainFileBuilder;
@@ -464,7 +466,8 @@ public class DeploymentServiceTestCase extends AbstractMuleTestCase {
     policyManager = new TestPolicyManager(deploymentService,
                                           new PolicyTemplateDescriptorFactory(
                                                                               muleArtifactResourcesRegistry
-                                                                                  .getArtifactPluginDescriptorLoader()));
+                                                                                  .getArtifactPluginDescriptorLoader(),
+                                                                              new ServiceRegistryDescriptorLoaderRepository(new SpiServiceRegistry())));
     // Reset test component state
     invocationCount = 0;
     policyParametrization = "";


### PR DESCRIPTION
_ Adding DescriptorLoader interface to generify loaders
_ Implementing the new interface on the available loaders
_ Adding DescriptorLoaderRepository to provide access to the available loaders
_ Adding ServiceRegistryDescriptorLoaderRepository to find loaders using a service registry
_ Adding SPI declarations for BundleDescriptorLoader and ClassLoaderModelLoader implementations