### PR TITLE
MULE-6619: flow initialState should support a property placeholder

### DIFF
--- a/modules/spring-config/src/main/resources/META-INF/mule.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule.xsd
@@ -2075,10 +2075,17 @@
                         </xsd:documentation>
                     </xsd:annotation>
                     <xsd:simpleType>
-                        <xsd:restriction base="xsd:NMTOKEN">
-                            <xsd:enumeration value="started"/>
-                            <xsd:enumeration value="stopped"/>
-                        </xsd:restriction>
+                        <xsd:union>
+                            <xsd:simpleType>
+                                <xsd:restriction base="propertyPlaceholderType"/>
+                            </xsd:simpleType>
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:NMTOKEN">
+                                    <xsd:enumeration value="started"/>
+                                    <xsd:enumeration value="stopped"/>
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:union>
                     </xsd:simpleType>
                 </xsd:attribute>
            </xsd:extension>


### PR DESCRIPTION
* Updating mule XSD for allowing a property placeholder on the initialState property of the flowType elemen