### PR TITLE
MULE-12832: Avoid generating stacktraces for exceptions when verbose is

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/api/exception/ExceptionHelperTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/exception/ExceptionHelperTestCase.java
@@ -28,6 +28,7 @@ import static org.mule.runtime.api.exception.ExceptionHelper.getNonMuleException
 import static org.mule.runtime.api.exception.ExceptionHelper.getRootException;
 import static org.mule.runtime.api.exception.ExceptionHelper.getRootMuleException;
 import static org.mule.runtime.api.exception.ExceptionHelper.summarise;
+import static org.mule.runtime.api.exception.MuleException.refreshVerboseExceptions;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.config.i18n.CoreMessages.failedToBuildMessage;
 
@@ -45,14 +46,36 @@ import org.apache.commons.collections.Closure;
 import org.apache.commons.collections.comparators.ComparableComparator;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
 @SmallTest
 public class ExceptionHelperTestCase extends AbstractMuleTestCase {
 
+  /**
+   * When running this tests alone, this ensures the environment is consistent with how the tests are run altogether.
+   */
+  @BeforeClass
+  public static void beforeClass() {
+    refreshVerboseExceptions();
+  }
+
   @Rule
-  public SystemProperty verbose = new SystemProperty("mule.verbose.exceptions", "true");
+  public SystemProperty verbose = new SystemProperty("mule.verbose.exceptions", "true") {
+
+    @Override
+    public void before() throws Throwable {
+      super.before();
+      refreshVerboseExceptions();
+    }
+
+    @Override
+    public void after() {
+      super.after();
+      refreshVerboseExceptions();
+    }
+  };
 
   @Test
   public void nestedExceptionRetrieval() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/util/PropertiesUtilsTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/util/PropertiesUtilsTestCase.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
 import org.mule.runtime.core.api.util.PropertiesUtils;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -107,10 +108,9 @@ public class PropertiesUtilsTestCase extends AbstractMuleTestCase {
   @Test
   public void testLoadAllProperties() {
     Properties properties =
-        PropertiesUtils.loadAllProperties("META-INF/org/mule/runtime/core/config/mule-exception-codes.properties",
+        PropertiesUtils.loadAllProperties("META-INF/org/mule/runtime/core/config/test.properties",
                                           this.getClass().getClassLoader());
     assertThat((String) properties.get("java.lang.IllegalArgumentException"), is("104000"));
-    assertThat((String) properties.get("org.mule.runtime.core.api.MuleException"), is("10000"));
   }
 
   @Test

--- a/core-tests/src/test/resources/META-INF/org/mule/runtime/core/config/test.properties
+++ b/core-tests/src/test/resources/META-INF/org/mule/runtime/core/config/test.properties
@@ -1,0 +1,1 @@
+java.lang.IllegalArgumentException=104000

--- a/core-tests/src/test/resources/META-INF/org/mule/runtime/core/config/test2-exception-mappings.properties
+++ b/core-tests/src/test/resources/META-INF/org/mule/runtime/core/config/test2-exception-mappings.properties
@@ -1,4 +1,0 @@
-#This file is dinamically changed by test. Do not reuse.
-error.code.property=status
-
-java.lang.RuntimeException=500


### PR DESCRIPTION
disabled
* Fix tests