### PR TITLE
MULE-12449: ArtifactClassLoaderRunner - Is not able to download missi…

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/ArtifactClassLoaderRunner.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/ArtifactClassLoaderRunner.java
@@ -8,6 +8,7 @@ package org.mule.test.runner;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.System.getProperty;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.mule.runtime.core.util.ClassUtils.withContextClassLoader;
 import static org.mule.test.runner.RunnerConfiguration.readConfiguration;
@@ -37,6 +38,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -214,9 +216,11 @@ public class ArtifactClassLoaderRunner extends Runner implements Filterable {
     WorkspaceLocationResolver workspaceLocationResolver = new AutoDiscoverWorkspaceLocationResolver(classPath,
                                                                                                     rootArtifactClassesFolder);
     final DependencyResolver dependencyResolver = RepositorySystemFactory
-        .newOfflineDependencyResolver(classPath,
-                                      workspaceLocationResolver,
-                                      getMavenLocalRepository());
+        .newDependencyResolver(classPath,
+                               workspaceLocationResolver,
+                               getMavenLocalRepository(),
+                               //TODO (gfernandes) MULE-12449 (read settings to pass enable remote repositories in addition to the ones in pom that have public access)
+                               emptyList());
     builder.setClassPathClassifier(new AetherClassPathClassifier(dependencyResolver,
                                                                  new ArtifactClassificationTypeResolver(
                                                                                                         dependencyResolver)));

--- a/tests/runner/src/test/java/org/mule/test/runner/api/RepositorySystemFactoryTestCase.java
+++ b/tests/runner/src/test/java/org/mule/test/runner/api/RepositorySystemFactoryTestCase.java
@@ -9,7 +9,6 @@ package org.mule.test.runner.api;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.io.File.separator;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
@@ -28,9 +27,7 @@ import java.util.Collections;
 
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
-import org.eclipse.aether.transfer.ArtifactNotFoundException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -57,32 +54,17 @@ public class RepositorySystemFactoryTestCase extends AbstractMuleTestCase {
 
     WorkspaceLocationResolver workspaceLocationResolver = mock(WorkspaceLocationResolver.class);
     File mavenLocalRepositoryLocation = root.newFolder("repository");
-    DependencyResolver dependencyResolver = RepositorySystemFactory.newOnlineDependencyResolver(
-                                                                                                Collections.<URL>emptyList(),
-                                                                                                workspaceLocationResolver,
-                                                                                                mavenLocalRepositoryLocation,
-                                                                                                newArrayList(MAVEN_CENTRAL));
+    DependencyResolver dependencyResolver = RepositorySystemFactory.newDependencyResolver(
+                                                                                          Collections.<URL>emptyList(),
+                                                                                          workspaceLocationResolver,
+                                                                                          mavenLocalRepositoryLocation,
+                                                                                          newArrayList(MAVEN_CENTRAL));
 
     final ArtifactResult artifactResult = dependencyResolver.resolveArtifact(commonsCollectionsArtifact);
     assertThat(artifactResult, not(nullValue()));
     assertThat(artifactResult.getArtifact().getFile().getParentFile(),
                equalTo(new File(mavenLocalRepositoryLocation,
                                 "commons-collections" + separator + "commons-collections" + separator + "3.2")));
-  }
-
-  @Test
-  public void offlineRepository() throws Exception {
-    WorkspaceLocationResolver workspaceLocationResolver = mock(WorkspaceLocationResolver.class);
-    File mavenLocalRepositoryLocation = root.newFolder("repository");
-    DependencyResolver dependencyResolver = RepositorySystemFactory.newOnlineDependencyResolver(
-                                                                                                Collections.<URL>emptyList(),
-                                                                                                workspaceLocationResolver,
-                                                                                                mavenLocalRepositoryLocation,
-                                                                                                Collections.<String>emptyList());
-
-    expectedException.expect(ArtifactResolutionException.class);
-    expectedException.expectCause(instanceOf(ArtifactNotFoundException.class));
-    dependencyResolver.resolveArtifact(commonsCollectionsArtifact);
   }
 
   private Matcher<String> isReachable() {


### PR DESCRIPTION
…ng dependencies - Change to work online and use pom repositories declaration. It will work with repositories that don't require authentication

* First change to test infrastructure to allow reading remote repositories declared in pom and work online to download any missing dependency from local maven repository.
