### PR TITLE
MULE-11869: Default Reconnect Strategy is ignored in DB Config.

### DIFF
--- a/modules/db/src/main/java/org/mule/module/db/internal/config/domain/database/DbConfigResolverFactoryBean.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/config/domain/database/DbConfigResolverFactoryBean.java
@@ -184,6 +184,7 @@ public class DbConfigResolverFactoryBean extends AnnotatedObjectFactoryBean<DbCo
     {
         this.muleContext = context;
         dataSourceConfig.setMuleContext(muleContext);
+        ((GenericDbConfigFactory) dbConfigFactory).setMuleContext(muleContext);
     }
 
     public void setUseXaTransactions(boolean useXaTransactions)

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactory.java
@@ -73,9 +73,4 @@ public class RetryConnectionFactory extends AbstractConnectionFactory
         return connectionRef.get();
     }
 
-    public RetryPolicyTemplate getRetryPolicyTemplate()
-    {
-        return retryPolicyTemplate;
-    }
-
 }

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/RetryConnectionFactory.java
@@ -72,4 +72,10 @@ public class RetryConnectionFactory extends AbstractConnectionFactory
 
         return connectionRef.get();
     }
+
+    public RetryPolicyTemplate getRetryPolicyTemplate()
+    {
+        return retryPolicyTemplate;
+    }
+
 }

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/TransactionalDbConnectionFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/TransactionalDbConnectionFactory.java
@@ -206,4 +206,9 @@ public class TransactionalDbConnectionFactory implements DbConnectionFactory
             }
         }
     }
+
+    public ConnectionFactory getConnectionFactory()
+    {
+        return connectionFactory;
+    }
 }

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/TransactionalDbConnectionFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/connection/TransactionalDbConnectionFactory.java
@@ -207,8 +207,4 @@ public class TransactionalDbConnectionFactory implements DbConnectionFactory
         }
     }
 
-    public ConnectionFactory getConnectionFactory()
-    {
-        return connectionFactory;
-    }
 }

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/database/GenericDbConfigFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/database/GenericDbConfigFactory.java
@@ -179,7 +179,7 @@ public class GenericDbConfigFactory implements ConfigurableDbConfigFactory
         this.muleContext = muleContext;
     }
 
-    private RetryPolicyTemplate getDefaultRetryPolicyTemplate ()
+    protected RetryPolicyTemplate getDefaultRetryPolicyTemplate ()
     {
         RetryPolicyTemplate retryPolicyTemplate = muleContext.getRegistry().lookupObject(OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE);
         return retryPolicyTemplate instanceof NoRetryPolicyTemplate ? null : retryPolicyTemplate;

--- a/modules/db/src/main/java/org/mule/module/db/internal/domain/database/GenericDbConfigFactory.java
+++ b/modules/db/src/main/java/org/mule/module/db/internal/domain/database/GenericDbConfigFactory.java
@@ -7,7 +7,9 @@
 
 package org.mule.module.db.internal.domain.database;
 
+import static org.mule.api.config.MuleProperties.OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE;
 import org.mule.AbstractAnnotatedObject;
+import org.mule.api.MuleContext;
 import org.mule.api.NamedObject;
 import org.mule.api.retry.RetryPolicyTemplate;
 import org.mule.module.db.internal.domain.connection.ConnectionCreationException;
@@ -24,6 +26,7 @@ import org.mule.module.db.internal.domain.type.JdbcTypes;
 import org.mule.module.db.internal.domain.type.MappedStructResolvedDbType;
 import org.mule.module.db.internal.domain.type.MetadataDbTypeManager;
 import org.mule.module.db.internal.domain.type.StaticDbTypeManager;
+import org.mule.retry.policies.NoRetryPolicyTemplate;
 
 import java.sql.Connection;
 import java.util.ArrayList;
@@ -40,6 +43,7 @@ import javax.xml.namespace.QName;
  */
 public class GenericDbConfigFactory implements ConfigurableDbConfigFactory
 {
+
     private class AnnotatedConnectionFactory extends AbstractAnnotatedObject implements ConnectionFactory, NamedObject
     {
 
@@ -69,6 +73,7 @@ public class GenericDbConfigFactory implements ConfigurableDbConfigFactory
 
     private List<DbType> customDataTypes;
     private RetryPolicyTemplate retryPolicyTemplate;
+    private MuleContext muleContext;
 
     @Override
     public DbConfig create(String name, Map<QName, Object> annotations, DataSource dataSource)
@@ -76,6 +81,10 @@ public class GenericDbConfigFactory implements ConfigurableDbConfigFactory
         ConnectionFactory connectionFactory;
 
         SimpleConnectionFactory simpleConnectionFactory = new SimpleConnectionFactory(createTypeMapping());
+        if (retryPolicyTemplate == null)
+        {
+            retryPolicyTemplate = getDefaultRetryPolicyTemplate();
+        }
         if (retryPolicyTemplate == null)
         {
             connectionFactory = simpleConnectionFactory;
@@ -86,7 +95,6 @@ public class GenericDbConfigFactory implements ConfigurableDbConfigFactory
         }
 
         DbTypeManager dbTypeManager = doCreateTypeManager();
-
         DbConnectionFactory dbConnectionFactory = createDbConnectionFactory(dataSource, connectionFactory, dbTypeManager);
 
         return doCreateDbConfig(dataSource, dbTypeManager, dbConnectionFactory, name);
@@ -165,4 +173,16 @@ public class GenericDbConfigFactory implements ConfigurableDbConfigFactory
     {
         this.retryPolicyTemplate = retryPolicyTemplate;
     }
+
+    public void setMuleContext(MuleContext muleContext)
+    {
+        this.muleContext = muleContext;
+    }
+
+    private RetryPolicyTemplate getDefaultRetryPolicyTemplate ()
+    {
+        RetryPolicyTemplate retryPolicyTemplate = muleContext.getRegistry().lookupObject(OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE);
+        return retryPolicyTemplate instanceof NoRetryPolicyTemplate ? null : retryPolicyTemplate;
+    }
+
 }

--- a/modules/db/src/test/java/org/mule/module/db/internal/config/domain/database/DbConfigFactoryBeanTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/config/domain/database/DbConfigFactoryBeanTestCase.java
@@ -9,24 +9,40 @@ package org.mule.module.db.internal.config.domain.database;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mule.api.config.MuleProperties.OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE;
+import org.mule.api.MuleContext;
+import org.mule.api.registry.MuleRegistry;
 import org.mule.module.db.internal.domain.database.DataSourceFactory;
 import org.mule.module.db.internal.domain.type.DbType;
+import org.mule.retry.policies.NoRetryPolicyTemplate;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
 import java.util.Collections;
 
+import org.junit.Before;
 import org.junit.Test;
 
 @SmallTest
 public class DbConfigFactoryBeanTestCase extends AbstractMuleTestCase
 {
 
+    final MuleContext muleContext = mock(MuleContext.class);
+    final MuleRegistry muleRegistry = mock(MuleRegistry.class);
+    private final NoRetryPolicyTemplate noRetryPolicyTemplate = mock(NoRetryPolicyTemplate.class);
+
+    @Before
+    public void setUp() throws Exception
+    {
+        when(muleContext.getRegistry()).thenReturn(muleRegistry);
+        when(muleRegistry.lookupObject(OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE)).thenReturn(noRetryPolicyTemplate);
+    }
+
     @Test
     public void disposesDataSourceFactory() throws Exception
     {
         final DataSourceFactory dataSourceFactory = mock(DataSourceFactory.class);
-
         DbConfigResolverFactoryBean dbConfigFactoryBean = new DbConfigResolverFactoryBean()
         {
             @Override
@@ -35,11 +51,12 @@ public class DbConfigFactoryBeanTestCase extends AbstractMuleTestCase
                 return dataSourceFactory;
             }
         };
+
         dbConfigFactoryBean.setCustomDataTypes(Collections.<DbType>emptyList());
+        dbConfigFactoryBean.setMuleContext(muleContext);
         dbConfigFactoryBean.createInstance();
-
         dbConfigFactoryBean.dispose();
-
         verify(dataSourceFactory).dispose();
     }
+
 }

--- a/modules/db/src/test/java/org/mule/module/db/internal/domain/database/GenericDbConfigFactoryTestCase.java
+++ b/modules/db/src/test/java/org/mule/module/db/internal/domain/database/GenericDbConfigFactoryTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.db.internal.domain.database;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.api.config.MuleProperties.OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE;
+import org.mule.api.MuleContext;
+import org.mule.api.registry.MuleRegistry;
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.module.db.internal.domain.connection.RetryConnectionFactory;
+import org.mule.module.db.internal.domain.connection.SimpleConnectionFactory;
+import org.mule.module.db.internal.domain.connection.TransactionalDbConnectionFactory;
+import org.mule.module.db.internal.domain.type.DbType;
+import org.mule.retry.policies.NoRetryPolicyTemplate;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+import javax.xml.namespace.QName;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class GenericDbConfigFactoryTestCase extends AbstractMuleTestCase
+{
+
+    private final GenericDbConfigFactory genericDbConfigFactory = new GenericDbConfigFactory();
+    private final Map<QName, Object> annotations = mock(Map.class);
+    private final DataSource dataSource = mock(DataSource.class);
+    private final List<DbType> customDataTypes = new ArrayList<>();
+    private final MuleContext muleContext = mock(MuleContext.class);
+    private final MuleRegistry muleRegistry = mock(MuleRegistry.class);
+    private final RetryPolicyTemplate globalRetryPolicyTemplate = mock(RetryPolicyTemplate.class);
+    private final NoRetryPolicyTemplate noRetryPolicyTemplate = mock(NoRetryPolicyTemplate.class);
+    private final RetryPolicyTemplate specificRetryPolicyTemplate = mock(RetryPolicyTemplate.class);
+    private DbConfig dbConfig = null;
+    private TransactionalDbConnectionFactory transactionalDbConnectionFactory = null;
+    private RetryConnectionFactory retryConnectionFactory = null;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        genericDbConfigFactory.setMuleContext(muleContext);
+        genericDbConfigFactory.setCustomDataTypes(customDataTypes);
+        when(muleContext.getRegistry()).thenReturn(muleRegistry);
+        when(globalRetryPolicyTemplate.isSynchronous()).thenReturn(true);
+        when(specificRetryPolicyTemplate.isSynchronous()).thenReturn(true);
+    }
+
+    @Test
+    public void testOnlyExistsGlobalRetryPolicyTemplate() throws Exception
+    {
+        when(muleRegistry.lookupObject(OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE)).thenReturn(globalRetryPolicyTemplate);
+        dbConfig = genericDbConfigFactory.create("name", annotations, dataSource);
+        assertThat(dbConfig.getConnectionFactory(), instanceOf(TransactionalDbConnectionFactory.class));
+        transactionalDbConnectionFactory = (TransactionalDbConnectionFactory) dbConfig.getConnectionFactory();
+        assertThat(transactionalDbConnectionFactory.getConnectionFactory(), instanceOf(RetryConnectionFactory.class));
+        retryConnectionFactory = (RetryConnectionFactory) transactionalDbConnectionFactory.getConnectionFactory();
+        assertEquals(retryConnectionFactory.getRetryPolicyTemplate(), globalRetryPolicyTemplate);
+    }
+
+    @Test
+    public void testOnlyExistsSpecificRetryPolicyTemplate() throws Exception
+    {
+        genericDbConfigFactory.setRetryPolicyTemplate(specificRetryPolicyTemplate);
+        dbConfig = genericDbConfigFactory.create("name", annotations, dataSource);
+        assertThat(dbConfig.getConnectionFactory(), instanceOf(TransactionalDbConnectionFactory.class));
+        transactionalDbConnectionFactory = (TransactionalDbConnectionFactory) dbConfig.getConnectionFactory();
+        assertThat(transactionalDbConnectionFactory.getConnectionFactory(), instanceOf(RetryConnectionFactory.class));
+        retryConnectionFactory = (RetryConnectionFactory) transactionalDbConnectionFactory.getConnectionFactory();
+        assertEquals(retryConnectionFactory.getRetryPolicyTemplate(), specificRetryPolicyTemplate);
+    }
+
+    @Test
+    public void testNotExistAnyRetryPolicyTemplate() throws Exception
+    {
+        when(muleRegistry.lookupObject(OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE)).thenReturn(noRetryPolicyTemplate);
+        dbConfig = genericDbConfigFactory.create("name", annotations, dataSource);
+        assertThat(dbConfig.getConnectionFactory(), instanceOf(TransactionalDbConnectionFactory.class));
+        transactionalDbConnectionFactory = (TransactionalDbConnectionFactory) dbConfig.getConnectionFactory();
+        assertThat(transactionalDbConnectionFactory.getConnectionFactory(), instanceOf(SimpleConnectionFactory.class));
+    }
+
+    @Test
+    public void testExistsBothRetryPolicyTemplates() throws Exception
+    {
+        genericDbConfigFactory.setRetryPolicyTemplate(specificRetryPolicyTemplate);
+        when(muleRegistry.lookupObject(OBJECT_DEFAULT_RETRY_POLICY_TEMPLATE)).thenReturn(globalRetryPolicyTemplate);
+        dbConfig = genericDbConfigFactory.create("name", annotations, dataSource);
+        assertThat(dbConfig.getConnectionFactory(), instanceOf(TransactionalDbConnectionFactory.class));
+        transactionalDbConnectionFactory = (TransactionalDbConnectionFactory) dbConfig.getConnectionFactory();
+        assertThat(transactionalDbConnectionFactory.getConnectionFactory(), instanceOf(RetryConnectionFactory.class));
+        retryConnectionFactory = (RetryConnectionFactory) transactionalDbConnectionFactory.getConnectionFactory();
+        assertEquals("Specific Retry Policy should override Global Retry Policy", retryConnectionFactory.getRetryPolicyTemplate(), specificRetryPolicyTemplate);
+    }
+
+}


### PR DESCRIPTION
If there is an specific Reconnection Strategy defined in the DB Config, It should be taken.
However, If an specific Reconnection Strategy doesn't exist, but a Global Reconnection Strategy does, It shouldn't be ignored as Currently It does.