### PR TITLE
MULE-12393: HTTP Listener config with the same name in different

### DIFF
--- a/modules/container/src/main/java/org/mule/runtime/container/api/ServiceInvocationHandler.java
+++ b/modules/container/src/main/java/org/mule/runtime/container/api/ServiceInvocationHandler.java
@@ -8,6 +8,7 @@ package org.mule.runtime.container.api;
 
 import static java.lang.reflect.Proxy.getInvocationHandler;
 import static java.lang.reflect.Proxy.isProxyClass;
+import static java.util.Arrays.asList;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 
 import org.mule.runtime.api.service.Service;
@@ -16,6 +17,8 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Extends {@link InvocationHandler} to provide and expose metadata about the inner {@link Service} implementation.
@@ -45,7 +48,14 @@ public abstract class ServiceInvocationHandler implements InvocationHandler {
     if (isProxyClass(getService().getClass()) && getInvocationHandler(getService()) instanceof ServiceInvocationHandler) {
       return ((ServiceInvocationHandler) getInvocationHandler(getService())).getServiceImplementationDeclaredMethods();
     } else {
-      return getService().getClass().getDeclaredMethods();
+      List<Method> methods = new LinkedList<>();
+      Class<?> clazz = getService().getClass();
+      while (clazz != Object.class) {
+        methods.addAll(asList(clazz.getDeclaredMethods()));
+        clazz = clazz.getSuperclass();
+      }
+
+      return methods.toArray(new Method[methods.size()]);
     }
   }
 

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/InjectParamsFromContextServiceProxyTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/InjectParamsFromContextServiceProxyTestCase.java
@@ -65,6 +65,17 @@ public class InjectParamsFromContextServiceProxyTestCase extends AbstractMuleCon
   }
 
   @Test
+  public void augmentedSubclassInvocation() throws Exception {
+    BaseService service = new AugmentedSubclassMethodService();
+
+    final BaseService serviceProxy = (BaseService) createInjectProviderParamsServiceProxy(service, muleContext);
+
+    serviceProxy.augmented();
+
+    assertThat(augmentedParam, sameInstance(muleContext));
+  }
+
+  @Test
   public void augmentedWithPreferredInvocation() throws Exception {
     muleContext.getRegistry().registerObject("myBean", new MyBean());
     final MyPreferredBean preferredBean = new MyPreferredBean();
@@ -219,6 +230,15 @@ public class InjectParamsFromContextServiceProxyTestCase extends AbstractMuleCon
     public void augmented(MuleContext context) {
       augmentedParam = context;
     }
+  }
+
+  public class AugmentedSubclassMethodService extends AugmentedMethodService {
+
+    @Override
+    public String getName() {
+      return "AugmentedSubclassMethodService";
+    }
+
   }
 
   public class AugmentedWithPreferredMethodService implements BaseService {


### PR DESCRIPTION
applications fails