### PR TITLE
MULE-12942: MetadataContext returns a ConfigurationInstance instead o…

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/metadata/DefaultMetadataContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/metadata/DefaultMetadataContext.java
@@ -63,7 +63,7 @@ public class DefaultMetadataContext implements MetadataContext {
    */
   @Override
   public <C> Optional<C> getConfig() {
-    return (Optional<C>) configInstance.map(Optional::of);
+    return (Optional<C>) configInstance.map(ConfigurationInstance::getValue);
   }
 
   /**


### PR DESCRIPTION
…f the Configuration it self