### PR TITLE
MULE-12435: Dependency resolution fails when the path has special

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/context/DefaultMuleContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/context/DefaultMuleContextTestCase.java
@@ -27,6 +27,7 @@ import static org.mule.runtime.core.api.registry.ServiceType.EXCEPTION;
 import static org.mule.runtime.core.config.ExceptionHelper.RESOURCE_ROOT;
 import static org.mule.runtime.core.config.ExceptionHelper.getErrorMapping;
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.core.DefaultMuleContext;
@@ -50,7 +51,6 @@ import org.mule.tck.junit4.AbstractMuleTestCase;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.net.URL;
 
 import org.junit.After;
 import org.junit.Before;
@@ -109,10 +109,8 @@ public class DefaultMuleContextTestCase extends AbstractMuleTestCase {
 
   @Test
   public void testClearExceptionHelperCacheForAppWhenDispose() throws Exception {
-    URL baseUrl = DefaultMuleContextTestCase.class.getClassLoader().getResource(".");
-    File file =
-        new File(baseUrl.getFile() + RESOURCE_ROOT + EXCEPTION.getPath() + "/" + TEST_PROTOCOL
-            + "-exception-mappings.properties");
+    File file = new File(DefaultMuleContextTestCase.class.getClassLoader()
+        .getResource(RESOURCE_ROOT + EXCEPTION.getPath() + "/" + TEST_PROTOCOL + "-exception-mappings.properties").toURI());
     createExceptionMappingFile(file, INITIAL_VALUE);
 
     createMuleContext();

--- a/core-tests/src/test/java/org/mule/runtime/core/el/mvel/MVELExpressionLanguageTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/el/mvel/MVELExpressionLanguageTestCase.java
@@ -24,6 +24,7 @@ import static org.mule.runtime.api.metadata.DataType.OBJECT;
 import static org.mule.runtime.api.metadata.DataType.STRING;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
+
 import org.mule.mvel2.CompileException;
 import org.mule.mvel2.ParserContext;
 import org.mule.mvel2.PropertyAccessException;
@@ -40,13 +41,13 @@ import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.el.ExpressionLanguageContext;
 import org.mule.runtime.core.api.el.ExpressionLanguageExtension;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
-import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.runtime.core.api.registry.RegistrationException;
 import org.mule.runtime.core.config.MuleManifest;
 import org.mule.runtime.core.context.notification.DefaultFlowCallStack;
 import org.mule.runtime.core.el.context.AppContext;
 import org.mule.runtime.core.el.context.MessageContext;
 import org.mule.runtime.core.el.function.RegexExpressionLanguageFuntion;
+import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import java.io.File;
@@ -56,6 +57,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -506,8 +508,9 @@ public class MVELExpressionLanguageTestCase extends AbstractMuleContextTestCase 
    * @return The classes
    * @throws ClassNotFoundException
    * @throws IOException
+   * @throws URISyntaxException
    */
-  private static Class[] getClasses(String packageName) throws ClassNotFoundException, IOException {
+  private static Class[] getClasses(String packageName) throws ClassNotFoundException, IOException, URISyntaxException {
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     assert classLoader != null;
     String path = packageName.replace('.', '/');
@@ -515,7 +518,7 @@ public class MVELExpressionLanguageTestCase extends AbstractMuleContextTestCase 
     List<File> dirs = new ArrayList<>();
     while (resources.hasMoreElements()) {
       URL resource = resources.nextElement();
-      dirs.add(new File(resource.getFile()));
+      dirs.add(new File(resource.toURI()));
     }
     ArrayList<Class> classes = new ArrayList<>();
     for (File directory : dirs) {

--- a/core-tests/src/test/java/org/mule/runtime/core/util/FileUtilsTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/util/FileUtilsTestCase.java
@@ -13,8 +13,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mule.tck.ZipUtils.compress;
 import static org.mule.runtime.core.api.util.FileUtils.unzip;
+import static org.mule.tck.ZipUtils.compress;
+
 import org.mule.runtime.core.api.util.FileUtils;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.tck.ZipUtils.ZipResource;
@@ -333,7 +334,7 @@ public class FileUtilsTestCase extends AbstractMuleTestCase {
   @Test
   public void testUnzipFileToSameFolderTwice() throws Exception {
     URL resourceAsUrl = IOUtils.getResourceAsUrl("testFolder.zip", getClass());
-    File zipFile = new File(resourceAsUrl.getFile());
+    File zipFile = new File(resourceAsUrl.toURI());
     File outputDir = FileUtils.newFile(TEST_DIRECTORY);
 
     for (int i = 0; i < 2; i++) {

--- a/core/src/main/java/org/mule/runtime/core/config/builders/AutoConfigurationBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/config/builders/AutoConfigurationBuilder.java
@@ -9,15 +9,16 @@ package org.mule.runtime.core.config.builders;
 import static org.apache.commons.lang.StringUtils.substringAfterLast;
 import static org.mule.runtime.core.api.util.ClassUtils.getResource;
 import static org.mule.runtime.core.util.PropertiesUtils.loadProperties;
+
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.config.ConfigurationException;
 import org.mule.runtime.core.api.config.ParentMuleContextAwareConfigurationBuilder;
+import org.mule.runtime.core.api.util.ClassUtils;
 import org.mule.runtime.core.config.ConfigResource;
 import org.mule.runtime.core.config.bootstrap.ArtifactType;
 import org.mule.runtime.core.config.i18n.CoreMessages;
-import org.mule.runtime.core.api.util.ClassUtils;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -61,14 +62,14 @@ public class AutoConfigurationBuilder extends AbstractResourceConfigurationBuild
   protected void autoConfigure(MuleContext muleContext, ConfigResource[] resources) throws ConfigurationException {
     Map<String, List<ConfigResource>> configsMap = new LinkedHashMap<String, List<ConfigResource>>();
 
-    for (int i = 0; i < resources.length; i++) {
-      String configExtension = substringAfterLast((resources[i]).getUrl().getFile(), ".");
+    for (ConfigResource resource : resources) {
+      String configExtension = substringAfterLast(resource.getUrl().getPath(), ".");
       List<ConfigResource> configs = configsMap.get(configExtension);
       if (configs == null) {
         configs = new ArrayList<ConfigResource>();
         configsMap.put(configExtension, configs);
       }
-      configs.add(resources[i]);
+      configs.add(resource);
     }
 
     try {

--- a/distributions/embedded/embedded-impl/src/main/java/org/mule/runtime/module/embedded/impl/EmbeddedController.java
+++ b/distributions/embedded/embedded-impl/src/main/java/org/mule/runtime/module/embedded/impl/EmbeddedController.java
@@ -10,6 +10,7 @@ import static java.io.File.separator;
 import static java.lang.String.format;
 import static java.lang.System.setProperty;
 import static org.apache.commons.io.FileUtils.copyFile;
+import static org.apache.commons.io.FileUtils.toFile;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainsFolder;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getServicesFolder;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;
@@ -17,6 +18,7 @@ import static org.mule.runtime.core.api.util.FileUtils.deleteTree;
 import static org.mule.runtime.module.deployment.impl.internal.application.DeployableMavenClassLoaderModelLoader.ADD_TEST_DEPENDENCIES_KEY;
 import static org.mule.runtime.module.embedded.impl.SerializationUtils.deserialize;
 import static org.mule.runtime.module.embedded.internal.MavenUtils.createModelFromPom;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.container.api.MuleFoldersUtil;
 import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
@@ -97,8 +99,8 @@ public class EmbeddedController {
     File containerFolder = new File(containerInfo.getContainerBaseFolder().getPath());
     File servicesFolder = new File(containerFolder, "services");
     for (URL url : containerInfo.getServices()) {
-      File originalFile = new File(url.getFile());
-      File destinationFile = new File(servicesFolder, FilenameUtils.getName(url.getFile()));
+      File originalFile = toFile(url);
+      File destinationFile = new File(servicesFolder, FilenameUtils.getName(originalFile.getPath()));
       copyFile(originalFile, destinationFile);
     }
 
@@ -151,12 +153,12 @@ public class EmbeddedController {
     muleArtifactFolder.mkdirs();
     File descriptorFile = new File(muleArtifactFolder, "mule-application.json");
 
-    File pomFile = new File(applicationConfiguration.getApplication().getPomFile().getFile());
+    File pomFile = toFile(applicationConfiguration.getApplication().getPomFile());
     Model pomModel = createModelFromPom(pomFile);
     String pomLocation = format("META-INF%smaven%s%s%s%s%spom.xml", separator, separator, pomModel.getGroupId(), separator,
                                 pomModel.getArtifactId(), separator);
     File appPomFileLocation = new File(applicationFolder, pomLocation);
-    copyFile(new File(applicationConfiguration.getApplication().getDescriptorFile().getFile()), descriptorFile);
+    copyFile(toFile(applicationConfiguration.getApplication().getDescriptorFile()), descriptorFile);
     copyFile(pomFile, appPomFileLocation);
     return applicationFolder;
   }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDependency.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/descriptor/BundleDependency.java
@@ -9,7 +9,7 @@ package org.mule.runtime.module.artifact.descriptor;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 
-import java.net.URL;
+import java.net.URI;
 
 /**
  * Describes a dependency on a bundle.
@@ -20,7 +20,7 @@ public class BundleDependency {
 
   private BundleDescriptor descriptor;
   private BundleScope scope;
-  private URL bundleUrl;
+  private URI bundleUri;
 
   private BundleDependency() {}
 
@@ -32,8 +32,8 @@ public class BundleDependency {
     return descriptor;
   }
 
-  public URL getBundleUrl() {
-    return bundleUrl;
+  public URI getBundleUri() {
+    return bundleUri;
   }
 
   @Override
@@ -41,7 +41,7 @@ public class BundleDependency {
     return "BundleDependency{" +
         "descriptor=" + descriptor +
         ", scope=" + scope +
-        ", bundleUrl=" + bundleUrl +
+        ", bundleUri=" + bundleUri +
         '}';
   }
 
@@ -96,9 +96,9 @@ public class BundleDependency {
       return this;
     }
 
-    public Builder setBundleUrl(URL bundleUrl) {
-      validateIsNotNull(bundleUrl, "Bundle URL cannot be null");
-      this.bundleDependency.bundleUrl = bundleUrl;
+    public Builder setBundleUri(URI bundleUri) {
+      validateIsNotNull(bundleUri, "Bundle URI cannot be null");
+      this.bundleDependency.bundleUri = bundleUri;
       return this;
     }
 

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/util/FileJarExplorer.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/util/FileJarExplorer.java
@@ -13,8 +13,7 @@ import static org.apache.commons.lang.ClassUtils.getPackageName;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLDecoder;
+import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -31,12 +30,12 @@ public class FileJarExplorer implements JarExplorer {
   protected static final String CLASS_EXTENSION = ".class";
 
   @Override
-  public JarInfo explore(URL library) {
+  public JarInfo explore(URI library) {
     Set<String> packages = new HashSet<>();
     Set<String> resources = new HashSet<>();
 
     try {
-      final File libraryFile = new File(URLDecoder.decode(library.getFile(), "UTF-8"));
+      final File libraryFile = new File(library);
       if (!libraryFile.exists()) {
         throw new IllegalArgumentException("Library file does not exists: " + library);
       }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/util/JarExplorer.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/util/JarExplorer.java
@@ -7,7 +7,7 @@
 
 package org.mule.runtime.module.artifact.util;
 
-import java.net.URL;
+import java.net.URI;
 
 /**
  * Explores jar files or exploded jar folders to find packages and resources.
@@ -20,5 +20,5 @@ public interface JarExplorer {
    * @param library folder or JAR file to explore. Non null
    * @return the {@link JarInfo} containing the found resources and packages. Non null.
    */
-  JarInfo explore(URL library);
+  JarInfo explore(URI library);
 }

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocolTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/serializer/CustomJavaSerializationProtocolTestCase.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.module.artifact.classloader.ParentFirstLookupStrategy.PARENT_FIRST;
+
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.serialization.SerializationException;
 import org.mule.runtime.core.internal.message.InternalMessage;
@@ -69,7 +70,7 @@ public class CustomJavaSerializationProtocolTestCase extends AbstractSerializerP
     final File compiledClasses = new File(temporaryFolder.getRoot(), "compiledClasses");
     compiledClasses.mkdirs();
 
-    final File sourceFile = new File(getClass().getResource("/org/foo/SerializableClass.java").getFile());
+    final File sourceFile = new File(getClass().getResource("/org/foo/SerializableClass.java").toURI());
 
     CompilerUtils.SingleClassCompiler compiler = new CompilerUtils.SingleClassCompiler();
     compiler.compile(sourceFile);

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/util/FileJarExplorerTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/util/FileJarExplorerTestCase.java
@@ -11,6 +11,7 @@ import static org.apache.commons.io.FileUtils.writeStringToFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
+
 import org.mule.tck.ZipUtils;
 import org.mule.tck.ZipUtils.ZipResource;
 import org.mule.tck.junit4.AbstractMuleTestCase;
@@ -34,7 +35,7 @@ public class FileJarExplorerTestCase extends AbstractMuleTestCase {
     jarFile.delete();
     ZipUtils.compress(jarFile, zipResources);
 
-    final Set<String> packages = packageExplorer.explore(jarFile.toURI().toURL()).getPackages();
+    final Set<String> packages = packageExplorer.explore(jarFile.toURI()).getPackages();
     assertThat(packages.size(), equalTo(2));
     assertThat(packages, hasItem("org.foo"));
     assertThat(packages, hasItem("org.bar"));
@@ -51,7 +52,7 @@ public class FileJarExplorerTestCase extends AbstractMuleTestCase {
     writeStringToFile(new File(orgFooFolder, "Foo.class"), "foo");
     writeStringToFile(new File(orgFooBarFolder, "Bar.class"), "bar");
 
-    final Set<String> packages = packageExplorer.explore(folder.toURI().toURL()).getPackages();
+    final Set<String> packages = packageExplorer.explore(folder.toURI()).getPackages();
     assertThat(packages.size(), equalTo(2));
     assertThat(packages, hasItem("org.foo"));
     assertThat(packages, hasItem("org.bar"));

--- a/modules/container/src/test/java/org/mule/runtime/container/internal/JreExplorerTestCase.java
+++ b/modules/container/src/test/java/org/mule/runtime/container/internal/JreExplorerTestCase.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mule.runtime.container.internal.ExportedServiceMatcher.like;
+
 import org.mule.runtime.module.artifact.classloader.ExportedService;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -19,6 +20,7 @@ import org.mule.tck.util.CompilerUtils;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -49,21 +52,28 @@ public class JreExplorerTestCase extends AbstractMuleTestCase {
   private static final String RESOURCE_PATH = "/resource.txt";
 
 
-  private static final File fooJar = new CompilerUtils.JarCompiler()
-      .compiling(new File(JreExplorerTestCase.class.getResource("/org/foo/Foo.java").getFile()))
-      .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).getFile()), FOO_RESOURCE)
-      .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).getFile()), SERVICE_RESOURCE)
-      .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).getFile()), FOO_SERVICE_PATH)
-      .compile(FOO_JAR_FILENAME);
+  private static File fooJar;
 
-  private static final File barJar = new CompilerUtils.JarCompiler()
-      .compiling(new File(JreExplorerTestCase.class.getResource("/org/bar/Bar.java").getFile()))
-      .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).getFile()), BAR_RESOURCE)
-      .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).getFile()), BAR_SERVICE_PATH)
-      .compile(BAR_JAR_FILENAMEß);
+  private static File barJar;
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @BeforeClass
+  public static void beforeClass() throws URISyntaxException {
+    fooJar = new CompilerUtils.JarCompiler()
+        .compiling(new File(JreExplorerTestCase.class.getResource("/org/foo/Foo.java").toURI()))
+        .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).toURI()), FOO_RESOURCE)
+        .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).toURI()), SERVICE_RESOURCE)
+        .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).toURI()), FOO_SERVICE_PATH)
+        .compile(FOO_JAR_FILENAME);
+
+    barJar = new CompilerUtils.JarCompiler()
+        .compiling(new File(JreExplorerTestCase.class.getResource("/org/bar/Bar.java").toURI()))
+        .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).toURI()), BAR_RESOURCE)
+        .including(new File(JreExplorerTestCase.class.getResource(RESOURCE_PATH).toURI()), BAR_SERVICE_PATH)
+        .compile(BAR_JAR_FILENAMEß);
+  }
 
   @Test
   public void readsJar() throws Exception {

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultApplicationFactory.java
@@ -9,11 +9,11 @@ package org.mule.runtime.module.deployment.impl.internal.application;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
-import static org.apache.commons.io.FileUtils.toFile;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.deployment.model.internal.AbstractArtifactClassLoaderBuilder.PLUGIN_CLASSLOADER_IDENTIFIER;
 import static org.mule.runtime.deployment.model.internal.AbstractArtifactClassLoaderBuilder.getArtifactPluginId;
+
 import org.mule.runtime.deployment.model.api.DeploymentException;
 import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
@@ -98,6 +98,7 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
     this.muleContextListenerFactory = muleContextListenerFactory;
   }
 
+  @Override
   public Application createArtifact(File appDir) throws IOException {
     String appName = appDir.getName();
     if (appName.contains(" ")) {
@@ -174,7 +175,7 @@ public class DefaultApplicationFactory implements ArtifactFactory<Application> {
     Set<ArtifactPluginDescriptor> pluginDescriptors = new HashSet<>();
     for (BundleDependency bundleDependency : descriptor.getClassLoaderModel().getDependencies()) {
       if (bundleDependency.getDescriptor().isPlugin()) {
-        File pluginZip = toFile(bundleDependency.getBundleUrl());
+        File pluginZip = new File(bundleDependency.getBundleUri());
         pluginDescriptors.add(pluginDescriptorLoader.load(pluginZip));
       }
     }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultMuleApplication.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultMuleApplication.java
@@ -109,8 +109,8 @@ public class DefaultMuleApplication implements Application {
     updateStatusFor(NotInLifecyclePhase.PHASE_NAME);
 
     try {
-      for (String configResourceAbsolutePatch : this.descriptor.getAbsoluteResourcePaths()) {
-        File configResource = new File(configResourceAbsolutePatch);
+      for (String configResourceAbsolutePath : this.descriptor.getAbsoluteResourcePaths()) {
+        File configResource = new File(configResourceAbsolutePath);
         if (!configResource.exists()) {
           String message = format("Config for app '%s' not found: %s", getArtifactName(), configResource);
           throw new InstallException(createStaticMessage(message));

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DeployableMavenClassLoaderModelLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DeployableMavenClassLoaderModelLoader.java
@@ -104,7 +104,7 @@ public class DeployableMavenClassLoaderModelLoader extends AbstractMavenClassLoa
                           && bundleDependency.getDescriptor().getGroupId().equals(groupId))
                       .findFirst();
                   bundleDependencyOptional.map(bundleDependency -> {
-                    JarInfo jarInfo = fileJarExplorer.explore(bundleDependency.getBundleUrl());
+                    JarInfo jarInfo = fileJarExplorer.explore(bundleDependency.getBundleUri());
                     classLoaderModelBuilder.exportingPackages(jarInfo.getPackages());
                     classLoaderModelBuilder.exportingResources(jarInfo.getResources());
                     return bundleDependency;

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/domain/DefaultMuleDomain.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/domain/DefaultMuleDomain.java
@@ -6,13 +6,15 @@
  */
 package org.mule.runtime.module.deployment.impl.internal.domain;
 
+import static org.apache.commons.io.FileUtils.toFile;
 import static org.apache.commons.lang.exception.ExceptionUtils.getRootCause;
 import static org.apache.commons.lang.exception.ExceptionUtils.getRootCauseMessage;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
-import static org.mule.runtime.core.config.bootstrap.ArtifactType.DOMAIN;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.core.config.bootstrap.ArtifactType.DOMAIN;
 import static org.mule.runtime.core.internal.util.splash.SplashScreen.miniSplash;
 import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactContextBuilder.newBuilder;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -35,9 +37,8 @@ import org.mule.runtime.module.service.ServiceRepository;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.Scanner;
 
 import org.slf4j.Logger;
@@ -69,9 +70,9 @@ public class DefaultMuleDomain implements Domain {
     URL resource = deploymentClassLoader.findLocalResource(DOMAIN_CONFIG_FILE_LOCATION);
     if (resource != null) {
       try {
-        this.configResourceFile = new File(URLDecoder.decode(resource.getFile(), "UTF-8"));
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException("Unable to find config resource file: " + resource.getFile());
+        this.configResourceFile = new File(resource.toURI());
+      } catch (URISyntaxException e) {
+        throw new MuleRuntimeException(e);
       }
     }
   }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/AbstractMavenClassLoaderModelLoader.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/AbstractMavenClassLoaderModelLoader.java
@@ -19,6 +19,7 @@ import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConst
 import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.EXPORTED_RESOURCES;
 import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.MAVEN;
 import static org.mule.runtime.module.reboot.MuleContainerBootstrapUtils.isStandalone;
+
 import org.mule.maven.client.api.LocalRepositorySupplierFactory;
 import org.mule.maven.client.api.MavenClient;
 import org.mule.runtime.api.deployment.meta.MuleArtifactLoaderDescriptor;
@@ -36,7 +37,6 @@ import org.mule.runtime.module.artifact.descriptor.InvalidDescriptorLoaderExcept
 
 import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -137,7 +137,7 @@ public abstract class AbstractMavenClassLoaderModelLoader implements ClassLoader
   protected BundleDependency convertBundleDependency(org.mule.maven.client.api.model.BundleDependency mavenClientDependency) {
     BundleDependency.Builder builder = new BundleDependency.Builder()
         .setScope(BundleScope.valueOf(mavenClientDependency.getScope().name()))
-        .setBundleUrl(mavenClientDependency.getBundleUrl())
+        .setBundleUri(mavenClientDependency.getBundleUri())
         .setDescriptor(convertBundleDescriptor(mavenClientDependency.getDescriptor()));
     return builder.build();
   }
@@ -193,14 +193,10 @@ public abstract class AbstractMavenClassLoaderModelLoader implements ClassLoader
                                               Set<BundleDependency> dependencies) {
     dependencies.stream()
         .filter(dependency -> !MULE_PLUGIN_CLASSIFIER.equals(dependency.getDescriptor().getClassifier().orElse(null)))
-        .filter(dependency -> dependency.getBundleUrl() != null)
+        .filter(dependency -> dependency.getBundleUri() != null)
         .forEach(dependency -> {
           try {
-            try {
-              classLoaderModelBuilder.containing(dependency.getBundleUrl().toURI().toURL());
-            } catch (URISyntaxException e) {
-              throw new MuleRuntimeException(e);
-            }
+            classLoaderModelBuilder.containing(dependency.getBundleUri().toURL());
           } catch (MalformedURLException e) {
             throw new MuleRuntimeException(e);
           }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactory.java
@@ -9,11 +9,13 @@ package org.mule.runtime.module.deployment.impl.internal.policy;
 
 import static java.io.File.separator;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.config.bootstrap.ArtifactType.POLICY;
 import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.META_INF;
 import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.MULE_ARTIFACT;
 import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.MULE_POLICY_JSON;
+
 import org.mule.runtime.api.deployment.meta.MuleArtifactLoaderDescriptor;
 import org.mule.runtime.api.deployment.meta.MulePolicyModel;
 import org.mule.runtime.api.deployment.persistence.MulePolicyModelJsonSerializer;
@@ -40,7 +42,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 
@@ -145,15 +146,15 @@ public class PolicyTemplateDescriptorFactory implements ArtifactDescriptorFactor
 
   private Set<ArtifactPluginDescriptor> parseArtifactPluginDescriptors(PolicyTemplateDescriptor descriptor) {
     Set<BundleDependency> pluginDependencies = descriptor.getClassLoaderModel().getDependencies().stream()
-        .filter(dependency -> dependency.getDescriptor().isPlugin()).collect(Collectors.toSet());
+        .filter(dependency -> dependency.getDescriptor().isPlugin()).collect(toSet());
 
     return pluginDependencies.stream().map(dependency -> {
       try {
-        return artifactPluginDescriptorLoader.load(new File(dependency.getBundleUrl().getFile()));
+        return artifactPluginDescriptorLoader.load(new File(dependency.getBundleUri()));
       } catch (IOException e) {
         throw new MuleRuntimeException(e);
       }
-    }).collect(Collectors.toSet());
+    }).collect(toSet());
   }
 
   private MulePolicyModel getMulePolicyJsonDescriber(File jsonFile) {

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/artifact/MavenClassLoaderModelLoaderTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/artifact/MavenClassLoaderModelLoaderTestCase.java
@@ -19,11 +19,12 @@ import static org.junit.Assert.fail;
 import static org.junit.rules.ExpectedException.none;
 import static org.mule.runtime.core.config.bootstrap.ArtifactType.APP;
 import static org.mule.tck.MuleTestUtils.testWithSystemProperties;
+
 import org.mule.runtime.globalconfig.api.GlobalConfigLoader;
 import org.mule.tck.junit4.rule.SystemProperty;
 
 import java.io.File;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,7 @@ public class MavenClassLoaderModelLoaderTestCase {
   public static final String MULE_RUNTIME_CONFIG_MAVEN_REPOSITORY_LOCATION = "muleRuntimeConfig.maven.repositoryLocation";
   private MavenClassLoaderModelLoader mavenClassLoaderModelLoader;
 
-  private File artifactFile = getApplicationFolder("apps/single-dependency");
+  private File artifactFile;
 
   @Rule
   public SystemProperty repositoryLocation = new SystemProperty(MULE_RUNTIME_CONFIG_MAVEN_REPOSITORY_LOCATION,
@@ -51,8 +52,9 @@ public class MavenClassLoaderModelLoaderTestCase {
   public ExpectedException expectedException = none();
 
   @Before
-  public void before() {
+  public void before() throws URISyntaxException {
     mavenClassLoaderModelLoader = new MavenClassLoaderModelLoader();
+    artifactFile = getApplicationFolder("apps/single-dependency");
   }
 
   @Test
@@ -92,9 +94,8 @@ public class MavenClassLoaderModelLoaderTestCase {
                              });
   }
 
-  private File getApplicationFolder(String appPath) {
-    URL noDependenciesFolderUrl = getClass().getClassLoader().getResource(appPath);
-    return new File(noDependenciesFolderUrl.getFile());
+  private File getApplicationFolder(String appPath) throws URISyntaxException {
+    return new File(getClass().getClassLoader().getResource(appPath).toURI());
   }
 
 }

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactoryTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/PolicyTemplateDescriptorFactoryTestCase.java
@@ -11,6 +11,7 @@ import static java.io.File.createTempFile;
 import static java.io.File.separator;
 import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptyList;
+import static org.apache.commons.io.FileUtils.toFile;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -19,8 +20,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.maven.client.api.model.MavenConfiguration.newMavenConfigurationBuilder;
-import static org.mule.runtime.core.config.bootstrap.ArtifactType.POLICY;
 import static org.mule.runtime.core.api.util.FileUtils.unzip;
+import static org.mule.runtime.core.config.bootstrap.ArtifactType.POLICY;
 import static org.mule.runtime.deployment.model.api.plugin.MavenClassLoaderConstants.MAVEN;
 import static org.mule.runtime.module.artifact.descriptor.ClassLoaderModel.NULL_CLASSLOADER_MODEL;
 import static org.mule.runtime.module.deployment.impl.internal.policy.FileSystemPolicyClassLoaderModelLoader.CLASSES_DIR;
@@ -35,6 +36,7 @@ import static org.mule.runtime.module.deployment.impl.internal.policy.Properties
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.TYPE;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.VERSION;
+
 import org.mule.maven.client.api.MavenClientProvider;
 import org.mule.runtime.api.deployment.meta.MuleArtifactLoaderDescriptor;
 import org.mule.runtime.api.deployment.meta.MulePolicyModel.MulePolicyModelBuilder;
@@ -87,7 +89,7 @@ public class PolicyTemplateDescriptorFactoryTestCase extends AbstractMuleTestCas
 
 
   private static File getResourceFile(String resource) {
-    return new File(PolicyTemplateDescriptorFactoryTestCase.class.getResource(resource).getFile());
+    return toFile(PolicyTemplateDescriptorFactoryTestCase.class.getResource(resource));
   }
 
   @Rule
@@ -147,8 +149,8 @@ public class PolicyTemplateDescriptorFactoryTestCase extends AbstractMuleTestCas
     PolicyTemplateDescriptor desc = descriptorFactory.create(tempFolder);
 
     assertThat(desc.getClassLoaderModel().getUrls().length, equalTo(2));
-    assertThat(desc.getClassLoaderModel().getUrls()[0].getFile(), equalTo(new File(tempFolder, CLASSES_DIR).toString()));
-    assertThat(desc.getClassLoaderModel().getUrls()[1].getFile(),
+    assertThat(toFile(desc.getClassLoaderModel().getUrls()[0]).getPath(), equalTo(new File(tempFolder, CLASSES_DIR).toString()));
+    assertThat(toFile(desc.getClassLoaderModel().getUrls()[1]).getPath(),
                equalTo(new File(tempFolder, LIB_DIR + separator + JAR_FILE_NAME).toString()));
   }
 

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/application/MuleApplicationClassLoader.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/application/MuleApplicationClassLoader.java
@@ -9,6 +9,7 @@ package org.mule.runtime.deployment.model.internal.application;
 import static java.lang.Thread.currentThread;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.io.FileUtils.toFile;
 
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.deployment.model.api.application.ApplicationClassLoader;
@@ -55,7 +56,7 @@ public class MuleApplicationClassLoader extends MuleDeployableArtifactClassLoade
   protected String[] getLocalResourceLocations() {
     // Always the first element corresponds to the application's classes folder
     ClassLoaderModel classLoaderModel = this.<ApplicationDescriptor>getArtifactDescriptor().getClassLoaderModel();
-    return new String[] {classLoaderModel.getUrls()[0].getFile()};
+    return new String[] {toFile(classLoaderModel.getUrls()[0]).getPath()};
   }
 
   /**

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/plugin/BundlePluginDependenciesResolver.java
@@ -10,6 +10,7 @@ package org.mule.runtime.deployment.model.internal.plugin;
 import static java.lang.String.format;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import static org.mule.runtime.module.artifact.descriptor.BundleDescriptorUtils.isCompatibleVersion;
+
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.descriptor.ArtifactDescriptorFactory;
 import org.mule.runtime.module.artifact.descriptor.BundleDependency;
@@ -142,8 +143,8 @@ public class BundlePluginDependenciesResolver implements PluginDependenciesResol
               .forEach(dependency -> {
                 if (isPlugin(dependency) && !isResolvedDependency(visited, dependency.getDescriptor())) {
                   File mulePluginLocation;
-                  if (dependency.getBundleUrl() != null) {
-                    mulePluginLocation = new File(dependency.getBundleUrl().getFile());
+                  if (dependency.getBundleUri() != null) {
+                    mulePluginLocation = new File(dependency.getBundleUri());
                   } else {
                     throw new PluginResolutionError(format("Bundle URL should have been resolved for %s.",
                                                            dependency.getDescriptor()));

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/api/DeploymentService.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/api/DeploymentService.java
@@ -10,7 +10,7 @@ import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.domain.Domain;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
@@ -74,10 +74,10 @@ public interface DeploymentService extends DeploymentListenerManager, DomainDepl
   /**
    * Deploys and application bundled as a zip from the given URL to the mule container
    *
-   * @param appArchiveUrl location of the zip application file
+   * @param appArchiveUri location of the zip application file
    * @throws IOException
    */
-  void deploy(URL appArchiveUrl) throws IOException;
+  void deploy(URI appArchiveUri) throws IOException;
 
   /**
    * Undeploys and redeploys an application
@@ -96,10 +96,10 @@ public interface DeploymentService extends DeploymentListenerManager, DomainDepl
   /**
    * Deploys a domain bundled as a zip from the given URL to the mule container
    *
-   * @param domainArchiveUrl location of the zip domain file
+   * @param domainArchiveUri location of the zip domain file
    * @throws IOException
    */
-  void deployDomain(URL domainArchiveUrl) throws IOException;
+  void deployDomain(URI domainArchiveUri) throws IOException;
 
   /**
    * Undeploys and redeploys a domain

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArchiveDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArchiveDeployer.java
@@ -7,11 +7,11 @@
 package org.mule.runtime.module.deployment.internal;
 
 import org.mule.runtime.deployment.model.api.DeploymentException;
-import org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactFactory;
 import org.mule.runtime.module.artifact.Artifact;
+import org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactFactory;
 
 import java.io.File;
-import java.net.URL;
+import java.net.URI;
 import java.util.Map;
 
 /**
@@ -33,7 +33,7 @@ public interface ArchiveDeployer<T extends Artifact> {
    */
   boolean isUpdatedZombieArtifact(String artifactName);
 
-  T deployPackagedArtifact(URL artifactAchivedUrl);
+  T deployPackagedArtifact(URI artifactAchivedUri);
 
   void undeployArtifact(String artifactId);
 
@@ -43,7 +43,7 @@ public interface ArchiveDeployer<T extends Artifact> {
 
   void redeploy(T artifact) throws DeploymentException;
 
-  Map<URL, Long> getArtifactsZombieMap();
+  Map<URI, Long> getArtifactsZombieMap();
 
   void setArtifactFactory(ArtifactFactory<T> artifactFactory);
 

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainArchiveDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainArchiveDeployer.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.module.deployment.internal;
 
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.JAR_FILE_SUFFIX;
+
 import org.mule.runtime.api.util.Preconditions;
 import org.mule.runtime.deployment.model.api.DeploymentException;
 import org.mule.runtime.deployment.model.api.application.Application;
@@ -17,7 +18,7 @@ import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 
@@ -68,7 +69,7 @@ public class DomainArchiveDeployer implements ArchiveDeployer<Domain> {
   }
 
   @Override
-  public Domain deployPackagedArtifact(URL artifactAchivedUrl) {
+  public Domain deployPackagedArtifact(URI artifactAchivedUrl) {
     Domain domain = domainDeployer.deployPackagedArtifact(artifactAchivedUrl);
     deployBundledAppsIfDomainWasCreated(domain);
     return domain;
@@ -135,7 +136,7 @@ public class DomainArchiveDeployer implements ArchiveDeployer<Domain> {
   }
 
   @Override
-  public Map<URL, Long> getArtifactsZombieMap() {
+  public Map<URI, Long> getArtifactsZombieMap() {
     return domainDeployer.getArtifactsZombieMap();
   }
 

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleDeploymentService.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/MuleDeploymentService.java
@@ -32,7 +32,7 @@ import org.mule.runtime.module.deployment.internal.util.ObservableList;
 import org.mule.runtime.module.service.ServiceManager;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -176,11 +176,11 @@ public class MuleDeploymentService implements DeploymentService {
   /**
    * @return URL/lastModified of apps which previously failed to deploy
    */
-  Map<URL, Long> getZombieApplications() {
+  Map<URI, Long> getZombieApplications() {
     return applicationDeployer.getArtifactsZombieMap();
   }
 
-  Map<URL, Long> getZombieDomains() {
+  Map<URI, Long> getZombieDomains() {
     return domainDeployer.getArtifactsZombieMap();
   }
 
@@ -199,8 +199,8 @@ public class MuleDeploymentService implements DeploymentService {
   }
 
   @Override
-  public void deploy(URL appArchiveUrl) throws IOException {
-    executeSynchronized(() -> applicationDeployer.deployPackagedArtifact(appArchiveUrl));
+  public void deploy(URI appArchiveUri) throws IOException {
+    executeSynchronized(() -> applicationDeployer.deployPackagedArtifact(appArchiveUri));
   }
 
   @Override
@@ -222,8 +222,8 @@ public class MuleDeploymentService implements DeploymentService {
   }
 
   @Override
-  public void deployDomain(URL domainArchiveUrl) throws IOException {
-    executeSynchronized(() -> domainDeployer.deployPackagedArtifact(domainArchiveUrl));
+  public void deployDomain(URI domainArchiveUri) throws IOException {
+    executeSynchronized(() -> domainDeployer.deployPackagedArtifact(domainArchiveUri));
   }
 
   @Override

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/ClasspathBasedDslContext.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/capability/xml/schema/ClasspathBasedDslContext.java
@@ -15,6 +15,7 @@ import static org.mule.runtime.core.util.annotation.AnnotationUtils.getAnnotatio
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.loadExtension;
 import static org.reflections.util.ClasspathHelper.forClassLoader;
+
 import org.mule.runtime.api.dsl.DslResolvingContext;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.type.TypeCatalog;
@@ -81,7 +82,7 @@ class ClasspathBasedDslContext implements DslResolvingContext {
 
   private void findExtensionsInClasspath() {
     final Collection<URL> mulePluginsUrls = forClassLoader(classLoader).stream()
-        .filter(url -> url.getFile().contains(MULE_PLUGIN_CLASSIFIER))
+        .filter(url -> url.getPath().contains(MULE_PLUGIN_CLASSIFIER))
         .collect(toList());
     Set<Class<?>> annotated = getExtensionTypes(mulePluginsUrls);
 

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
@@ -24,7 +24,7 @@ import static org.mule.runtime.api.meta.model.display.LayoutModel.builder;
 import static org.mule.runtime.api.meta.model.parameter.ParameterRole.BEHAVIOUR;
 import static org.mule.runtime.config.spring.XmlConfigurationDocumentLoader.schemaValidatingDocumentLoader;
 import static org.mule.runtime.extension.api.util.XmlModelUtils.createXmlLanguageModel;
-import com.google.common.collect.ImmutableMap;
+
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.runtime.api.component.ComponentIdentifier;
@@ -57,7 +57,8 @@ import org.mule.runtime.extension.api.exception.IllegalParameterModelDefinitionE
 import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
 import org.mule.runtime.extension.internal.loader.catalog.loader.xml.TypesCatalogXmlLoader;
 import org.mule.runtime.extension.internal.loader.catalog.model.TypesCatalog;
-import org.w3c.dom.Document;
+
+import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
 import java.net.URL;
@@ -71,6 +72,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import org.w3c.dom.Document;
 
 /**
  * Describes an {@link ExtensionModel} by scanning an XML provided in the constructor
@@ -193,7 +196,8 @@ final class XmlExtensionLoaderDelegate {
     }
     ComponentModelReader componentModelReader =
         new ComponentModelReader(new DefaultArtifactProperties(emptyMap(), emptyMap(), emptyMap()));
-    //TODO MULE-12291: we would, ideally, leave either the relative path (modulePath) or the URL to the current config file, rather than just the name of the file (which will be useless from a tooling POV)
+    // TODO MULE-12291: we would, ideally, leave either the relative path (modulePath) or the URL to the current config file,
+    // rather than just the name of the file (which will be useless from a tooling POV)
     final String configFileName = modulePath.substring(modulePath.lastIndexOf("/") + 1);
     ComponentModel componentModel = componentModelReader.extractComponentDefinitionModel(parseModule.get(), configFileName);
 
@@ -323,7 +327,7 @@ final class XmlExtensionLoaderDelegate {
     extractOutputType(operationDeclarer, operationModel);
   }
 
-  //TODO MULE-12619: until the internals of ExtensionModel doesn't validate or corrects the name, this is the custom validation
+  // TODO MULE-12619: until the internals of ExtensionModel doesn't validate or corrects the name, this is the custom validation
   private String assertValidName(String name) {
     if (!VALID_XML_NAME.matcher(name).matches()) {
       throw new IllegalModelDefinitionException(format("The name being used '%s' is not XML valid, it must start with a letter and can be followed by any letter, number or -, _. ",

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextConfigurer.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextConfigurer.java
@@ -7,13 +7,13 @@
 package org.mule.runtime.module.launcher.log4j2;
 
 import org.mule.runtime.api.exception.MuleRuntimeException;
-import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.api.i18n.I18nMessageFactory;
+import org.mule.runtime.core.api.config.MuleProperties;
+import org.mule.runtime.core.api.util.ClassUtils;
+import org.mule.runtime.core.api.util.FileUtils;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.classloader.ShutdownListener;
 import org.mule.runtime.module.reboot.MuleContainerBootstrapUtils;
-import org.mule.runtime.core.api.util.ClassUtils;
-import org.mule.runtime.core.api.util.FileUtils;
 
 import java.io.File;
 import java.io.Serializable;
@@ -231,8 +231,8 @@ final class LoggerContextConfigurer {
     }
 
     if (directory != null && FileUtils.isFile(url)) {
-      File urlFile = new File(url.getFile());
-      return directory.equals(urlFile.getParentFile());
+      File uriFile = new File(uri);
+      return directory.equals(uriFile.getParentFile());
     }
 
     return false;

--- a/tests/functional/src/main/java/org/mule/functional/util/ftp/Server.java
+++ b/tests/functional/src/main/java/org/mule/functional/util/ftp/Server.java
@@ -6,10 +6,11 @@
  */
 package org.mule.functional.util.ftp;
 
-import org.mule.runtime.core.api.util.IOUtils;
+import static org.mule.runtime.core.api.util.IOUtils.getResourceAsUrl;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
 
@@ -60,18 +61,18 @@ public class Server {
     serverFactory.addListener("default", listenerFactory.createListener());
   }
 
-  private void setupUserManagerFactory(FtpServerFactory serverFactory) throws IOException {
+  private void setupUserManagerFactory(FtpServerFactory serverFactory) throws IOException, URISyntaxException {
     UserManager userManager = createUserManager();
     serverFactory.setUserManager(userManager);
   }
 
-  protected UserManager createUserManager() throws IOException {
+  protected UserManager createUserManager() throws IOException, URISyntaxException {
     PropertiesUserManagerFactory userManagerFactory = new PropertiesUserManagerFactory();
-    URL usersFile = IOUtils.getResourceAsUrl("users.properties", getClass());
+    URL usersFile = getResourceAsUrl("users.properties", getClass());
     if (usersFile == null) {
       throw new IOException("users.properties file not found in the classpath");
     }
-    userManagerFactory.setFile(new File(usersFile.getFile()));
+    userManagerFactory.setFile(new File(usersFile.toURI()));
 
     return userManagerFactory.createUserManager();
   }

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/MuleContextProcessApplication.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/MuleContextProcessApplication.java
@@ -9,6 +9,8 @@ package org.mule.test.infrastructure.process;
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.mule.runtime.deployment.model.api.application.ApplicationDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
 import static org.mule.test.infrastructure.process.MuleContextProcessBuilder.MULE_CORE_EXTENSIONS_PROPERTY;
+import static org.mule.test.infrastructure.process.MuleContextProcessBuilder.TIMEOUT_IN_SECONDS;
+
 import org.mule.runtime.container.api.MuleCoreExtension;
 import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.test.infrastructure.deployment.FakeMuleServer;
@@ -47,7 +49,7 @@ public class MuleContextProcessApplication {
       System.out.println("Creating app config file");
       String applicationConfiguration = System.getProperty(MuleContextProcessBuilder.CONFIG_FILE_KEY);
       File applicationConfigurationFile =
-          new File(MuleContextProcessApplication.class.getClassLoader().getResource(applicationConfiguration).getFile());
+          new File(MuleContextProcessApplication.class.getClassLoader().getResource(applicationConfiguration).toURI());
       if (!applicationConfigurationFile.exists()) {
         throw new RuntimeException("Could not find file for application configuration " + applicationConfiguration);
       }
@@ -64,8 +66,7 @@ public class MuleContextProcessApplication {
       notifyMuleContextStarted();
 
       while (true) {
-        if (System.currentTimeMillis()
-            - initialTime > (Integer.valueOf(System.getProperty(MuleContextProcessBuilder.TIMEOUT_IN_SECONDS)) * 1000)) {
+        if (System.currentTimeMillis() - initialTime > (Integer.valueOf(System.getProperty(TIMEOUT_IN_SECONDS)) * 1000)) {
           System.exit(-1);
         }
         Thread.sleep(1000);

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/server/ftp/EmbeddedFtpServer.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/server/ftp/EmbeddedFtpServer.java
@@ -10,6 +10,7 @@ import org.mule.runtime.core.api.util.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.apache.ftpserver.FtpServerFactory;
@@ -51,13 +52,13 @@ public class EmbeddedFtpServer {
     return listenerFactory;
   }
 
-  private void setupUserManagerFactory(FtpServerFactory serverFactory) throws IOException {
+  private void setupUserManagerFactory(FtpServerFactory serverFactory) throws IOException, URISyntaxException {
     PropertiesUserManagerFactory userManagerFactory = new PropertiesUserManagerFactory();
     URL usersFile = IOUtils.getResourceAsUrl("users.properties", getClass());
     if (usersFile == null) {
       throw new IOException("users.properties file not found in the classpath");
     }
-    userManagerFactory.setFile(new File(usersFile.getFile()));
+    userManagerFactory.setFile(new File(usersFile.toURI()));
     serverFactory.setUserManager(userManagerFactory.createUserManager());
   }
 

--- a/tests/unit/src/main/java/org/mule/tck/ZipUtils.java
+++ b/tests/unit/src/main/java/org/mule/tck/ZipUtils.java
@@ -7,6 +7,7 @@
 
 package org.mule.tck;
 
+import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.core.api.util.ClassUtils;
 
 import java.io.File;
@@ -14,6 +15,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -54,7 +56,7 @@ public class ZipUtils {
           resourceUrl = new File(zipResource.file).toURI().toURL();
         }
 
-        try (FileInputStream in = new FileInputStream(resourceUrl.getFile())) {
+        try (FileInputStream in = new FileInputStream(new File(resourceUrl.toURI()))) {
           out.putNextEntry(new ZipEntry(zipResource.alias == null ? zipResource.file : zipResource.alias));
 
           byte[] buffer = new byte[1024];
@@ -63,6 +65,8 @@ public class ZipUtils {
           while ((count = in.read(buffer)) > 0) {
             out.write(buffer, 0, count);
           }
+        } catch (URISyntaxException e) {
+          throw new MuleRuntimeException(e);
         }
       }
     } catch (IOException e) {


### PR DESCRIPTION
characters
* Remove usages of URL.getFile() for building a File from an URI
* Replace usages of URL with URI