### PR TITLE
MULE-12755: Upgrade Drools to 5.2.1.Final (#5005)

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -252,7 +252,7 @@
 /mule-standalone-${productVersion}/lib/opt/knowledge-api-5.2.1.Final.jar
 /mule-standalone-${productVersion}/lib/opt/drools-compiler-5.2.1.Final.jar
 /mule-standalone-${productVersion}/lib/opt/drools-core-5.2.1.Final.jar
-/mule-standalone-${productVersion}/lib/opt/ecj-4.3.1.jar
+/mule-standalone-${productVersion}/lib/opt/ecj-3.5.1.jar
 /mule-standalone-${productVersion}/lib/opt/el-api-6.0.53.jar
 /mule-standalone-${productVersion}/lib/opt/geronimo-ejb_2.1_spec-1.1.jar
 /mule-standalone-${productVersion}/lib/opt/geronimo-j2ee-connector_1.5_spec-2.0.0.jar
@@ -353,7 +353,7 @@
 /mule-standalone-${productVersion}/lib/opt/mimepull-1.9.3.jar
 /mule-standalone-${productVersion}/lib/opt/msg-simple-1.1.jar
 /mule-standalone-${productVersion}/lib/opt/msv-core-2011.1.jar
-/mule-standalone-${productVersion}/lib/opt/mvel2-2.0.10.jar
+/mule-standalone-${productVersion}/lib/opt/mvel2-2.1.Beta6.jar
 /mule-standalone-${productVersion}/lib/opt/mx4j-impl-2.1.1.jar
 /mule-standalone-${productVersion}/lib/opt/mx4j-jmx-2.1.1.jar
 /mule-standalone-${productVersion}/lib/opt/mx4j-remote-2.1.1.jar

--- a/modules/drools/pom.xml
+++ b/modules/drools/pom.xml
@@ -39,6 +39,10 @@
                     <artifactId>antlr-runtime</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>antlr</groupId>
+                    <artifactId>antlr</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>janino</groupId>
                     <artifactId>janino</artifactId>
                 </exclusion>


### PR DESCRIPTION
Fixing assembly whitelist.