### PR TITLE
MULE-11843: Http Server scheduler is shutdown before the connections …

### DIFF
--- a/services/http/src/test/java/org/mule/services/http/impl/service/server/grizzly/GrizzlyServerManagerTestCase.java
+++ b/services/http/src/test/java/org/mule/services/http/impl/service/server/grizzly/GrizzlyServerManagerTestCase.java
@@ -9,6 +9,7 @@ package org.mule.services.http.impl.service.server.grizzly;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mule.service.http.api.HttpConstants.HttpStatus.OK;
 import org.mule.service.http.api.domain.message.response.HttpResponse;
@@ -86,7 +87,7 @@ public class GrizzlyServerManagerTestCase extends AbstractMuleContextTestCase {
         }
       }
 
-      verify(responseStatusCallback).responseSendSuccessfully();
+      verify(responseStatusCallback, timeout(1000)).responseSendSuccessfully();
       server.stop();
       serverManager.dispose();
 


### PR DESCRIPTION
…are closed

_ Fixing flaky test