### PR TITLE
MULE-11924: After multiform request, Mule Message has an invalid data type

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleMessage.java
+++ b/core/src/main/java/org/mule/DefaultMuleMessage.java
@@ -541,7 +541,12 @@ public class DefaultMuleMessage implements MuleMessage, ThreadSafeAccess, Deseri
             {
                 final String contentType = getStringPropertyValue(CONTENT_TYPE_PROPERTY, value);
                 MimeType mimeType = new MimeType(contentType);
-                dataType.setMimeType(mimeType.getPrimaryType() + "/" + mimeType.getSubType());
+
+                if(payload != NullPayload.getInstance())
+                {
+                    dataType.setMimeType(mimeType.getPrimaryType() + "/" + mimeType.getSubType());
+                }
+
                 String encoding = mimeType.getParameter(CHARSET_PARAM);
                 if (!StringUtils.isEmpty(encoding))
                 {

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -104,7 +104,7 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
             }
         }
 
-        if (!outboundProperties.contains(MuleProperties.CONTENT_TYPE_PROPERTY))
+        if (!outboundProperties.contains(MuleProperties.CONTENT_TYPE_PROPERTY) && event.getMessage().getPayload() != NullPayload.getInstance())
         {
             DataType<?> dataType = event.getMessage().getDataType();
             if (!MimeTypes.ANY.equals(dataType.getMimeType()))

--- a/modules/http/src/test/java/org/mule/module/http/functional/HttpInboundAttachmentTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/HttpInboundAttachmentTestCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.http.functional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.MuleClient;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.transport.NullPayload;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class HttpInboundAttachmentTestCase extends FunctionalTestCase
+{
+
+    @Rule
+    public DynamicPort port = new DynamicPort("port");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-listener-inbound-attachment-config.xml";
+    }
+
+    @Test
+    public void testStateOfMessageAfterMultiFormRequest() throws Exception
+    {
+        runFlow("testFlowRequester");
+        MuleClient client = muleContext.getClient();
+        MuleMessage result = client.request("vm://out", RECEIVE_TIMEOUT);
+        assertThat(result.getPayload(), is((Object) NullPayload.getInstance()));
+        assertThat(result.getDataType().getType(), is(equalTo((Class)NullPayload.class)));
+    }
+
+}

--- a/modules/http/src/test/resources/http-listener-inbound-attachment-config.xml
+++ b/modules/http/src/test/resources/http-listener-inbound-attachment-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xsi:schemaLocation="
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+		http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <http:request-config name="HTTP_Request_Configuration" protocol="HTTP" host="0.0.0.0" port="${port}"/>
+    <http:listener-config name="HTTP_Listener_Configuration" host="0.0.0.0" port="${port}"/>
+
+    <flow name="testFlowRequester">
+        <http:listener config-ref="HTTP_Listener_Configuration" path="/in"/>
+        <set-attachment attachmentName="someJson"
+                        value="#[new java.io.ByteArrayInputStream('{ \'Test attachment\' }'.getBytes('UTF-8'))]"
+                        contentType="#['text/json']"/>
+        <http:request config-ref="HTTP_Request_Configuration" path="/" method="POST"/>
+    </flow>
+
+    <flow name="testFlowListener">
+        <http:listener config-ref="HTTP_Listener_Configuration" path="/"/>
+        <vm:outbound-endpoint path="out"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
… type.

When a multiform request is sent through the HTTP Requester, the payload is set to null, but the data type is set to "multiform data". It is a issue, because when the Http response is built in the HTTP Listener, It takes the multiform data type from the mule message, but without the expected boundary that is necesary to process the attachment. Therefore, an missing boundary exception is triggered.
If a Payload is set to NullPayload, content-type of transports should be ignored in the mule message.