### PR TITLE
MULE-11970: Update of logs which are indirectly causing a deadlock co…

### DIFF
--- a/core/src/main/java/org/mule/transaction/AbstractSingleResourceTransaction.java
+++ b/core/src/main/java/org/mule/transaction/AbstractSingleResourceTransaction.java
@@ -167,7 +167,6 @@ public abstract class AbstractSingleResourceTransaction extends AbstractTransact
                 .append('@').append(id)
                 .append("[status=").append(statusName)
                 .append(", key=").append(key)
-                .append(", resource=").append(resource)
                 .append("]").toString();
     }
 

--- a/core/src/main/java/org/mule/transaction/AbstractTransaction.java
+++ b/core/src/main/java/org/mule/transaction/AbstractTransaction.java
@@ -6,6 +6,8 @@
  */
 package org.mule.transaction;
 
+import static java.lang.System.identityHashCode;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mule.api.MuleContext;
@@ -61,7 +63,7 @@ public abstract class AbstractTransaction implements Transaction
 
     public void begin() throws TransactionException
     {
-        logger.debug("Beginning transaction");
+        logger.debug("Beginning transaction " + identityHashCode(this));
         doBegin();
         TransactionCoordination.getInstance().bindTransaction(this);
         fireNotification(new TransactionNotification(this, TransactionNotification.TRANSACTION_BEGAN, getApplicationName()));
@@ -71,7 +73,7 @@ public abstract class AbstractTransaction implements Transaction
     {
         try
         {
-            logger.debug("Committing transaction " + this);
+            logger.debug("Committing transaction " + identityHashCode(this));
 
             if (isRollbackOnly())
             {
@@ -91,7 +93,7 @@ public abstract class AbstractTransaction implements Transaction
     {
         try
         {
-            logger.debug("Rolling back transaction");
+            logger.debug("Rolling back transaction " + identityHashCode(this));
             setRollbackOnly();
             doRollback();
             fireNotification(new TransactionNotification(this, TransactionNotification.TRANSACTION_ROLLEDBACK, getApplicationName()));


### PR DESCRIPTION
…ndition.

The faster solution to this problem, is to update the log that is calling the toString() method. After analysis, we can confirm this invocation isn't giving traceability to the logs, because It is only invoked in commit() method. As identifier of the transaction, we can use the hashcode.