### PR TITLE
MULE-12612: FTP should only allow synchronous Reconnection Strategy.

### DIFF
--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -18,7 +18,7 @@ MULE-10979: The default response timeout and default transaction timeout can't b
 MULE-11118: The HTTP listener now replies with status code 503 when the thread pool is exhausted (and poolExhaustedAction="ABORT") instead of closing the socket.
 MULE-11825: In a DB template query, to set a DB param with the null value, you can use the "NULL" literal value. For example: <db:in-param name="name" defaultValue="NULL"/>
 MULE-12385: Reconnection Strategies can only be defined in connector components or globally (using <configuration> element). In mule 3.x, defining reconnection strategies was being supported by the XSD, but ignored by Runtime. Now, the XSD was changed to not allow to use this invalid configuration.
-MULE-12612: As FTP reconnection is at operation level, FTP connector does not support asynchronous reconnection strategies.
+MULE-12612: As FTP reconnection is at operation level, FTP connector does not support asynchronous reconnection strategies because it only makes sense if reconnection takes place during  the start phase of the connector lifecycle. In case you use this kind of reconnection, please change them as follows: <reconnect blocking="true"/> inside FTP Connector, or just remove the blocking attribute.
 
 Migration changes from 3.7.x to 3.8.x
 MULE-9368: System property mule.sftp.knownHostsFile is now removed. Instead, the file with the known hosts must now be provided through the mule xml config file, in the knownHostsFile attribute of the connector or the endpoints.

--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -18,7 +18,7 @@ MULE-10979: The default response timeout and default transaction timeout can't b
 MULE-11118: The HTTP listener now replies with status code 503 when the thread pool is exhausted (and poolExhaustedAction="ABORT") instead of closing the socket.
 MULE-11825: In a DB template query, to set a DB param with the null value, you can use the "NULL" literal value. For example: <db:in-param name="name" defaultValue="NULL"/>
 MULE-12385: Reconnection Strategies can only be defined in connector components or globally (using <configuration> element). In mule 3.x, defining reconnection strategies was being supported by the XSD, but ignored by Runtime. Now, the XSD was changed to not allow to use this invalid configuration.
-MULE-12612: As FTP reconnection is at operation level, FTP connector does not support asynchronous reconnection strategies because it only makes sense if reconnection takes place during  the start phase of the connector lifecycle. In case you use this kind of reconnection, please change them as follows: <reconnect blocking="true"/> inside FTP Connector, or just remove the blocking attribute.
+MULE-12612: As FTP reconnection is at operation level, FTP connector does not support asynchronous reconnection strategies because it only makes sense if reconnection takes place during the start phase of the connector lifecycle. In case you use this kind of reconnection, please change them as follows: <reconnect blocking="true"/> inside FTP Connector, or just remove the blocking attribute.
 
 Migration changes from 3.7.x to 3.8.x
 MULE-9368: System property mule.sftp.knownHostsFile is now removed. Instead, the file with the known hosts must now be provided through the mule xml config file, in the knownHostsFile attribute of the connector or the endpoints.

--- a/distributions/standalone/src/main/resources/MIGRATION.txt
+++ b/distributions/standalone/src/main/resources/MIGRATION.txt
@@ -18,6 +18,7 @@ MULE-10979: The default response timeout and default transaction timeout can't b
 MULE-11118: The HTTP listener now replies with status code 503 when the thread pool is exhausted (and poolExhaustedAction="ABORT") instead of closing the socket.
 MULE-11825: In a DB template query, to set a DB param with the null value, you can use the "NULL" literal value. For example: <db:in-param name="name" defaultValue="NULL"/>
 MULE-12385: Reconnection Strategies can only be defined in connector components or globally (using <configuration> element). In mule 3.x, defining reconnection strategies was being supported by the XSD, but ignored by Runtime. Now, the XSD was changed to not allow to use this invalid configuration.
+MULE-12612: As FTP reconnection is at operation level, FTP connector does not support asynchronous reconnection strategies.
 
 Migration changes from 3.7.x to 3.8.x
 MULE-9368: System property mule.sftp.knownHostsFile is now removed. Instead, the file with the known hosts must now be provided through the mule xml config file, in the knownHostsFile attribute of the connector or the endpoints.

--- a/transports/ftp/src/main/java/org/mule/transport/ftp/FtpConnector.java
+++ b/transports/ftp/src/main/java/org/mule/transport/ftp/FtpConnector.java
@@ -60,7 +60,6 @@ public class FtpConnector extends AbstractInboundEndpointNameableConnector
     public static final String PROPERTY_BINARY_TRANSFER = "binary";
     public static final String ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE = "FTP Connector doesn't support asynchronous retry policies.";
 
-
     // message properties
     public static final String PROPERTY_FILENAME = "filename";
 

--- a/transports/ftp/src/main/java/org/mule/transport/ftp/FtpConnector.java
+++ b/transports/ftp/src/main/java/org/mule/transport/ftp/FtpConnector.java
@@ -58,6 +58,8 @@ public class FtpConnector extends AbstractInboundEndpointNameableConnector
     public static final String PROPERTY_OUTPUT_PATTERN = "outputPattern"; // outbound only
     public static final String PROPERTY_PASSIVE_MODE = "passive";
     public static final String PROPERTY_BINARY_TRANSFER = "binary";
+    public static final String ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE = "FTP Connector doesn't support asynchronous retry policies.";
+
 
     // message properties
     public static final String PROPERTY_FILENAME = "filename";
@@ -588,7 +590,7 @@ public class FtpConnector extends AbstractInboundEndpointNameableConnector
             }
             else
             {
-                throw new IllegalArgumentException("FTP Connector doesn't support asynchronous retry policies.");
+                throw new IllegalArgumentException(ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE);
             }
 
             return storeFileStream(client[0], filename, uri);

--- a/transports/ftp/src/main/java/org/mule/transport/ftp/FtpConnector.java
+++ b/transports/ftp/src/main/java/org/mule/transport/ftp/FtpConnector.java
@@ -575,13 +575,20 @@ public class FtpConnector extends AbstractInboundEndpointNameableConnector
                     return FtpConnector.this;
                 }
             };
-            try
+            if (getRetryPolicyTemplate().isSynchronous())
             {
-                getRetryPolicyTemplate().execute(callbackReconnection, muleContext.getWorkManager());
+                try
+                {
+                    getRetryPolicyTemplate().execute(callbackReconnection, muleContext.getWorkManager());
+                }
+                catch (RetryPolicyExhaustedException retryPolicyExhaustedException)
+                {
+                    throw retryPolicyExhaustedException;
+                }
             }
-            catch (RetryPolicyExhaustedException retryPolicyExhaustedException)
+            else
             {
-                throw retryPolicyExhaustedException;
+                throw new IllegalArgumentException("FTP Connector doesn't support asynchronous retry policies.");
             }
 
             return storeFileStream(client[0], filename, uri);

--- a/transports/ftp/src/main/java/org/mule/transport/ftp/FtpMessageReceiver.java
+++ b/transports/ftp/src/main/java/org/mule/transport/ftp/FtpMessageReceiver.java
@@ -6,6 +6,7 @@
  */
 package org.mule.transport.ftp;
 
+import static org.mule.transport.ftp.FtpConnector.ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleMessage;
@@ -169,7 +170,7 @@ public class FtpMessageReceiver extends AbstractPollingMessageReceiver
         }
         else
         {
-            throw new IllegalArgumentException("FTP Connector doesn't support asynchronous retry policies.");
+            throw new IllegalArgumentException(ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE);
         }
 
 

--- a/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionStrategyTestCase.java
+++ b/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionStrategyTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.transport.ftp;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mule.api.construct.FlowConstruct;
+import org.mule.api.endpoint.EndpointURI;
+import org.mule.api.endpoint.InboundEndpoint;
+import org.mule.api.transport.Connector;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+
+public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
+{
+
+    @Rule
+    public DynamicPort ftpPort = new DynamicPort("port");
+
+    private final FlowConstruct flowConstruct = mock (FlowConstruct.class);
+    private final InboundEndpoint inboundEndpoint = mock(InboundEndpoint.class, RETURNS_DEEP_STUBS);
+    private  FtpMessageReceiver ftpMessageReceiver = null;
+    private Connector connector = null;
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "ftp-asynchronous-reconnection-config.xml";
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        connector = muleContext.getRegistry().lookupConnector("FTP");
+        EndpointURI endpointUri = mock(EndpointURI.class, RETURNS_DEEP_STUBS);
+        when(inboundEndpoint.getConnector()).thenReturn(connector);
+        when(inboundEndpoint.getRetryPolicyTemplate()).thenReturn(null);
+        when(inboundEndpoint.getEndpointURI()).thenReturn(endpointUri);
+        when(inboundEndpoint.getMuleContext()).thenReturn(muleContext);
+        when(endpointUri.getHost()).thenReturn("localhost");
+        when(endpointUri.getPort()).thenReturn(Integer.parseInt(ftpPort.getValue()));
+        when(endpointUri.getUser()).thenReturn("user");
+        when(endpointUri.getPassword()).thenReturn("password");
+        ftpMessageReceiver = new FtpMessageReceiver(connector, flowConstruct, inboundEndpoint, 1000);
+        ftpMessageReceiver.initialise();
+    }
+
+    @Test
+    public void testAsynchronousReconnectionStrategyInReceiver()
+    {
+        try
+        {
+            ftpMessageReceiver.listFiles();
+            fail("As asynchronous reconnection strategy is not supported in FTP Connector, an exception must be triggered");
+        }
+        catch (Exception e)
+        {
+            assertThat(e.getMessage(), is("FTP Connector doesn't support asynchronous retry policies."));
+        }
+    }
+
+    @Test
+    public void testAsynchronousReconnectionStrategyInDispatcher()
+    {
+        try
+        {
+            runFlow("testDispatcher");
+            fail("As asynchronous reconnection strategy is not supported in FTP Connector, an exception must be triggered");
+        }
+        catch (Exception e)
+        {
+            assertThat(e.getCause().getMessage(), is("FTP Connector doesn't support asynchronous retry policies."));
+        }
+    }
+
+}
+

--- a/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionStrategyTestCase.java
+++ b/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionStrategyTestCase.java
@@ -7,6 +7,7 @@
 
 package org.mule.transport.ftp;
 
+import static java.lang.Integer.parseInt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -35,6 +36,7 @@ public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
     private final InboundEndpoint inboundEndpoint = mock(InboundEndpoint.class, RETURNS_DEEP_STUBS);
     private  FtpMessageReceiver ftpMessageReceiver = null;
     private Connector connector = null;
+    private static final String ASYNCHRONOUS_RECCONECTION_ERROR_MESSAGE = "FTP Connector doesn't support asynchronous retry policies.";
 
     @Override
     protected String getConfigFile()
@@ -52,7 +54,7 @@ public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
         when(inboundEndpoint.getEndpointURI()).thenReturn(endpointUri);
         when(inboundEndpoint.getMuleContext()).thenReturn(muleContext);
         when(endpointUri.getHost()).thenReturn("localhost");
-        when(endpointUri.getPort()).thenReturn(Integer.parseInt(ftpPort.getValue()));
+        when(endpointUri.getPort()).thenReturn(parseInt(ftpPort.getValue()));
         when(endpointUri.getUser()).thenReturn("user");
         when(endpointUri.getPassword()).thenReturn("password");
         ftpMessageReceiver = new FtpMessageReceiver(connector, flowConstruct, inboundEndpoint, 1000);
@@ -69,7 +71,7 @@ public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
         }
         catch (Exception e)
         {
-            assertThat(e.getMessage(), is("FTP Connector doesn't support asynchronous retry policies."));
+            assertThat(e.getMessage(), is(ASYNCHRONOUS_RECCONECTION_ERROR_MESSAGE));
         }
     }
 
@@ -83,7 +85,7 @@ public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
         }
         catch (Exception e)
         {
-            assertThat(e.getCause().getMessage(), is("FTP Connector doesn't support asynchronous retry policies."));
+            assertThat(e.getCause().getMessage(), is(ASYNCHRONOUS_RECCONECTION_ERROR_MESSAGE));
         }
     }
 

--- a/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionStrategyTestCase.java
+++ b/transports/ftp/src/test/java/org/mule/transport/ftp/FtpReconnectionStrategyTestCase.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.transport.ftp.FtpConnector.ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +37,6 @@ public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
     private final InboundEndpoint inboundEndpoint = mock(InboundEndpoint.class, RETURNS_DEEP_STUBS);
     private  FtpMessageReceiver ftpMessageReceiver = null;
     private Connector connector = null;
-    private static final String ASYNCHRONOUS_RECCONECTION_ERROR_MESSAGE = "FTP Connector doesn't support asynchronous retry policies.";
 
     @Override
     protected String getConfigFile()
@@ -71,7 +71,7 @@ public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
         }
         catch (Exception e)
         {
-            assertThat(e.getMessage(), is(ASYNCHRONOUS_RECCONECTION_ERROR_MESSAGE));
+            assertThat(e.getMessage(), is(ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE));
         }
     }
 
@@ -85,7 +85,7 @@ public class FtpReconnectionStrategyTestCase extends FunctionalTestCase
         }
         catch (Exception e)
         {
-            assertThat(e.getCause().getMessage(), is(ASYNCHRONOUS_RECCONECTION_ERROR_MESSAGE));
+            assertThat(e.getCause().getMessage(), is(ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE));
         }
     }
 

--- a/transports/ftp/src/test/resources/ftp-asynchronous-reconnection-config.xml
+++ b/transports/ftp/src/test/resources/ftp-asynchronous-reconnection-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ftp="http://www.mulesoft.org/schema/mule/ftp"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/ftp http://www.mulesoft.org/schema/mule/ftp/current/mule-ftp.xsd">
+
+    <ftp:connector name="FTP" >
+        <reconnect blocking="false"/>
+    </ftp:connector>
+
+    <flow name="testDispatcher">
+        <ftp:outbound-endpoint host="localhost" port="${port}" path="~" user="mule-test" password="mule-test"
+                               connector-ref="FTP"/>
+    </flow>
+</mule>


### PR DESCRIPTION
Due Ftp uses reconnection strategies when FTP Client is created and not during its start phase, Asynchronous Reconnection strategy shouldn't be
allowed.
I've also opened [this PR](https://github.com/mulesoft/mule-ee/pull/2127) to update the migration guide in ee.