### PR TITLE
MULE-11954: Support for craftedExtensionModelLoader

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/api/ExtensionPluginMetadataGenerator.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/ExtensionPluginMetadataGenerator.java
@@ -9,8 +9,6 @@ package org.mule.test.runner.api;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.io.File.separator;
-import static java.util.stream.Collectors.toList;
-import static org.apache.commons.io.FileUtils.toFile;
 import static org.mule.test.runner.api.MulePluginBasedLoaderFinder.META_INF_MULE_PLUGIN;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.meta.model.ExtensionModel;
@@ -144,16 +142,11 @@ class ExtensionPluginMetadataGenerator {
    * @return {@link Class} annotated with {@link Extension} or {@code null}
    */
   Class scanForExtensionAnnotatedClasses(Artifact plugin, List<URL> urls) {
-    logger.debug("Scanning plugin '{}' for annotated Extension class", plugin);
+    final URL firstURL = urls.stream().findFirst().get();
+    logger.debug("Scanning plugin '{}' for annotated Extension class from {}", plugin, firstURL);
     ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
     scanner.addIncludeFilter(new AnnotationTypeFilter(Extension.class));
-    try (URLClassLoader classLoader = new URLClassLoader(urls.stream()
-        .filter(url -> {
-          File urlFile = toFile(url);
-          return urlFile.isDirectory() || urlFile.getName().endsWith("-mule-plugin.jar");
-        })
-        .collect(toList())
-        .toArray(new URL[0]), null)) {
+    try (URLClassLoader classLoader = new URLClassLoader(new URL[] {firstURL}, null)) {
       scanner.setResourceLoader(new PathMatchingResourcePatternResolver(classLoader));
       Set<BeanDefinition> extensionsAnnotatedClasses = scanner.findCandidateComponents("");
       if (!extensionsAnnotatedClasses.isEmpty()) {

--- a/tests/runner/src/main/java/org/mule/test/runner/api/IsolatedClassLoaderExtensionsManagerConfigurationBuilder.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/IsolatedClassLoaderExtensionsManagerConfigurationBuilder.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IsolatedClassLoaderExtensionsManagerConfigurationBuilder extends AbstractConfigurationBuilder {
 
+  private static final String META_INF_MULE_ARTIFACT_MULE_PLUGIN = "META-INF/mule-artifact/mule-plugin.json";
   private static Logger LOGGER = LoggerFactory.getLogger(IsolatedClassLoaderExtensionsManagerConfigurationBuilder.class);
 
   private final ExtensionManagerFactory extensionManagerFactory;
@@ -104,6 +105,9 @@ public class IsolatedClassLoaderExtensionsManagerConfigurationBuilder extends Ab
             (ClassLoader) pluginClassLoader.getClass().getMethod("getClassLoader").invoke(pluginClassLoader);
         Method findResource = classLoader.getClass().getMethod("findResource", String.class);
         URL json = ((URL) findResource.invoke(classLoader, META_INF_MULE_PLUGIN));
+        if (json == null) {
+          json = ((URL) findResource.invoke(classLoader, META_INF_MULE_ARTIFACT_MULE_PLUGIN));
+        }
         if (json != null) {
           LOGGER.debug("Discovered extension '{}'", artifactName);
           MulePluginBasedLoaderFinder finder = new MulePluginBasedLoaderFinder(json.openStream());


### PR DESCRIPTION
* Only look for @Extension on first plugin URL
* Allow to handle mule-plugin.json on both places (when generated goes in another location that is not the one expected by the Runtime)