### PR TITLE
MULE-8990: State param encoding in OAuth support not compatible with …

### DIFF
--- a/modules/devkit-support/src/main/java/org/mule/security/oauth/OAuthProperties.java
+++ b/modules/devkit-support/src/main/java/org/mule/security/oauth/OAuthProperties.java
@@ -12,12 +12,17 @@ package org.mule.security.oauth;
 public interface OAuthProperties
 {
 
-    public static final String VERIFIER = "_oauthVerifier";
-    public static final String ACCESS_TOKEN_ID = "OAuthAccessTokenId";
-    public static final String EVENT_STATE_TEMPLATE = "<<MULE_EVENT_ID=%s>>";
-    public static final String HTTP_STATUS = "http.status";
-    public static final String CALLBACK_LOCATION = "Location";
-    public static final String AUTHORIZATION_EVENT_KEY_TEMPLATE = "%s-authorization-event";
+    String VERIFIER = "_oauthVerifier";
+    String ACCESS_TOKEN_ID = "OAuthAccessTokenId";
+    String BASE_EVENT_STATE_TEMPLATE = "MULE_EVENT_ID=%s";
+    String DEFAULT_EVENT_STATE_TEMPLATE_SUFFIX = ">>";
+    String DEFAULT_EVENT_STATE_TEMPLATE = BASE_EVENT_STATE_TEMPLATE + DEFAULT_EVENT_STATE_TEMPLATE_SUFFIX;
+    String EVENT_ID_REGEX = "MULE_EVENT_ID=([\\w-]*)";
+    String ORIGINAL_STATE_REGEX = "MULE_EVENT_ID=[\\w-]*";
+    String EVENT_STATE_REGEX_SUFFIX = "(.*)";
+    String HTTP_STATUS = "http.status";
+    String CALLBACK_LOCATION = "Location";
+    String AUTHORIZATION_EVENT_KEY_TEMPLATE = "%s-authorization-event";
 }
 
 

--- a/modules/devkit-support/src/main/java/org/mule/security/oauth/processor/BaseOAuth2AuthorizeMessageProcessor.java
+++ b/modules/devkit-support/src/main/java/org/mule/security/oauth/processor/BaseOAuth2AuthorizeMessageProcessor.java
@@ -7,6 +7,10 @@
 
 package org.mule.security.oauth.processor;
 
+import static java.lang.System.getProperty;
+import static org.mule.api.config.MuleProperties.SYSTEM_PROPERTY_PREFIX;
+import static org.mule.security.oauth.OAuthProperties.BASE_EVENT_STATE_TEMPLATE;
+import static org.mule.security.oauth.OAuthProperties.DEFAULT_EVENT_STATE_TEMPLATE_SUFFIX;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -49,7 +53,7 @@ public abstract class BaseOAuth2AuthorizeMessageProcessor<T extends OAuth2Manage
             }
         }
 
-        FetchAccessTokenMessageProcessor fetchAccessTokenMessageProcessor = new OAuth2FetchAccessTokenMessageProcessor(module, accessTokenId);
+        FetchAccessTokenMessageProcessor fetchAccessTokenMessageProcessor = new OAuth2FetchAccessTokenMessageProcessor(module, accessTokenId, getSuffix());
 
         this.startCallback(module, fetchAccessTokenMessageProcessor);
 
@@ -66,7 +70,7 @@ public abstract class BaseOAuth2AuthorizeMessageProcessor<T extends OAuth2Manage
 
     /**
      * Starts the OAuth authorization process
-     * 
+     *
      * @param event MuleEvent to be processed
      * @throws Exception
      */
@@ -97,7 +101,7 @@ public abstract class BaseOAuth2AuthorizeMessageProcessor<T extends OAuth2Manage
 
     private void setState(Map<String, String> extraParameters, MuleEvent event)
     {
-        String state = String.format(OAuthProperties.EVENT_STATE_TEMPLATE, event.getId());
+        String state = String.format(BASE_EVENT_STATE_TEMPLATE + getSuffix(), event.getId());
 
         if (this.getState() != null)
         {
@@ -175,6 +179,15 @@ public abstract class BaseOAuth2AuthorizeMessageProcessor<T extends OAuth2Manage
         {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Override this method when it's necessary override the separator of Ids.
+     * @return the value of CUSTOM_SUFFIX_PROPERTY if it was defined, DEFAULT_EVENT_STATE_SUFFIX otherwise.
+     */
+    protected String getSuffix()
+    {
+        return DEFAULT_EVENT_STATE_TEMPLATE_SUFFIX;
     }
 
 }

--- a/modules/devkit-support/src/test/java/org/mule/security/oauth/FetchAccessTokenTestCase.java
+++ b/modules/devkit-support/src/test/java/org/mule/security/oauth/FetchAccessTokenTestCase.java
@@ -46,7 +46,7 @@ public class FetchAccessTokenTestCase extends AbstractMuleContextTestCase implem
         this.objectStore = new InMemoryObjectStore<Serializable>();
 
         this.event = getTestEvent("");
-        event.getMessage().setProperty("state", "<<MULE_EVENT_ID=whatever>>", PropertyScope.INBOUND);
+        event.getMessage().setProperty("state", "MULE_EVENT_ID=whatever>>", PropertyScope.INBOUND);
         this.latch = new CountDownLatch(1);
         this.exception = null;
 

--- a/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2AuthorizeMessageProcessorTestCase.java
+++ b/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2AuthorizeMessageProcessorTestCase.java
@@ -173,7 +173,7 @@ public class OAuth2AuthorizeMessageProcessorTestCase
                 public String answer(InvocationOnMock invocation) throws Throwable
                 {
                     Map<String, String> parameters = (Map<String, String>) invocation.getArguments()[0];
-                    String expectedState = String.format(OAuthProperties.EVENT_STATE_TEMPLATE, eventId)
+                    String expectedState = String.format(OAuthProperties.DEFAULT_EVENT_STATE_TEMPLATE, eventId)
                                            + state;
                     Assert.assertEquals(expectedState, URLDecoder.decode(parameters.get("state"), "UTF-8"));
                     Assert.assertEquals(customField.toLowerCase(), parameters.get("customField"));

--- a/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2AuthorizeMessageProcessorWithCustomSuffixTestCase.java
+++ b/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2AuthorizeMessageProcessorWithCustomSuffixTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.security.oauth.processor;
+
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.security.oauth.OAuthProperties.BASE_EVENT_STATE_TEMPLATE;
+import static org.mule.security.oauth.processor.OAuth2FetchAccessTokenProcessorWithCustomSuffixTestCase.STATE_AFTER_SEPARATOR;
+import static org.mule.security.oauth.processor.OAuth2FetchAccessTokenProcessorWithCustomSuffixTestCase.STATE_BEFORE_SEPARATOR;
+
+import org.mule.api.MuleContext;
+import org.mule.api.MuleEvent;
+import org.mule.api.callback.HttpCallback;
+import org.mule.security.oauth.OAuth2Adapter;
+import org.mule.security.oauth.OAuth2Manager;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class OAuth2AuthorizeMessageProcessorWithCustomSuffixTestCase
+{
+
+    private static String CUSTOM_EVENT_STATE_TEMPLATE_SUFFIX = "__";
+
+    private AuthorizeMessageProcessorOverrideSuffix authorizeMessageProcessorOverrideSuffix = new AuthorizeMessageProcessorOverrideSuffix();
+    private MuleEvent event = mock(MuleEvent.class, RETURNS_DEEP_STUBS);
+    private String processedState = null;
+
+    @Test
+    public void testOverrideTemplateSuffixThroughImplementedMethod() throws Exception
+    {
+        String customSuffix = authorizeMessageProcessorOverrideSuffix.getSuffix();
+        assertThat(customSuffix, is(CUSTOM_EVENT_STATE_TEMPLATE_SUFFIX));
+    }
+
+    @Test
+    public void testProcessWithImplementedMethod() throws Exception
+    {
+        final String expectedResult = format(BASE_EVENT_STATE_TEMPLATE + "%s%s", STATE_BEFORE_SEPARATOR, CUSTOM_EVENT_STATE_TEMPLATE_SUFFIX, STATE_AFTER_SEPARATOR);
+        setMocks();
+        authorizeMessageProcessorOverrideSuffix.doProcess(event);
+        assertThat(processedState, is(expectedResult));
+    }
+
+    private void setMocks()
+    {
+        final OAuth2Manager manager = mock(OAuth2Manager.class, RETURNS_DEEP_STUBS);
+        final HttpCallback callback = mock(HttpCallback.class, RETURNS_DEEP_STUBS);
+        final MuleContext context = mock(MuleContext.class, RETURNS_DEEP_STUBS);
+        when(context.getExpressionManager().parse(STATE_AFTER_SEPARATOR, event.getMessage())).thenReturn(STATE_AFTER_SEPARATOR);
+        authorizeMessageProcessorOverrideSuffix.setOauthCallback(callback);
+        authorizeMessageProcessorOverrideSuffix.setMuleContext(context);
+        authorizeMessageProcessorOverrideSuffix.setModuleObject(manager);
+        authorizeMessageProcessorOverrideSuffix.setState(STATE_AFTER_SEPARATOR);
+        when(event.getId()).thenReturn(STATE_BEFORE_SEPARATOR);
+        doAnswer(buildAuthorizeUrlAnswer).when(manager).buildAuthorizeUrl(any(Map.class), any(String.class), any(String.class));
+    }
+
+    private Answer buildAuthorizeUrlAnswer = new Answer()
+    {
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable
+        {
+            Map<String, String> map = (Map) invocation.getArguments()[0];
+            processedState = map.get("state");
+            return null;
+        }
+    };
+
+    private class AuthorizeMessageProcessorOverrideSuffix extends
+            BaseOAuth2AuthorizeMessageProcessor<OAuth2Manager<OAuth2Adapter>>
+    {
+
+        @Override
+        protected Class<OAuth2Manager<OAuth2Adapter>> getOAuthManagerClass()
+        {
+            return null;
+        }
+
+        @Override
+        protected String getSuffix()
+        {
+            return CUSTOM_EVENT_STATE_TEMPLATE_SUFFIX;
+        }
+
+        @Override
+        protected String getAuthCodeRegex()
+        {
+            return null;
+        }
+    }
+
+}

--- a/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2FetchAccessTokenProcessorTestCase.java
+++ b/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2FetchAccessTokenProcessorTestCase.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_QUERY_PARAMS;
-import static org.mule.security.oauth.OAuthProperties.EVENT_STATE_TEMPLATE;
+import static org.mule.security.oauth.OAuthProperties.DEFAULT_EVENT_STATE_TEMPLATE;
 import static org.mule.security.oauth.notification.OAuthAuthorizeNotification.OAUTH_AUTHORIZATION_END;
 import org.mule.RequestContext;
 import org.mule.api.MessagingException;
@@ -74,7 +74,7 @@ public class OAuth2FetchAccessTokenProcessorTestCase
     public void setUp() throws Exception
     {
         state = "my state";
-        incomingState = String.format(EVENT_STATE_TEMPLATE + "%s", eventId, state);
+        incomingState = String.format(DEFAULT_EVENT_STATE_TEMPLATE + "%s", eventId, state);
         exception = false;
 
         restoredEvent = mock(MuleEvent.class, RETURNS_DEEP_STUBS);

--- a/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2FetchAccessTokenProcessorWithCustomSuffixTestCase.java
+++ b/modules/devkit-support/src/test/java/org/mule/security/oauth/processor/OAuth2FetchAccessTokenProcessorWithCustomSuffixTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.security.oauth.processor;
+
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.module.http.api.HttpConstants.RequestProperties.HTTP_QUERY_PARAMS;
+import static org.mule.security.oauth.OAuthProperties.BASE_EVENT_STATE_TEMPLATE;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleMessage;
+import org.mule.api.transport.PropertyScope;
+import org.mule.module.http.internal.ParameterMap;
+import org.mule.security.oauth.OAuth2Manager;
+import org.mule.tck.size.SmallTest;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+@SmallTest
+@RunWith(MockitoJUnitRunner.class)
+public class OAuth2FetchAccessTokenProcessorWithCustomSuffixTestCase
+{
+
+    private static final String CUSTOM_PREFIX = "__";
+    public static final String STATE_BEFORE_SEPARATOR = "stateBeforeSeparator";
+    public static final String STATE_AFTER_SEPARATOR = "stateAfterSeparator";
+
+    private final OAuth2Manager oAuth2Manager = mock(OAuth2Manager.class);
+    private OAuth2FetchAccessTokenMessageProcessor oAuth2FetchAccessTokenMessageProcessor = new OAuth2FetchAccessTokenMessageProcessor(oAuth2Manager, "accessTokenId", CUSTOM_PREFIX);
+    private MuleEvent event = mock(MuleEvent.class, RETURNS_DEEP_STUBS);
+    private MuleEvent restoredEvent = mock(MuleEvent.class, RETURNS_DEEP_STUBS);
+    private MuleMessage message = mock(MuleMessage.class);
+    private String processedId = null;
+    private ParameterMap parameterMap = new ParameterMap();
+    private HashMap<String, String> returnMap = null;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        String myState = format(BASE_EVENT_STATE_TEMPLATE + CUSTOM_PREFIX + "%s", STATE_BEFORE_SEPARATOR, STATE_AFTER_SEPARATOR);
+        parameterMap.put("state", myState);
+        when(event.getMessage().getInboundProperty("http.query.params")).thenReturn(parameterMap);
+        when(restoredEvent.getMessage()).thenReturn(message);
+        when(message.getInboundProperty("http.query.params")).thenReturn(new ParameterMap());
+        doAnswer(answerToRestoreAuthorizationEvent).when(oAuth2Manager).restoreAuthorizationEvent(anyString());
+        doAnswer(answerToSetProperty).when(message).setProperty(any(String.class), any(Map.class), any(PropertyScope.class));
+    }
+
+    @Test
+    public void testRestoreOriginalEvent() throws Exception
+    {
+        oAuth2FetchAccessTokenMessageProcessor.restoreOriginalEvent(event);
+        assertThat(processedId, is(STATE_BEFORE_SEPARATOR));
+        assertThat(returnMap.get("state"), is(STATE_AFTER_SEPARATOR));
+    }
+
+    private Answer answerToRestoreAuthorizationEvent = new Answer()
+    {
+        @Override
+        public Object answer(InvocationOnMock invocationOnMock) throws Throwable
+        {
+            processedId = (String) invocationOnMock.getArguments()[0];
+            return restoredEvent;
+        }
+    };
+
+    private Answer answerToSetProperty = new Answer()
+    {
+        @Override
+        public Object answer(InvocationOnMock invocationOnMock) throws Throwable
+        {
+            if (invocationOnMock.getArguments()[0].equals(HTTP_QUERY_PARAMS))
+            {
+                returnMap = ((HashMap) invocationOnMock.getArguments()[1]);
+            }
+            return null;
+        }
+    };
+
+}


### PR DESCRIPTION
…certain services like Concur

Concur (and others new connectors) complains about getting characters like '<'  '>' in the URL parameters, claiming it is a dangerous request.
Currently, We used it in the constant variable EVENT_STATE_TEMPLATE.
Devkit needs a mechanism to replace this character when they generate code.
With this fix, Devkit will able to implement the getSuffix method to override the respective character.
If the implemented method isn't overridden, the default ">>" prefix will be used.
"<<" Prefix will be removed because It's not used.