### PR TITLE
MULE-12385: Fix: Some endpoints allow to define a reconnection strategy

### DIFF
--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -16,7 +16,7 @@ MULE-10686: XML entity expansion in Jersey is now disabled by default because it
 MULE-10979: The default response timeout and default transaction timeout can't be configured using system properties on the command line or in the wrapper.conf file anymore. In replacement, use the configuration element. For example: <configuration defaultResponseTimeout="20000"  defaultTransactionTimeout="40000"/>.
 MULE-11118: The HTTP listener now replies with status code 503 when the thread pool is exhausted (and poolExhaustedAction="ABORT") instead of closing the socket.
 MULE-11825: In a DB template query, to set a DB param with the null value, you can use the "NULL" literal value. For example: <db:in-param name="name" defaultValue="NULL"/>
-MULE-12385: Reconnection Strategies can only be defined in connector components or globally (using <configuration> element). Defining reconnection strategies in endpoints isn't already supported.
+MULE-12385: Reconnection Strategies can only be defined in connector components or globally (using <configuration> element). In mule 3.x, defining reconnection strategies was being supported by the XSD, but ignored by Runtime. Now, the XSD was changed to not allow to use this invalid configuration.
 
 Migration changes from 3.7.x to 3.8.x
 MULE-9368: System property mule.sftp.knownHostsFile is now removed. Instead, the file with the known hosts must now be provided through the mule xml config file, in the knownHostsFile attribute of the connector or the endpoints.

--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -16,6 +16,7 @@ MULE-10686: XML entity expansion in Jersey is now disabled by default because it
 MULE-10979: The default response timeout and default transaction timeout can't be configured using system properties on the command line or in the wrapper.conf file anymore. In replacement, use the configuration element. For example: <configuration defaultResponseTimeout="20000"  defaultTransactionTimeout="40000"/>.
 MULE-11118: The HTTP listener now replies with status code 503 when the thread pool is exhausted (and poolExhaustedAction="ABORT") instead of closing the socket.
 MULE-11825: In a DB template query, to set a DB param with the null value, you can use the "NULL" literal value. For example: <db:in-param name="name" defaultValue="NULL"/>
+MULE-12385: Reconnection Strategies can only be defined in connector components or globally (using <configuration> element). Defining reconnection strategies in endpoints isn't already supported.
 
 Migration changes from 3.7.x to 3.8.x
 MULE-9368: System property mule.sftp.knownHostsFile is now removed. Instead, the file with the known hosts must now be provided through the mule xml config file, in the knownHostsFile attribute of the connector or the endpoints.

--- a/modules/spring-config/src/main/resources/META-INF/mule.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule.xsd
@@ -3670,7 +3670,6 @@
     <xsd:group name="defaultEndpointElements">
         <xsd:sequence>
             <xsd:group ref="commonDefaultEndpointElements"/>
-            <xsd:element ref="abstract-reconnection-strategy" minOccurs="0"/>
             <xsd:element ref="abstract-multi-transaction" minOccurs="0"/>
             <xsd:group ref="propertiesGroup"/>
         </xsd:sequence>

--- a/tests/integration/src/test/java/org/mule/test/reconnection/InvalidReconnectionStrategyTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/reconnection/InvalidReconnectionStrategyTestCase.java
@@ -11,21 +11,43 @@ import org.junit.Test;
 import org.mule.config.spring.AbstractSchemaValidationTestCase;
 import org.xml.sax.SAXException;
 
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.containsString;
+
+
 public class InvalidReconnectionStrategyTestCase extends AbstractSchemaValidationTestCase
 {
+    private static final String ERROR_MESSAGE  = "Invalid content was found starting with element 'reconnect'";
 
-    @Test(expected = SAXException.class)
+    @Test
     public void testInvalidReconnectStrategyWithinInboundEndpoint() throws Exception
     {
         addSchema("http://www.mulesoft.org/schema/mule/ftp","META-INF/mule-ftp.xsd");
-        doTest("org/mule/test/reconnection/invalid-reconnection-within-inbound-endpoint-config.xml");
+        try
+        {
+            doTest("org/mule/test/reconnection/invalid-reconnection-within-inbound-endpoint-config.xml");
+            fail("SaxException must be triggered, because it's an invalid configuration.");
+        }
+        catch (SAXException e)
+        {
+            assertThat(e.getMessage(), containsString(ERROR_MESSAGE));
+        }
     }
 
-    @Test(expected = SAXException.class)
+    @Test
     public void testInvalidReconnectStrategyWithinOutboundEndpoint() throws Exception
     {
         addSchema("http://www.mulesoft.org/schema/mule/ftp","META-INF/mule-ftp.xsd");
-        doTest("org/mule/test/reconnection/invalid-reconnection-within-outbound-endpoint-config.xml");
+        try
+        {
+            doTest("org/mule/test/reconnection/invalid-reconnection-within-outbound-endpoint-config.xml");
+            fail("SaxException must be triggered, because it's an invalid configuration.");
+        }
+        catch (SAXException e)
+        {
+            assertThat(e.getMessage(), containsString(ERROR_MESSAGE));
+        }
     }
 
 }

--- a/tests/integration/src/test/java/org/mule/test/reconnection/InvalidReconnectionStrategyTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/reconnection/InvalidReconnectionStrategyTestCase.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.test.reconnection;
+
+import org.junit.Test;
+import org.mule.config.spring.AbstractSchemaValidationTestCase;
+import org.xml.sax.SAXException;
+
+public class InvalidReconnectionStrategyTestCase extends AbstractSchemaValidationTestCase
+{
+
+    @Test(expected = SAXException.class)
+    public void testInvalidReconnectStrategyWithinInboundEndpoint() throws Exception
+    {
+        addSchema("http://www.mulesoft.org/schema/mule/ftp","META-INF/mule-ftp.xsd");
+        doTest("org/mule/test/reconnection/invalid-reconnection-within-inbound-endpoint-config.xml");
+    }
+
+    @Test(expected = SAXException.class)
+    public void testInvalidReconnectStrategyWithinOutboundEndpoint() throws Exception
+    {
+        addSchema("http://www.mulesoft.org/schema/mule/ftp","META-INF/mule-ftp.xsd");
+        doTest("org/mule/test/reconnection/invalid-reconnection-within-outbound-endpoint-config.xml");
+    }
+
+}

--- a/tests/integration/src/test/resources/org/mule/test/reconnection/invalid-reconnection-within-inbound-endpoint-config.xml
+++ b/tests/integration/src/test/resources/org/mule/test/reconnection/invalid-reconnection-within-inbound-endpoint-config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ftp="http://www.mulesoft.org/schema/mule/ftp"
+      xsi:schemaLocation="
+          http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+          http://www.mulesoft.org/schema/mule/ftp http://www.mulesoft.org/schema/mule/ftp/current/mule-ftp.xsd">
+
+    <flow name="main">
+        <ftp:inbound-endpoint address="ftp://anonymous:password@localhost:${port1}" binary="true" passive="true">
+            <reconnect/>
+        </ftp:inbound-endpoint>
+        <echo-component/>
+    </flow>
+</mule>

--- a/tests/integration/src/test/resources/org/mule/test/reconnection/invalid-reconnection-within-outbound-endpoint-config.xml
+++ b/tests/integration/src/test/resources/org/mule/test/reconnection/invalid-reconnection-within-outbound-endpoint-config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ftp="http://www.mulesoft.org/schema/mule/ftp"
+      xsi:schemaLocation="
+          http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+          http://www.mulesoft.org/schema/mule/ftp http://www.mulesoft.org/schema/mule/ftp/current/mule-ftp.xsd">
+
+    <flow name="main">
+        <ftp:outbound-endpoint address="ftp://anonymous:password@localhost:${port1}" binary="true" passive="true">
+            <reconnect/>
+        </ftp:outbound-endpoint>
+    </flow>
+</mule>


### PR DESCRIPTION
In mule 2.x, it was allowed to define reconnection strategies within endpoints.
In mule 3.x, Reconnection strategies only must be defined in connectors or globally.
However, currently, in some connectors, such as HTTP, FTP, AMQP, Mail, so on, it's still possible to define reconnection strategies within endpoints (in the xml configuration, but it doesn't work).
A possible solution is to modify the scheme.
This change only be applied to 3.x.