### PR TITLE
SE-712: flow initialState should support a property placeholder

### DIFF
--- a/modules/spring-config/src/main/resources/META-INF/mule.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule.xsd
@@ -2437,7 +2437,7 @@
                         </xsd:documentation>
                     </xsd:annotation>
                     <xsd:simpleType>
-                        <xsd:restriction base="xsd:NMTOKEN">
+                        <xsd:restriction base="substitutableName">
                             <xsd:enumeration value="started"/>
                             <xsd:enumeration value="stopped"/>
                         </xsd:restriction>
@@ -2584,7 +2584,7 @@
                         </xsd:documentation>
                     </xsd:annotation>
                     <xsd:simpleType>
-                        <xsd:restriction base="xsd:NMTOKEN">
+                        <xsd:restriction base="substitutableName">
                             <xsd:enumeration value="started"/>
                             <xsd:enumeration value="stopped"/>
                         </xsd:restriction>


### PR DESCRIPTION
* Updating mule XSD for changing the restriction base type of the initialState properties of the baseFlowConstructType and flowType
* This change was based on the selector property (mule.xsd:884) of the watermarkType which currently have the desired behavior