### PR TITLE
MULE-12672: JDOM 1 was excluded in distribution but Flatpack needs it.

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -297,7 +297,8 @@
 /mule-standalone-${productVersion}/lib/opt/jbossjta-4.15.0.Final.jar
 /mule-standalone-${productVersion}/lib/opt/jcifs-1.3.3.jar
 /mule-standalone-${productVersion}/lib/opt/jcodings-1.0.16.jar
-/mule-standalone-${productVersion}/lib/opt/jdom-2.0.2.jar
+/mule-standalone-${productVersion}/lib/opt/jdom-1.1.3.jar
+/mule-standalone-${productVersion}/lib/opt/jdom2-2.0.6.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-client-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-common-2.11.jar
 /mule-standalone-${productVersion}/lib/opt/jersey-guava-2.11.jar

--- a/modules/rss/pom.xml
+++ b/modules/rss/pom.xml
@@ -34,8 +34,8 @@
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>
-            <artifactId>jdom</artifactId>
-            <version>${jdomVersion}</version>
+            <artifactId>jdom2</artifactId>
+            <version>${jdom2Version}</version>
         </dependency>
 
         <!--test deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,8 @@
         <jaxenVersion>1.1.1</jaxenVersion>
         <jbossTsVersion>4.15.0.Final</jbossTsVersion>
         <jcrVersion>1.0</jcrVersion>
-        <jdomVersion>2.0.2</jdomVersion>
+        <jdomVersion>1.1.3</jdomVersion>
+        <jdom2Version>2.0.6</jdom2Version>
         <jettyVersion>9.0.7.v20131107</jettyVersion>
         <jodaTimeVersion>2.9.1</jodaTimeVersion>
         <jschVersion>0.1.54</jschVersion>
@@ -1007,10 +1008,15 @@
                 <version>${antVersion}</version>
             </dependency>
             <dependency>
-                <!-- this really should be the org.jdom groupId but all the other modules use the jdom groupId -->
                 <groupId>org.jdom</groupId>
                 <artifactId>jdom</artifactId>
                 <version>${jdomVersion}</version>
+            </dependency>
+            <dependency>
+                <!-- this really should be the org.jdom groupId but all the other modules use the jdom groupId -->
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom2</artifactId>
+                <version>${jdom2Version}</version>
             </dependency>
             <dependency>
                 <groupId>dom4j</groupId>


### PR DESCRIPTION
When Rome was upgraded to 1.5, JDom was upgraded to 2.0.2. However, Flatpack parser uses JDOM1 in its last version.