### PR TITLE
MULE-11903: Fix: Http requester can't handle large headers.

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
@@ -7,6 +7,11 @@
 package org.mule.module.http.internal.request.grizzly;
 
 import static com.ning.http.client.Realm.AuthScheme.NTLM;
+import static com.ning.http.client.providers.grizzly.GrizzlyAsyncHttpProviderConfig.Property.MAX_HTTP_PACKET_HEADER_SIZE;
+import static java.lang.Integer.valueOf;
+import static java.lang.System.getProperty;
+import static org.glassfish.grizzly.http.HttpCodecFilter.DEFAULT_MAX_HTTP_PACKET_HEADER_SIZE;
+import static org.mule.api.config.MuleProperties.SYSTEM_PROPERTY_PREFIX;
 import static org.mule.config.i18n.MessageFactory.createStaticMessage;
 import static org.mule.module.http.api.HttpHeaders.Names.CONNECTION;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_DISPOSITION;
@@ -17,10 +22,12 @@ import static org.mule.module.http.api.HttpHeaders.Values.CLOSE;
 import org.mule.api.CompletionHandler;
 import org.mule.api.DefaultMuleException;
 import org.mule.api.MuleException;
+import org.mule.api.MuleRuntimeException;
 import org.mule.api.context.WorkManager;
 import org.mule.api.context.WorkManagerSource;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.api.lifecycle.LifecycleUtils;
+import org.mule.config.i18n.CoreMessages;
 import org.mule.module.http.api.requester.proxy.ProxyConfig;
 import org.mule.module.http.internal.domain.ByteArrayHttpEntity;
 import org.mule.module.http.internal.domain.InputStreamHttpEntity;
@@ -78,6 +85,8 @@ public class GrizzlyHttpClient implements HttpClient
 {
 
     private static final int MAX_CONNECTION_LIFETIME = 30 * 60 * 1000;
+
+    public static final String CUSTOM_MAX_HTTP_PACKET_HEADER_SIZE = SYSTEM_PROPERTY_PREFIX + "http.client.headerSectionSize";
 
     private static final Logger logger = LoggerFactory.getLogger(GrizzlyHttpClient.class);
 
@@ -228,6 +237,7 @@ public class GrizzlyHttpClient implements HttpClient
         providerConfig.addProperty(GrizzlyAsyncHttpProviderConfig.Property.TRANSPORT_CUSTOMIZER, compositeTransportCustomizer);
         //Grizzly now decompresses encoded responses, this flag maintains the previous behaviour
         providerConfig.addProperty(GrizzlyAsyncHttpProviderConfig.Property.DECOMPRESS_RESPONSE, Boolean.FALSE);
+        providerConfig.addProperty(MAX_HTTP_PACKET_HEADER_SIZE, retrieveMaximumHeaderSectionSize());
         builder.setAsyncHttpClientProviderConfig(providerConfig);
     }
 
@@ -637,4 +647,17 @@ public class GrizzlyHttpClient implements HttpClient
         }
 
     }
+
+    private int retrieveMaximumHeaderSectionSize()
+    {
+        try
+        {
+            return valueOf(getProperty(CUSTOM_MAX_HTTP_PACKET_HEADER_SIZE, String.valueOf(DEFAULT_MAX_HTTP_PACKET_HEADER_SIZE)));
+        }
+        catch (NumberFormatException e)
+        {
+            throw new MuleRuntimeException(CoreMessages.createStaticMessage(String.format("Invalid value %s for %s configuration.", getProperty(CUSTOM_MAX_HTTP_PACKET_HEADER_SIZE), CUSTOM_MAX_HTTP_PACKET_HEADER_SIZE)), e);
+        }
+    }
+
 }

--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequesterHeaderSizeTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequesterHeaderSizeTestCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.http.functional.requester;
+
+import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.api.transport.PropertyScope.INBOUND;
+import static org.mule.module.http.internal.request.grizzly.GrizzlyHttpClient.CUSTOM_MAX_HTTP_PACKET_HEADER_SIZE;
+import org.mule.api.MessagingException;
+import org.mule.api.MuleEvent;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.tck.junit4.rule.SystemProperty;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class HttpRequesterHeaderSizeTestCase extends FunctionalTestCase
+{
+
+    private static final int SIZE_DELTA = 1000;
+
+    private static final Integer HEADER_SIZE = 10000;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public SystemProperty maxHeaderSectionSizeSystemProperty = new SystemProperty(CUSTOM_MAX_HTTP_PACKET_HEADER_SIZE, HEADER_SIZE.toString());
+
+    @Rule
+    public SystemProperty exceededContentValue = new SystemProperty("exceededContentValue", randomAlphanumeric(HEADER_SIZE + SIZE_DELTA));
+
+    @Rule
+    public SystemProperty notExceededContentValue = new SystemProperty("notExceededContentValue", randomAlphanumeric(HEADER_SIZE - SIZE_DELTA));
+
+    @Rule
+    public DynamicPort dynamicPort = new DynamicPort("port");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-requester-max-header-size-config.xml";
+    }
+
+    @Test
+    public void testMaxHeaderSizeExceeded() throws Exception
+    {
+        expectedException.expect(MessagingException.class);
+        try
+        {
+            runFlow("requestToListenerWithExceededHeaderFlow");
+        }
+        finally
+        {
+            expectedException.expectMessage(containsString("Error sending HTTP request"));
+        }
+
+    }
+
+    @Test
+    public void testMaxHeaderSizeNotExceeded() throws Exception
+    {
+        MuleEvent event = runFlow("requestToListenerWithNotExceededHeaderFlow");
+        String stringContent = event.getMessage().getProperty("content", INBOUND);
+        assertThat(stringContent.getBytes().length, is(HEADER_SIZE - SIZE_DELTA));
+    }
+
+}

--- a/modules/http/src/test/resources/http-requester-max-header-size-config.xml
+++ b/modules/http/src/test/resources/http-requester-max-header-size-config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+    <http:listener-config name="HTTP_Listener_Configuration" host="0.0.0.0" port="${port}" />
+    <http:request-config name="HTTP_Request_Configuration" host="localhost" port="${port}" />
+    <flow name="listenerWithNotExceededHeaderFlow">
+        <http:listener config-ref="HTTP_Listener_Configuration" path="/notExceededHeader" />
+        <set-property propertyName="#['content']" value="${notExceededContentValue}" />
+    </flow>
+    <flow name="listenerWithExceededHeaderFlow">
+        <http:listener config-ref="HTTP_Listener_Configuration" path="/exceededHeader" />
+        <set-property propertyName="#['content']" value="${exceededContentValue}" />
+    </flow>
+    <flow name="requestToListenerWithNotExceededHeaderFlow">
+        <http:request config-ref="HTTP_Request_Configuration" path="/notExceededHeader" method="GET" />
+    </flow>
+    <flow name="requestToListenerWithExceededHeaderFlow">
+        <http:request config-ref="HTTP_Request_Configuration" path="/exceededHeader" method="GET" />
+    </flow>
+</mule>


### PR DESCRIPTION
Grizzly has a limitation of the HTTP response header section size. This is the expected behaviour because It is a bad practice to use big headers.
Due to a customer request, It should be possible to set the max header size.
It will be possible through the following system property:
-M-Dmule.http.client.headerSectionSize=MAX_HEADER_SIZE
This fix is similar to MULE-8653 but in the client side.