### PR TITLE
MULE-11825: Template-query isn't validating the definition of params …

### DIFF
--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -14,6 +14,7 @@ MULE-10306: XML entity expansion in XML transformers is now disabled by default 
 MULE-10686: XML entity expansion in Jersey is now disabled by default because it allows DoS attacks. To restore previous behaviour use the mule.xml.expandInternalEntities=true property.
 MULE-10979: The default response timeout and default transaction timeout can't be configured using system properties on the command line or in the wrapper.conf file anymore. In replacement, use the configuration element. For example: <configuration defaultResponseTimeout="20000"  defaultTransactionTimeout="40000"/>.
 MULE-11118: The HTTP listener now replies with status code 503 when the thread pool is exhausted (and poolExhaustedAction="ABORT") instead of closing the socket.
+MULE-11825: In a DB template query, to set a DB param with the null value, you can use the "NULL" literal value. For example: <db:in-param name="name" defaultValue="NULL"/>
 
 Migration changes from 3.7.x to 3.8.x
 MULE-9368: System property mule.sftp.knownHostsFile is now removed. Instead, the file with the known hosts must now be provided through the mule xml config file, in the knownHostsFile attribute of the connector or the endpoints.
@@ -291,4 +292,3 @@ MULE-7524: Encoded mule expressions in dynamic endpoints address components are 
 MULE-7546: Implementations of org.mule.api.MuleMessage now need to implement clearAttachments() which was added to the interface. Implementations that extend org.mule.el.context.AbstractMapContext must now implement clear() given this method has been removed from the abstract implementation.
 MULE-7612: maps returned by queries using the Database connector can have different keys as now column's aliases are used instead of column's names.
 MULE-8066: Since 3.6 MuleClient uses the new HTTP module for processing HTTP URLs. To use the previous behaviour use the attribute 'useTransportForUris' in the http:config  element that's located inside the mule configuration element. You can also set this globally by using the system property 'mule.http.useTransportForUris'.
-MULE-11825: In a DB template query, to set a DB param with the null value, you can use the "NULL" literal value. For example: <db:in-param name="name" defaultValue="NULL"/>


### PR DESCRIPTION
…used in query text.

Update of MIGRATION.txt
MULE-11825 changes description was in an incorrect place.