### PR TITLE
MULE-12449: Add support for authenticator selector on Aether code bas…

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/api/DependencyResolver.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/DependencyResolver.java
@@ -27,6 +27,7 @@ import org.eclipse.aether.collection.DependencyCollectionException;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
@@ -66,7 +67,8 @@ public class DependencyResolver {
 
     this.resolutionContext = new AetherResolutionContext(mavenConfiguration);
     this.repositoryState =
-        new AetherRepositoryState(this.resolutionContext.getLocalRepositoryLocation(), workspaceReader, false, false);
+        new AetherRepositoryState(this.resolutionContext.getLocalRepositoryLocation(), workspaceReader, false,
+                                  false, resolutionContext.getAuthenticatorSelector());
   }
 
   /**
@@ -124,6 +126,7 @@ public class DependencyResolver {
    *        {@code null}
    * @param dependencyFilter {@link DependencyFilter} to include/exclude dependency nodes during collection and resolve operation.
    *        May be {@code null} to no filter
+   * @param remoteRepositories {@link RemoteRepository} to be used when resolving dependencies in addition to the ones already defined in the context.
    * @return a {@link List} of {@link File}s for each dependency resolved
    * @throws {@link DependencyCollectionException} if the dependency tree could not be built
    * @thwows {@link DependencyResolutionException} if the dependency tree could not be built or any dependency artifact could not
@@ -131,13 +134,14 @@ public class DependencyResolver {
    */
   public List<File> resolveDependencies(Dependency root, List<Dependency> directDependencies,
                                         List<Dependency> managedDependencies,
-                                        DependencyFilter dependencyFilter)
+                                        DependencyFilter dependencyFilter, List<RemoteRepository> remoteRepositories)
       throws DependencyCollectionException, DependencyResolutionException {
     CollectRequest collectRequest = new CollectRequest();
     collectRequest.setRoot(root);
     collectRequest.setDependencies(directDependencies);
     collectRequest.setManagedDependencies(managedDependencies);
     collectRequest.setRepositories(resolutionContext.getRemoteRepositories());
+    remoteRepositories.forEach(remoteRepository -> collectRequest.addRepository(remoteRepository));
 
     DependencyNode node;
     try {

--- a/tests/runner/src/test/java/org/mule/test/runner/api/AetherClassPathClassifierTestCase.java
+++ b/tests/runner/src/test/java/org/mule/test/runner/api/AetherClassPathClassifierTestCase.java
@@ -8,6 +8,7 @@
 package org.mule.test.runner.api;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static org.eclipse.aether.util.artifact.ArtifactIdUtils.toId;
 import static org.eclipse.aether.util.artifact.JavaScopes.COMPILE;
 import static org.eclipse.aether.util.artifact.JavaScopes.PROVIDED;
@@ -40,7 +41,6 @@ import org.mule.tck.size.SmallTest;
 import java.io.File;
 import java.io.FileWriter;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -150,7 +150,8 @@ public class AetherClassPathClassifierTestCase extends AbstractMuleTestCase {
                                                 (List<Dependency>) argThat(hasItems(equalTo(compileMuleCoreDep),
                                                                                     equalTo(compileMuleArtifactDep))),
                                                 (List<Dependency>) argThat(hasItems(equalTo(guavaDep))),
-                                                argThat(instanceOf(DependencyFilter.class))))
+                                                argThat(instanceOf(DependencyFilter.class)),
+                                                argThat(equalTo(emptyList()))))
                                                     .thenReturn(newArrayList(fooCoreArtifactFile, fooToolsArtifactFile));
 
     ArtifactsUrlClassification classification = classifier.classify(context);
@@ -170,7 +171,8 @@ public class AetherClassPathClassifierTestCase extends AbstractMuleTestCase {
                                                                               hasItems(equalTo(compileMuleCoreDep),
                                                                                        equalTo(compileMuleArtifactDep))),
                                                    (List<Dependency>) argThat(hasItems(equalTo(guavaDep))),
-                                                   argThat(instanceOf(DependencyFilter.class)));
+                                                   argThat(instanceOf(DependencyFilter.class)),
+                                                   argThat(equalTo(emptyList())));
     verify(artifactClassificationTypeResolver).resolveArtifactClassificationType(rootArtifact);
     verify(rootArtifactResult).getArtifact();
   }
@@ -204,10 +206,11 @@ public class AetherClassPathClassifierTestCase extends AbstractMuleTestCase {
                                                 (List<Dependency>) argThat(hasItems(equalTo(compileMuleCoreDep),
                                                                                     equalTo(compileMuleArtifactDep))),
                                                 (List<Dependency>) argThat(hasItems(equalTo(guavaDep))),
-                                                argThat(instanceOf(DependencyFilter.class))))
+                                                argThat(instanceOf(DependencyFilter.class)),
+                                                argThat(equalTo(emptyList()))))
                                                     .thenReturn(newArrayList(fooCoreArtifactFile, fooToolsArtifactFile));
 
-    URL url = mock(URL.class);
+    URL url = temporaryFolder.newFile().toURI().toURL();
     List<URL> appUrls = newArrayList(url);
     when(context.getApplicationUrls()).thenReturn(appUrls);
 
@@ -228,7 +231,8 @@ public class AetherClassPathClassifierTestCase extends AbstractMuleTestCase {
                                                                               hasItems(equalTo(compileMuleCoreDep),
                                                                                        equalTo(compileMuleArtifactDep))),
                                                    (List<Dependency>) argThat(hasItems(equalTo(guavaDep))),
-                                                   argThat(instanceOf(DependencyFilter.class)));
+                                                   argThat(instanceOf(DependencyFilter.class)),
+                                                   argThat(equalTo(emptyList())));
     verify(artifactClassificationTypeResolver).resolveArtifactClassificationType(rootArtifact);
     verify(context, atLeastOnce()).getApplicationUrls();
     verify(rootArtifactResult).getArtifact();
@@ -317,9 +321,11 @@ public class AetherClassPathClassifierTestCase extends AbstractMuleTestCase {
 
     List<File> fooServiceUrls = newArrayList(fooServiceArtifactFile, metaInfFolder);
     when(dependencyResolver.resolveDependencies(argThat(equalTo(new Dependency(fooServiceDep.getArtifact(), COMPILE))),
-                                                argThat(equalTo(Collections.<Dependency>emptyList())),
-                                                argThat(equalTo(Collections.<Dependency>emptyList())),
-                                                argThat(instanceOf(DependencyFilter.class)))).thenReturn(fooServiceUrls);
+                                                argThat(equalTo(emptyList())),
+                                                argThat(equalTo(emptyList())),
+                                                argThat(instanceOf(DependencyFilter.class)),
+                                                argThat(equalTo(emptyList()))))
+                                                    .thenReturn(fooServiceUrls);
 
     File rootArtifactFile = temporaryFolder.newFile();
 
@@ -351,8 +357,9 @@ public class AetherClassPathClassifierTestCase extends AbstractMuleTestCase {
                                                 (List<Dependency>) and((argThat(hasItems(equalTo(compileMuleCoreDep),
                                                                                          equalTo(compileMuleArtifactDep)))),
                                                                        argThat(hasSize(2))),
-                                                argThat(equalTo(Collections.<Dependency>emptyList())),
-                                                argThat(instanceOf(DependencyFilter.class))))
+                                                argThat(equalTo(emptyList())),
+                                                argThat(instanceOf(DependencyFilter.class)),
+                                                argThat(equalTo(emptyList()))))
                                                     .thenReturn(newArrayList(fooCoreArtifactFile, fooToolsArtifactFile));
 
     ArtifactsUrlClassification classification = classifier.classify(context);
@@ -369,21 +376,23 @@ public class AetherClassPathClassifierTestCase extends AbstractMuleTestCase {
     verify(dependencyResolver, atLeastOnce()).readArtifactDescriptor(any(Artifact.class));
     verify(dependencyResolver, atLeastOnce())
         .resolveDependencies(argThat(equalTo(new Dependency(fooServiceDep.getArtifact(), COMPILE))),
-                             argThat(equalTo(Collections.<Dependency>emptyList())),
-                             argThat(equalTo(Collections.<Dependency>emptyList())),
-                             argThat(instanceOf(DependencyFilter.class)));
+                             argThat(equalTo(emptyList())),
+                             argThat(equalTo(emptyList())),
+                             argThat(instanceOf(DependencyFilter.class)),
+                             argThat(equalTo(emptyList())));
     verify(artifactClassificationTypeResolver).resolveArtifactClassificationType(rootArtifact);
     verify(dependencyResolver, atLeastOnce()).resolveDependencies(argThat(nullValue(Dependency.class)),
                                                                   (List<Dependency>) and((argThat(hasItems(equalTo(compileMuleCoreDep),
                                                                                                            equalTo(compileMuleArtifactDep)))),
                                                                                          argThat(hasSize(2))),
-                                                                  argThat(equalTo(Collections.<Dependency>emptyList())),
-                                                                  argThat(instanceOf(DependencyFilter.class)));
+                                                                  argThat(equalTo(emptyList())),
+                                                                  argThat(instanceOf(DependencyFilter.class)),
+                                                                  argThat(equalTo(emptyList())));
   }
 
   private ArtifactDescriptorResult noManagedDependencies() throws ArtifactDescriptorException {
     ArtifactDescriptorResult artifactDescriptorResult = mock(ArtifactDescriptorResult.class);
-    List<Dependency> managedDependencies = Collections.<Dependency>emptyList();
+    List<Dependency> managedDependencies = emptyList();
     when(artifactDescriptorResult.getManagedDependencies()).thenReturn(managedDependencies);
     when(dependencyResolver.readArtifactDescriptor(any(Artifact.class))).thenReturn(artifactDescriptorResult);
     return artifactDescriptorResult;


### PR DESCRIPTION
…ed on settings.xml server definitions
- Changed validation to log a warn message instead of throwing an exception when an snapshot version was resolved and not found in classpath (miss matching from IDE and Maven resolution)