### PR TITLE
MULE-11940: Fix For each collection doesn't work with iterator.

### DIFF
--- a/core/src/main/java/org/mule/routing/ExpressionSplitter.java
+++ b/core/src/main/java/org/mule/routing/ExpressionSplitter.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -99,6 +100,18 @@ public class ExpressionSplitter extends AbstractSplitter
             {
                 messages.add(new DefaultMuleMessage(nodeList.item(i), muleContext));
             }
+            return messages;
+        }
+        else if (result instanceof Iterator)
+        {
+            Iterator iterator = (Iterator) result;
+            List<MuleMessage> messages = new ArrayList<>();
+
+            while (iterator.hasNext())
+            {
+                messages.add(new DefaultMuleMessage(iterator.next(), muleContext));
+            }
+
             return messages;
         }
         else if (result == null)

--- a/core/src/test/java/org/mule/routing/ExpressionSplitterIteratorTestCase.java
+++ b/core/src/test/java/org/mule/routing/ExpressionSplitterIteratorTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+
+package org.mule.routing;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mule.api.MuleContext;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleMessage;
+import org.mule.api.config.MuleConfiguration;
+import org.mule.api.expression.ExpressionManager;
+import org.mule.expression.ExpressionConfig;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class ExpressionSplitterIteratorTestCase extends AbstractMuleTestCase
+{
+
+    private MuleEvent muleEvent = mock(MuleEvent.class);
+    private MuleContext muleContext = mock(MuleContext.class);
+    private ExpressionManager expressionManager = mock(ExpressionManager.class);
+    private final List<Integer> integers = createListOfIntegers();
+    private final ExpressionConfig expressionConfig = mock(ExpressionConfig.class);
+    private final ExpressionSplitter expressionSplitter = new ExpressionSplitter(expressionConfig);
+    private final MuleConfiguration muleConfiguration = mock(MuleConfiguration.class);
+
+    @Before
+    public void setUp() throws Exception
+    {
+        expressionSplitter.setMuleContext(muleContext);
+        when(muleEvent.getMuleContext()).thenReturn(muleContext);
+        when(muleContext.getExpressionManager()).thenReturn(expressionManager);
+        when(muleContext.getConfiguration()).thenReturn(muleConfiguration);
+        when(expressionConfig.getFullExpression(any(ExpressionManager.class))).thenReturn("fullExpression");
+        when(expressionManager.evaluate(any(String.class), any(MuleEvent.class))).thenReturn(integers.iterator());
+    }
+
+    @Test
+    public void testExpressionSplitterWithIteratorInput() throws Exception
+    {
+        List<MuleMessage> muleMessages = expressionSplitter.splitMessage(muleEvent);
+        assertThat(muleMessages.size(), is(integers.size()));
+        assertListValues(muleMessages);
+    }
+
+    private List<Integer> createListOfIntegers()
+    {
+        List<Integer> integers = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++)
+        {
+            integers.add(i);
+        }
+        return integers;
+    }
+
+    private void assertListValues(List<MuleMessage> messages)
+    {
+        Integer i = 0;
+        for (MuleMessage message : messages)
+        {
+            assertThat(message.getPayload(), instanceOf(Integer.class));
+            assertThat(message.getPayload(), is((Object) i++));
+        }
+    }
+
+}


### PR DESCRIPTION
According to Mule Documentation, It is possible to combine foreach element with split DataWeave function.
However, Currently ForEach isn't supporting iterators as Input Type.