### PR TITLE
Revert "MULE-12105: Provide a way to avoid properties be overridden w…

### DIFF
--- a/distributions/standalone/src/main/resources/bin/additional.groovy
+++ b/distributions/standalone/src/main/resources/bin/additional.groovy
@@ -48,7 +48,7 @@ wrapperAdditionalConfFile.withWriter() {
                     break
             }
         }
-        paramIndex += getNumberOfAdditionalJavaProperties(args)
+        paramIndex++
 
         if (debugEnabled) {
             writeJpdaOpts(w)
@@ -158,27 +158,4 @@ def String getArchitecture() {
             println "ERROR: Architecture $arch is not supported by profiler"
             return
     }
-}
-
-/**
- * @param args : arguments passed to the mule.bat script
- * @return the value of -additionalJavaProperties argument command line if it was set, DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS otherwise.
- */
-def int getNumberOfAdditionalJavaProperties(String[] args)
-{
-    int DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS = 20;
-
-    // Finds the item in the list
-    def additionalJavaArguments = args.find { it ==~ /-additionalJavaProperties=(\d+)+/ }
-
-    // Gets the number of JavaArguments
-    additionalJavaArgumentsMatcher = additionalJavaArguments =~ /-additionalJavaProperties=(\d+)+/
-    additionalJavaArgumentsMatcher.find()
-
-    if (additionalJavaArgumentsMatcher.matches())
-    {
-        return additionalJavaArgumentsMatcher[0][1].toInteger() + 1
-    }
-
-    return DEFAULT_NUMBER_OF_ADDITIONAL_JAVA_ARGUMENTS + 1
 }


### PR DESCRIPTION
…hen Runt… (#4405)"

Mule Community Edition has an older version of Tanuki (3.2.3).
The use of gaps in numbering of index was added in Tanuki from 3.3.6 version.
Then this change must be reverted.