### PR TITLE
MULE-11949: OAuth: token refresh overrides payload when resending

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/request/DefaultHttpRequester.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/DefaultHttpRequester.java
@@ -289,7 +289,7 @@ public class DefaultHttpRequester extends AbstractNonBlockingMessageProcessor im
             {
                 try
                 {
-
+                    Object originalPayload = muleEvent.getMessage().getPayload();
                     httpResponseToMuleEvent.convert(muleEvent, httpResponse, httpRequest.getUri());
                     notificationHelper.fireNotification(muleEvent, httpRequest.getUri(),
                                                         muleEvent.getFlowConstruct(), MESSAGE_REQUEST_END);
@@ -299,6 +299,7 @@ public class DefaultHttpRequester extends AbstractNonBlockingMessageProcessor im
                     if (resendRequest(muleEvent, retryCount, authentication))
                     {
                         consumePayload(muleEvent);
+                        muleEvent.getMessage().setPayload(originalPayload);
                         innerProcessNonBlocking(muleEvent, originalCompletionHandler, 0);
                     }
                     else


### PR DESCRIPTION
request (#4250)
* Fix for non-blocking