### PR TITLE
MULE-12523: Exception is thrown if Logger is placed between file:read…

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/processor/LoggerMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/api/processor/LoggerMessageProcessor.java
@@ -59,7 +59,7 @@ public class LoggerMessageProcessor extends AbstractAnnotatedObject
   @Override
   public Event process(Event event) throws MuleException {
     return withCursoredEvent(event, cursored -> {
-      log(event);
+      log(cursored);
       return event;
     });
   }

--- a/core/src/main/java/org/mule/runtime/core/api/util/StreamingUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/api/util/StreamingUtils.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.api.util;
 
+import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.mule.runtime.core.api.rx.Exceptions.rxExceptionToMuleException;
 import static reactor.core.Exceptions.unwrap;
 import org.mule.runtime.api.exception.MuleException;
@@ -78,7 +79,7 @@ public final class StreamingUtils {
       return value;
     } finally {
       if (cursor != null) {
-        cursor.release();
+        closeQuietly(cursor);
       }
     }
   }


### PR DESCRIPTION
… and transform componentinitial solution