### PR TITLE
MULE-11835: RSS parser isn't parsing elements with namespaces.

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -305,7 +305,7 @@
 /mule-standalone-${productVersion}/lib/opt/jbossjta-4.15.0.Final.jar
 /mule-standalone-${productVersion}/lib/opt/jcifs-1.3.3.jar
 /mule-standalone-${productVersion}/lib/opt/jcodings-1.0.16.jar
-/mule-standalone-${productVersion}/lib/opt/jdom-2.0.2.jar
+/mule-standalone-${productVersion}/lib/opt/jdom2-2.0.6.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-client-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-common-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-guava-2.11.jar

--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -305,7 +305,7 @@
 /mule-standalone-${productVersion}/lib/opt/jbossjta-4.15.0.Final.jar
 /mule-standalone-${productVersion}/lib/opt/jcifs-1.3.3.jar
 /mule-standalone-${productVersion}/lib/opt/jcodings-1.0.16.jar
-/mule-standalone-${productVersion}/lib/opt/jdom-1.1.3.jar
+/mule-standalone-${productVersion}/lib/opt/jdom-2.0.2.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-client-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-common-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-guava-2.11.jar
@@ -379,7 +379,8 @@
 /mule-standalone-${productVersion}/lib/opt/reflections-0.9.9.jar
 /mule-standalone-${productVersion}/lib/opt/relaxngDatatype-20020414.jar
 /mule-standalone-${productVersion}/lib/opt/rhino-1.7R4.jar
-/mule-standalone-${productVersion}/lib/opt/rome-0.9.jar
+/mule-standalone-${productVersion}/lib/opt/rome-1.5.0.jar
+/mule-standalone-${productVersion}/lib/opt/rome-utils-1.5.0.jar
 /mule-standalone-${productVersion}/lib/opt/Saxon-HE-9.6.0-7.jar
 /mule-standalone-${productVersion}/lib/opt/Saxon-HE-9.6.0-7-xqj.jar
 /mule-standalone-${productVersion}/lib/opt/signpost-core-1.2.1.2.jar

--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -305,7 +305,7 @@
 /mule-standalone-${productVersion}/lib/opt/jbossjta-4.15.0.Final.jar
 /mule-standalone-${productVersion}/lib/opt/jcifs-1.3.3.jar
 /mule-standalone-${productVersion}/lib/opt/jcodings-1.0.16.jar
-/mule-standalone-${productVersion}/lib/opt/jdom2-2.0.6.jar
+/mule-standalone-${productVersion}/lib/opt/jdom-2.0.2.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-client-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-common-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-guava-2.11.jar

--- a/modules/rss/pom.xml
+++ b/modules/rss/pom.xml
@@ -31,12 +31,6 @@
                 <groupId>com.rometools</groupId>
                 <artifactId>rome</artifactId>
                 <version>1.5.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jdom</groupId>
-                    <artifactId>jdom</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>

--- a/modules/rss/pom.xml
+++ b/modules/rss/pom.xml
@@ -28,12 +28,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>rome</groupId>
-            <artifactId>rome</artifactId>
-            <version>0.9</version>
+                <groupId>com.rometools</groupId>
+                <artifactId>rome</artifactId>
+                <version>1.5.0</version>
             <exclusions>
                 <exclusion>
-                    <groupId>jdom</groupId>
+                    <groupId>org.jdom</groupId>
                     <artifactId>jdom</artifactId>
                 </exclusion>
             </exclusions>

--- a/modules/rss/pom.xml
+++ b/modules/rss/pom.xml
@@ -30,17 +30,17 @@
         <dependency>
                 <groupId>com.rometools</groupId>
                 <artifactId>rome</artifactId>
-                <version>1.5.0</version>
+                <version>1.7.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jdom</groupId>
-                    <artifactId>jdom</artifactId>
+                    <artifactId>jdom2</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>
-            <artifactId>jdom</artifactId>
+            <artifactId>jdom2</artifactId>
             <version>${jdomVersion}</version>
         </dependency>
 

--- a/modules/rss/pom.xml
+++ b/modules/rss/pom.xml
@@ -30,17 +30,17 @@
         <dependency>
                 <groupId>com.rometools</groupId>
                 <artifactId>rome</artifactId>
-                <version>1.7.1</version>
+                <version>1.5.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jdom</groupId>
-                    <artifactId>jdom2</artifactId>
+                    <artifactId>jdom</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>
-            <artifactId>jdom2</artifactId>
+            <artifactId>jdom</artifactId>
             <version>${jdomVersion}</version>
         </dependency>
 

--- a/modules/rss/src/main/java/org/mule/module/rss/routing/EntryLastUpdatedFilter.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/routing/EntryLastUpdatedFilter.java
@@ -12,8 +12,7 @@ import org.mule.api.routing.filter.Filter;
 import org.mule.api.transformer.TransformerException;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.transformer.types.DataTypeFactory;
-
-import com.sun.syndication.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntry;
 
 import java.util.Date;
 

--- a/modules/rss/src/main/java/org/mule/module/rss/routing/FeedLastUpdatedFilter.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/routing/FeedLastUpdatedFilter.java
@@ -13,7 +13,8 @@ import org.mule.api.transformer.TransformerException;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.transformer.types.DataTypeFactory;
 
-import com.sun.syndication.feed.synd.SyndFeed;
+
+import com.rometools.rome.feed.synd.SyndFeed;
 
 import java.util.Date;
 

--- a/modules/rss/src/main/java/org/mule/module/rss/routing/FeedSplitter.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/routing/FeedSplitter.java
@@ -16,8 +16,9 @@ import org.mule.api.transformer.TransformerException;
 import org.mule.module.rss.transformers.ObjectToRssFeed;
 import org.mule.routing.AbstractSplitter;
 
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndFeed;
+
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
 
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/modules/rss/src/main/java/org/mule/module/rss/transformers/ObjectToRssFeed.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/transformers/ObjectToRssFeed.java
@@ -10,9 +10,10 @@ import org.mule.api.transformer.TransformerException;
 import org.mule.transformer.AbstractDiscoverableTransformer;
 import org.mule.transformer.types.DataTypeFactory;
 
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.io.SyndFeedInput;
-import com.sun.syndication.io.XmlReader;
+
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
@@ -33,8 +33,9 @@ import org.jdom2.Element;
 import org.jdom2.Namespace;
 
 /**
- * Parses RSS item elements and its children.
- * Considers the use of namespaces that were added in RSS 1.0
+ * RSS20Parser considers all the elements added in the last standard (and earlier standards).
+ * However Rome doesn't support the use of namespaces although this feature was added in RSS 1.0 Standard.
+ * Therefore, RssParser calls in each method the parent method first, and then checks if elements that haven't been parsed by the parent Parser exist but were ignored because of namespaces.
  */
 public class RssParser extends RSS20Parser implements WireFeedParser
 {

--- a/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
@@ -61,130 +61,17 @@ public class RssParser extends RSS20Parser implements WireFeedParser
     {
 
         final Item item = super.parseItem(rssRoot, itemElement, locale);
-
-        if (item.getTitle() == null)
-        {
-            final Element title = parseChildWithNamespaces(itemElement, "title");
-            if (item.getTitle() == null)
-            {
-                item.setTitle(title.getText());
-            }
-        }
-
-        if (item.getLink() == null)
-        {
-            final Element link = parseChildWithNamespaces(itemElement, "link");
-            if (link != null)
-            {
-                item.setLink(link.getText());
-                item.setUri(link.getText());
-            }
-        }
-
-        if (item.getDescription() == null)
-        {
-            final Element description = parseChildWithNamespaces(itemElement, "description");
-
-            if (description != null)
-            {
-                Description descriptionBean = new Description();
-                descriptionBean.setValue(description.getText());
-                item.setDescription(descriptionBean);
-                final String type = description.getAttributeValue("type");
-                if (type != null)
-                {
-                    item.getDescription().setType(type);
-                }
-            }
-        }
-
-        if (item.getAuthor() == null)
-        {
-            final Element author = parseChildWithNamespaces(itemElement, "author");
-
-            if (author != null)
-            {
-                item.setAuthor(author.getText());
-            }
-
-        }
-
-        if (item.getComments() == null)
-        {
-            final Element comments = parseChildWithNamespaces(itemElement, "comments");
-
-            if (comments != null)
-            {
-                item.setComments(comments.getText());
-            }
-        }
-
-        if (item.getSource() == null)
-        {
-            final Element source = parseChildWithNamespaces(itemElement, "source");
-            if (source != null)
-            {
-                Source sourceBean = new Source();
-                sourceBean.setValue(source.getText());
-                final String url = source.getAttributeValue("url");
-                sourceBean.setUrl(url);
-                item.setSource(sourceBean);
-            }
-        }
-
-        if (item.getGuid() == null)
-        {
-            final Element guid = parseChildWithNamespaces(itemElement, "guid");
-            if (guid != null)
-            {
-                Guid guidBean = new Guid();
-                final String isPermaLink = guid.getAttributeValue("isPermaLink");
-
-                if (isPermaLink != null)
-                {
-                    guidBean.setPermaLink(isPermaLink.equalsIgnoreCase("true"));
-                }
-                guidBean.setValue(guid.getText());
-                item.setGuid(guidBean);
-            }
-        }
-
-        if (item.getPubDate() == null)
-        {
-            final Element pubDate = parseChildWithNamespaces(itemElement, "pubDate");
-
-            if (pubDate != null)
-            {
-                item.setPubDate(parseDate(pubDate.getText(), locale));
-            }
-        }
-
-        if (item.getExpirationDate() == null)
-        {
-            final Element expirationDate = parseChildWithNamespaces(itemElement, "expirationDate");
-            if (expirationDate != null)
-            {
-                item.setExpirationDate(parseDate(expirationDate.getText(), locale));
-            }
-        }
-
-        if (item.getContent() == null)
-        {
-            final Element encoded = parseChildWithNamespaces(itemElement, "encoded");
-            if (encoded != null)
-            {
-                final Content content = new Content();
-                content.setType(Content.HTML);
-                content.setValue(encoded.getText());
-                item.setContent(content);
-            }
-        }
-
-        if (item.getCategories() != null && item.getCategories().size() == 0)
-        {
-            final List<Element> categories = parseChildrenWithNamespaces(itemElement, "category");
-            item.setCategories(parseCategories(categories));
-        }
+        parseTitle(item, itemElement);
+        parseLink(item, itemElement);
+        parseDescription(item, itemElement);
+        parseAuthor(item, itemElement);
+        parseComments(item, itemElement);
+        parseSource(item, itemElement);
+        parseGuid(item, itemElement);
+        parsePubDate(item, itemElement, locale);
+        parseExpirationDate(item, itemElement, locale);
+        parseContent(item, itemElement);
+        parseCategories(item, itemElement);
 
         return item;
     }
@@ -224,6 +111,162 @@ public class RssParser extends RSS20Parser implements WireFeedParser
         namespaces = new ArrayList<>(rssRoot.getAdditionalNamespaces());
         namespaces.add(NO_NAMESPACE);
         return parseChannel(rssRoot, locale);
+    }
+
+    private void parseTitle(Item item, final Element itemElement)
+    {
+        if (item.getTitle() == null)
+        {
+            final Element title = parseChildWithNamespaces(itemElement, "title");
+            if (title != null)
+            {
+                item.setTitle(title.getText());
+            }
+        }
+    }
+
+    private void parseLink(Item item, final Element itemElement)
+    {
+        if (item.getLink() == null)
+        {
+            final Element link = parseChildWithNamespaces(itemElement, "link");
+            if (link != null)
+            {
+                item.setLink(link.getText());
+                item.setUri(link.getText());
+            }
+        }
+    }
+
+    private void parseDescription(Item item, final Element itemElement)
+    {
+        if (item.getDescription() == null)
+        {
+            final Element description = parseChildWithNamespaces(itemElement, "description");
+            if (description != null)
+            {
+                Description descriptionBean = new Description();
+                descriptionBean.setValue(description.getText());
+                item.setDescription(descriptionBean);
+                final String type = description.getAttributeValue("type");
+                if (type != null)
+                {
+                    item.getDescription().setType(type);
+                }
+            }
+        }
+    }
+
+    private void parseAuthor(Item item, final Element itemElement)
+    {
+        if (item.getAuthor() == null)
+        {
+            final Element author = parseChildWithNamespaces(itemElement, "author");
+
+            if (author != null)
+            {
+                item.setAuthor(author.getText());
+            }
+
+        }
+    }
+
+    private void parseComments(Item item, final Element itemElement)
+    {
+        if (item.getComments() == null)
+        {
+            final Element comments = parseChildWithNamespaces(itemElement, "comments");
+
+            if (comments != null)
+            {
+                item.setComments(comments.getText());
+            }
+        }
+    }
+
+    private void parseSource(Item item, final Element itemElement)
+    {
+        if (item.getSource() == null)
+        {
+            final Element source = parseChildWithNamespaces(itemElement, "source");
+            if (source != null)
+            {
+                Source sourceBean = new Source();
+                sourceBean.setValue(source.getText());
+                final String url = source.getAttributeValue("url");
+                sourceBean.setUrl(url);
+                item.setSource(sourceBean);
+            }
+        }
+    }
+
+    private void parseGuid(Item item, final Element itemElement)
+    {
+        if (item.getGuid() == null)
+        {
+            final Element guid = parseChildWithNamespaces(itemElement, "guid");
+            if (guid != null)
+            {
+                Guid guidBean = new Guid();
+                final String isPermaLink = guid.getAttributeValue("isPermaLink");
+
+                if (isPermaLink != null)
+                {
+                    guidBean.setPermaLink(isPermaLink.equalsIgnoreCase("true"));
+                }
+                guidBean.setValue(guid.getText());
+                item.setGuid(guidBean);
+            }
+        }
+    }
+
+    private void parsePubDate(Item item, final Element itemElement, Locale locale)
+    {
+        if (item.getPubDate() == null)
+        {
+            final Element pubDate = parseChildWithNamespaces(itemElement, "pubDate");
+
+            if (pubDate != null)
+            {
+                item.setPubDate(parseDate(pubDate.getText(), locale));
+            }
+        }
+    }
+
+    private void parseExpirationDate(Item item, final Element itemElement, Locale locale)
+    {
+        if (item.getExpirationDate() == null)
+        {
+            final Element expirationDate = parseChildWithNamespaces(itemElement, "expirationDate");
+            if (expirationDate != null)
+            {
+                item.setExpirationDate(parseDate(expirationDate.getText(), locale));
+            }
+        }
+    }
+
+    private void parseContent(Item item, final Element itemElement)
+    {
+        if (item.getContent() == null)
+        {
+            final Element encoded = parseChildWithNamespaces(itemElement, "encoded");
+            if (encoded != null)
+            {
+                final Content content = new Content();
+                content.setType(Content.HTML);
+                content.setValue(encoded.getText());
+                item.setContent(content);
+            }
+        }
+    }
+
+    private void parseCategories(Item item, final Element itemElement)
+    {
+        if (item.getCategories() != null && item.getCategories().size() == 0)
+        {
+            final List<Element> categories = parseChildrenWithNamespaces(itemElement, "category");
+            item.setCategories(parseCategories(categories));
+        }
     }
 
 }

--- a/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.rss.transformers;
+
+
+import static org.jdom2.Namespace.NO_NAMESPACE;
+
+import com.rometools.rome.feed.WireFeed;
+import com.rometools.rome.feed.rss.Content;
+import com.rometools.rome.feed.rss.Description;
+import com.rometools.rome.feed.rss.Guid;
+import com.rometools.rome.feed.rss.Item;
+import com.rometools.rome.feed.rss.Source;
+import com.rometools.rome.io.FeedException;
+import com.rometools.rome.io.WireFeedParser;
+
+import static com.rometools.rome.io.impl.DateParser.parseDate;
+
+import com.rometools.rome.io.impl.RSS20Parser;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+
+public class RssParser extends RSS20Parser implements WireFeedParser
+{
+
+    private List<Namespace> namespaces;
+
+    @Override
+    public String getType()
+    {
+        return "rss_2.0";
+    }
+
+    @Override
+    public boolean isMyType(Document document)
+    {
+        return true;
+    }
+
+    @Override
+    protected Namespace getRSSNamespace()
+    {
+        return NO_NAMESPACE;
+    }
+
+    @Override
+    public Item parseItem(final Element rssRoot, final Element itemElement, final Locale locale)
+    {
+
+        final Item item = super.parseItem(rssRoot, itemElement, locale);
+
+        if (item.getTitle() == null)
+        {
+            final Element title = parseChildWithNamespaces(itemElement, "title");
+            if (item.getTitle() == null)
+            {
+                item.setTitle(title.getText());
+            }
+        }
+
+        if (item.getLink() == null)
+        {
+            final Element link = parseChildWithNamespaces(itemElement, "link");
+            if (link != null)
+            {
+                item.setLink(link.getText());
+                item.setUri(link.getText());
+            }
+        }
+
+        if (item.getDescription() == null)
+        {
+            final Element description = parseChildWithNamespaces(itemElement, "description");
+
+            if (description != null)
+            {
+                Description descriptionBean = new Description();
+                descriptionBean.setValue(description.getText());
+                item.setDescription(descriptionBean);
+                final String type = description.getAttributeValue("type");
+                if (type != null)
+                {
+                    item.getDescription().setType(type);
+                }
+            }
+        }
+
+        if (item.getAuthor() == null)
+        {
+            final Element author = parseChildWithNamespaces(itemElement, "author");
+
+            if (author != null)
+            {
+                item.setAuthor(author.getText());
+            }
+
+        }
+
+        if (item.getComments() == null)
+        {
+            final Element comments = parseChildWithNamespaces(itemElement, "comments");
+
+            if (comments != null)
+            {
+                item.setComments(comments.getText());
+            }
+        }
+
+        if (item.getSource() == null)
+        {
+            final Element source = parseChildWithNamespaces(itemElement, "source");
+            if (source != null)
+            {
+                Source sourceBean = new Source();
+                sourceBean.setValue(source.getText());
+                final String url = source.getAttributeValue("url");
+                sourceBean.setUrl(url);
+                item.setSource(sourceBean);
+            }
+        }
+
+        if (item.getGuid() == null)
+        {
+            final Element guid = parseChildWithNamespaces(itemElement, "guid");
+            if (guid != null)
+            {
+                Guid guidBean = new Guid();
+                final String isPermaLink = guid.getAttributeValue("isPermaLink");
+
+                if (isPermaLink != null)
+                {
+                    guidBean.setPermaLink(isPermaLink.equalsIgnoreCase("true"));
+                }
+                guidBean.setValue(guid.getText());
+                item.setGuid(guidBean);
+            }
+        }
+
+        if (item.getPubDate() == null)
+        {
+            final Element pubDate = parseChildWithNamespaces(itemElement, "pubDate");
+
+            if (pubDate != null)
+            {
+                item.setPubDate(parseDate(pubDate.getText(), locale));
+            }
+        }
+
+        if (item.getExpirationDate() == null)
+        {
+            final Element expirationDate = parseChildWithNamespaces(itemElement, "expirationDate");
+            if (expirationDate != null)
+            {
+                item.setExpirationDate(parseDate(expirationDate.getText(), locale));
+            }
+        }
+
+        if (item.getContent() == null)
+        {
+            final Element encoded = parseChildWithNamespaces(itemElement, "encoded");
+            if (encoded != null)
+            {
+                final Content content = new Content();
+                content.setType(Content.HTML);
+                content.setValue(encoded.getText());
+                item.setContent(content);
+            }
+        }
+
+        if (item.getCategories() != null && item.getCategories().size() == 0)
+        {
+            final List<Element> categories = parseChildrenWithNamespaces(itemElement, "category");
+            item.setCategories(parseCategories(categories));
+        }
+
+        return item;
+    }
+
+    private Element parseChildWithNamespaces(Element parentElement, String childName)
+    {
+        Element element = null;
+        Iterator itr = namespaces.iterator();
+
+        while (itr.hasNext() && element == null)
+        {
+            Namespace namespace = (Namespace) itr.next();
+            element = parentElement.getChild(childName, namespace);
+        }
+
+        return element;
+    }
+
+    private List<Element> parseChildrenWithNamespaces(Element parentElement, String childName)
+    {
+        List<Element> elements = new ArrayList<>();
+        Iterator itr = namespaces.iterator();
+
+        while (itr.hasNext() && elements.size() == 0)
+        {
+            Namespace namespace = (Namespace) itr.next();
+            elements = parentElement.getChildren(childName, namespace);
+        }
+
+        return elements;
+    }
+
+    @Override
+    public WireFeed parse(final Document document, final boolean validate, final Locale locale) throws IllegalArgumentException, FeedException
+    {
+        final Element rssRoot = document.getRootElement();
+        namespaces = new ArrayList<>(rssRoot.getAdditionalNamespaces());
+        namespaces.add(NO_NAMESPACE);
+        return parseChannel(rssRoot, locale);
+    }
+
+}

--- a/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
+++ b/modules/rss/src/main/java/org/mule/module/rss/transformers/RssParser.java
@@ -32,7 +32,10 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 
-
+/**
+ * Parses RSS item elements and its children.
+ * Considers the use of namespaces that were added in RSS 1.0
+ */
 public class RssParser extends RSS20Parser implements WireFeedParser
 {
 
@@ -59,7 +62,6 @@ public class RssParser extends RSS20Parser implements WireFeedParser
     @Override
     public Item parseItem(final Element rssRoot, final Element itemElement, final Locale locale)
     {
-
         final Item item = super.parseItem(rssRoot, itemElement, locale);
         parseTitle(item, itemElement);
         parseLink(item, itemElement);
@@ -79,11 +81,11 @@ public class RssParser extends RSS20Parser implements WireFeedParser
     private Element parseChildWithNamespaces(Element parentElement, String childName)
     {
         Element element = null;
-        Iterator itr = namespaces.iterator();
+        Iterator namespacesIterator = namespaces.iterator();
 
-        while (itr.hasNext() && element == null)
+        while (namespacesIterator.hasNext() && element == null)
         {
-            Namespace namespace = (Namespace) itr.next();
+            Namespace namespace = (Namespace) namespacesIterator.next();
             element = parentElement.getChild(childName, namespace);
         }
 
@@ -93,11 +95,11 @@ public class RssParser extends RSS20Parser implements WireFeedParser
     private List<Element> parseChildrenWithNamespaces(Element parentElement, String childName)
     {
         List<Element> elements = new ArrayList<>();
-        Iterator itr = namespaces.iterator();
+        Iterator namespacesIterator = namespaces.iterator();
 
-        while (itr.hasNext() && elements.size() == 0)
+        while (namespacesIterator.hasNext() && elements.size() == 0)
         {
-            Namespace namespace = (Namespace) itr.next();
+            Namespace namespace = (Namespace) namespacesIterator.next();
             elements = parentElement.getChildren(childName, namespace);
         }
 

--- a/modules/rss/src/main/resources/rome.properties
+++ b/modules/rss/src/main/resources/rome.properties
@@ -1,0 +1,1 @@
+WireFeedParser.classes=org.mule.module.rss.transformers.RssParser

--- a/modules/rss/src/test/java/org/mule/module/rss/TransformerDiscoveryTestCase.java
+++ b/modules/rss/src/test/java/org/mule/module/rss/TransformerDiscoveryTestCase.java
@@ -10,13 +10,14 @@ import org.mule.api.transformer.Transformer;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.transformer.types.DataTypeFactory;
 
-import com.sun.syndication.feed.synd.SyndFeed;
 
 import java.io.DataInputStream;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+
+import com.rometools.rome.feed.synd.SyndFeed;
 
 public class TransformerDiscoveryTestCase extends AbstractMuleContextTestCase
 {

--- a/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
+++ b/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
@@ -42,12 +42,22 @@ public class RssParserTestCase extends AbstractMuleTestCase
     @Test
     public void testParsedEntries() throws Exception
     {
-        assertValues(entries.get(0));
-        assertValues(entries.get(1));
+        assertRSSEntriesWithoutNamespaces(entries.get(0));
+        assertRSSEntriesWithNamespaces(entries.get(1));
         assertThat(entries.size(), is(2));
     }
 
-    public void assertValues(SyndEntry entry)
+    private void assertRSSEntriesWithNamespaces(SyndEntry entry)
+    {
+        assertValues(entry);
+    }
+
+    private void assertRSSEntriesWithoutNamespaces(SyndEntry entry)
+    {
+        assertValues(entry);
+    }
+
+    private void assertValues(SyndEntry entry)
     {
         List<SyndCategory> categories = entry.getCategories();
         SyndCategory category = categories.get(0);

--- a/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
+++ b/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.rss.transformers;
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+import com.rometools.rome.feed.synd.SyndCategory;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RssParserTestCase
+{
+    private static List<SyndEntry> entries = null;
+    @BeforeClass
+    public static void  setup() throws Exception
+    {
+        ObjectToRssFeed objectToRssFeed = new ObjectToRssFeed();
+        InputStream fileInputStream;
+        fileInputStream = new FileInputStream(new File("src/test/resources/rss-test.xml"));
+        SyndFeed feed = (SyndFeed) objectToRssFeed.doTransform(fileInputStream, null);
+        entries = feed.getEntries();
+    }
+
+    @Test
+    public void testEntriesSize() throws Exception
+    {
+        assertThat(entries.size(), is(2));
+    }
+
+    @Test
+    public void testRSSWithoutNamespaces() throws Exception
+    {
+        assertValues(entries.get(0));
+    }
+
+    @Test
+    public void testRSSWithNamespaces() throws Exception
+    {
+        assertValues(entries.get(1));
+    }
+
+    public void assertValues(SyndEntry entry)
+    {
+        List<SyndCategory> categories = entry.getCategories();
+        SyndCategory category = categories.get(0);
+        SyndCategory category2 = categories.get(1);
+        assertThat(entry.getTitle(), is("Title"));
+        assertThat(entry.getLink(), is("Link"));
+        assertThat(entry.getAuthor(), is("Creator"));
+        assertThat(entry.getLink(), is("Link"));
+        assertThat(categories.size(), is(2));
+        assertThat(category.getName(), is("Category"));
+        assertThat(category2.getName(), is("Category2"));
+        assertThat(entry.getDescription().getValue(), is("Description"));
+    }
+}

--- a/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
+++ b/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
@@ -7,10 +7,10 @@
 
 package org.mule.module.rss.transformers;
 
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import com.rometools.rome.feed.synd.SyndCategory;
 import com.rometools.rome.feed.synd.SyndEntry;
@@ -24,11 +24,13 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class RssParserTestCase
+public class RssParserTestCase extends AbstractMuleTestCase
 {
+
     private static List<SyndEntry> entries = null;
+
     @BeforeClass
-    public static void  setup() throws Exception
+    public static void setup() throws Exception
     {
         ObjectToRssFeed objectToRssFeed = new ObjectToRssFeed();
         InputStream fileInputStream;

--- a/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
+++ b/modules/rss/src/test/java/org/mule/module/rss/transformers/RssParserTestCase.java
@@ -11,50 +11,40 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.size.SmallTest;
 
 import com.rometools.rome.feed.synd.SyndCategory;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.List;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
+@SmallTest
 public class RssParserTestCase extends AbstractMuleTestCase
 {
 
-    private static List<SyndEntry> entries = null;
+    private List<SyndEntry> entries = null;
 
-    @BeforeClass
-    public static void setup() throws Exception
+    @Before
+    public void setup() throws Exception
     {
         ObjectToRssFeed objectToRssFeed = new ObjectToRssFeed();
         InputStream fileInputStream;
-        fileInputStream = new FileInputStream(new File("src/test/resources/rss-test.xml"));
+        fileInputStream = getClass().getResourceAsStream("/rss-test.xml");
         SyndFeed feed = (SyndFeed) objectToRssFeed.doTransform(fileInputStream, null);
         entries = feed.getEntries();
     }
 
     @Test
-    public void testEntriesSize() throws Exception
-    {
-        assertThat(entries.size(), is(2));
-    }
-
-    @Test
-    public void testRSSWithoutNamespaces() throws Exception
+    public void testParsedEntries() throws Exception
     {
         assertValues(entries.get(0));
-    }
-
-    @Test
-    public void testRSSWithNamespaces() throws Exception
-    {
         assertValues(entries.get(1));
+        assertThat(entries.size(), is(2));
     }
 
     public void assertValues(SyndEntry entry)
@@ -71,4 +61,5 @@ public class RssParserTestCase extends AbstractMuleTestCase
         assertThat(category2.getName(), is("Category2"));
         assertThat(entry.getDescription().getValue(), is("Description"));
     }
+
 }

--- a/modules/rss/src/test/resources/rss-test.xml
+++ b/modules/rss/src/test/resources/rss-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+    <channel>
+        <item>
+            <title>Title</title>
+            <link>Link</link>
+            <comments>Comments</comments>
+            <pubDate>Fri, 12 Aug 2011 06:25:22 +0000</pubDate>
+            <dc:creator>Creator</dc:creator>
+            <category><![CDATA[Category]]></category>
+            <category><![CDATA[Category2]]></category>
+            <description>Description</description>
+        </item>
+        <item>
+            <media:title>Title</media:title>
+            <media:link>Link</media:link>
+            <media:comments>Comments</media:comments>
+            <media:pubDate>Fri, 12 Aug 2011 06:25:22 +0000</media:pubDate>
+            <dc:creator>Creator</dc:creator>
+            <media:category><![CDATA[Category]]></media:category>
+            <media:category><![CDATA[Category2]]></media:category>
+            <media:description>Description</media:description>
+        </item>
+    </channel>
+</rss>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <jaxenVersion>1.1.1</jaxenVersion>
         <jbossTsVersion>4.15.0.Final</jbossTsVersion>
         <jcrVersion>1.0</jcrVersion>
-        <jdomVersion>2.0.2</jdomVersion>
+        <jdomVersion>2.0.6</jdomVersion>
         <jettyVersion>9.0.7.v20131107</jettyVersion>
         <jodaTimeVersion>2.9.1</jodaTimeVersion>
         <jschVersion>0.1.51</jschVersion>
@@ -1010,7 +1010,7 @@
             <dependency>
                 <!-- this really should be the org.jdom groupId but all the other modules use the jdom groupId -->
                 <groupId>org.jdom</groupId>
-                <artifactId>jdom</artifactId>
+                <artifactId>jdom2</artifactId>
                 <version>${jdomVersion}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <jaxenVersion>1.1.1</jaxenVersion>
         <jbossTsVersion>4.15.0.Final</jbossTsVersion>
         <jcrVersion>1.0</jcrVersion>
-        <jdomVersion>1.1.3</jdomVersion>
+        <jdomVersion>2.0.2</jdomVersion>
         <jettyVersion>9.0.7.v20131107</jettyVersion>
         <jodaTimeVersion>2.9.1</jodaTimeVersion>
         <jschVersion>0.1.51</jschVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <jaxenVersion>1.1.1</jaxenVersion>
         <jbossTsVersion>4.15.0.Final</jbossTsVersion>
         <jcrVersion>1.0</jcrVersion>
-        <jdomVersion>2.0.6</jdomVersion>
+        <jdomVersion>2.0.2</jdomVersion>
         <jettyVersion>9.0.7.v20131107</jettyVersion>
         <jodaTimeVersion>2.9.1</jodaTimeVersion>
         <jschVersion>0.1.51</jschVersion>
@@ -1010,7 +1010,7 @@
             <dependency>
                 <!-- this really should be the org.jdom groupId but all the other modules use the jdom groupId -->
                 <groupId>org.jdom</groupId>
-                <artifactId>jdom2</artifactId>
+                <artifactId>jdom</artifactId>
                 <version>${jdomVersion}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Use of Namespaces in RSS was added in RSS 1.0.
Currently, We used the Rome API, that doesn't implement the parsing of elements that have namespaces.
However, Rome API allows us to implement our own parser.
An own parser should be created to parse elements with namespaces.