### PR TITLE
MULE-12406: HTTP, Oauth and Soap services have wrong package name

### DIFF
--- a/modules/extensions-spring-support/src/test/resources/models/ram.json
+++ b/modules/extensions-spring-support/src/test/resources/models/ram.json
@@ -253,7 +253,209 @@
                   "type": "String"
                 },
                 {
-                  "type": "@ref:org.mule.runtime.soap.api.message.SoapMultipartPayload"
+                  "type": "Object",
+                  "annotations": {
+                    "typeId": "org.mule.runtime.soap.api.message.SoapMultipartPayload",
+                    "classInformation": {
+                      "hasDefaultConstructor": false,
+                      "isInterface": false,
+                      "isInstantiable": false,
+                      "isAbstract": false,
+                      "isFinal": false,
+                      "implementedInterfaces": [],
+                      "parent": "org.mule.runtime.core.message.DefaultMultiPartPayload",
+                      "genericTypes": []
+                    },
+                    "typeAlias": {
+                      "value": "SoapMultipartPayload"
+                    }
+                  },
+                  "fields": [
+                    {
+                      "key": {
+                        "name": "attachments"
+                      },
+                      "model": {
+                        "type": "Object",
+                        "annotations": {
+                          "typeId": "java.util.Map",
+                          "classInformation": {
+                            "hasDefaultConstructor": false,
+                            "isInterface": true,
+                            "isInstantiable": false,
+                            "isAbstract": true,
+                            "isFinal": false,
+                            "implementedInterfaces": [],
+                            "parent": "",
+                            "genericTypes": [
+                              "java.lang.String",
+                              "java.lang.Object"
+                            ]
+                          }
+                        },
+                        "open": {
+                          "type": "Object",
+                          "annotations": {
+                            "typeId": "java.lang.Object",
+                            "classInformation": {
+                              "hasDefaultConstructor": true,
+                              "isInterface": false,
+                              "isInstantiable": true,
+                              "isAbstract": false,
+                              "isFinal": false,
+                              "implementedInterfaces": [],
+                              "parent": "",
+                              "genericTypes": []
+                            },
+                            "typeAlias": {
+                              "value": "Object"
+                            }
+                          },
+                          "fields": []
+                        },
+                        "fields": []
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "body"
+                      },
+                      "model": {
+                        "type": "String",
+                        "annotations": {
+                          "typeId": "java.lang.String"
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "bodyPart"
+                      },
+                      "model": {
+                        "type": "Object",
+                        "annotations": {
+                          "typeId": "org.mule.runtime.api.message.Message",
+                          "classInformation": {
+                            "hasDefaultConstructor": false,
+                            "isInterface": true,
+                            "isInstantiable": false,
+                            "isAbstract": true,
+                            "isFinal": false,
+                            "implementedInterfaces": [
+                              "java.io.Serializable"
+                            ],
+                            "parent": "",
+                            "genericTypes": []
+                          },
+                          "typeAlias": {
+                            "value": "Message"
+                          }
+                        },
+                        "fields": []
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "nonBodyParts"
+                      },
+                      "model": {
+                        "type": "Array",
+                        "annotations": {
+                          "typeId": "java.util.List"
+                        },
+                        "item": {
+                          "type": "Object",
+                          "annotations": {
+                            "typeId": "org.mule.runtime.api.message.Message",
+                            "classInformation": {
+                              "hasDefaultConstructor": false,
+                              "isInterface": true,
+                              "isInstantiable": false,
+                              "isAbstract": true,
+                              "isFinal": false,
+                              "implementedInterfaces": [
+                                "java.io.Serializable"
+                              ],
+                              "parent": "",
+                              "genericTypes": []
+                            },
+                            "typeAlias": {
+                              "value": "Message"
+                            }
+                          },
+                          "fields": []
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "partNames"
+                      },
+                      "model": {
+                        "type": "Array",
+                        "annotations": {
+                          "typeId": "java.util.List"
+                        },
+                        "item": {
+                          "type": "String",
+                          "annotations": {
+                            "typeId": "java.lang.String"
+                          }
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "parts"
+                      },
+                      "model": {
+                        "type": "Array",
+                        "annotations": {
+                          "typeId": "java.util.List"
+                        },
+                        "item": {
+                          "type": "Object",
+                          "annotations": {
+                            "typeId": "org.mule.runtime.api.message.Message",
+                            "classInformation": {
+                              "hasDefaultConstructor": false,
+                              "isInterface": true,
+                              "isInstantiable": false,
+                              "isAbstract": true,
+                              "isFinal": false,
+                              "implementedInterfaces": [
+                                "java.io.Serializable"
+                              ],
+                              "parent": "",
+                              "genericTypes": []
+                            },
+                            "typeAlias": {
+                              "value": "Message"
+                            }
+                          },
+                          "fields": []
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -1399,7 +1601,209 @@
               "type": "String"
             },
             {
-              "type": "@ref:org.mule.runtime.soap.api.message.SoapMultipartPayload"
+              "type": "Object",
+              "annotations": {
+                "typeId": "org.mule.runtime.soap.api.message.SoapMultipartPayload",
+                "classInformation": {
+                  "hasDefaultConstructor": false,
+                  "isInterface": false,
+                  "isInstantiable": false,
+                  "isAbstract": false,
+                  "isFinal": false,
+                  "implementedInterfaces": [],
+                  "parent": "org.mule.runtime.core.message.DefaultMultiPartPayload",
+                  "genericTypes": []
+                },
+                "typeAlias": {
+                  "value": "SoapMultipartPayload"
+                }
+              },
+              "fields": [
+                {
+                  "key": {
+                    "name": "attachments"
+                  },
+                  "model": {
+                    "type": "Object",
+                    "annotations": {
+                      "typeId": "java.util.Map",
+                      "classInformation": {
+                        "hasDefaultConstructor": false,
+                        "isInterface": true,
+                        "isInstantiable": false,
+                        "isAbstract": true,
+                        "isFinal": false,
+                        "implementedInterfaces": [],
+                        "parent": "",
+                        "genericTypes": [
+                          "java.lang.String",
+                          "java.lang.Object"
+                        ]
+                      }
+                    },
+                    "open": {
+                      "type": "Object",
+                      "annotations": {
+                        "typeId": "java.lang.Object",
+                        "classInformation": {
+                          "hasDefaultConstructor": true,
+                          "isInterface": false,
+                          "isInstantiable": true,
+                          "isAbstract": false,
+                          "isFinal": false,
+                          "implementedInterfaces": [],
+                          "parent": "",
+                          "genericTypes": []
+                        },
+                        "typeAlias": {
+                          "value": "Object"
+                        }
+                      },
+                      "fields": []
+                    },
+                    "fields": []
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "body"
+                  },
+                  "model": {
+                    "type": "String",
+                    "annotations": {
+                      "typeId": "java.lang.String"
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "bodyPart"
+                  },
+                  "model": {
+                    "type": "Object",
+                    "annotations": {
+                      "typeId": "org.mule.runtime.api.message.Message",
+                      "classInformation": {
+                        "hasDefaultConstructor": false,
+                        "isInterface": true,
+                        "isInstantiable": false,
+                        "isAbstract": true,
+                        "isFinal": false,
+                        "implementedInterfaces": [
+                          "java.io.Serializable"
+                        ],
+                        "parent": "",
+                        "genericTypes": []
+                      },
+                      "typeAlias": {
+                        "value": "Message"
+                      }
+                    },
+                    "fields": []
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "nonBodyParts"
+                  },
+                  "model": {
+                    "type": "Array",
+                    "annotations": {
+                      "typeId": "java.util.List"
+                    },
+                    "item": {
+                      "type": "Object",
+                      "annotations": {
+                        "typeId": "org.mule.runtime.api.message.Message",
+                        "classInformation": {
+                          "hasDefaultConstructor": false,
+                          "isInterface": true,
+                          "isInstantiable": false,
+                          "isAbstract": true,
+                          "isFinal": false,
+                          "implementedInterfaces": [
+                            "java.io.Serializable"
+                          ],
+                          "parent": "",
+                          "genericTypes": []
+                        },
+                        "typeAlias": {
+                          "value": "Message"
+                        }
+                      },
+                      "fields": []
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "partNames"
+                  },
+                  "model": {
+                    "type": "Array",
+                    "annotations": {
+                      "typeId": "java.util.List"
+                    },
+                    "item": {
+                      "type": "String",
+                      "annotations": {
+                        "typeId": "java.lang.String"
+                      }
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "parts"
+                  },
+                  "model": {
+                    "type": "Array",
+                    "annotations": {
+                      "typeId": "java.util.List"
+                    },
+                    "item": {
+                      "type": "Object",
+                      "annotations": {
+                        "typeId": "org.mule.runtime.api.message.Message",
+                        "classInformation": {
+                          "hasDefaultConstructor": false,
+                          "isInterface": true,
+                          "isInstantiable": false,
+                          "isAbstract": true,
+                          "isFinal": false,
+                          "implementedInterfaces": [
+                            "java.io.Serializable"
+                          ],
+                          "parent": "",
+                          "genericTypes": []
+                        },
+                        "typeAlias": {
+                          "value": "Message"
+                        }
+                      },
+                      "fields": []
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1997,212 +2401,6 @@
   ],
   "modelProperties": {},
   "types": [
-    {
-      "format": "java",
-      "type": "Object",
-      "annotations": {
-        "typeId": "org.mule.runtime.soap.api.message.SoapMultipartPayload",
-        "classInformation": {
-          "hasDefaultConstructor": false,
-          "isInterface": false,
-          "isInstantiable": false,
-          "isAbstract": false,
-          "isFinal": false,
-          "implementedInterfaces": [],
-          "parent": "org.mule.runtime.core.message.DefaultMultiPartPayload",
-          "genericTypes": []
-        },
-        "typeAlias": {
-          "value": "SoapMultipartPayload"
-        }
-      },
-      "fields": [
-        {
-          "key": {
-            "name": "attachments"
-          },
-          "model": {
-            "type": "Object",
-            "annotations": {
-              "typeId": "java.util.Map",
-              "classInformation": {
-                "hasDefaultConstructor": false,
-                "isInterface": true,
-                "isInstantiable": false,
-                "isAbstract": true,
-                "isFinal": false,
-                "implementedInterfaces": [],
-                "parent": "",
-                "genericTypes": [
-                  "java.lang.String",
-                  "java.lang.Object"
-                ]
-              }
-            },
-            "open": {
-              "type": "Object",
-              "annotations": {
-                "typeId": "java.lang.Object",
-                "classInformation": {
-                  "hasDefaultConstructor": true,
-                  "isInterface": false,
-                  "isInstantiable": true,
-                  "isAbstract": false,
-                  "isFinal": false,
-                  "implementedInterfaces": [],
-                  "parent": "",
-                  "genericTypes": []
-                },
-                "typeAlias": {
-                  "value": "Object"
-                }
-              },
-              "fields": []
-            },
-            "fields": []
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "body"
-          },
-          "model": {
-            "type": "String",
-            "annotations": {
-              "typeId": "java.lang.String"
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "bodyPart"
-          },
-          "model": {
-            "type": "Object",
-            "annotations": {
-              "typeId": "org.mule.runtime.api.message.Message",
-              "classInformation": {
-                "hasDefaultConstructor": false,
-                "isInterface": true,
-                "isInstantiable": false,
-                "isAbstract": true,
-                "isFinal": false,
-                "implementedInterfaces": [
-                  "java.io.Serializable"
-                ],
-                "parent": "",
-                "genericTypes": []
-              },
-              "typeAlias": {
-                "value": "Message"
-              }
-            },
-            "fields": []
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "nonBodyParts"
-          },
-          "model": {
-            "type": "Array",
-            "annotations": {
-              "typeId": "java.util.List"
-            },
-            "item": {
-              "type": "Object",
-              "annotations": {
-                "typeId": "org.mule.runtime.api.message.Message",
-                "classInformation": {
-                  "hasDefaultConstructor": false,
-                  "isInterface": true,
-                  "isInstantiable": false,
-                  "isAbstract": true,
-                  "isFinal": false,
-                  "implementedInterfaces": [
-                    "java.io.Serializable"
-                  ],
-                  "parent": "",
-                  "genericTypes": []
-                },
-                "typeAlias": {
-                  "value": "Message"
-                }
-              },
-              "fields": []
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "partNames"
-          },
-          "model": {
-            "type": "Array",
-            "annotations": {
-              "typeId": "java.util.List"
-            },
-            "item": {
-              "type": "String",
-              "annotations": {
-                "typeId": "java.lang.String"
-              }
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "parts"
-          },
-          "model": {
-            "type": "Array",
-            "annotations": {
-              "typeId": "java.util.List"
-            },
-            "item": {
-              "type": "Object",
-              "annotations": {
-                "typeId": "org.mule.runtime.api.message.Message",
-                "classInformation": {
-                  "hasDefaultConstructor": false,
-                  "isInterface": true,
-                  "isInstantiable": false,
-                  "isAbstract": true,
-                  "isFinal": false,
-                  "implementedInterfaces": [
-                    "java.io.Serializable"
-                  ],
-                  "parent": "",
-                  "genericTypes": []
-                },
-                "typeAlias": {
-                  "value": "Message"
-                }
-              },
-              "fields": []
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        }
-      ]
-    },
     {
       "format": "java",
       "type": "Object",

--- a/modules/extensions-spring-support/src/test/resources/models/soap.json
+++ b/modules/extensions-spring-support/src/test/resources/models/soap.json
@@ -174,7 +174,209 @@
                   "type": "String"
                 },
                 {
-                  "type": "@ref:org.mule.runtime.soap.api.message.SoapMultipartPayload"
+                  "type": "Object",
+                  "annotations": {
+                    "typeId": "org.mule.runtime.soap.api.message.SoapMultipartPayload",
+                    "classInformation": {
+                      "hasDefaultConstructor": false,
+                      "isInterface": false,
+                      "isInstantiable": false,
+                      "isAbstract": false,
+                      "isFinal": false,
+                      "implementedInterfaces": [],
+                      "parent": "org.mule.runtime.core.message.DefaultMultiPartPayload",
+                      "genericTypes": []
+                    },
+                    "typeAlias": {
+                      "value": "SoapMultipartPayload"
+                    }
+                  },
+                  "fields": [
+                    {
+                      "key": {
+                        "name": "attachments"
+                      },
+                      "model": {
+                        "type": "Object",
+                        "annotations": {
+                          "typeId": "java.util.Map",
+                          "classInformation": {
+                            "hasDefaultConstructor": false,
+                            "isInterface": true,
+                            "isInstantiable": false,
+                            "isAbstract": true,
+                            "isFinal": false,
+                            "implementedInterfaces": [],
+                            "parent": "",
+                            "genericTypes": [
+                              "java.lang.String",
+                              "java.lang.Object"
+                            ]
+                          }
+                        },
+                        "open": {
+                          "type": "Object",
+                          "annotations": {
+                            "typeId": "java.lang.Object",
+                            "classInformation": {
+                              "hasDefaultConstructor": true,
+                              "isInterface": false,
+                              "isInstantiable": true,
+                              "isAbstract": false,
+                              "isFinal": false,
+                              "implementedInterfaces": [],
+                              "parent": "",
+                              "genericTypes": []
+                            },
+                            "typeAlias": {
+                              "value": "Object"
+                            }
+                          },
+                          "fields": []
+                        },
+                        "fields": []
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "body"
+                      },
+                      "model": {
+                        "type": "String",
+                        "annotations": {
+                          "typeId": "java.lang.String"
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "bodyPart"
+                      },
+                      "model": {
+                        "type": "Object",
+                        "annotations": {
+                          "typeId": "org.mule.runtime.api.message.Message",
+                          "classInformation": {
+                            "hasDefaultConstructor": false,
+                            "isInterface": true,
+                            "isInstantiable": false,
+                            "isAbstract": true,
+                            "isFinal": false,
+                            "implementedInterfaces": [
+                              "java.io.Serializable"
+                            ],
+                            "parent": "",
+                            "genericTypes": []
+                          },
+                          "typeAlias": {
+                            "value": "Message"
+                          }
+                        },
+                        "fields": []
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "nonBodyParts"
+                      },
+                      "model": {
+                        "type": "Array",
+                        "annotations": {
+                          "typeId": "java.util.List"
+                        },
+                        "item": {
+                          "type": "Object",
+                          "annotations": {
+                            "typeId": "org.mule.runtime.api.message.Message",
+                            "classInformation": {
+                              "hasDefaultConstructor": false,
+                              "isInterface": true,
+                              "isInstantiable": false,
+                              "isAbstract": true,
+                              "isFinal": false,
+                              "implementedInterfaces": [
+                                "java.io.Serializable"
+                              ],
+                              "parent": "",
+                              "genericTypes": []
+                            },
+                            "typeAlias": {
+                              "value": "Message"
+                            }
+                          },
+                          "fields": []
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "partNames"
+                      },
+                      "model": {
+                        "type": "Array",
+                        "annotations": {
+                          "typeId": "java.util.List"
+                        },
+                        "item": {
+                          "type": "String",
+                          "annotations": {
+                            "typeId": "java.lang.String"
+                          }
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "parts"
+                      },
+                      "model": {
+                        "type": "Array",
+                        "annotations": {
+                          "typeId": "java.util.List"
+                        },
+                        "item": {
+                          "type": "Object",
+                          "annotations": {
+                            "typeId": "org.mule.runtime.api.message.Message",
+                            "classInformation": {
+                              "hasDefaultConstructor": false,
+                              "isInterface": true,
+                              "isInstantiable": false,
+                              "isAbstract": true,
+                              "isFinal": false,
+                              "implementedInterfaces": [
+                                "java.io.Serializable"
+                              ],
+                              "parent": "",
+                              "genericTypes": []
+                            },
+                            "typeAlias": {
+                              "value": "Message"
+                            }
+                          },
+                          "fields": []
+                        }
+                      },
+                      "annotations": {
+                        "visibility": "READ_ONLY"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -2097,7 +2299,209 @@
               "type": "String"
             },
             {
-              "type": "@ref:org.mule.runtime.soap.api.message.SoapMultipartPayload"
+              "type": "Object",
+              "annotations": {
+                "typeId": "org.mule.runtime.soap.api.message.SoapMultipartPayload",
+                "classInformation": {
+                  "hasDefaultConstructor": false,
+                  "isInterface": false,
+                  "isInstantiable": false,
+                  "isAbstract": false,
+                  "isFinal": false,
+                  "implementedInterfaces": [],
+                  "parent": "org.mule.runtime.core.message.DefaultMultiPartPayload",
+                  "genericTypes": []
+                },
+                "typeAlias": {
+                  "value": "SoapMultipartPayload"
+                }
+              },
+              "fields": [
+                {
+                  "key": {
+                    "name": "attachments"
+                  },
+                  "model": {
+                    "type": "Object",
+                    "annotations": {
+                      "typeId": "java.util.Map",
+                      "classInformation": {
+                        "hasDefaultConstructor": false,
+                        "isInterface": true,
+                        "isInstantiable": false,
+                        "isAbstract": true,
+                        "isFinal": false,
+                        "implementedInterfaces": [],
+                        "parent": "",
+                        "genericTypes": [
+                          "java.lang.String",
+                          "java.lang.Object"
+                        ]
+                      }
+                    },
+                    "open": {
+                      "type": "Object",
+                      "annotations": {
+                        "typeId": "java.lang.Object",
+                        "classInformation": {
+                          "hasDefaultConstructor": true,
+                          "isInterface": false,
+                          "isInstantiable": true,
+                          "isAbstract": false,
+                          "isFinal": false,
+                          "implementedInterfaces": [],
+                          "parent": "",
+                          "genericTypes": []
+                        },
+                        "typeAlias": {
+                          "value": "Object"
+                        }
+                      },
+                      "fields": []
+                    },
+                    "fields": []
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "body"
+                  },
+                  "model": {
+                    "type": "String",
+                    "annotations": {
+                      "typeId": "java.lang.String"
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "bodyPart"
+                  },
+                  "model": {
+                    "type": "Object",
+                    "annotations": {
+                      "typeId": "org.mule.runtime.api.message.Message",
+                      "classInformation": {
+                        "hasDefaultConstructor": false,
+                        "isInterface": true,
+                        "isInstantiable": false,
+                        "isAbstract": true,
+                        "isFinal": false,
+                        "implementedInterfaces": [
+                          "java.io.Serializable"
+                        ],
+                        "parent": "",
+                        "genericTypes": []
+                      },
+                      "typeAlias": {
+                        "value": "Message"
+                      }
+                    },
+                    "fields": []
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "nonBodyParts"
+                  },
+                  "model": {
+                    "type": "Array",
+                    "annotations": {
+                      "typeId": "java.util.List"
+                    },
+                    "item": {
+                      "type": "Object",
+                      "annotations": {
+                        "typeId": "org.mule.runtime.api.message.Message",
+                        "classInformation": {
+                          "hasDefaultConstructor": false,
+                          "isInterface": true,
+                          "isInstantiable": false,
+                          "isAbstract": true,
+                          "isFinal": false,
+                          "implementedInterfaces": [
+                            "java.io.Serializable"
+                          ],
+                          "parent": "",
+                          "genericTypes": []
+                        },
+                        "typeAlias": {
+                          "value": "Message"
+                        }
+                      },
+                      "fields": []
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "partNames"
+                  },
+                  "model": {
+                    "type": "Array",
+                    "annotations": {
+                      "typeId": "java.util.List"
+                    },
+                    "item": {
+                      "type": "String",
+                      "annotations": {
+                        "typeId": "java.lang.String"
+                      }
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                },
+                {
+                  "key": {
+                    "name": "parts"
+                  },
+                  "model": {
+                    "type": "Array",
+                    "annotations": {
+                      "typeId": "java.util.List"
+                    },
+                    "item": {
+                      "type": "Object",
+                      "annotations": {
+                        "typeId": "org.mule.runtime.api.message.Message",
+                        "classInformation": {
+                          "hasDefaultConstructor": false,
+                          "isInterface": true,
+                          "isInstantiable": false,
+                          "isAbstract": true,
+                          "isFinal": false,
+                          "implementedInterfaces": [
+                            "java.io.Serializable"
+                          ],
+                          "parent": "",
+                          "genericTypes": []
+                        },
+                        "typeAlias": {
+                          "value": "Message"
+                        }
+                      },
+                      "fields": []
+                    }
+                  },
+                  "annotations": {
+                    "visibility": "READ_ONLY"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -2694,212 +3098,5 @@
     }
   ],
   "modelProperties": {},
-  "types": [
-    {
-      "format": "java",
-      "type": "Object",
-      "annotations": {
-        "typeId": "org.mule.runtime.soap.api.message.SoapMultipartPayload",
-        "classInformation": {
-          "hasDefaultConstructor": false,
-          "isInterface": false,
-          "isInstantiable": false,
-          "isAbstract": false,
-          "isFinal": false,
-          "implementedInterfaces": [],
-          "parent": "org.mule.runtime.core.message.DefaultMultiPartPayload",
-          "genericTypes": []
-        },
-        "typeAlias": {
-          "value": "SoapMultipartPayload"
-        }
-      },
-      "fields": [
-        {
-          "key": {
-            "name": "attachments"
-          },
-          "model": {
-            "type": "Object",
-            "annotations": {
-              "typeId": "java.util.Map",
-              "classInformation": {
-                "hasDefaultConstructor": false,
-                "isInterface": true,
-                "isInstantiable": false,
-                "isAbstract": true,
-                "isFinal": false,
-                "implementedInterfaces": [],
-                "parent": "",
-                "genericTypes": [
-                  "java.lang.String",
-                  "java.lang.Object"
-                ]
-              }
-            },
-            "open": {
-              "type": "Object",
-              "annotations": {
-                "typeId": "java.lang.Object",
-                "classInformation": {
-                  "hasDefaultConstructor": true,
-                  "isInterface": false,
-                  "isInstantiable": true,
-                  "isAbstract": false,
-                  "isFinal": false,
-                  "implementedInterfaces": [],
-                  "parent": "",
-                  "genericTypes": []
-                },
-                "typeAlias": {
-                  "value": "Object"
-                }
-              },
-              "fields": []
-            },
-            "fields": []
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "body"
-          },
-          "model": {
-            "type": "String",
-            "annotations": {
-              "typeId": "java.lang.String"
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "bodyPart"
-          },
-          "model": {
-            "type": "Object",
-            "annotations": {
-              "typeId": "org.mule.runtime.api.message.Message",
-              "classInformation": {
-                "hasDefaultConstructor": false,
-                "isInterface": true,
-                "isInstantiable": false,
-                "isAbstract": true,
-                "isFinal": false,
-                "implementedInterfaces": [
-                  "java.io.Serializable"
-                ],
-                "parent": "",
-                "genericTypes": []
-              },
-              "typeAlias": {
-                "value": "Message"
-              }
-            },
-            "fields": []
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "nonBodyParts"
-          },
-          "model": {
-            "type": "Array",
-            "annotations": {
-              "typeId": "java.util.List"
-            },
-            "item": {
-              "type": "Object",
-              "annotations": {
-                "typeId": "org.mule.runtime.api.message.Message",
-                "classInformation": {
-                  "hasDefaultConstructor": false,
-                  "isInterface": true,
-                  "isInstantiable": false,
-                  "isAbstract": true,
-                  "isFinal": false,
-                  "implementedInterfaces": [
-                    "java.io.Serializable"
-                  ],
-                  "parent": "",
-                  "genericTypes": []
-                },
-                "typeAlias": {
-                  "value": "Message"
-                }
-              },
-              "fields": []
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "partNames"
-          },
-          "model": {
-            "type": "Array",
-            "annotations": {
-              "typeId": "java.util.List"
-            },
-            "item": {
-              "type": "String",
-              "annotations": {
-                "typeId": "java.lang.String"
-              }
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        },
-        {
-          "key": {
-            "name": "parts"
-          },
-          "model": {
-            "type": "Array",
-            "annotations": {
-              "typeId": "java.util.List"
-            },
-            "item": {
-              "type": "Object",
-              "annotations": {
-                "typeId": "org.mule.runtime.api.message.Message",
-                "classInformation": {
-                  "hasDefaultConstructor": false,
-                  "isInterface": true,
-                  "isInstantiable": false,
-                  "isAbstract": true,
-                  "isFinal": false,
-                  "implementedInterfaces": [
-                    "java.io.Serializable"
-                  ],
-                  "parent": "",
-                  "genericTypes": []
-                },
-                "typeAlias": {
-                  "value": "Message"
-                }
-              },
-              "fields": []
-            }
-          },
-          "annotations": {
-            "visibility": "READ_ONLY"
-          }
-        }
-      ]
-    }
-  ]
+  "types": []
 }


### PR DESCRIPTION
Fixes `ExtensionModelJsonGeneratorTestCase`

Now that the packages are fixed, the generation of these extension json
files is different because of the filter in
`org.mule.runtime.api.meta.model.declaration.fluent.ExtensionDeclarer.UNREGISTERED_PACKAGES`