### PR TITLE
MULE-11875: Race condition when putting an object in the registry

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/LifecycleAwareConfigurationProvider.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/LifecycleAwareConfigurationProvider.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.config;
 
+import static java.lang.String.format;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
@@ -13,6 +14,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.runtime.core.util.ClassUtils.withContextClassLoader;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.getClassLoader;
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.Initialisable;
@@ -56,8 +58,7 @@ public abstract class LifecycleAwareConfigurationProvider extends AbstractAnnota
   private final ConfigurationModel configurationModel;
   private final List<ConfigurationInstance> configurationInstances = new LinkedList<>();
   private final ClassLoader extensionClassLoader;
-  protected SimpleLifecycleManager lifecycleManager =
-      new DefaultLifecycleManager<>(String.format("%s-%s", getClass().getName(), getName()), this);
+  protected final SimpleLifecycleManager lifecycleManager;
 
   @Inject
   protected MuleContext muleContext;
@@ -67,6 +68,7 @@ public abstract class LifecycleAwareConfigurationProvider extends AbstractAnnota
     this.extensionModel = extensionModel;
     this.configurationModel = configurationModel;
     extensionClassLoader = getClassLoader(extensionModel);
+    lifecycleManager = new DefaultLifecycleManager<>(format("%s-%s", getClass().getName(), getName()), this);
   }
 
   /**

--- a/modules/file-extension-common/pom.xml
+++ b/modules/file-extension-common/pom.xml
@@ -7,7 +7,6 @@
         <artifactId>mule-modules</artifactId>
         <version>4.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.mule.modules</groupId>
     <artifactId>mule-module-file-extension-common</artifactId>
     <name>Mule File Extension Common</name>
     <packaging>mule-plugin</packaging>
@@ -32,7 +31,7 @@
             <artifactId>spring-core</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!--Test Dependencies-->
+        <!--Test Dependencies -->
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-core</artifactId>
@@ -69,6 +68,19 @@
                 <groupId>org.mule.plugins</groupId>
                 <artifactId>mule-app-plugins-maven-plugin</artifactId>
                 <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/modules/file-extension-common/pom.xml
+++ b/modules/file-extension-common/pom.xml
@@ -7,6 +7,7 @@
         <artifactId>mule-modules</artifactId>
         <version>4.0-SNAPSHOT</version>
     </parent>
+    <groupId>org.mule.modules</groupId>
     <artifactId>mule-module-file-extension-common</artifactId>
     <name>Mule File Extension Common</name>
     <packaging>mule-plugin</packaging>
@@ -31,7 +32,7 @@
             <artifactId>spring-core</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!--Test Dependencies -->
+        <!--Test Dependencies-->
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-core</artifactId>
@@ -68,19 +69,6 @@
                 <groupId>org.mule.plugins</groupId>
                 <artifactId>mule-app-plugins-maven-plugin</artifactId>
                 <extensions>true</extensions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>jar</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/SpringRegistryTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/SpringRegistryTestCase.java
@@ -6,14 +6,33 @@
  */
 package org.mule.runtime.config.spring;
 
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.lifecycle.Disposable;
+import org.mule.runtime.api.lifecycle.Startable;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.registry.RegistrationException;
 import org.mule.runtime.core.api.registry.Registry;
 import org.mule.runtime.core.registry.AbstractRegistryTestCase;
+import org.mule.runtime.core.util.concurrent.Latch;
+import org.mule.tck.probe.JUnitLambdaProbe;
+import org.mule.tck.probe.PollingProber;
 
 import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 import org.hamcrest.core.Is;
 import org.junit.Test;
@@ -70,5 +89,66 @@ public class SpringRegistryTestCase extends AbstractRegistryTestCase {
     applicationContext = new StaticApplicationContext();
     parentApplicationContext = new StaticApplicationContext();
     springRegistry = new SpringRegistry(REGISTERY_ID, applicationContext, parentApplicationContext, null);
+  }
+
+  @Test
+  public void registerObjectAsynchronously() throws MuleException, InterruptedException, ExecutionException {
+    final MuleContext muleContext = mock(MuleContext.class);
+    springRegistry = new SpringRegistry(new StaticApplicationContext(), muleContext);
+    springRegistry.initialise();
+    springRegistry.getLifecycleManager().fireLifecycle(Startable.PHASE_NAME);
+
+    final Startable asyncStartableBean = mock(Startable.class, withSettings().extraInterfaces(Disposable.class));
+
+    final Latch startingLatch = new Latch();
+
+    doAnswer(invocation -> {
+      startingLatch.countDown();
+      sleep(1000);
+      verify((Disposable) asyncStartableBean, never()).dispose();
+      return null;
+    }).when(asyncStartableBean).start();
+
+    ((Disposable) doAnswer(invocation -> {
+      return null;
+    }).when(asyncStartableBean)).dispose();
+
+    final ExecutorService threadPool = newCachedThreadPool();
+
+    try {
+      final Future<?> submittedStop = threadPool.submit(() -> {
+        try {
+          springRegistry.registerObject(BEAN_KEY, asyncStartableBean);
+        } catch (RegistrationException e) {
+          throw new MuleRuntimeException(e);
+        }
+      });
+      final Future<?> submittedRegistryDispose = threadPool.submit(() -> {
+        try {
+          startingLatch.await();
+        } catch (InterruptedException e) {
+          throw new MuleRuntimeException(e);
+        }
+        synchronized (muleContext) {
+          springRegistry.dispose();
+        }
+      });
+
+      submittedRegistryDispose.get();
+      submittedStop.get();
+    } finally {
+      threadPool.shutdownNow();
+    }
+
+    new PollingProber().check(new JUnitLambdaProbe(() -> {
+      try {
+        verify(asyncStartableBean).start();
+        verify((Disposable) asyncStartableBean).dispose();
+        return true;
+      } catch (MuleException e) {
+        throw new MuleRuntimeException(e);
+      }
+    }));
+
   }
 }

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -92,6 +92,7 @@
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-file-extension-common</artifactId>
             <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
asynchronously and disposing the muleContext at the same time

Also includes:
* Fix for the issue that prevented running integration tests alone
* Name of the lifecycle manager was not being properly generated