### PR TITLE
Mule-9950: Make FreePortFinder thread safe

### DIFF
--- a/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
+++ b/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
@@ -6,10 +6,11 @@
  */
 package org.mule.tck.junit4.rule;
 
+import static java.nio.channels.FileChannel.open;
+import static java.nio.file.Paths.get;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
 import static java.nio.file.StandardOpenOption.WRITE;
-import static java.nio.channels.FileChannel.open;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -19,7 +20,6 @@ import java.net.ServerSocket;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
-import static java.nio.file.Paths.get;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -49,10 +49,10 @@ public class FreePortFinder
     {
         for (int i = 0; i < portRange; i++)
         {
+            int port = minPortNumber + random.nextInt(portRange);
+            String portFile = port + LOCK_FILE_EXTENSION;
             try
             {
-                int port = minPortNumber + random.nextInt(portRange);
-                String portFile = port + LOCK_FILE_EXTENSION;
                 FileChannel channel = open(get(portFile), CREATE, WRITE, DELETE_ON_CLOSE);
                 FileLock lock = channel.tryLock();
                 if (lock == null)
@@ -110,7 +110,9 @@ public class FreePortFinder
         if (isPortFree(port) && locks.containsKey(port) && files.containsKey(port))
         {
             FileLock lock = locks.get(port);
+            locks.remove(port);
             FileChannel file = files.get(port);
+            files.remove(port);
             try {
                 lock.release();
                 file.close();

--- a/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
+++ b/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
@@ -17,6 +17,7 @@ import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Paths;
 import java.util.*;
 
+import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
 
 /**
@@ -47,7 +48,7 @@ public class FreePortFinder
             {
                 int port = minPortNumber + random.nextInt(portRange);
                 String portFile = String.valueOf(port) + LOCK_FILE_EXTENSION;
-                FileChannel channel = FileChannel.open(Paths.get(portFile), WRITE);
+                FileChannel channel = FileChannel.open(Paths.get(portFile), CREATE, WRITE);
                 FileLock lock = channel.tryLock();
 
                 if (isPortFree(port))

--- a/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
+++ b/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
@@ -109,10 +109,8 @@ public class FreePortFinder
     {
         if (isPortFree(port) && locks.containsKey(port) && files.containsKey(port))
         {
-            FileLock lock = locks.get(port);
-            locks.remove(port);
-            FileChannel file = files.get(port);
-            files.remove(port);
+            FileLock lock = locks.remove(port);
+            FileChannel file = files.remove(port);
             try {
                 lock.release();
                 file.close();

--- a/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
+++ b/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
@@ -14,10 +14,11 @@ import java.net.ServerSocket;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
-import java.nio.file.Paths;
+import static java.nio.file.Paths.get;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+
 
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -49,9 +50,14 @@ public class FreePortFinder
             try
             {
                 int port = minPortNumber + random.nextInt(portRange);
-                String portFile = String.valueOf(port) + LOCK_FILE_EXTENSION;
-                FileChannel channel = FileChannel.open(Paths.get(portFile), CREATE, WRITE);
+                String portFile = port + LOCK_FILE_EXTENSION;
+                FileChannel channel = FileChannel.open(get(portFile), CREATE, WRITE);
                 FileLock lock = channel.tryLock();
+                if (lock == null)
+                {
+                    // If the lock couldn't be acquired and tryLock didn't throw the exception, we throw it here
+                    throw new OverlappingFileLockException();
+                }
 
                 if (isPortFree(port))
                 {

--- a/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
+++ b/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
@@ -15,7 +15,9 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
 
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;

--- a/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
+++ b/core/src/test/java/org/mule/tck/junit4/rule/FreePortFinder.java
@@ -6,6 +6,10 @@
  */
 package org.mule.tck.junit4.rule;
 
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.nio.channels.FileChannel.open;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -18,10 +22,6 @@ import static java.nio.file.Paths.get;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-
-
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.WRITE;
 
 /**
  * Finds available port numbers in a specified range.
@@ -51,7 +51,7 @@ public class FreePortFinder
             {
                 int port = minPortNumber + random.nextInt(portRange);
                 String portFile = port + LOCK_FILE_EXTENSION;
-                FileChannel channel = FileChannel.open(get(portFile), CREATE, WRITE);
+                FileChannel channel = open(get(portFile), CREATE, WRITE);
                 FileLock lock = channel.tryLock();
                 if (lock == null)
                 {


### PR DESCRIPTION
Changed how Free Port Finder stores the ports being used. Now it's stores them in files (one per used port) and locks them until they are freed.

https://www.mulesoft.org/jira/browse/MULE-9950