### PR TITLE
MULE-11891: NotPermittedException in http sends status 405 (method not

### DIFF
--- a/modules/spring-security/src/test/java/org/mule/module/spring/security/AuthorizationFilterTestCase.java
+++ b/modules/spring-security/src/test/java/org/mule/module/spring/security/AuthorizationFilterTestCase.java
@@ -64,7 +64,7 @@ public class AuthorizationFilterTestCase extends FunctionalTestCase
     @Test
     public void testAuthenticatedButNotAuthorized() throws Exception
     {
-        doRequest(null, "localhost", "anon", "anon", getUrl(), false, 405);
+        doRequest(null, "localhost", "anon", "anon", getUrl(), false, 403);
     }
     
     @Test

--- a/transports/http/src/main/resources/META-INF/services/org/mule/config/http-exception-mappings.properties
+++ b/transports/http/src/main/resources/META-INF/services/org/mule/config/http-exception-mappings.properties
@@ -9,7 +9,6 @@ error.code.property=http.status
 java.lang.Exception=500
 org.mule.api.security.SecurityException=403
 org.mule.api.security.UnauthorisedException=401
-org.mule.api.security.NotPermittedException=405
 org.mule.api.transport.NoReceiverForEndpointException=404
 org.mule.api.routing.RoutePathNotFoundException=406
 org.mule.api.routing.filter.FilterUnacceptedException=406

--- a/transports/http/src/main/resources/META-INF/services/org/mule/config/https-exception-mappings.properties
+++ b/transports/http/src/main/resources/META-INF/services/org/mule/config/https-exception-mappings.properties
@@ -9,7 +9,6 @@ error.code.property=http.status
 java.lang.Exception=500
 org.mule.api.security.SecurityException=403
 org.mule.api.security.UnauthorisedException=401
-org.mule.api.security.NotPermittedException=405
 org.mule.api.transport.NoReceiverForEndpointException=404
 org.mule.api.routing.RoutePathNotFoundException=406
 org.mule.api.routing.filter.FilterUnacceptedException=406


### PR DESCRIPTION
allowed) instead of 403 (forbidden)

This seems to have been introduced in https://github.com/mulesoft/mule/commit/0e973acba2906d48ae49a8c1cdc5da775f213450