### PR TITLE
MULE-12393: HTTP Listener config with the same name in different

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/InjectParamsFromContextServiceProxy.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/InjectParamsFromContextServiceProxy.java
@@ -11,6 +11,7 @@ import static java.lang.String.format;
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Proxy.newProxyInstance;
 import static java.util.Arrays.asList;
+import static java.util.Arrays.deepEquals;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.util.ClassUtils.findImplementedInterfaces;
 
@@ -95,7 +96,9 @@ public class InjectParamsFromContextServiceProxy extends ServiceInvocationHandle
           && serviceImplMethod.getName().equals(method.getName())
           && serviceImplMethod.getAnnotationsByType(Inject.class).length > 0
           && equivalentParams(method.getParameters(), serviceImplMethod.getParameters())) {
-        if (candidate != null) {
+        if (candidate != null
+            && !(candidate.getName().equals(serviceImplMethod.getName())
+                && deepEquals(candidate.getParameterTypes(), serviceImplMethod.getParameterTypes()))) {
           throw new IllegalDependencyInjectionException(format(MANY_CANDIDATES_ERROR_MSG_TEMPLATE, method.getName(),
                                                                getService().getName()));
         }

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/spring/InjectParamsFromContextServiceProxyTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/spring/InjectParamsFromContextServiceProxyTestCase.java
@@ -76,6 +76,17 @@ public class InjectParamsFromContextServiceProxyTestCase extends AbstractMuleCon
   }
 
   @Test
+  public void augmentedSubclassOverridesInvocation() throws Exception {
+    BaseService service = new AugmentedSubclassOverridesMethodService();
+
+    final BaseService serviceProxy = (BaseService) createInjectProviderParamsServiceProxy(service, muleContext);
+
+    serviceProxy.augmented();
+
+    assertThat(augmentedParam, is(true));
+  }
+
+  @Test
   public void augmentedWithPreferredInvocation() throws Exception {
     muleContext.getRegistry().registerObject("myBean", new MyBean());
     final MyPreferredBean preferredBean = new MyPreferredBean();
@@ -239,6 +250,20 @@ public class InjectParamsFromContextServiceProxyTestCase extends AbstractMuleCon
       return "AugmentedSubclassMethodService";
     }
 
+  }
+
+  public class AugmentedSubclassOverridesMethodService extends AugmentedMethodService {
+
+    @Override
+    public String getName() {
+      return "AugmentedSubclassOverridesMethodService";
+    }
+
+    @Override
+    @Inject
+    public void augmented(MuleContext context) {
+      augmentedParam = true;
+    }
   }
 
   public class AugmentedWithPreferredMethodService implements BaseService {


### PR DESCRIPTION
applications fails
* Addendum