### PR TITLE
MULE-11651 HTTP request lost when a failing one is processed first.  …

### DIFF
--- a/compatibility/modules/module-support/src/test/resources/spring-security/secure-http-polling-server-flow.xml
+++ b/compatibility/modules/module-support/src/test/resources/spring-security/secure-http-polling-server-flow.xml
@@ -35,7 +35,8 @@
     	<httpn:listener-connection host="localhost" port="${port1}"/>
     </httpn:listener-config>
 
-    <flow name="SecureUMO">
+    <!-- TODO MULE-11651 HTTP request lost when a failing one is processed first. Remove sync processing strategy. -->
+    <flow name="SecureUMO" processingStrategy="synchronous">
         <httpn:listener path="*" config-ref="listenerConfig"/>
         <transports:http-security-filter realm="mule-realm" />
         <test:component>

--- a/modules/spring-security/src/test/resources/secure-http-polling-server-flow.xml
+++ b/modules/spring-security/src/test/resources/secure-http-polling-server-flow.xml
@@ -33,7 +33,8 @@
         <httpn:listener-connection host="localhost" port="${port1}"/>
     </httpn:listener-config>
 
-    <flow name="SecureUMO">
+    <!-- TODO MULE-11651 HTTP request lost when a failing one is processed first. Remove sync processing strategy. -->
+    <flow name="SecureUMO" processingStrategy="synchronous">
         <httpn:listener path="*" config-ref="listenerConfig"/>
         <httpn:basic-security-filter realm="mule-realm" />
         <test:component>


### PR DESCRIPTION
…Fix tests via use of sync processing strategy and add TODO.