### PR TITLE
MULE-12472: RejectionPolicy configuration is confusing

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/scheduler/SchedulerConfig.java
+++ b/core/src/main/java/org/mule/runtime/core/api/scheduler/SchedulerConfig.java
@@ -106,7 +106,7 @@ public class SchedulerConfig {
   }
 
   /**
-   * whether the threads of the target custom {@link Scheduler} may block to wait when dispatching to a busy {@link Scheduler}.
+   * Whether the threads of the target custom {@link Scheduler} may block to wait when dispatching to a busy {@link Scheduler}.
    * <p>
    * This is only applicable for <b>custom</b> {@link Scheduler}s. This behaviour cannot be changed for the runtime managed
    * {@link Scheduler}.

--- a/core/src/main/java/org/mule/runtime/core/api/scheduler/SchedulerConfig.java
+++ b/core/src/main/java/org/mule/runtime/core/api/scheduler/SchedulerConfig.java
@@ -8,11 +8,9 @@ package org.mule.runtime.core.api.scheduler;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.mule.runtime.core.api.scheduler.SchedulerConfig.RejectionAction.DEFAULT;
 
 import org.mule.runtime.api.scheduler.Scheduler;
 
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -24,26 +22,6 @@ import java.util.function.Supplier;
 public class SchedulerConfig {
 
   /**
-   * Different possible actions to handle the scenario where a task is dispatched to a busy {@link Scheduler}.
-   * <p>
-   * A {@link Scheduler} is considered busy when all of its threads are busy and it cannot accept a new task for execution.
-   */
-  public enum RejectionAction {
-    /**
-     * The actual {@link RejectedExecutionHandler} of the target {@link Scheduler} will depend on the type of scheduler the thread
-     * is from. For cpu-bound threads (cpuLight and cpuIntensive) it will be <b>abort</b>, and for the other cases it will be
-     * <b>wait</b>.
-     */
-    DEFAULT,
-
-    /**
-     * The {@link RejectedExecutionHandler} of the target {@link Scheduler} will cause the dispatcher thread to wait for the task
-     * to be taken by the target scheduler, effectively blocking until that happens.
-     */
-    WAIT;
-  }
-
-  /**
    * @return a default configuration, which can be further customized.
    */
   public static SchedulerConfig config() {
@@ -53,23 +31,23 @@ public class SchedulerConfig {
   private final Integer maxConcurrentTasks;
   private final String schedulerPrefix;
   private final String schedulerName;
-  private final RejectionAction rejectionAction;
+  private final Boolean waitAllowed;
   private final Supplier<Long> shutdownTimeoutMillis;
 
   private SchedulerConfig() {
     this.maxConcurrentTasks = null;
     this.schedulerPrefix = null;
     this.schedulerName = null;
-    this.rejectionAction = DEFAULT;
+    this.waitAllowed = null;
     this.shutdownTimeoutMillis = () -> null;
   }
 
   private SchedulerConfig(Integer maxConcurrentTasks, String schedulerPrefix, String schedulerName,
-                          RejectionAction rejectionAction, Supplier<Long> shutdownTimeoutMillis) {
+                          Boolean waitAllowed, Supplier<Long> shutdownTimeoutMillis) {
     this.maxConcurrentTasks = maxConcurrentTasks;
     this.schedulerPrefix = schedulerPrefix;
     this.schedulerName = schedulerName;
-    this.rejectionAction = rejectionAction;
+    this.waitAllowed = waitAllowed;
     this.shutdownTimeoutMillis = shutdownTimeoutMillis;
   }
 
@@ -83,7 +61,7 @@ public class SchedulerConfig {
    * @return the updated configuration.
    */
   public SchedulerConfig withMaxConcurrentTasks(int maxConcurrentTasks) {
-    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, rejectionAction, shutdownTimeoutMillis);
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
   }
 
   /**
@@ -100,7 +78,7 @@ public class SchedulerConfig {
    * @return the updated configuration.
    */
   public SchedulerConfig withPrefix(String schedulerPrefix) {
-    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, rejectionAction, shutdownTimeoutMillis);
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
   }
 
   /**
@@ -110,7 +88,7 @@ public class SchedulerConfig {
    * @return the updated configuration.
    */
   public SchedulerConfig withName(String schedulerName) {
-    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, rejectionAction, shutdownTimeoutMillis);
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
   }
 
   /**
@@ -128,25 +106,23 @@ public class SchedulerConfig {
   }
 
   /**
-   * Sets the rejection policy to use when dispatching to a busy {@link Scheduler}.
+   * whether the threads of the target custom {@link Scheduler} may block to wait when dispatching to a busy {@link Scheduler}.
    * <p>
-   * This is only applicable for <b>custom</b> {@link Scheduler}s. The policy cannot be changed for the runtime managed
+   * This is only applicable for <b>custom</b> {@link Scheduler}s. This behaviour cannot be changed for the runtime managed
    * {@link Scheduler}.
-   * 
-   * @see SchedulerBusyException
    * 
    * @return the updated configuration
    */
-  public SchedulerConfig withRejectionAction(RejectionAction rejectionAction) {
-    requireNonNull(rejectionAction);
-    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, rejectionAction, shutdownTimeoutMillis);
+  public SchedulerConfig withWaitAllowed(boolean waitAllowed) {
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
   }
 
   /**
-   * @return the {@link RejectionAction} for the target custom {@link Scheduler}.
+   * @return whether the threads of the target custom {@link Scheduler} may block to wait when dispatching to a busy
+   *         {@link Scheduler}.
    */
-  public RejectionAction getRejectionAction() {
-    return rejectionAction;
+  public Boolean getWaitAllowed() {
+    return waitAllowed;
   }
 
   /**
@@ -160,7 +136,7 @@ public class SchedulerConfig {
   public SchedulerConfig withShutdownTimeout(Supplier<Long> shutdownTimeoutSupplier, TimeUnit shutdownTimeoutUnit) {
     requireNonNull(shutdownTimeoutUnit);
 
-    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, rejectionAction, () -> {
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, () -> {
       long shutdownTimeout = shutdownTimeoutSupplier.get();
       validateTimeoutValue(shutdownTimeout);
       return shutdownTimeoutUnit.toMillis(shutdownTimeout);

--- a/core/src/main/java/org/mule/runtime/core/api/scheduler/SchedulerConfig.java
+++ b/core/src/main/java/org/mule/runtime/core/api/scheduler/SchedulerConfig.java
@@ -8,9 +8,12 @@ package org.mule.runtime.core.api.scheduler;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 
 import org.mule.runtime.api.scheduler.Scheduler;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -31,19 +34,19 @@ public class SchedulerConfig {
   private final Integer maxConcurrentTasks;
   private final String schedulerPrefix;
   private final String schedulerName;
-  private final Boolean waitAllowed;
+  private final Optional<Boolean> waitAllowed;
   private final Supplier<Long> shutdownTimeoutMillis;
 
   private SchedulerConfig() {
     this.maxConcurrentTasks = null;
     this.schedulerPrefix = null;
     this.schedulerName = null;
-    this.waitAllowed = null;
+    this.waitAllowed = empty();
     this.shutdownTimeoutMillis = () -> null;
   }
 
   private SchedulerConfig(Integer maxConcurrentTasks, String schedulerPrefix, String schedulerName,
-                          Boolean waitAllowed, Supplier<Long> shutdownTimeoutMillis) {
+                          Optional<Boolean> waitAllowed, Supplier<Long> shutdownTimeoutMillis) {
     this.maxConcurrentTasks = maxConcurrentTasks;
     this.schedulerPrefix = schedulerPrefix;
     this.schedulerName = schedulerName;
@@ -114,14 +117,14 @@ public class SchedulerConfig {
    * @return the updated configuration
    */
   public SchedulerConfig withWaitAllowed(boolean waitAllowed) {
-    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, waitAllowed, shutdownTimeoutMillis);
+    return new SchedulerConfig(maxConcurrentTasks, schedulerPrefix, schedulerName, of(waitAllowed), shutdownTimeoutMillis);
   }
 
   /**
    * @return whether the threads of the target custom {@link Scheduler} may block to wait when dispatching to a busy
    *         {@link Scheduler}.
    */
-  public Boolean getWaitAllowed() {
+  public Optional<Boolean> getWaitAllowed() {
     return waitAllowed;
   }
 

--- a/core/src/main/java/org/mule/runtime/core/processor/strategy/ReactorStreamProcessingStrategyFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/strategy/ReactorStreamProcessingStrategyFactory.java
@@ -10,7 +10,6 @@ import static java.lang.Math.min;
 import static java.lang.Runtime.getRuntime;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE_ASYNC;
-import static org.mule.runtime.core.api.scheduler.SchedulerConfig.RejectionAction.WAIT;
 import static reactor.core.publisher.Flux.from;
 import static reactor.core.scheduler.Schedulers.fromExecutorService;
 
@@ -21,7 +20,6 @@ import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
-import org.mule.runtime.core.api.scheduler.SchedulerConfig;
 import org.mule.runtime.core.api.scheduler.SchedulerService;
 
 import java.util.function.Supplier;
@@ -44,7 +42,7 @@ public class ReactorStreamProcessingStrategyFactory extends AbstractStreamProces
     return new ReactorStreamProcessingStrategy(() -> muleContext.getSchedulerService()
         .customScheduler(muleContext.getSchedulerBaseConfig()
             .withName(schedulersNamePrefix + RING_BUFFER_SCHEDULER_NAME_SUFFIX)
-            .withMaxConcurrentTasks(getSubscriberCount() + 1).withRejectionAction(WAIT)), getBufferSize(), getSubscriberCount(),
+            .withMaxConcurrentTasks(getSubscriberCount() + 1).withWaitAllowed(true)), getBufferSize(), getSubscriberCount(),
                                                getWaitStrategy(),
                                                () -> muleContext.getSchedulerService()
                                                    .cpuLightScheduler(muleContext.getSchedulerBaseConfig()

--- a/core/src/main/java/org/mule/runtime/core/processor/strategy/WorkQueueStreamProcessingStrategyFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/processor/strategy/WorkQueueStreamProcessingStrategyFactory.java
@@ -9,7 +9,6 @@ package org.mule.runtime.core.processor.strategy;
 import static java.util.Objects.requireNonNull;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.BLOCKING;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE_ASYNC;
-import static org.mule.runtime.core.api.scheduler.SchedulerConfig.RejectionAction.WAIT;
 import static reactor.core.publisher.Flux.from;
 import static reactor.core.publisher.Flux.just;
 import static reactor.core.scheduler.Schedulers.fromExecutorService;
@@ -42,7 +41,7 @@ public class WorkQueueStreamProcessingStrategyFactory extends AbstractStreamProc
     return new WorkQueueStreamProcessingStrategy(() -> muleContext.getSchedulerService()
         .customScheduler(muleContext.getSchedulerBaseConfig()
             .withName(schedulersNamePrefix + RING_BUFFER_SCHEDULER_NAME_SUFFIX)
-            .withMaxConcurrentTasks(getSubscriberCount() + 1).withRejectionAction(WAIT)),
+            .withMaxConcurrentTasks(getSubscriberCount() + 1).withWaitAllowed(true)),
                                                  getBufferSize(),
                                                  getSubscriberCount(),
                                                  getWaitStrategy(),


### PR DESCRIPTION
* Replace `RejectionPolicy` with a `waitAllowed` flag
* Add logging of failures in test schedulers