### PR TITLE
MULE-12919: Improve FTP Receiver Reconnection.

### DIFF
--- a/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
+++ b/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
@@ -37,6 +37,8 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
 
     private MuleContext muleContext;
 
+    private boolean lastRetryInterrupted = false;
+
     protected transient final Log logger = LogFactory.getLog(getClass());
 
     public void setMuleContext(MuleContext context)
@@ -63,6 +65,13 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
                     {
                         notifier.onSuccess(context);
                     }
+                    // Needed for Polling Connectors as FTP.
+                    if(lastRetryInterrupted)
+                    {
+                        logger.info("Successfully connected to " + context.getDescription() + " after Interrupted IOException");
+                        lastRetryInterrupted = false;
+                    }
+
                     break;
                 }
                 catch (Exception e)
@@ -79,6 +88,7 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
                     if (cause instanceof InterruptedException || cause instanceof InterruptedIOException)
                     {
                         logger.error("Process was interrupted (InterruptedException), ceasing process");
+                        lastRetryInterrupted = true;
                         break;
                     }
                     else

--- a/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
+++ b/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
@@ -37,7 +37,7 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
 
     private MuleContext muleContext;
 
-    private boolean lastRetryInterrupted = false;
+    private volatile boolean lastRetryInterrupted = false;
 
     protected transient final Log logger = LogFactory.getLog(getClass());
 
@@ -51,7 +51,7 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
         PolicyStatus status = null;
         RetryPolicy policy = createRetryInstance();
         DefaultRetryContext context = new DefaultRetryContext(callback.getWorkDescription(),
-            metaInfo);
+                                                              metaInfo);
         context.setMuleContext(muleContext);
         try
         {
@@ -65,8 +65,9 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
                     {
                         notifier.onSuccess(context);
                     }
+
                     // Needed for Polling Connectors as FTP.
-                    if(lastRetryInterrupted)
+                    if (lastRetryInterrupted)
                     {
                         logger.info("Successfully connected to " + context.getDescription() + " after Interrupted IOException");
                         lastRetryInterrupted = false;

--- a/transports/ftp/src/main/java/org/mule/transport/ftp/FtpMessageReceiver.java
+++ b/transports/ftp/src/main/java/org/mule/transport/ftp/FtpMessageReceiver.java
@@ -155,6 +155,7 @@ public class FtpMessageReceiver extends AbstractPollingMessageReceiver
             try
             {
                 retryTemplate.execute(callbackReconnection, this.connector.getMuleContext().getWorkManager());
+                return filesToFTPArray(client[0]);
             }
             catch (RetryPolicyExhaustedException retryPolicyExhaustedException)
             {
@@ -172,9 +173,6 @@ public class FtpMessageReceiver extends AbstractPollingMessageReceiver
         {
             throw new IllegalArgumentException(ASYNCHRONOUS_RECONNECTION_ERROR_MESSAGE);
         }
-
-
-        return filesToFTPArray(client[0]);
 
     }
 


### PR DESCRIPTION
In FTP Polling, Reconnection policy is applied in each poll. However, if a InterruptedIOException is triggered, Mule Logs shows the following message:
 "Process was interrupted (InterruptedException), ceasing process".

If in the next polling, Connection is successful, logs only shows it in debug mode.
This is causing confussion in some customers that after the failure message, think that the polling was cancelled.
Additionally, it is needed to call FTPMessageReceiver#filesToFTPArray(), only if the client creation was succesful to avoid NPE.