### PR TITLE
MULE-12656: Descriptions are not populated in the extension model

### DIFF
--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/description/ConfigurationDescriptionDocumenter.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/description/ConfigurationDescriptionDocumenter.java
@@ -9,6 +9,7 @@ package org.mule.runtime.module.extension.internal.capability.xml.description;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.mule.runtime.extension.api.util.NameUtils.hyphenize;
+import static org.mule.runtime.module.extension.internal.loader.java.ConnectionProviderModelLoaderDelegate.CUSTOM_CONNECTION_PROVIDER_SUFFIX;
 import org.mule.runtime.api.meta.model.declaration.fluent.ConfigurationDeclaration;
 import org.mule.runtime.api.meta.model.declaration.fluent.ConnectedDeclaration;
 import org.mule.runtime.api.meta.model.declaration.fluent.ConnectionProviderDeclaration;
@@ -62,7 +63,7 @@ final class ConfigurationDescriptionDocumenter extends AbstractDescriptionDocume
     String defaultNaming = hyphenize(element.getSimpleName().toString().replace("Provider", ""));
     return declaration.getConnectionProviders().stream()
         .filter(provider -> {
-          String name = provider.getName().replace("-connection", "");
+          String name = provider.getName().replace(CUSTOM_CONNECTION_PROVIDER_SUFFIX, "");
           if (isNotBlank(alias)) {
             return name.equals(alias);
           } else {

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/description/ExtensionDescriptionDocumenter.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/description/ExtensionDescriptionDocumenter.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.module.extension.internal.capability.xml.description;
 
 import static org.mule.runtime.extension.api.util.NameUtils.hyphenize;
+import static org.mule.runtime.module.extension.internal.loader.java.ConfigModelLoaderDelegate.CUSTOM_CONFIG_SUFFIX;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.declaration.fluent.ConfigurationDeclaration;
 import org.mule.runtime.api.meta.model.declaration.fluent.ExtensionDeclaration;
@@ -77,7 +78,7 @@ final class ExtensionDescriptionDocumenter extends AbstractDescriptionDocumenter
     return configurations.stream()
         .filter(config -> {
           Configuration configurationAnnotation = element.getAnnotation(Configuration.class);
-          String name = config.getName();
+          String name = config.getName().replace(CUSTOM_CONFIG_SUFFIX, "");
           String annotationName = configurationAnnotation != null ? configurationAnnotation.name() : "";
           String defaultNaming = hyphenize(element.getSimpleName().toString().replace("Configuration", ""));
           return name.equals(defaultNaming) || name.equals(annotationName);

--- a/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/capability/xml/TestAnotherDocumentedConfig.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/capability/xml/TestAnotherDocumentedConfig.java
@@ -14,7 +14,7 @@ import org.mule.runtime.extension.api.annotation.param.Parameter;
 /**
  * This is some Another Config documentation.
  */
-@Configuration(name = "anotherConfig")
+@Configuration(name = "another")
 @ConnectionProviders(TestAnotherDocumentedProvider.class)
 @Operations({TestDocumentedExtensionOperations.class})
 public class TestAnotherDocumentedConfig {

--- a/modules/extensions-spring-support/src/test/resources/META-INF/documentation-extension-descriptions.xml
+++ b/modules/extensions-spring-support/src/test/resources/META-INF/documentation-extension-descriptions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension-documentation>
-    <elements name="anotherConfig">
+    <elements name="another-config">
         <description><![CDATA[This is some Another Config documentation.]]></description>
         <parameters>
             <parameter name="magicParam">

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/ConfigModelLoaderDelegate.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/ConfigModelLoaderDelegate.java
@@ -28,10 +28,10 @@ import java.util.Optional;
  *
  * @since 4.0
  */
-final class ConfigModelLoaderDelegate extends AbstractModelLoaderDelegate {
+public final class ConfigModelLoaderDelegate extends AbstractModelLoaderDelegate {
 
+  public static final String CUSTOM_CONFIG_SUFFIX = "-config";
   private static final String CONFIGURATION = "Configuration";
-  private static final String CUSTOM_CONFIG_SUFFIX = "-config";
 
   ConfigModelLoaderDelegate(DefaultJavaModelLoaderDelegate delegate) {
     super(delegate);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/ConnectionProviderModelLoaderDelegate.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/ConnectionProviderModelLoaderDelegate.java
@@ -37,9 +37,9 @@ import java.util.Map;
  * Helper class for declaring connection providers through a {@link DefaultJavaModelLoaderDelegate}
  * @since 4.0
  */
-final class ConnectionProviderModelLoaderDelegate extends AbstractModelLoaderDelegate {
+public final class ConnectionProviderModelLoaderDelegate extends AbstractModelLoaderDelegate {
 
-  private static final String CUSTOM_CONNECTION_PROVIDER_SUFFIX = "-" + DEFAULT_CONNECTION_PROVIDER_NAME;
+  public static final String CUSTOM_CONNECTION_PROVIDER_SUFFIX = "-" + DEFAULT_CONNECTION_PROVIDER_NAME;
   private static final String CONNECTION_PROVIDER = "Connection Provider";
 
   private final Map<Class<?>, ConnectionProviderDeclarer> connectionProviderDeclarers = new HashMap<>();


### PR DESCRIPTION
No tests has been added since the current ones still apply, the problem was that the test configuration was named "anotherConfig" which ends up hyphenized as `another-config`, this way the documenter could always find the config because the `-config` suffix was not added by the SDK, the config has been renamed to just `another` so the SDK will add the suffix when creating the extension making the test plausible