### PR TITLE
MULE-12105: Provide a way to avoid properties be overridden when Runt…

### DIFF
--- a/distributions/standalone/src/main/resources/bin/additional.groovy
+++ b/distributions/standalone/src/main/resources/bin/additional.groovy
@@ -164,7 +164,6 @@ def String getArchitecture() {
  * @param args : arguments passed to the mule.bat script
  * @return the value of -additionalJavaProperties argument command line if it was set, DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS otherwise.
  */
-
 def int getNumberOfAdditionalJavaProperties(String[] args)
 {
     int DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS = 20;

--- a/distributions/standalone/src/main/resources/bin/additional.groovy
+++ b/distributions/standalone/src/main/resources/bin/additional.groovy
@@ -161,22 +161,22 @@ def String getArchitecture() {
 }
 
 /**
- *
- * @param args
- * @return the value of -additionalJavaProperties argument command line if It was set, DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS otherwise.
+ * @param args : arguments passed to the mule.bat script
+ * @return the value of -additionalJavaProperties argument command line if it was set, DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS otherwise.
  */
 
-def int getNumberOfAdditionalJavaProperties(String[] args) {
+def int getNumberOfAdditionalJavaProperties(String[] args)
+{
     int DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS = 20;
 
-    //find the item in the list
+    // Finds the item in the list
     def additionalJavaArguments = args.find { it ==~ /-additionalJavaProperties=(\d+)+/ }
 
-    //get the number of JavaArguments
+    // Gets the number of JavaArguments
     additionalJavaArgumentsMatcher = additionalJavaArguments =~ /-additionalJavaProperties=(\d+)+/
     additionalJavaArgumentsMatcher.find()
 
-    if(additionalJavaArgumentsMatcher.matches())
+    if (additionalJavaArgumentsMatcher.matches())
     {
         return additionalJavaArgumentsMatcher[0][1].toInteger() + 1
     }

--- a/distributions/standalone/src/main/resources/bin/additional.groovy
+++ b/distributions/standalone/src/main/resources/bin/additional.groovy
@@ -48,7 +48,7 @@ wrapperAdditionalConfFile.withWriter() {
                     break
             }
         }
-        paramIndex++
+        paramIndex += getNumberOfAdditionalJavaProperties(args)
 
         if (debugEnabled) {
             writeJpdaOpts(w)
@@ -158,4 +158,28 @@ def String getArchitecture() {
             println "ERROR: Architecture $arch is not supported by profiler"
             return
     }
+}
+
+/**
+ *
+ * @param args
+ * @return the value of -additionalJavaProperties argument command line if It was set, DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS otherwise.
+ */
+
+def int getNumberOfAdditionalJavaProperties(String[] args) {
+    int DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS = 20;
+
+    //find the item in the list
+    def additionalJavaArguments = args.find { it ==~ /-additionalJavaProperties=(\d+)+/ }
+
+    //get the number of JavaArguments
+    additionalJavaArgumentsMatcher = additionalJavaArguments =~ /-additionalJavaProperties=(\d+)+/
+    additionalJavaArgumentsMatcher.find()
+
+    if(additionalJavaArgumentsMatcher.matches())
+    {
+        return additionalJavaArgumentsMatcher[0][1].toInteger() + 1
+    }
+
+    return DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS + 1
 }


### PR DESCRIPTION
…ime is run as Windows Service

The solution for this bug, It is to take advantage of the gaps in the numbering that Tanuki allows.
By default, wrapper.additional.conf will be created starting the numbering of the properties with a gap of twenty in the index. The grap between the last index in wrapper.conf and the first index in wrapper.additional.conf could be set through the command line argument -additionalJavaProperties=value.
For example:
-additionalJavaProperties=50.
In this case, the user could add fifty properties after install the service.