### PR TITLE
MULE-12717: Add status parameter to mule.bat (#4960)

### DIFF
--- a/distributions/standalone/src/main/resources/bin/mule.bat
+++ b/distributions/standalone/src/main/resources/bin/mule.bat
@@ -128,7 +128,16 @@ goto :eof
 goto :eof
 
 :status
-"%_WRAPPER_EXE%" -q %_WRAPPER_CONF% %MULE_OPTS%
+if not defined JAVA_HOME (
+    echo Please, set the JAVA_HOME environment variable to run this command.
+    goto :eof
+)
+for /F "usebackq" %%i IN (`CALL "%JAVA_HOME%\bin\jps" ^| find "MuleContainerBootstrap"`) do (set PID=%%i)
+if defined PID (
+    echo %MULE_APP_LONG% is running (%PID%^).
+) else (
+    echo %MULE_APP_LONG% is not running.
+)
 goto :eof
 
 :pause


### PR DESCRIPTION
Using wrapper command to check the status of mule is not enough since it only checks the status of mule running as a service.