### PR TITLE
MULE-11106: Minor changes in CE/EE to automate the 4.x release.

### DIFF
--- a/compatibility/modules/module-support/src/main/resources/plugin.properties
+++ b/compatibility/modules/module-support/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 #TODO MULE-10735 generate this file from maven dependencies so we won't have issues with the hard-coded version, packages or resources there
 #TODO MULE-11047 Remove dependency to HTTP extension plugin once HTTP service is implemented and compatibility module support migrated to use the service
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring.editors,\
                               org.mule.compatibility.config.spring.factories,\

--- a/compatibility/pom.xml
+++ b/compatibility/pom.xml
@@ -17,4 +17,29 @@
         <module>transports</module>
         <module>tests</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <executions>
+                    <execution>
+                        <id>replace-plugin-properties-deps-version</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>${project.build.directory}/classes/plugin.properties</include>
+                    </includes>
+                    <token>%PROJECT_VERSION%</token>
+                    <value>${project.version}</value>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/compatibility/tests/integration-transports/src/main/resources/plugin.properties
+++ b/compatibility/tests/integration-transports/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 
 #TODO MULE-10735 generate this from maven dependencies so we won't have issues with the hard-coded version there
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring,\
                               org.mule.compatibility.config.spring.editors,\

--- a/compatibility/transports/file/src/main/resources/plugin.properties
+++ b/compatibility/transports/file/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 #TODO MULE-10735 generate this file from maven dependencies so we won't have issues with the hard-coded version, packages or resources there
 #TODO MULE-11047 Remove dependency to HTTP extension plugin once HTTP service is implemented and compatibility module support migrated to use the service
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring.editors,\
                               org.mule.compatibility.config.spring.factories,\

--- a/compatibility/transports/http/src/main/resources/plugin.properties
+++ b/compatibility/transports/http/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 #TODO MULE-10735 generate this file from maven dependencies so we won't have issues with the hard-coded version, packages or resources there
 #TODO MULE-11047 Remove dependency to HTTP extension plugin once HTTP service is implemented and compatibility module support migrated to use the service
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring.editors,\
                               org.mule.compatibility.config.spring.factories,\

--- a/compatibility/transports/jms/src/main/resources/plugin.properties
+++ b/compatibility/transports/jms/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 #TODO MULE-10735 generate this file from maven dependencies so we won't have issues with the hard-coded version, packages or resources there
 #TODO MULE-11047 Remove dependency to HTTP extension plugin once HTTP service is implemented and compatibility module support migrated to use the service
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring.editors,\
                               org.mule.compatibility.config.spring.factories,\

--- a/compatibility/transports/ssl/src/main/resources/plugin.properties
+++ b/compatibility/transports/ssl/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 #TODO MULE-10735 generate this file from maven dependencies so we won't have issues with the hard-coded version, packages or resources there
 #TODO MULE-11047 Remove dependency to HTTP extension plugin once HTTP service is implemented and compatibility module support migrated to use the service
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring.editors,\
                               org.mule.compatibility.config.spring.factories,\

--- a/compatibility/transports/tcp/src/main/resources/plugin.properties
+++ b/compatibility/transports/tcp/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 #TODO MULE-10735 generate this file from maven dependencies so we won't have issues with the hard-coded version, packages or resources there
 #TODO MULE-11047 Remove dependency to HTTP extension plugin once HTTP service is implemented and compatibility module support migrated to use the service
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring.editors,\
                               org.mule.compatibility.config.spring.factories,\

--- a/compatibility/transports/vm/src/main/resources/plugin.properties
+++ b/compatibility/transports/vm/src/main/resources/plugin.properties
@@ -1,7 +1,7 @@
 #Plugin Properties
 #TODO MULE-10735 generate this file from maven dependencies so we won't have issues with the hard-coded version, packages or resources there
 #TODO MULE-11047 Remove dependency to HTTP extension plugin once HTTP service is implemented and compatibility module support migrated to use the service
-plugin.dependencies=mule-module-http-ext-4.0-SNAPSHOT
+plugin.dependencies=mule-module-http-ext-%PROJECT_VERSION% 
 
 artifact.export.classPackages=org.mule.compatibility.config.spring.editors,\
                               org.mule.compatibility.config.spring.factories,\

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -19,8 +19,6 @@
 
     <properties>
         <generateDocs>false</generateDocs>
-        <mule.extensions.maven.plugin.version>1.0.0-SNAPSHOT</mule.extensions.maven.plugin.version>
-        <mule.metadata.version>1.0.0-SNAPSHOT</mule.metadata.version>
     </properties>
 
     <modules>
@@ -65,19 +63,19 @@
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-metadata-model-xml</artifactId>
-            <version>${mule.metadata.version}</version>
+            <version>${muleMetadataModelVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-metadata-model-java</artifactId>
-            <version>${mule.metadata.version}</version>
+            <version>${muleMetadataModelVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-metadata-model-json</artifactId>
-            <version>${mule.metadata.version}</version>
+            <version>${muleMetadataModelVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/modules/dsl-api/pom.xml
+++ b/modules/dsl-api/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mule-module-dsl-api</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>${muleDslApiVersion}</version>
     <name>Mule module DSL API</name>
     <description>Module with the API to define how to build runtime objects from configuration files</description>
 

--- a/modules/file-extension-common/pom.xml
+++ b/modules/file-extension-common/pom.xml
@@ -17,7 +17,6 @@
 
     <properties>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
-        <mule.plugins.maven.app.plugins.version>1.0.0-SNAPSHOT</mule.plugins.maven.app.plugins.version>
     </properties>
 
     <dependencies>
@@ -69,7 +68,6 @@
             <plugin>
                 <groupId>org.mule.plugins</groupId>
                 <artifactId>mule-app-plugins-maven-plugin</artifactId>
-                <version>${mule.plugins.maven.app.plugins.version}</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,10 @@
         <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <mule.module.maven.plugin.version>1.0-SNAPSHOT</mule.module.maven.plugin.version>
-        <!-- v1.1.0 has an issue with Optional dependencies, when resolving the graph it overrides the optionality of a transitive
+        <mule.extensions.maven.plugin.version>1.0.0-SNAPSHOT</mule.extensions.maven.plugin.version>
+        <mule.app.plugins.maven.plugin.version>1.0.0-SNAPSHOT</mule.app.plugins.maven.plugin.version>
+
+        <!-- v1.1.0 has an issue with Optional dependencies, whenjbpmVersion resolving the graph it overrides the optionality of a transitive
              dependency with the one define in the dependency management (which is mostly in all the cases "false")
              https://bugs.eclipse.org/bugs/show_bug.cgi?id=501019 -->
         <aetherVersion>1.0.2.v20150114</aetherVersion>
@@ -1818,6 +1821,18 @@
                     <version>${mule.module.maven.plugin.version}</version>
                     <extensions>true</extensions>
                 </plugin>
+                <plugin>
+                    <groupId>org.mule.plugins</groupId>
+                    <artifactId>mule-app-plugins-maven-plugin</artifactId>
+                    <version>${mule.app.plugins.maven.plugin.version}</version>
+                    <extensions>true</extensions>
+                </plugin>
+                <plugin>
+                    <groupId>org.mule.extensions</groupId>
+                    <artifactId>mule-extensions-maven-plugin</artifactId>
+                    <version>${mule.extensions.maven.plugin.version}</version>
+                    <extensions>true</extensions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -2200,6 +2215,7 @@
                 <skipTests>true</skipTests>
                 <skipSystemTests>true</skipSystemTests>
                 <skipGpg>false</skipGpg>
+                <skipNoSnapshotsEnforcerPluginRule>false</skipNoSnapshotsEnforcerPluginRule>
             </properties>
             <build>
                 <defaultGoal>deploy</defaultGoal>
@@ -2247,6 +2263,27 @@
                         <configuration>
                             <skip>${skipGpg}</skip>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${maven.enforcer.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots-in-deps</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseDeps>
+                                            <message>No Snapshots Allowed!</message>
+                                        </requireReleaseDeps>
+                                    </rules>
+                                    <skip>${skipNoSnapshotsEnforcerPluginRule}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/services/http/pom.xml
+++ b/services/http/pom.xml
@@ -40,7 +40,6 @@
             <plugin>
                 <groupId>org.mule.plugins</groupId>
                 <artifactId>mule-app-plugins-maven-plugin</artifactId>
-                <version>1.0.0-SNAPSHOT</version>
                 <extensions>true</extensions>
             </plugin>
 

--- a/services/scheduler/pom.xml
+++ b/services/scheduler/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
-        <mule.plugins.maven.app.plugins.version>1.0.0-SNAPSHOT</mule.plugins.maven.app.plugins.version>
     </properties>
 
     <build>
@@ -38,7 +37,6 @@
             <plugin>
                 <groupId>org.mule.plugins</groupId>
                 <artifactId>mule-app-plugins-maven-plugin</artifactId>
-                <version>${mule.plugins.maven.app.plugins.version}</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/tests/test-extensions/pom.xml
+++ b/tests/test-extensions/pom.xml
@@ -15,10 +15,6 @@
     <packaging>pom</packaging>
     <name>Parent Pom for Mule Test Extension</name>
 
-    <properties>
-        <mule.extensions.maven.plugin.version>1.0.0-SNAPSHOT</mule.extensions.maven.plugin.version>
-    </properties>
-
     <modules>
         <module>petstore-extension</module>
         <module>heisenberg-extension</module>


### PR DESCRIPTION
 * Remove plugins properties versions that doesn't appear in the root.
 * Add enforcer plugin to avoid using SNAPSHOT deps in the release.
 * Add replacer plugin to update versions in plugin.properties file