### PR TITLE
Revert "MULE-11651 HTTP request lost when a failing one is processed …

### DIFF
--- a/compatibility/modules/module-support/src/test/resources/spring-security/secure-http-polling-server-flow.xml
+++ b/compatibility/modules/module-support/src/test/resources/spring-security/secure-http-polling-server-flow.xml
@@ -35,8 +35,7 @@
     	<httpn:listener-connection host="localhost" port="${port1}"/>
     </httpn:listener-config>
 
-    <!-- TODO MULE-11651 HTTP request lost when a failing one is processed first. Remove sync processing strategy. -->
-    <flow name="SecureUMO" processingStrategy="synchronous">
+    <flow name="SecureUMO">
         <httpn:listener path="*" config-ref="listenerConfig"/>
         <transports:http-security-filter realm="mule-realm" />
         <test:component>

--- a/modules/spring-security/src/test/resources/secure-http-polling-server-flow.xml
+++ b/modules/spring-security/src/test/resources/secure-http-polling-server-flow.xml
@@ -33,8 +33,7 @@
         <httpn:listener-connection host="localhost" port="${port1}"/>
     </httpn:listener-config>
 
-    <!-- TODO MULE-11651 HTTP request lost when a failing one is processed first. Remove sync processing strategy. -->
-    <flow name="SecureUMO" processingStrategy="synchronous">
+    <flow name="SecureUMO">
         <httpn:listener path="*" config-ref="listenerConfig"/>
         <httpn:basic-security-filter realm="mule-realm" />
         <test:component>


### PR DESCRIPTION
…first.  Fix tests via use of sync processing strategy and add TODO. (#4098)"

This reverts commit f23331998586670e89c60d4a170fa9eaadd509a9.