### PR TITLE
MULE-10545: Change http selectors/workers to use a connector pool from

### DIFF
--- a/modules/http/src/main/java/org/mule/runtime/module/http/internal/request/DefaultHttpRequesterConfig.java
+++ b/modules/http/src/main/java/org/mule/runtime/module/http/internal/request/DefaultHttpRequesterConfig.java
@@ -121,7 +121,7 @@ public class DefaultHttpRequesterConfig extends AbstractAnnotatedObject
     if (httpClientFactory == null) {
       httpClient = new GrizzlyHttpClient(configuration, schedulerService);
     } else {
-      httpClient = httpClientFactory.create(configuration);
+      httpClient = httpClientFactory.create(configuration, schedulerService);
     }
     initialised = true;
   }

--- a/modules/http/src/main/java/org/mule/runtime/module/http/internal/request/HttpClientFactory.java
+++ b/modules/http/src/main/java/org/mule/runtime/module/http/internal/request/HttpClientFactory.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.module.http.internal.request;
 
+import org.mule.runtime.core.api.scheduler.SchedulerService;
+
 /**
  * Factory object for {@link HttpClient} mule-to-httpLibrary adapters.
  */
@@ -13,8 +15,9 @@ public interface HttpClientFactory {
 
   /**
    * @param configuration the configuration to use for the underlying http library.
+   * @param schedulerService the provider of the thread pools to be used by the grizzly client
    * @return a newly built {@link HttpClient}
    */
-  HttpClient create(HttpClientConfiguration configuration);
+  HttpClient create(HttpClientConfiguration configuration, SchedulerService schedulerService);
 
 }

--- a/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportScheduler.java
+++ b/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportScheduler.java
@@ -38,7 +38,7 @@ public class SimpleUnitTestSupportScheduler extends ScheduledThreadPoolExecutor 
 
   @Override
   public void stop(long gracefulShutdownTimeoutSecs, TimeUnit unit) {
-    // Nothing to do. The lifecycle of this pool is managed by the UnitTestSchedulerService that instantiated this
+    shutdownNow();
   }
 
   @Override

--- a/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportSchedulerService.java
+++ b/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportSchedulerService.java
@@ -89,7 +89,9 @@ public class SimpleUnitTestSupportSchedulerService implements SchedulerService, 
   public Scheduler customScheduler(SchedulerConfig config) {
     final SimpleUnitTestSupportLifecycleSchedulerDecorator decorator =
         decorateScheduler(new SimpleUnitTestSupportScheduler(config.getMaxConcurrentTasks(),
-                                                             new NamedThreadFactory(config.getSchedulerName()),
+                                                             new NamedThreadFactory(config.getSchedulerName() != null
+                                                                 ? config.getSchedulerName()
+                                                                 : "SimpleUnitTestSupportSchedulerService_custom"),
                                                              new AbortPolicy()));
     decorators.add(decorator);
     return decorator;
@@ -99,7 +101,9 @@ public class SimpleUnitTestSupportSchedulerService implements SchedulerService, 
   public Scheduler customScheduler(SchedulerConfig config, int queueSize) {
     final SimpleUnitTestSupportLifecycleSchedulerDecorator decorator =
         decorateScheduler(new SimpleUnitTestSupportScheduler(config.getMaxConcurrentTasks(),
-                                                             new NamedThreadFactory(config.getSchedulerName()),
+                                                             new NamedThreadFactory(config.getSchedulerName() != null
+                                                                 ? config.getSchedulerName()
+                                                                 : "SimpleUnitTestSupportSchedulerService_custom"),
                                                              new AbortPolicy()));
     decorators.add(decorator);
     return decorator;

--- a/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportSchedulerService.java
+++ b/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportSchedulerService.java
@@ -140,7 +140,9 @@ public class SimpleUnitTestSupportSchedulerService implements SchedulerService, 
 
   @Override
   public void stop() throws MuleException {
-    scheduler.shutdownNow();
+    if (!scheduler.isShutdown()) {
+      scheduler.shutdownNow();
+    }
   }
 
   @Override


### PR DESCRIPTION
the service
* Fix tests that use http over the testing scheduler service