### PR TITLE
MULE-12739: Set Drools Assert Behavior Option to EQUALITY to avoid du…

### DIFF
--- a/modules/drools/pom.xml
+++ b/modules/drools/pom.xml
@@ -84,5 +84,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <artifactId>ecj</artifactId>
+            <version>4.6.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/drools/src/main/java/org/mule/module/drools/Drools.java
+++ b/modules/drools/src/main/java/org/mule/module/drools/Drools.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class Drools implements RulesEngine
 {
 
-    public static final String equalityAssertBehavior= SYSTEM_PROPERTY_PREFIX  + "droolsEqualityAssertBehavior";
+    public static final String USE_EQUALITY_ASSERT_BEHAVIOR = SYSTEM_PROPERTY_PREFIX  + "drools.useEqualityAssert";
 
     /** An optional logical name for the Rules Engine. */
     private String name;
@@ -73,7 +73,7 @@ public class Drools implements RulesEngine
         KnowledgeBaseConfiguration conf = 
             KnowledgeBaseFactory.newKnowledgeBaseConfiguration(null, Thread.currentThread().getContextClassLoader());
 
-        if (isEqualityAssertBehavior())
+        if (useEqualityAssertBehavior())
         {
             conf.setOption(EQUALITY);
         }
@@ -192,9 +192,9 @@ public class Drools implements RulesEngine
         return name;
     }
 
-    private boolean isEqualityAssertBehavior ()
+    private boolean useEqualityAssertBehavior ()
     {
-        return getBoolean(equalityAssertBehavior);
+        return getBoolean(USE_EQUALITY_ASSERT_BEHAVIOR);
     }
 }
 

--- a/modules/drools/src/main/java/org/mule/module/drools/Drools.java
+++ b/modules/drools/src/main/java/org/mule/module/drools/Drools.java
@@ -6,6 +6,8 @@
  */
 package org.mule.module.drools;
 
+import static org.drools.conf.AssertBehaviorOption.EQUALITY;
+
 import org.drools.conf.AssertBehaviorOption;
 import org.mule.api.config.ConfigurationException;
 import org.mule.config.i18n.CoreMessages;
@@ -67,7 +69,7 @@ public class Drools implements RulesEngine
         KnowledgeBaseConfiguration conf = 
             KnowledgeBaseFactory.newKnowledgeBaseConfiguration(null, Thread.currentThread().getContextClassLoader());
 
-        conf.setOption(AssertBehaviorOption.EQUALITY);
+        conf.setOption(EQUALITY);
 
         if (rules.getConfiguration() != null)
         {

--- a/modules/drools/src/main/java/org/mule/module/drools/Drools.java
+++ b/modules/drools/src/main/java/org/mule/module/drools/Drools.java
@@ -6,9 +6,10 @@
  */
 package org.mule.module.drools;
 
+import static java.lang.Boolean.getBoolean;
 import static org.drools.conf.AssertBehaviorOption.EQUALITY;
+import static org.mule.api.config.MuleProperties.SYSTEM_PROPERTY_PREFIX;
 
-import org.drools.conf.AssertBehaviorOption;
 import org.mule.api.config.ConfigurationException;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.config.i18n.MessageFactory;
@@ -39,6 +40,9 @@ import org.slf4j.LoggerFactory;
 
 public class Drools implements RulesEngine
 {
+
+    public static final String equalityAssertBehavior= SYSTEM_PROPERTY_PREFIX  + "droolsEqualityAssertBehavior";
+
     /** An optional logical name for the Rules Engine. */
     private String name;
 
@@ -69,7 +73,10 @@ public class Drools implements RulesEngine
         KnowledgeBaseConfiguration conf = 
             KnowledgeBaseFactory.newKnowledgeBaseConfiguration(null, Thread.currentThread().getContextClassLoader());
 
-        conf.setOption(EQUALITY);
+        if (isEqualityAssertBehavior())
+        {
+            conf.setOption(EQUALITY);
+        }
 
         if (rules.getConfiguration() != null)
         {
@@ -183,6 +190,11 @@ public class Drools implements RulesEngine
     public String getName()
     {
         return name;
+    }
+
+    private boolean isEqualityAssertBehavior ()
+    {
+        return getBoolean(equalityAssertBehavior);
     }
 }
 

--- a/modules/drools/src/main/java/org/mule/module/drools/Drools.java
+++ b/modules/drools/src/main/java/org/mule/module/drools/Drools.java
@@ -6,6 +6,7 @@
  */
 package org.mule.module.drools;
 
+import org.drools.conf.AssertBehaviorOption;
 import org.mule.api.config.ConfigurationException;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.config.i18n.MessageFactory;
@@ -65,6 +66,9 @@ public class Drools implements RulesEngine
 
         KnowledgeBaseConfiguration conf = 
             KnowledgeBaseFactory.newKnowledgeBaseConfiguration(null, Thread.currentThread().getContextClassLoader());
+
+        conf.setOption(AssertBehaviorOption.EQUALITY);
+
         if (rules.getConfiguration() != null)
         {
             conf.setOption((KnowledgeBaseOption) rules.getConfiguration());

--- a/modules/drools/src/test/java/org.mule.module.drools/DroolsAssertBehaviorTestCase.java
+++ b/modules/drools/src/test/java/org.mule.module.drools/DroolsAssertBehaviorTestCase.java
@@ -7,6 +7,7 @@
 
 package org.mule.module.drools;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -52,11 +53,10 @@ public class DroolsAssertBehaviorTestCase extends AbstractMuleTestCase
         });
     }
 
-    private static void setUp () throws Exception {
+    @BeforeClass
+    public static void setUp () throws Exception {
         when(rules.getResource()).thenReturn("rulesFile.drl");
         drools.setMessageService(messageService);
-        DroolsSessionData sessionData = (DroolsSessionData) drools.createSession(rules);
-        when(rules.getSessionData()).thenReturn(sessionData);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class DroolsAssertBehaviorTestCase extends AbstractMuleTestCase
     static TestCallback identityBehaviourCallback =  new TestCallback(){
         @Override
         public void run() throws Exception {
-            setUp();
+            createSession();
             Object handle1 = drools.assertFact(rules, new TestFact("idTest", "descriptionTest"));
             Object handle2 = drools.assertFact(rules, new TestFact("idTest", "descriptionTest"));
             assertThat(handle1, is(not(handle2)));
@@ -120,10 +120,16 @@ public class DroolsAssertBehaviorTestCase extends AbstractMuleTestCase
     static TestCallback equalityBehaviourCallback =  new TestCallback(){
         @Override
         public void run() throws Exception {
-            setUp();
+            createSession();
             Object handle1 = drools.assertFact(rules, new TestFact("idTest", "descriptionTest"));
             Object handle2 = drools.assertFact(rules, new TestFact("idTest", "descriptionTest"));
             assertThat(handle1, is(handle2));
         }
     };
+
+    private static void createSession () throws Exception
+    {
+        DroolsSessionData sessionData = (DroolsSessionData) drools.createSession(rules);
+        when(rules.getSessionData()).thenReturn(sessionData);
+    }
 }

--- a/modules/drools/src/test/java/org.mule.module.drools/DroolsAssertBehaviorTestCase.java
+++ b/modules/drools/src/test/java/org.mule.module.drools/DroolsAssertBehaviorTestCase.java
@@ -28,7 +28,6 @@ import static org.mule.tck.MuleTestUtils.testWithSystemProperty;
 import static org.mule.tck.MuleTestUtils.TestCallback;
 import static org.junit.runners.Parameterized.Parameters;
 
-
 @RunWith(Parameterized. class)
 public class DroolsAssertBehaviorTestCase extends AbstractMuleTestCase
 {

--- a/modules/drools/src/test/java/org.mule.module.drools/DroolsAssertBehaviorTestCase.java
+++ b/modules/drools/src/test/java/org.mule.module.drools/DroolsAssertBehaviorTestCase.java
@@ -29,7 +29,7 @@ import static org.mule.tck.MuleTestUtils.testWithSystemProperty;
 import static org.mule.tck.MuleTestUtils.TestCallback;
 import static org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized. class)
+@RunWith(Parameterized.class)
 public class DroolsAssertBehaviorTestCase extends AbstractMuleTestCase
 {
 

--- a/modules/drools/src/test/java/org.mule.module.drools/DroolsTestCase.java
+++ b/modules/drools/src/test/java/org.mule.module.drools/DroolsTestCase.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mule.module.bpm.MessageService;
 import org.mule.module.bpm.Rules;
+import org.mule.tck.junit4.AbstractMuleTestCase;
 
 
 import static org.hamcrest.CoreMatchers.is;
@@ -19,7 +20,8 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DroolsTestCase {
+public class DroolsTestCase extends AbstractMuleTestCase
+{
 
     private final Drools drools = new Drools();
     private final Rules rules = mock(Rules.class);

--- a/modules/drools/src/test/java/org.mule.module.drools/DroolsTestCase.java
+++ b/modules/drools/src/test/java/org.mule.module.drools/DroolsTestCase.java
@@ -8,10 +8,12 @@
 package org.mule.module.drools;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mule.module.bpm.MessageService;
 import org.mule.module.bpm.Rules;
 import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.junit4.rule.SystemProperty;
 
 
 import static org.hamcrest.CoreMatchers.is;
@@ -19,9 +21,12 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.module.drools.Drools.equalityAssertBehavior;
 
 public class DroolsTestCase extends AbstractMuleTestCase
 {
+    @Rule
+    public SystemProperty equalityAssertBehaviorSystemProperty = new SystemProperty(equalityAssertBehavior, "true");
 
     private final Drools drools = new Drools();
     private final Rules rules = mock(Rules.class);

--- a/modules/drools/src/test/java/org.mule.module.drools/DroolsTestCase.java
+++ b/modules/drools/src/test/java/org.mule.module.drools/DroolsTestCase.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.drools;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.module.bpm.MessageService;
+import org.mule.module.bpm.Rules;
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DroolsTestCase {
+
+    private final Drools drools = new Drools();
+    private final Rules rules = mock(Rules.class);
+    private final MessageService messageService = mock(MessageService.class, RETURNS_DEEP_STUBS);
+
+    @Before
+    public void setUp() throws Exception
+    {
+        when(rules.getResource()).thenReturn("rulesFile.drl");
+        drools.setMessageService(messageService);
+        DroolsSessionData sessionData = (DroolsSessionData) drools.createSession(rules);
+        when(rules.getSessionData()).thenReturn(sessionData);
+    }
+
+    @Test
+    public void testMemoryLeakCausedBySaveDuplicatedObjects() throws Exception
+    {
+        Object handle1 = drools.assertFact(rules, new TestFact("idTest", "descriptionTest"));
+        Object handle2 = drools.assertFact(rules, new TestFact("idTest", "descriptionTest"));
+        assertThat(handle1, is(handle2));
+    }
+
+    public class TestFact {
+        private final String id;
+        private String description;
+
+        public TestFact(String id, String description) {
+            this.id = id;
+            this.description = description;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            TestFact testFact = (TestFact) o;
+
+            if (id != null ? !id.equals(testFact.id) : testFact.id != null) return false;
+            return description != null ? description.equals(testFact.description) : testFact.description == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = id != null ? id.hashCode() : 0;
+            result = 31 * result + (description != null ? description.hashCode() : 0);
+            return result;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description)
+        {
+            this.description = description;
+        }
+    }
+}

--- a/modules/drools/src/test/resources/rulesFile.drl
+++ b/modules/drools/src/test/resources/rulesFile.drl
@@ -1,6 +1,6 @@
 
 package mule;
-import org.mule.module.drools.DroolsTestCase.TestFact;
+import org.mule.module.drools.DroolsAssertBehaviorTestCase.TestFact;
 global org.mule.module.bpm.MessageService mule;
 
 

--- a/modules/drools/src/test/resources/rulesFile.drl
+++ b/modules/drools/src/test/resources/rulesFile.drl
@@ -1,0 +1,14 @@
+
+package mule;
+import org.mule.module.drools.DroolsTestCase.TestFact;
+global org.mule.module.bpm.MessageService mule;
+
+
+rule "TestRule"
+    dialect "mvel"
+    when
+        t : TestFact( description == "test")
+    then
+        t.setDescription("Test rule passed.")
+end
+


### PR DESCRIPTION
…plicated facts be saved.

From Drools 3.0, Drools allows to customize how checks if an object already exists in the working memory.
By default AssertBehaviorOption is set to IDENTITY that ignores hashCode() and equals() method to compare objects.
This is causing that duplicated objects (facts) are saved in the working memory causing a memory leak.
We need to set this property, by default, to EQUALITY. In this way, equals() and hashCode() method will be invoked in the objects comparison.