### PR TITLE
MULE-12663: In Message Filter, When unaccepted events are handled, execution of flow caller is not stopped.

### DIFF
--- a/core/src/main/java/org/mule/processor/AbstractFilteringMessageProcessor.java
+++ b/core/src/main/java/org/mule/processor/AbstractFilteringMessageProcessor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.processor;
 
+import static java.lang.Boolean.getBoolean;
+import static org.mule.api.config.MuleProperties.SYSTEM_PROPERTY_PREFIX;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -23,6 +25,9 @@ import org.mule.config.i18n.CoreMessages;
  */
 public abstract class AbstractFilteringMessageProcessor extends AbstractInterceptingMessageProcessor  implements NonBlockingSupported
 {
+
+    public static final String FILTER_ON_UNACCEPTED_NOT_STOP_PARENT_FLOW = SYSTEM_PROPERTY_PREFIX + "filterOnUnacceptedNotStopParentFlow";
+
     /** 
      * Throw a FilterUnacceptedException when a message is rejected by the filter? 
      */
@@ -63,7 +68,13 @@ public abstract class AbstractFilteringMessageProcessor extends AbstractIntercep
     {
         if (unacceptedMessageProcessor != null)
         {
-            unacceptedMessageProcessor.process(event);
+            MuleEvent result = unacceptedMessageProcessor.process(event);
+
+            if(shouldNotFilterStopParentFlow())
+            {
+                return result;
+            }
+
             return null;
         }
         else if (throwOnUnaccepted)
@@ -108,5 +119,10 @@ public abstract class AbstractFilteringMessageProcessor extends AbstractIntercep
     public void setThrowOnUnaccepted(boolean throwOnUnaccepted)
     {
         this.throwOnUnaccepted = throwOnUnaccepted;
+    }
+
+    private boolean shouldNotFilterStopParentFlow()
+    {
+        return getBoolean(FILTER_ON_UNACCEPTED_NOT_STOP_PARENT_FLOW);
     }
 }

--- a/core/src/main/java/org/mule/processor/AbstractFilteringMessageProcessor.java
+++ b/core/src/main/java/org/mule/processor/AbstractFilteringMessageProcessor.java
@@ -6,7 +6,6 @@
  */
 package org.mule.processor;
 
-import org.mule.VoidMuleEvent;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;

--- a/core/src/main/java/org/mule/processor/AbstractFilteringMessageProcessor.java
+++ b/core/src/main/java/org/mule/processor/AbstractFilteringMessageProcessor.java
@@ -6,6 +6,7 @@
  */
 package org.mule.processor;
 
+import org.mule.VoidMuleEvent;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -60,10 +61,11 @@ public abstract class AbstractFilteringMessageProcessor extends AbstractIntercep
     protected abstract boolean accept(MuleEvent event);
 
     protected MuleEvent handleUnaccepted(MuleEvent event) throws MuleException
-    {        
+    {
         if (unacceptedMessageProcessor != null)
         {
-            return unacceptedMessageProcessor.process(event);
+            unacceptedMessageProcessor.process(event);
+            return null;
         }
         else if (throwOnUnaccepted)
         {

--- a/core/src/test/java/org/mule/routing/MessageFilterTestCase.java
+++ b/core/src/test/java/org/mule/routing/MessageFilterTestCase.java
@@ -86,7 +86,7 @@ public class MessageFilterTestCase extends AbstractMuleContextTestCase
         MuleEvent resultEvent = mp.process(inEvent);
 
         assertNull(out.event);
-        assertSame(VoidMuleEvent.getInstance(), resultEvent);
+        assertSame(null, resultEvent);
         assertNotNull(unaccepted.event);
         assertSame(inEvent, unaccepted.event);
     }

--- a/tests/integration/src/test/java/org/mule/routing/outbound/MessageFilterCompatibilityFunctionalTestCase.java
+++ b/tests/integration/src/test/java/org/mule/routing/outbound/MessageFilterCompatibilityFunctionalTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.routing.outbound;
+
+import static org.mule.processor.AbstractFilteringMessageProcessor.FILTER_ON_UNACCEPTED_NOT_STOP_PARENT_FLOW;
+import static org.mule.tck.functional.FlowAssert.verify;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.SystemProperty;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MessageFilterCompatibilityFunctionalTestCase extends FunctionalTestCase
+{
+
+    @Rule
+    public SystemProperty systemProperty = new SystemProperty(FILTER_ON_UNACCEPTED_NOT_STOP_PARENT_FLOW, "true");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "message-filter-compatibility-config.xml";
+    }
+
+    @Test
+    public void testFlowCallerStopsAfterUnacceptedEvent() throws Exception
+    {
+        runFlow("MainFlow");
+        verify();
+    }
+
+}

--- a/tests/integration/src/test/java/org/mule/routing/outbound/MessageFilterFunctionalTestCase.java
+++ b/tests/integration/src/test/java/org/mule/routing/outbound/MessageFilterFunctionalTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.routing.outbound;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.mule.api.MuleEventContext;
+import org.mule.api.lifecycle.Callable;
+import org.mule.tck.junit4.FunctionalTestCase;
+
+import org.junit.Test;
+
+public class MessageFilterFunctionalTestCase extends FunctionalTestCase
+{
+
+    private static boolean componentWasCalled = false;
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "message-filter-config.xml";
+    }
+
+    @Test
+    public void testFlowCallerStopsAfterUnacceptedEvent() throws Exception
+    {
+        runFlow("MainFlow");
+        assertThat(componentWasCalled, is(false));
+    }
+
+    public static class TestJavaComponent implements Callable {
+
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            componentWasCalled = true;
+            return eventContext.getMessage();
+        }
+    }
+}

--- a/tests/integration/src/test/java/org/mule/routing/outbound/MessageFilterFunctionalTestCase.java
+++ b/tests/integration/src/test/java/org/mule/routing/outbound/MessageFilterFunctionalTestCase.java
@@ -7,18 +7,14 @@
 
 package org.mule.routing.outbound;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import org.mule.api.MuleEventContext;
-import org.mule.api.lifecycle.Callable;
+import static org.mule.tck.functional.FlowAssert.verify;
+
 import org.mule.tck.junit4.FunctionalTestCase;
 
 import org.junit.Test;
 
 public class MessageFilterFunctionalTestCase extends FunctionalTestCase
 {
-
-    private static boolean componentWasCalled = false;
 
     @Override
     protected String getConfigFile()
@@ -30,16 +26,7 @@ public class MessageFilterFunctionalTestCase extends FunctionalTestCase
     public void testFlowCallerStopsAfterUnacceptedEvent() throws Exception
     {
         runFlow("MainFlow");
-        assertThat(componentWasCalled, is(false));
+        verify();
     }
 
-    public static class TestJavaComponent implements Callable {
-
-        @Override
-        public Object onCall(MuleEventContext eventContext) throws Exception
-        {
-            componentWasCalled = true;
-            return eventContext.getMessage();
-        }
-    }
 }

--- a/tests/integration/src/test/resources/message-filter-compatibility-config.xml
+++ b/tests/integration/src/test/resources/message-filter-compatibility-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <flow name="MainFlow">
+        <set-variable variableName="flag" value="false"/>
+        <flow-ref name="SubFlow_Level1"/>
+        <test:assert count="1"/>
+    </flow>
+
+    <sub-flow name="SubFlow_Level1" >
+        <message-filter onUnaccepted="SubFlow_level2">
+            <expression-filter expression="#[flowVars.flag == true]"/>
+        </message-filter>
+    </sub-flow>
+
+    <sub-flow name="SubFlow_level2">
+        <test:assert count="1"/>
+    </sub-flow>
+
+</mule>

--- a/tests/integration/src/test/resources/message-filter-config.xml
+++ b/tests/integration/src/test/resources/message-filter-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <flow name="MainFlow">
+        <set-variable variableName="flag" value="false"/>
+        <flow-ref name="SubFlow_Level1"/>
+        <component class="org.mule.routing.outbound.MessageFilterFunctionalTestCase$TestJavaComponent" />
+    </flow>
+
+    <sub-flow name="SubFlow_Level1" >
+        <message-filter onUnaccepted="SubFlow_level2">
+            <expression-filter expression="#[flowVars.flag == true]"/>
+        </message-filter>
+    </sub-flow>
+
+    <sub-flow name="SubFlow_level2">
+        <echo-component/>
+    </sub-flow>
+
+</mule>

--- a/tests/integration/src/test/resources/message-filter-config.xml
+++ b/tests/integration/src/test/resources/message-filter-config.xml
@@ -2,14 +2,16 @@
 
 <mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
       xsi:schemaLocation="
 http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
 http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
 
     <flow name="MainFlow">
         <set-variable variableName="flag" value="false"/>
         <flow-ref name="SubFlow_Level1"/>
-        <component class="org.mule.routing.outbound.MessageFilterFunctionalTestCase$TestJavaComponent" />
+        <test:assert count="0"/>
     </flow>
 
     <sub-flow name="SubFlow_Level1" >
@@ -19,7 +21,7 @@ http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/htt
     </sub-flow>
 
     <sub-flow name="SubFlow_level2">
-        <echo-component/>
+        <test:assert count="1"/>
     </sub-flow>
 
 </mule>

--- a/transports/rmi/src/test/java/org/mule/transport/AbstractFunctionalTestCase.java
+++ b/transports/rmi/src/test/java/org/mule/transport/AbstractFunctionalTestCase.java
@@ -10,9 +10,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mule.tck.AbstractServiceAndFlowTestCase.ConfigVariant.SERVICE;
 
+import org.mule.api.MuleEventContext;
 import org.mule.api.MuleMessage;
 import org.mule.api.client.MuleClient;
+import org.mule.api.lifecycle.Callable;
 import org.mule.api.transport.DispatchException;
 import org.mule.config.i18n.Message;
 import org.mule.tck.AbstractServiceAndFlowTestCase;
@@ -24,7 +27,10 @@ import org.junit.Test;
 
 public abstract class AbstractFunctionalTestCase extends AbstractServiceAndFlowTestCase
 {
+    private static String expectedPayload ;
+
     protected String prefix;
+
 
     public AbstractFunctionalTestCase(ConfigVariant variant, String configResources)
     {
@@ -46,13 +52,28 @@ public abstract class AbstractFunctionalTestCase extends AbstractServiceAndFlowT
 
         // send String
         message = client.send("vm://testin", "test matching component first time", null);
-        assertNotNull(message);
-        assertEquals(message.getPayload(), "emit tsrif tnenopmoc gnihctam tset");
+        if(variant.equals(SERVICE))
+        {
+            assertNotNull(message);
+            assertEquals(message.getPayload(), "emit tsrif tnenopmoc gnihctam tset");
+        }
+        else
+        {
+            assertEquals(expectedPayload, "emit tsrif tnenopmoc gnihctam tset");
+        }
 
         // send String
         message = client.send("vm://testin", "test mathching component second time", null);
-        assertNotNull(message);
-        assertEquals(message.getPayload(), "emit dnoces tnenopmoc gnihchtam tset");
+
+        if(variant.equals(SERVICE))
+        {
+            assertNotNull(message);
+            assertEquals(message.getPayload(), "emit dnoces tnenopmoc gnihchtam tset");
+        }
+        else
+        {
+            assertEquals(expectedPayload, "emit dnoces tnenopmoc gnihchtam tset");
+        }
 
         // send Integer
         message = client.send("vm://testin", 15, null);
@@ -136,5 +157,16 @@ public abstract class AbstractFunctionalTestCase extends AbstractServiceAndFlowT
         MuleMessage message = client.send("GoodType", "hello", null);
         assertNotNull(message);
         assertEquals("olleh", message.getPayloadAsString());
+    }
+
+    public static class TestJavaComponent implements Callable
+    {
+
+        @Override
+        public Object onCall(MuleEventContext eventContext) throws Exception
+        {
+            expectedPayload = eventContext.getMessage().getPayloadAsString();
+            return null;
+        }
     }
 }

--- a/transports/rmi/src/test/java/org/mule/transport/issues/RmiMethodTypeMule1857TestCase.java
+++ b/transports/rmi/src/test/java/org/mule/transport/issues/RmiMethodTypeMule1857TestCase.java
@@ -31,4 +31,3 @@ public class RmiMethodTypeMule1857TestCase extends AbstractFunctionalTestCase
     }      
     
 }
-//

--- a/transports/rmi/src/test/java/org/mule/transport/issues/RmiMethodTypeMule1857TestCase.java
+++ b/transports/rmi/src/test/java/org/mule/transport/issues/RmiMethodTypeMule1857TestCase.java
@@ -31,3 +31,4 @@ public class RmiMethodTypeMule1857TestCase extends AbstractFunctionalTestCase
     }      
     
 }
+//

--- a/transports/rmi/src/test/resources/jnp-functional-test-flow.xml
+++ b/transports/rmi/src/test/resources/jnp-functional-test-flow.xml
@@ -43,6 +43,7 @@
     <sub-flow name="Sender2SubFlow">
         <payload-type-filter expectedType="java.lang.String"/>
         <outbound-endpoint ref="Sender2"/>
+        <component class="org.mule.transport.AbstractFunctionalTestCase$TestJavaComponent"/>
     </sub-flow>
     
 </mule>

--- a/transports/rmi/src/test/resources/rmi-functional-test-flow.xml
+++ b/transports/rmi/src/test/resources/rmi-functional-test-flow.xml
@@ -43,6 +43,7 @@
     <sub-flow name="Sender2SubFlow">
         <payload-type-filter expectedType="java.lang.String"/>
         <rmi:outbound-endpoint ref="Sender2"/>
+        <component class="org.mule.transport.AbstractFunctionalTestCase$TestJavaComponent"/>
     </sub-flow>
     
 </mule>

--- a/transports/rmi/src/test/resources/rmi-method-type-1857-test-flow.xml
+++ b/transports/rmi/src/test/resources/rmi-method-type-1857-test-flow.xml
@@ -53,6 +53,7 @@
     <sub-flow name="Sender2SubFlow">
         <payload-type-filter expectedType="java.lang.String"/>
         <rmi:outbound-endpoint ref="Sender2"/>
+        <component class="org.mule.transport.AbstractFunctionalTestCase$TestJavaComponent"/>
     </sub-flow>
     
 </mule>


### PR DESCRIPTION
In a subflow with a filter, if the filter condition is not satisfied and the unaccepted event is handled, then the flow that called this subflow must stop its execution.