### PR TITLE
MULE-11982: Boot packages needs to be removed and modules must explic…

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -213,7 +213,6 @@
 /mule-standalone-${productVersion}/lib/opt/jcommander-1.69.jar
 /mule-standalone-${productVersion}/lib/opt/jgrapht-jdk1.5-0.7.3.jar
 /mule-standalone-${productVersion}/lib/opt/joda-time-2.9.1.jar
-/mule-standalone-${productVersion}/lib/opt/mail-1.4.3.jar
 /mule-standalone-${productVersion}/lib/opt/maven-aether-provider-3.3.9.jar
 /mule-standalone-${productVersion}/lib/opt/maven-artifact-3.3.9.jar
 /mule-standalone-${productVersion}/lib/opt/maven-builder-support-3.3.9.jar

--- a/distributions/standalone/pom.xml
+++ b/distributions/standalone/pom.xml
@@ -207,11 +207,6 @@
             <artifactId>aspectjweaver</artifactId>
         </dependency>
 
-        <!-- TODO: MULE-11982 This will not longer be required once boot packages are removed -->
-        <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>

--- a/modules/container/src/main/java/org/mule/runtime/container/internal/ContainerClassLoaderFactory.java
+++ b/modules/container/src/main/java/org/mule/runtime/container/internal/ContainerClassLoaderFactory.java
@@ -76,7 +76,7 @@ public class ContainerClassLoaderFactory {
    */
   public static final Set<String> BOOT_PACKAGES =
       ImmutableSet.of(// Java EE
-                      "javax.servlet", "javax.mail", "javax.inject", "org.apache.xerces",
+                      "org.apache.xerces",
                       // MULE-10194 Mechanism to add custom boot packages to be exported by the container
                       "com.yourkit");
 

--- a/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
@@ -696,7 +696,7 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
   private Dependency findPluginSharedLibArtifact(String pluginSharedLibCoords, Artifact rootArtifact,
                                                  List<Dependency> directDependencies) {
     Optional<Dependency> pluginSharedLibDependency = discoverDependency(pluginSharedLibCoords, rootArtifact, directDependencies);
-    if (!pluginSharedLibDependency.isPresent() || !pluginSharedLibDependency.get().getScope().equals(TEST)) {
+    if (!pluginSharedLibDependency.isPresent()) {
       throw new IllegalStateException("Plugin shared lib artifact '" + pluginSharedLibCoords +
           "' in order to be resolved has to be declared as " + TEST + " dependency of your Maven project (" + rootArtifact + ")");
     }

--- a/tests/runner/src/main/java/org/mule/test/runner/classloader/IsolatedClassLoaderFactory.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/classloader/IsolatedClassLoaderFactory.java
@@ -95,6 +95,8 @@ public class IsolatedClassLoaderFactory {
   public ArtifactClassLoaderHolder createArtifactClassLoader(List<String> extraBootPackages,
                                                              ArtifactsUrlClassification artifactsUrlClassification) {
     JarInfo testJarInfo = getTestJarInfo(artifactsUrlClassification);
+    Map<String, LookupStrategy> appExportedLookupStrategies = new HashMap<>();
+    testJarInfo.getPackages().stream().forEach(p -> appExportedLookupStrategies.put(p, PARENT_FIRST));
 
     ArtifactClassLoader containerClassLoader;
     ClassLoaderLookupPolicy childClassLoaderLookupPolicy;
@@ -124,8 +126,6 @@ public class IsolatedClassLoaderFactory {
           new RegionClassLoader("Region", new ArtifactDescriptor("Region"), containerClassLoader.getClassLoader(),
                                 childClassLoaderLookupPolicy);
 
-
-
       if (!artifactsUrlClassification.getPluginUrlClassifications().isEmpty()) {
         for (PluginUrlClassification pluginUrlClassification : artifactsUrlClassification.getPluginUrlClassifications()) {
           logClassLoaderUrls("PLUGIN (" + pluginUrlClassification.getName() + ")", pluginUrlClassification.getUrls());
@@ -136,6 +136,7 @@ public class IsolatedClassLoaderFactory {
               extendLookupPolicyForPrivilegedAccess(childClassLoaderLookupPolicy, moduleRepository,
                                                     testContainerClassLoaderFactory,
                                                     pluginUrlClassification);
+          pluginLookupPolicy = pluginLookupPolicy.extend(appExportedLookupStrategies);
 
           MuleArtifactClassLoader pluginCL =
               new MuleArtifactClassLoader(artifactId,


### PR DESCRIPTION
…itly define what they export

_ Removing javax.servlet, javax.mail and javax.inject from boot packages
_ Removing non required dependency from distribution
_ Updating aether classifier to enable sharing a compile dependency (to be able to create instances of plugin classes which are not shared)
_ Updating isolated classloader factory to update plugins lookup policies for compile dependency's packages