### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/source/ClusterizableMessageSourceWrapperTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/source/ClusterizableMessageSourceWrapperTestCase.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source;
+package org.mule.runtime.core.internal.source;
 
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/source/StartableCompositeMessageSourceTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/source/StartableCompositeMessageSourceTestCase.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source;
+package org.mule.runtime.core.internal.source;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/source/polling/DefaultSchedulerMessageSourceTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/source/polling/DefaultSchedulerMessageSourceTestCase.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source.polling;
+package org.mule.runtime.core.internal.source.polling;
 
 import static java.util.Collections.singletonMap;
 import static org.mockito.Matchers.any;
@@ -18,8 +18,8 @@ import static org.mule.tck.MuleTestUtils.getTestFlow;
 import static org.slf4j.LoggerFactory.getLogger;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.scheduler.Scheduler;
-import org.mule.runtime.core.source.scheduler.DefaultSchedulerMessageSource;
-import org.mule.runtime.core.source.scheduler.schedule.FixedFrequencyScheduler;
+import org.mule.runtime.core.internal.source.scheduler.DefaultSchedulerMessageSource;
+import org.mule.runtime.core.api.source.polling.FixedFrequencyScheduler;
 import org.mule.tck.SensingNullMessageProcessor;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.probe.PollingProber;

--- a/core/src/main/java/org/mule/runtime/core/api/source/ClusterizableMessageSource.java
+++ b/core/src/main/java/org/mule/runtime/core/api/source/ClusterizableMessageSource.java
@@ -6,9 +6,15 @@
  */
 package org.mule.runtime.core.api.source;
 
+import org.mule.runtime.api.lifecycle.Lifecycle;
+
 /**
  * Defines a message source that runs in only one node of a cluster.
  */
-public interface ClusterizableMessageSource extends MessageSource {
+public interface ClusterizableMessageSource extends MessageSource, Lifecycle {
 
+  /**
+   * @return true is the source is started in the current cluster node, false otherwise.
+   */
+  boolean isStarted();
 }

--- a/core/src/main/java/org/mule/runtime/core/api/source/polling/CronScheduler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/source/polling/CronScheduler.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source.scheduler.schedule;
+package org.mule.runtime.core.api.source.polling;
 
 import static java.lang.String.format;
 import static java.util.TimeZone.getDefault;
@@ -14,7 +14,6 @@ import java.util.TimeZone;
 import java.util.concurrent.ScheduledFuture;
 
 import org.mule.runtime.api.scheduler.Scheduler;
-import org.mule.runtime.core.api.source.polling.PeriodicScheduler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/org/mule/runtime/core/api/source/polling/FixedFrequencyScheduler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/source/polling/FixedFrequencyScheduler.java
@@ -4,14 +4,12 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source.scheduler.schedule;
+package org.mule.runtime.core.api.source.polling;
 
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
-
 import org.mule.runtime.api.scheduler.Scheduler;
-import org.mule.runtime.core.api.source.polling.PeriodicScheduler;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;

--- a/core/src/main/java/org/mule/runtime/core/internal/construct/DefaultFlowBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/construct/DefaultFlowBuilder.java
@@ -42,7 +42,7 @@ import org.mule.runtime.core.interceptor.ProcessingTimeInterceptor;
 import org.mule.runtime.core.internal.construct.processor.FlowConstructStatisticsMessageProcessor;
 import org.mule.runtime.core.processor.strategy.TransactionAwareWorkQueueProcessingStrategyFactory;
 import org.mule.runtime.core.routing.requestreply.AsyncReplyToPropertyRequestReplyReplier;
-import org.mule.runtime.core.source.ClusterizableMessageSourceWrapper;
+import org.mule.runtime.core.internal.source.ClusterizableMessageSourceWrapper;
 
 import java.util.List;
 import java.util.Optional;

--- a/core/src/main/java/org/mule/runtime/core/internal/source/ClusterizableMessageSourceWrapper.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/source/ClusterizableMessageSourceWrapper.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source;
+package org.mule.runtime.core.internal.source;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.Disposable;
@@ -21,7 +21,6 @@ import org.mule.runtime.core.api.context.MuleContextAware;
 import org.mule.runtime.core.api.lifecycle.PrimaryNodeLifecycleNotificationListener;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.source.ClusterizableMessageSource;
-import org.mule.runtime.core.api.source.MessageSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * the node is primary or not inside a cluster. Non clustered nodes are always primary.
  */
 public class ClusterizableMessageSourceWrapper extends AbstractAnnotatedObject
-    implements MessageSource, Lifecycle, MuleContextAware, FlowConstructAware {
+    implements ClusterizableMessageSource, MuleContextAware, FlowConstructAware {
 
   protected static final Logger logger = LoggerFactory.getLogger(ClusterizableMessageSourceWrapper.class);
 

--- a/core/src/main/java/org/mule/runtime/core/internal/source/StartableCompositeMessageSource.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/source/StartableCompositeMessageSource.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source;
+package org.mule.runtime.core.internal.source;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.Disposable;

--- a/core/src/main/java/org/mule/runtime/core/internal/source/scheduler/DefaultSchedulerMessageSource.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/source/scheduler/DefaultSchedulerMessageSource.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.core.source.scheduler;
+package org.mule.runtime.core.internal.source.scheduler;
 
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.DefaultEventContext.create;

--- a/core/src/main/resources/META-INF/mule-module.properties
+++ b/core/src/main/resources/META-INF/mule-module.properties
@@ -105,9 +105,6 @@ artifact.export.classPackages=org.mule.runtime.core,\
                               org.mule.runtime.core.routing.requestreply,\
                               org.mule.runtime.core.security,\
                               org.mule.runtime.core.security.filters,\
-                              org.mule.runtime.core.source,\
-                              org.mule.runtime.core.source.scheduler,\
-                              org.mule.runtime.core.source.scheduler.schedule,\
                               org.mule.runtime.core.streaming,\
                               org.mule.runtime.core.streaming.bytes,\
                               org.mule.runtime.core.streaming.object,\

--- a/modules/extensions-support/src/main/resources/META-INF/mule-extension-model.json
+++ b/modules/extensions-support/src/main/resources/META-INF/mule-extension-model.json
@@ -22,11 +22,11 @@
       "subTypes": [
         {
           "format": "java",
-          "type": "@ref:org.mule.runtime.core.source.scheduler.schedule.FixedFrequencyScheduler"
+          "type": "@ref:org.mule.runtime.core.api.source.polling.FixedFrequencyScheduler"
         },
         {
           "format": "java",
-          "type": "@ref:org.mule.runtime.core.source.scheduler.schedule.CronScheduler"
+          "type": "@ref:org.mule.runtime.core.api.source.polling.CronScheduler"
         }
       ]
     }
@@ -2808,7 +2808,7 @@
         "format": "java",
         "type": "Object",
         "annotations": {
-          "typeId": "org.mule.runtime.core.source.scheduler.schedule.FixedFrequencyScheduler",
+          "typeId": "org.mule.runtime.core.api.source.polling.FixedFrequencyScheduler",
           "classInformation": {
             "hasDefaultConstructor": true,
             "isInterface": false,
@@ -2891,7 +2891,7 @@
       "format": "java",
       "type": "Object",
       "annotations": {
-        "typeId": "org.mule.runtime.core.source.scheduler.schedule.CronScheduler",
+        "typeId": "org.mule.runtime.core.api.source.polling.CronScheduler",
         "classInformation": {
           "hasDefaultConstructor": true,
           "isInterface": false,

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/CoreComponentBuildingDefinitionProvider.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/model/CoreComponentBuildingDefinitionProvider.java
@@ -59,7 +59,6 @@ import static org.mule.runtime.internal.dsl.DslConstants.POOLING_PROFILE_ELEMENT
 import static org.mule.runtime.internal.dsl.DslConstants.RECONNECT_ELEMENT_IDENTIFIER;
 import static org.mule.runtime.internal.dsl.DslConstants.RECONNECT_FOREVER_ELEMENT_IDENTIFIER;
 import static org.mule.runtime.internal.dsl.DslConstants.REDELIVERY_POLICY_ELEMENT_IDENTIFIER;
-
 import org.mule.runtime.api.config.PoolingProfile;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.util.DataUnit;
@@ -88,7 +87,7 @@ import org.mule.runtime.config.spring.factories.AsyncMessageProcessorsFactoryBea
 import org.mule.runtime.config.spring.factories.ChoiceRouterFactoryBean;
 import org.mule.runtime.config.spring.factories.DefaultFlowFactoryBean;
 import org.mule.runtime.config.spring.factories.FlowRefFactoryBean;
-import org.mule.runtime.config.spring.factories.MessageProcessorChainFactoryBean;
+import org.mule.runtime.config.spring.factories.processor.MessageProcessorChainFactoryBean;
 import org.mule.runtime.config.spring.factories.MessageProcessorFilterPairFactoryBean;
 import org.mule.runtime.config.spring.factories.ModuleOperationMessageProcessorChainFactoryBean;
 import org.mule.runtime.config.spring.factories.ResponseMessageProcessorsFactoryBean;
@@ -158,6 +157,10 @@ import org.mule.runtime.core.internal.exception.ErrorHandler;
 import org.mule.runtime.core.internal.exception.OnErrorContinueHandler;
 import org.mule.runtime.core.internal.exception.OnErrorPropagateHandler;
 import org.mule.runtime.core.internal.exception.RedeliveryExceeded;
+import org.mule.runtime.core.internal.source.StartableCompositeMessageSource;
+import org.mule.runtime.core.internal.source.scheduler.DefaultSchedulerMessageSource;
+import org.mule.runtime.core.api.source.polling.CronScheduler;
+import org.mule.runtime.core.api.source.polling.FixedFrequencyScheduler;
 import org.mule.runtime.core.internal.transformer.codec.XmlEntityDecoder;
 import org.mule.runtime.core.internal.transformer.codec.XmlEntityEncoder;
 import org.mule.runtime.core.internal.transformer.compression.GZipCompressTransformer;
@@ -212,10 +215,6 @@ import org.mule.runtime.core.routing.requestreply.SimpleAsyncRequestReplyRequest
 import org.mule.runtime.core.security.MuleSecurityManagerConfigurator;
 import org.mule.runtime.core.security.PasswordBasedEncryptionStrategy;
 import org.mule.runtime.core.security.SecretKeyEncryptionStrategy;
-import org.mule.runtime.core.source.StartableCompositeMessageSource;
-import org.mule.runtime.core.source.scheduler.DefaultSchedulerMessageSource;
-import org.mule.runtime.core.source.scheduler.schedule.CronScheduler;
-import org.mule.runtime.core.source.scheduler.schedule.FixedFrequencyScheduler;
 import org.mule.runtime.core.streaming.bytes.CursorStreamProviderFactory;
 import org.mule.runtime.core.streaming.object.CursorIteratorProviderFactory;
 import org.mule.runtime.core.transformer.AbstractTransformer;

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/spring/CommonBeanDefinitionCreator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/spring/CommonBeanDefinitionCreator.java
@@ -309,9 +309,13 @@ public class CommonBeanDefinitionCreator extends BeanDefinitionCreator {
         return originalBeanDefinition;
       }
       try {
-        beanClass = org.apache.commons.lang3.ClassUtils.getClass(originalBeanDefinition.getBeanClassName());
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException(e);
+        beanClass = originalBeanDefinition.getBeanClass();
+      } catch (IllegalStateException e) {
+        try {
+          beanClass = org.apache.commons.lang3.ClassUtils.getClass(originalBeanDefinition.getBeanClassName());
+        } catch (ClassNotFoundException e2) {
+          throw new RuntimeException(e2);
+        }
       }
     }
     BeanDefinition newBeanDefinition;

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/spring/ComponentModelHelper.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/dsl/spring/ComponentModelHelper.java
@@ -22,7 +22,7 @@ import org.mule.runtime.core.api.source.MessageSource;
 import org.mule.runtime.core.internal.exception.ErrorHandler;
 import org.mule.runtime.core.internal.exception.TemplateOnErrorHandler;
 import org.mule.runtime.core.routing.AbstractSelectiveRouter;
-import org.mule.runtime.core.source.scheduler.DefaultSchedulerMessageSource;
+import org.mule.runtime.core.internal.source.scheduler.DefaultSchedulerMessageSource;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/CompositeMessageSourceFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/CompositeMessageSourceFactoryBean.java
@@ -10,7 +10,7 @@ import static java.util.Collections.emptyList;
 
 import org.mule.runtime.core.api.source.CompositeMessageSource;
 import org.mule.runtime.core.api.source.MessageSource;
-import org.mule.runtime.core.source.StartableCompositeMessageSource;
+import org.mule.runtime.core.internal.source.StartableCompositeMessageSource;
 
 import java.util.List;
 

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/ModuleOperationMessageProcessorChainFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/ModuleOperationMessageProcessorChainFactoryBean.java
@@ -10,6 +10,7 @@ import static java.lang.String.format;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.operation.OperationModel;
 import org.mule.runtime.api.meta.model.util.IdempotentExtensionWalker;
+import org.mule.runtime.config.spring.factories.processor.MessageProcessorChainFactoryBean;
 import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.core.api.processor.MessageProcessorChainBuilder;
 import org.mule.runtime.core.processor.chain.ModuleOperationMessageProcessorChainBuilder;

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/SchedulingMessageSourceFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/SchedulingMessageSourceFactoryBean.java
@@ -9,8 +9,8 @@ package org.mule.runtime.config.spring.factories;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.context.MuleContextAware;
 import org.mule.runtime.core.api.source.polling.PeriodicScheduler;
-import org.mule.runtime.core.source.scheduler.DefaultSchedulerMessageSource;
-import org.mule.runtime.core.source.scheduler.schedule.FixedFrequencyScheduler;
+import org.mule.runtime.core.internal.source.scheduler.DefaultSchedulerMessageSource;
+import org.mule.runtime.core.api.source.polling.FixedFrequencyScheduler;
 import org.mule.runtime.dsl.api.component.AbstractAnnotatedObjectFactory;
 
 public class SchedulingMessageSourceFactoryBean extends AbstractAnnotatedObjectFactory<DefaultSchedulerMessageSource>

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/SubflowMessageProcessorChainFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/SubflowMessageProcessorChainFactoryBean.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.config.spring.factories;
 
+import org.mule.runtime.config.spring.factories.processor.MessageProcessorChainFactoryBean;
 import org.mule.runtime.core.api.processor.MessageProcessorChainBuilder;
 import org.mule.runtime.core.processor.chain.SubflowMessageProcessorChainBuilder;
 

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/processor/MessageProcessorChainFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/spring/factories/processor/MessageProcessorChainFactoryBean.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.config.spring.factories;
+package org.mule.runtime.config.spring.factories.processor;
 
 import org.mule.runtime.api.meta.AbstractAnnotatedObject;
 import org.mule.runtime.core.api.MuleContext;

--- a/modules/spring-config/src/main/resources/META-INF/mule-module.properties
+++ b/modules/spring-config/src/main/resources/META-INF/mule-module.properties
@@ -9,13 +9,13 @@ artifact.export.classPackages=org.mule.runtime.config.spring.artifact,\
                               org.mule.runtime.config.spring.dsl.processor.xml,\
                               org.mule.runtime.config.spring.dsl.spring,\
                               org.mule.runtime.config.spring.editors,\
-                              org.mule.runtime.config.spring.factories,\
                               org.mule.runtime.config.spring.jndi,\
                               org.mule.runtime.config.spring.parsers,\
                               org.mule.runtime.config.spring.parsers.generic,\
                               org.mule.runtime.config.spring.parsers.specific,\
                               org.mule.runtime.config.spring.processors,\
                               org.mule.runtime.config.spring.factories.streaming,\
+                              org.mule.runtime.config.spring.factories.processor,\
                               org.mule.runtime.config.spring.util,\
                               org.aopalliance.aop,\
                               org.aopalliance.intercept,\


### PR DESCRIPTION
_ Moving classes from org.mule.runtime.core.source.* to internal/api