### PR TITLE
MULE-12395: Cannot load extension model in Windows

### DIFF
--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/MavenUtils.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/MavenUtils.java
@@ -9,12 +9,13 @@ package org.mule.runtime.module.deployment.impl.internal.maven;
 
 import static java.io.File.separator;
 import static java.lang.String.format;
+import static org.apache.commons.io.filefilter.DirectoryFileFilter.DIRECTORY;
 import static org.mule.runtime.api.util.Preconditions.checkState;
 import static org.mule.runtime.core.util.FileUtils.createFile;
 import static org.mule.runtime.core.util.JarUtils.getUrlWithinJar;
 import static org.mule.runtime.core.util.JarUtils.getUrlsWithinJar;
 import static org.mule.runtime.core.util.JarUtils.loadFileContentFrom;
-import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_ARTIFACT_FOLDER;
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_ARTIFACT_PATH_INSIDE_JAR;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_POM;
 import static org.mule.runtime.module.artifact.classloader.MuleMavenPlugin.MULE_MAVEN_PLUGIN_ARTIFACT_ID;
 import static org.mule.runtime.module.artifact.classloader.MuleMavenPlugin.MULE_MAVEN_PLUGIN_GROUP_ID;
@@ -36,7 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
@@ -62,7 +62,7 @@ public class MavenUtils {
    *         {@value ArtifactPluginDescriptor#MULE_PLUGIN_POM} file or the file can' be loaded
    */
   public static Model getPomModelFromJar(File artifactFile) {
-    String pomFilePath = MULE_ARTIFACT_FOLDER + separator + MULE_PLUGIN_POM;
+    String pomFilePath = MULE_ARTIFACT_PATH_INSIDE_JAR + "/" + MULE_PLUGIN_POM;
     try {
       MavenXpp3Reader reader = new MavenXpp3Reader();
       return reader.read(new ByteArrayInputStream(loadFileContentFrom(getPomUrlFromJar(artifactFile)).get()));
@@ -80,7 +80,7 @@ public class MavenUtils {
    * @return the URL to the pom file.
    */
   public static URL getPomUrlFromJar(File artifactFile) {
-    String pomFilePath = MULE_ARTIFACT_FOLDER + separator + MULE_PLUGIN_POM;
+    String pomFilePath = MULE_ARTIFACT_PATH_INSIDE_JAR + "/" + MULE_PLUGIN_POM;
     URL possibleUrl;
     try {
       possibleUrl = getUrlWithinJar(artifactFile, pomFilePath);
@@ -162,14 +162,14 @@ public class MavenUtils {
 
   private static File lookupPomFromMavenLocation(File artifactFolder) {
     File mulePluginPom = null;
-    File lookupFolder = new File(artifactFolder, "META-INF" + File.separator + "maven");
+    File lookupFolder = new File(artifactFolder, "META-INF" + separator + "maven");
     while (lookupFolder != null && lookupFolder.exists()) {
       File possiblePomLocation = new File(lookupFolder, MULE_PLUGIN_POM);
       if (possiblePomLocation.exists()) {
         mulePluginPom = possiblePomLocation;
         break;
       }
-      File[] directories = lookupFolder.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY);
+      File[] directories = lookupFolder.listFiles((FileFilter) DIRECTORY);
       checkState(directories != null || directories.length == 0,
                  format("No directories under %s so pom.xml file for artifact in folder %s could not be found",
                         lookupFolder.getAbsolutePath(), artifactFolder.getAbsolutePath()));

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactory.java
@@ -7,7 +7,6 @@
 
 package org.mule.runtime.module.deployment.impl.internal.plugin;
 
-import static java.io.File.separator;
 import static java.lang.String.format;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.config.bootstrap.ArtifactType.PLUGIN;
@@ -40,7 +39,7 @@ import java.util.Optional;
  */
 public class ArtifactPluginDescriptorFactory implements ArtifactDescriptorFactory<ArtifactPluginDescriptor> {
 
-  private static final String MULE_PLUGIN_JSON_PATH = MULE_ARTIFACT_FOLDER + separator + MULE_PLUGIN_JSON;
+  private static final String MULE_PLUGIN_JSON_PATH = MULE_ARTIFACT_FOLDER + "/" + MULE_PLUGIN_JSON;
 
   private final DescriptorLoaderRepository descriptorLoaderRepository;
 

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/ArtifactPluginFileBuilder.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/ArtifactPluginFileBuilder.java
@@ -16,6 +16,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.mule.runtime.container.internal.ClasspathModuleDiscoverer.EXPORTED_CLASS_PACKAGES_PROPERTY;
 import static org.mule.runtime.container.internal.ClasspathModuleDiscoverer.EXPORTED_RESOURCE_PROPERTY;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_ARTIFACT_FOLDER;
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_ARTIFACT_PATH_INSIDE_JAR;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_JSON;
 import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.EXPORTED_PACKAGES;
@@ -151,7 +152,8 @@ public class ArtifactPluginFileBuilder extends AbstractArtifactFileBuilder<Artif
       } catch (IOException e) {
         throw new IllegalStateException("There was an issue generating the JSON file for " + this.getId(), e);
       }
-      customResources.add(new ZipResource(jsonDescriptorFile.getAbsolutePath(), MULE_ARTIFACT_FOLDER + "/" + MULE_PLUGIN_JSON));
+      customResources
+          .add(new ZipResource(jsonDescriptorFile.getAbsolutePath(), MULE_ARTIFACT_PATH_INSIDE_JAR + "/" + MULE_PLUGIN_JSON));
     }
 
     return customResources;

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/plugin/ArtifactPluginDescriptorFactoryTestCase.java
@@ -7,12 +7,14 @@
 
 package org.mule.runtime.module.deployment.impl.internal.plugin;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.config.bootstrap.ArtifactType.PLUGIN;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_JSON;
 import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.MAVEN;
 import static org.mule.runtime.module.artifact.classloader.DefaultArtifactClassLoaderFilter.NULL_CLASSLOADER_FILTER;
 import static org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorFactory.invalidBundleDescriptorLoaderIdError;
@@ -128,8 +130,7 @@ public class ArtifactPluginDescriptorFactoryTestCase extends AbstractMuleTestCas
     File pluginJarLocation = pluginFileBuilder.getArtifactFile();
 
     expectedException.expect(ArtifactDescriptorCreateException.class);
-    expectedException
-        .expectMessage(ArtifactPluginDescriptorFactory.pluginDescriptorNotFound(pluginJarLocation));
+    expectedException.expectMessage(containsString(MULE_PLUGIN_JSON));
     descriptorFactory.create(pluginJarLocation);
   }
 

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginDescriptor.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/api/plugin/ArtifactPluginDescriptor.java
@@ -22,10 +22,15 @@ public class ArtifactPluginDescriptor extends DeployableArtifactDescriptor {
   private static final String META_INF = "META-INF";
   public static final String MULE_PLUGIN_CLASSIFIER = "mule-plugin";
   public static final String EXTENSION_BUNDLE_TYPE = "jar";
+  public static final String MULE_ARTIFACT = "mule-artifact";
   /**
    * Target folder for any files used at deployment time or when generating the {@link ExtensionModel}
    */
-  public static final String MULE_ARTIFACT_FOLDER = META_INF + separator + "mule-artifact";
+  public static final String MULE_ARTIFACT_FOLDER = META_INF + separator + MULE_ARTIFACT;
+  /**
+   * Target path as URL for any files used at deployment time or when generating the {@link ExtensionModel}
+   */
+  public static final String MULE_ARTIFACT_PATH_INSIDE_JAR = META_INF + "/" + MULE_ARTIFACT;
   public static final String MULE_PLUGIN_JSON = "mule-plugin.json";
   public static final String MULE_PLUGIN_POM = "pom.xml";
 

--- a/tests/runner/src/main/java/org/mule/test/runner/api/PluginResourcesResolver.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/PluginResourcesResolver.java
@@ -9,10 +9,11 @@ package org.mule.test.runner.api;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.format;
-import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_ARTIFACT_FOLDER;
+import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_ARTIFACT_PATH_INSIDE_JAR;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_JSON;
 import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.EXPORTED_PACKAGES;
 import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.EXPORTED_RESOURCES;
+import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.META_INF;
 import org.mule.runtime.api.deployment.meta.MulePluginModel;
 import org.mule.runtime.api.deployment.persistence.MulePluginModelJsonSerializer;
 
@@ -50,9 +51,9 @@ public class PluginResourcesResolver {
 
     try (URLClassLoader classLoader = new URLClassLoader(pluginUrlClassification.getUrls().toArray(new URL[0]), null)) {
       logger.debug("Loading plugin '{}' descriptor", pluginUrlClassification.getName());
-      URL pluginJsonUrl = classLoader.findResource("META-INF/" + MULE_PLUGIN_JSON);
+      URL pluginJsonUrl = classLoader.findResource(META_INF + "/" + MULE_PLUGIN_JSON);
       if (pluginJsonUrl == null) {
-        pluginJsonUrl = classLoader.getResource(MULE_ARTIFACT_FOLDER + "/" + MULE_PLUGIN_JSON);
+        pluginJsonUrl = classLoader.getResource(MULE_ARTIFACT_PATH_INSIDE_JAR + "/" + MULE_PLUGIN_JSON);
         if (pluginJsonUrl == null) {
           throw new IllegalStateException(MULE_PLUGIN_JSON + " couldn't be found for plugin: " +
               pluginUrlClassification.getName());


### PR DESCRIPTION
Path is used to locate the file inside the jar so it cannot use File.separator instead it should just be /