### PR TITLE
MULE-12595: HTTP transport endpoint >30% performance drop on Mule 3.8.5.

### DIFF
--- a/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpMuleMessageFactory.java
@@ -144,7 +144,10 @@ public class HttpMuleMessageFactory extends AbstractMuleMessageFactory
             httpVersion = httpRequest.getRequestLine().getHttpVersion();
             uri = httpRequest.getRequestLine().getUri();
             headers = convertHeadersToMap(httpRequest.getHeaders(), uri);
-            convertMultiPartHeaders(headers);
+            if (isHttpMultipartRequest(httpRequest))
+            {
+                convertMultiPartHeaders(headers);
+            }
         }
         else if (transportMessage instanceof HttpMethod)
         {
@@ -454,5 +457,10 @@ public class HttpMuleMessageFactory extends AbstractMuleMessageFactory
     public void setExchangePattern(MessageExchangePattern mep)
     {
         exchangePattern = mep;
+    }
+
+    protected boolean isHttpMultipartRequest (HttpRequest httpRequest)
+    {
+        return httpRequest.getContentType().contains("multipart/form-data");
     }
 }

--- a/transports/http/src/main/java/org/mule/transport/http/HttpMultipartMuleMessageFactory.java
+++ b/transports/http/src/main/java/org/mule/transport/http/HttpMultipartMuleMessageFactory.java
@@ -25,8 +25,16 @@ public class HttpMultipartMuleMessageFactory extends HttpMuleMessageFactory
     private Collection<Part> parts;
 
     @Override
-    protected synchronized MuleMessage doCreate(Object transportMessage, MuleMessage previousMessage, String encoding, MuleContext muleContext) throws Exception
+    protected MuleMessage doCreate(Object transportMessage, MuleMessage previousMessage, String encoding, MuleContext muleContext) throws Exception
     {
+        if (transportMessage instanceof HttpRequest && isHttpMultipartRequest((HttpRequest) transportMessage))
+        {
+            synchronized (this)
+            {
+                return super.doCreate(transportMessage, previousMessage, encoding, muleContext);
+            }
+        }
+
         return super.doCreate(transportMessage, previousMessage, encoding, muleContext);
     }
 
@@ -35,7 +43,7 @@ public class HttpMultipartMuleMessageFactory extends HttpMuleMessageFactory
     {
         Object body = null;
 
-        if (httpRequest.getContentType().contains("multipart/form-data"))
+        if (isHttpMultipartRequest(httpRequest))
         {
             MultiPartInputStream in = new MultiPartInputStream(httpRequest.getBody(), httpRequest.getContentType(), null);
 


### PR DESCRIPTION
Syncronized block is limited to only HTTP Multipart Requests.