### PR TITLE
MULE-12040: Don't use application log after the application is undepl…

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/AbstractArtifactClassLoader.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/AbstractArtifactClassLoader.java
@@ -61,6 +61,22 @@ public abstract class AbstractArtifactClassLoader extends FineGrainedControlClas
     @Override
     public void dispose()
     {
+
+        try
+        {
+            createResourceReleaserInstance().release();
+        }
+        catch (Exception e)
+        {
+            logger.error(e);
+        }
+
+        super.dispose();
+        shutdownListeners();
+    }
+
+    private void shutdownListeners ()
+    {
         for (ShutdownListener listener : shutdownListeners)
         {
             try
@@ -75,17 +91,6 @@ public abstract class AbstractArtifactClassLoader extends FineGrainedControlClas
 
         // Clean up references to shutdown listeners in order to avoid class loader leaks
         shutdownListeners.clear();
-
-        try
-        {
-            createResourceReleaserInstance().release();
-        }
-        catch (Exception e)
-        {
-            logger.error(e);
-        }
-
-        super.dispose();
     }
 
     public void setResourceReleaserClassLocation(String resourceReleaserClassLocation)

--- a/modules/launcher/src/main/java/org/mule/module/launcher/log4j2/LoggerContextConfigurer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/log4j2/LoggerContextConfigurer.java
@@ -215,7 +215,7 @@ final class LoggerContextConfigurer
             // If the artifact logging is configured using the global config file and there is no file appender for the artifact, then configure a default one
             if (isUrlInsideDirectory(context.getConfigFile(), MuleContainerBootstrapUtils.getMuleConfDir()))
             {
-                if (!hasFileAppender(context))
+                if (!context.isStopping() && !hasFileAppender(context))
                 {
                     addDefaultAppender(context, logFile.getAbsolutePath());
                     removeConsoleAppender(context);


### PR DESCRIPTION
…oyed.

The DefaultResourceReleaser's logger gets resolved to the application's logger, but it's called from AbstractArtifactClassLoader#dispose after the logging context is removed.
So a new MuleLoggerContext is created, locking the application's log file in Windows and keeping alive the JMS connection if logging through a JMSAppender. This stays that way after the application is undeployed.
To fix this we should either change the order of the logging context disposing.
In addition,we should also change the keys that are used in LoggerContextCache, because two differents instances of the same classloader are generating two LoggerContexts (HashCodes of classloaders are being used as keys). If we use the name of the application as key, we can guarantee only a loggerContext per application be created.
This fix is necessary but not enough to give a solution to this bug.
I have found a bug in log4j side, which is causing that some FileDescriptors aren't being closed, and I'll create a PR to fix it.