### PR TITLE
MULE-10056: Maven module plugin is not properly detecting transitive …

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -117,12 +117,6 @@
             <groupId>com.github.stephenc.eaio-uuid</groupId>
             <artifactId>uuid</artifactId>
             <version>3.4.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.stephenc.eaio-grabbag</groupId>
-                    <artifactId>grabbag</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -200,6 +200,7 @@
 /mule-standalone-${productVersion}/lib/opt/dom4j-1.6.1.jar
 /mule-standalone-${productVersion}/lib/opt/geronimo-j2ee-connector_1.5_spec-2.0.0.jar
 /mule-standalone-${productVersion}/lib/opt/geronimo-servlet_3.0_spec-1.0.jar
+/mule-standalone-${productVersion}/lib/opt/grabbag-1.8.1.jar
 /mule-standalone-${productVersion}/lib/opt/gson-2.6.2.jar
 /mule-standalone-${productVersion}/lib/opt/guava-18.0.jar
 /mule-standalone-${productVersion}/lib/opt/httpclient-4.2.6.jar


### PR DESCRIPTION
…exported dependencies

_ Re-adding excluded dependency which is required when MAC address cannot be resolved in the standard way