### PR TITLE
MULE-11665: Fix: Memory Leak in Custom Agreggator.

### DIFF
--- a/core/src/main/java/org/mule/routing/correlation/EventCorrelator.java
+++ b/core/src/main/java/org/mule/routing/correlation/EventCorrelator.java
@@ -90,13 +90,13 @@ public class EventCorrelator implements Startable, Stoppable, Disposable
     private final FlowConstruct flowConstruct;
 
     public EventCorrelator(EventCorrelatorCallback callback,
-            MessageProcessor timeoutMessageProcessor,
-            MessageInfoMapping messageInfoMapping,
-            MuleContext muleContext,
-            FlowConstruct flowConstruct,
-            PartitionableObjectStore correlatorStore,
-            String storePrefix,
-            ObjectStore<Long> processedGroups)
+                           MessageProcessor timeoutMessageProcessor,
+                           MessageInfoMapping messageInfoMapping,
+                           MuleContext muleContext,
+                           FlowConstruct flowConstruct,
+                           PartitionableObjectStore correlatorStore,
+                           String storePrefix,
+                           ObjectStore<Long> processedGroups)
     {
         if (callback == null)
         {
@@ -242,7 +242,25 @@ public class EventCorrelator implements Startable, Stoppable, Disposable
                 if (callback.shouldAggregateEvents(group))
                 {
                     // create the response event
-                    MuleEvent returnEvent = callback.aggregateEvents(group);
+                    MuleEvent returnEvent = null;
+                    try
+                    {
+                        returnEvent = callback.aggregateEvents(group);
+                    }
+                    catch (RoutingException routingException)
+                    {
+                        try
+                        {
+                            this.removeEventGroup(group);
+                            group.clear();
+                        }
+                        catch (ObjectStoreException objectStoreException)
+                        {
+                            throw new RoutingException(event, timeoutMessageProcessor, objectStoreException);
+                        }
+
+                        throw routingException;
+                    }
                     returnEvent.getMessage().setCorrelationId(groupId);
                     String rootId = group.getCommonRootId();
                     if (rootId != null)
@@ -585,7 +603,7 @@ public class EventCorrelator implements Startable, Stoppable, Disposable
     {
         return storePrefix + ".expiredAndDispatchedGroups";
     }
-    
+
     protected String getEventGroupsPartitionKey()
     {
         return storePrefix + ".eventGroups";

--- a/tests/integration/src/test/java/org/mule/routing/outbound/EventCorrelatorTestCase.java
+++ b/tests/integration/src/test/java/org/mule/routing/outbound/EventCorrelatorTestCase.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.routing.outbound;
+
+import org.mule.api.MuleContext;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleMessage;
+import org.mule.api.config.MuleConfiguration;
+import org.mule.api.construct.FlowConstruct;
+import org.mule.api.processor.MessageProcessor;
+import org.mule.api.routing.MessageInfoMapping;
+import org.mule.api.routing.RoutingException;
+import org.mule.api.store.ObjectDoesNotExistException;
+import org.mule.api.store.ObjectStore;
+import org.mule.api.store.ObjectStoreException;
+import org.mule.api.store.PartitionableObjectStore;
+import org.mule.routing.EventGroup;
+import org.mule.routing.correlation.EventCorrelator;
+import org.mule.routing.correlation.EventCorrelatorCallback;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+
+
+public class EventCorrelatorTestCase extends AbstractMuleTestCase
+{
+
+    private EventCorrelator eventCorrelator;
+    private final EventCorrelatorCallback eventCorrelatorCallback = mock(EventCorrelatorCallback.class);
+    private final MessageProcessor messageProcessor = mock(MessageProcessor.class);
+    private final MessageInfoMapping messageInfoMapping = mock(MessageInfoMapping.class);
+    private final FlowConstruct flowConstruct = mock(FlowConstruct.class);
+    private PartitionableObjectStore<EventGroup> partitionableObjectStore = mock(PartitionableObjectStore.class);
+    private ObjectStore<Long> objectStore =  mock(ObjectStore.class);
+    private MuleEvent event = mock(MuleEvent.class);
+    private MuleContext muleContext = mock(MuleContext.class);
+    private MuleConfiguration muleConfiguration = mock(MuleConfiguration.class);
+    private EventGroup eventGroup = mock(EventGroup.class);
+    private int countOfEventGroups = 0;
+    private boolean eventGroupWasSaved = false;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        setReturnsAndExceptions();
+        setAnswers();
+        eventCorrelator = new EventCorrelator(eventCorrelatorCallback, messageProcessor, messageInfoMapping,
+                                              muleContext, flowConstruct, partitionableObjectStore, "prefix", objectStore);
+    }
+
+    @Test
+    public void testEventGroupFreedInRoutingException() throws Exception
+    {
+        MuleEvent event = mock(MuleEvent.class);
+        try
+        {
+            eventCorrelator.process(event);
+            fail("Routing Exception must be catched.");
+        }
+        catch (RoutingException e)
+        {
+            assertTrue("Event Group wasn't saved", eventGroupWasSaved);
+            assertThat(countOfEventGroups, is(0));
+        }
+
+    }
+
+    private void setReturnsAndExceptions() throws Exception
+    {
+        when(muleContext.getConfiguration()).thenReturn(muleConfiguration);
+        when(messageInfoMapping.getCorrelationId(any(MuleMessage.class))).thenReturn("id");
+        when(partitionableObjectStore.retrieve(any(Serializable.class), any(String.class))).thenThrow(ObjectDoesNotExistException.class);
+        when(eventCorrelatorCallback.createEventGroup(any(MuleEvent.class), any(Object.class))).thenReturn(eventGroup);
+        when(eventCorrelatorCallback.aggregateEvents(any(EventGroup.class))).thenThrow(RoutingException.class);
+        when(eventCorrelatorCallback.shouldAggregateEvents(any(EventGroup.class))).thenReturn(true);
+    }
+
+    private void setAnswers() throws ObjectStoreException
+    {
+        doAnswer(new Answer<Void>()
+        {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable
+            {
+                countOfEventGroups++;
+                eventGroupWasSaved = true;
+                return null;
+            }
+        }).when(partitionableObjectStore).store(any(Serializable.class), any(EventGroup.class), any(String.class));
+
+        doAnswer(new Answer<Void>()
+        {
+
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable
+            {
+                countOfEventGroups--;
+                return null;
+            }
+        }).when(partitionableObjectStore).remove(any(Serializable.class), any(String.class));
+    }
+}
+
+


### PR DESCRIPTION
If an exception is triggered in aggregateEvents of an EventCorrelatorCallback, the created GroupEvent isn't freed. It is causing an increasing of the instances of the EventGroup class.
EventCorrelator was modified catching the exception.
EventCorrelatorTestCase was added.