### PR TITLE
MULE-12108: Fix useFailureExpressionIfInputValueHasExceptionPayloadAndFailureExpressionConfigured flaky test

### DIFF
--- a/core/src/test/java/org/mule/routing/AsynchronousUntilSuccessfulProcessingStrategyTestCase.java
+++ b/core/src/test/java/org/mule/routing/AsynchronousUntilSuccessfulProcessingStrategyTestCase.java
@@ -383,10 +383,13 @@ public class AsynchronousUntilSuccessfulProcessingStrategyTestCase extends Abstr
             @Override
             protected boolean test() throws Exception
             {
-                try {
+                try
+                {
                     verify(mockUntilSuccessfulConfiguration, atLeast(1)).getFailureExpressionFilter();
                     return true;
-                } catch (AssertionError e) {
+                }
+                catch (AssertionError e)
+                {
                     return false;
                 }
             }

--- a/core/src/test/java/org/mule/routing/AsynchronousUntilSuccessfulProcessingStrategyTestCase.java
+++ b/core/src/test/java/org/mule/routing/AsynchronousUntilSuccessfulProcessingStrategyTestCase.java
@@ -35,6 +35,8 @@ import org.mule.config.i18n.CoreMessages;
 import org.mule.retry.RetryPolicyExhaustedException;
 import org.mule.routing.filters.ExpressionFilter;
 import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.probe.JUnitProbe;
+import org.mule.tck.probe.PollingProber;
 import org.mule.tck.size.SmallTest;
 import org.mule.util.concurrent.Latch;
 import org.mule.util.store.SimpleMemoryObjectStore;
@@ -376,7 +378,19 @@ public class AsynchronousUntilSuccessfulProcessingStrategyTestCase extends Abstr
         when(mockUntilSuccessfulConfiguration.isUsingDefaultExpression()).thenReturn(false);
         executeUntilSuccessful();
         waitUntilRouteIsExecuted();
-        verify(mockUntilSuccessfulConfiguration, atLeast(1)).getFailureExpressionFilter();
+        new PollingProber().check(new JUnitProbe()
+        {
+            @Override
+            protected boolean test() throws Exception
+            {
+                try {
+                    verify(mockUntilSuccessfulConfiguration, atLeast(1)).getFailureExpressionFilter();
+                    return true;
+                } catch (AssertionError e) {
+                    return false;
+                }
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
Add PollingProber to verify getFailureExpression invocation