### PR TITLE
MULE-12929: Mule Core Extensions aren't being stopped if RuntimeExcep…

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManager.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManager.java
@@ -106,7 +106,7 @@ public class DefaultMuleCoreExtensionManager implements MuleCoreExtensionManager
             {
                 extension.stop();
             }
-            catch (Exception e)
+            catch (Throwable e)
             {
                 logger.warn("Error stopping core extension: " + extension.getName(), e);
             }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManager.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManager.java
@@ -106,7 +106,7 @@ public class DefaultMuleCoreExtensionManager implements MuleCoreExtensionManager
             {
                 extension.stop();
             }
-            catch (MuleException e)
+            catch (Exception e)
             {
                 logger.warn("Error stopping core extension: " + extension.getName(), e);
             }

--- a/modules/launcher/src/test/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManagerTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManagerTestCase.java
@@ -216,12 +216,12 @@ public class DefaultMuleCoreExtensionManagerTestCase extends AbstractMuleTestCas
     public void testAllCoreExtensionsAreStoppedAfterRuntimeException() throws Exception
     {
         TestDeploymentServiceAwareExtension extensionFailsStops = mock(TestDeploymentServiceAwareExtension.class);
-        TestDeploymentServiceAwareExtension extension = mock(TestDeploymentServiceAwareExtension.class);
+        TestDeploymentServiceAwareExtension extensionStopsOk = mock(TestDeploymentServiceAwareExtension.class);
         List<MuleCoreExtension> extensions = new LinkedList<>();
         when(coreExtensionDiscoverer.discover()).thenReturn(extensions);
         when(coreExtensionDependencyResolver.resolveDependencies(extensions)).thenReturn(extensions);
         doThrow(RuntimeException.class).when(extensionFailsStops).stop();
-        extensions.add(extension);
+        extensions.add(extensionStopsOk);
         extensions.add(extensionFailsStops);
         coreExtensionManager.initialise();
         try
@@ -230,7 +230,9 @@ public class DefaultMuleCoreExtensionManagerTestCase extends AbstractMuleTestCas
         }
         finally
         {
-            verify(extension).stop();
+            InOrder stopsInOrder = inOrder(extensionFailsStops, extensionStopsOk);
+            stopsInOrder.verify(extensionFailsStops).stop();
+            stopsInOrder.verify(extensionStopsOk).stop();
         }
     }
 


### PR DESCRIPTION
…tions are triggered.

If a Runtime Exception is triggered in some extension.stop() execution (for instance NPE), Mule doesn't keep stopping the remaining extensions and not
finish the MuleContainer#stop() execution.
Among other consequences, this is causing shutdown time is not being honored.