### PR TITLE
Revert "MULE-12828 The version of Xerces used in endorsed directory performs …"

### DIFF
--- a/distributions/standalone/src/main/resources/conf/wrapper.conf
+++ b/distributions/standalone/src/main/resources/conf/wrapper.conf
@@ -39,9 +39,6 @@ wrapper.java.additional.15=-Dorg.quartz.scheduler.skipUpdateCheck=true
 # For large maps (>512) make the hash function depend on the JVM instance to prevent collision attacks (see MULE-11206)
 wrapper.java.additional.16=-Djdk.map.althashing.threshold=512
 
-# Specify explicitly which XMLParserConfiguration implementation Xerces should use to avoid runtime service provider lookup (See MULE-12828)
-wrapper.java.additional.17=-Dorg.apache.xerces.xni.parser.XMLParserConfiguration=org.apache.xerces.parsers.XIncludeAwareParserConfiguration
-
 # Allows modifying Grizzly's memory manager. See https://javaee.github.io/grizzly/memory.html
 # wrapper.java.additional.<n>=-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager
 


### PR DESCRIPTION
In mule-3.x we aren't using external xerces anymore.