### PR TITLE
MULE-12929: Mule Core Extensions aren't being stopped if RuntimeExcep…

### DIFF
--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/coreextension/DefaultMuleCoreExtensionManagerServer.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/coreextension/DefaultMuleCoreExtensionManagerServer.java
@@ -90,7 +90,7 @@ public class DefaultMuleCoreExtensionManagerServer implements MuleCoreExtensionM
 
       try {
         extension.stop();
-      } catch (MuleException e) {
+      } catch (Throwable e) {
         logger.warn("Error stopping core extension: " + extension.getName(), e);
       }
     }


### PR DESCRIPTION
…tions are triggered.

If a Runtime Exception is triggered in some extension.stop() execution (for instance NPE), Mule doesn't keep stopping the remaining extensions and not
finish the MuleContainer#stop() execution.# Please enter the commit message for your changes. Lines starting
Among other consequences, this is causing shutdown time is not being honored.