### PR TITLE
MULE-12449: Fixed resolution to use correctly the remote repositories

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/api/ExtensionModelLoaderFinder.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/ExtensionModelLoaderFinder.java
@@ -14,11 +14,13 @@ import org.mule.test.runner.maven.MavenModelFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.maven.model.Model;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
 
@@ -43,10 +45,11 @@ class ExtensionModelLoaderFinder {
    * Searches in the plugin pom.xml for the {@code testExtensionModelLoaderId} property which specifies with which loader the
    * extension must be loaded. The main use of this is for Test Extensions that don't generate a mule-plugin.json.
    */
-  public Optional<ExtensionModelLoader> findLoaderByProperty(Artifact plugin, DependencyResolver dependencyResolver) {
+  public Optional<ExtensionModelLoader> findLoaderByProperty(Artifact plugin, DependencyResolver dependencyResolver,
+                                                             List<RemoteRepository> rootArtifactRemoteRepositories) {
     DefaultArtifact artifact = new DefaultArtifact(plugin.getGroupId(), plugin.getArtifactId(), "pom", plugin.getVersion());
     try {
-      ArtifactResult artifactResult = dependencyResolver.resolveArtifact(artifact);
+      ArtifactResult artifactResult = dependencyResolver.resolveArtifact(artifact, rootArtifactRemoteRepositories);
       File pomFile = artifactResult.getArtifact().getFile();
       Model mavenProject = MavenModelFactory.createMavenProject(pomFile);
       String id = mavenProject.getProperties().getProperty("testExtensionModelLoaderId");

--- a/tests/runner/src/main/java/org/mule/test/runner/classification/DefaultWorkspaceReader.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/classification/DefaultWorkspaceReader.java
@@ -8,6 +8,7 @@
 package org.mule.test.runner.classification;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.apache.commons.io.FileUtils.toFile;
 import static org.mule.runtime.api.util.Preconditions.checkNotNull;
 import org.mule.test.runner.api.WorkspaceLocationResolver;
@@ -148,7 +149,7 @@ public class DefaultWorkspaceReader implements WorkspaceReader {
    */
   @Override
   public List<String> findVersions(Artifact artifact) {
-    return emptyList();
+    return findArtifact(artifact) == null ? emptyList() : singletonList(artifact.getVersion());
   }
 
   /**

--- a/tests/runner/src/test/java/org/mule/test/runner/api/ExtensionPluginMetadataGeneratorTestCase.java
+++ b/tests/runner/src/test/java/org/mule/test/runner/api/ExtensionPluginMetadataGeneratorTestCase.java
@@ -8,6 +8,7 @@
 package org.mule.test.runner.api;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -50,7 +51,8 @@ public class ExtensionPluginMetadataGeneratorTestCase {
   public void before() throws Exception {
     depResolver = mock(DependencyResolver.class);
     ExtensionModelLoaderFinder finder = mock(ExtensionModelLoaderFinder.class);
-    when(finder.findLoaderByProperty(anyObject(), anyObject())).thenReturn(Optional.of(new DefaultJavaExtensionModelLoader()));
+    when(finder.findLoaderByProperty(anyObject(), anyObject(), anyObject()))
+        .thenReturn(Optional.of(new DefaultJavaExtensionModelLoader()));
     generator = new ExtensionPluginMetadataGenerator(temporaryFolder.newFolder(), finder);
   }
 
@@ -66,15 +68,19 @@ public class ExtensionPluginMetadataGeneratorTestCase {
 
   @Test
   public void generateExtensionManifestForTwoExtensionsInDifferentFolders() {
-    File heisenbergPluginFolder = generator.generateExtensionResources(heisenbergPlugin, HeisenbergExtension.class, depResolver);
-    File petStorePluginFolder = generator.generateExtensionResources(petStorePlugin, PetStoreConnector.class, depResolver);
+    File heisenbergPluginFolder =
+        generator.generateExtensionResources(heisenbergPlugin, HeisenbergExtension.class, depResolver, emptyList());
+    File petStorePluginFolder =
+        generator.generateExtensionResources(petStorePlugin, PetStoreConnector.class, depResolver, emptyList());
     assertThat(heisenbergPluginFolder, not(equalTo(petStorePluginFolder)));
   }
 
   @Test
   public void generateExtensionMetadataForTwoExtensionsInDifferentFolders() throws Exception {
-    File heisenbergPluginFolder = generator.generateExtensionResources(heisenbergPlugin, HeisenbergExtension.class, depResolver);
-    File petStorePluginFolder = generator.generateExtensionResources(petStorePlugin, PetStoreConnector.class, depResolver);
+    File heisenbergPluginFolder =
+        generator.generateExtensionResources(heisenbergPlugin, HeisenbergExtension.class, depResolver, emptyList());
+    File petStorePluginFolder =
+        generator.generateExtensionResources(petStorePlugin, PetStoreConnector.class, depResolver, emptyList());
     generator.generateDslResources();
 
     assertThat(listFiles(heisenbergPluginFolder, "heisenberg.xsd"), arrayWithSize(1));


### PR DESCRIPTION
- When resolving direct dependencies or artifactDescriptors it should use the remote repositories declared in the rootArtifact pom.