### PR TITLE
MULE-12973: Add support for start parameter in http multipart/related…

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/HttpParser.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/HttpParser.java
@@ -280,6 +280,26 @@ public class HttpParser
     }
 
     /**
+     * Extracts a parameter value from a content type
+     *
+     * @param contentType the content type
+     * @param parameterName: the name of the parameter to extract.
+     * @return the value of the extracted parameter.
+     */
+    public static String getContentTypeParameter(String contentType, String parameterName)
+    {
+        try
+        {
+            ContentType contentTypeValue = new ContentType(contentType);
+            return contentTypeValue.getParameter(parameterName);
+        }
+        catch (ParseException e)
+        {
+            throw new MuleRuntimeException(e);
+        }
+    }
+
+    /**
      * Normalize a path that may contains spaces, %20 or +.
      *
      * @param path path with encoded spaces or raw spaces

--- a/modules/http/src/main/java/org/mule/module/http/internal/multipart/HttpMultipartEncoder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/multipart/HttpMultipartEncoder.java
@@ -6,8 +6,12 @@
  */
 package org.mule.module.http.internal.multipart;
 
+import static org.mule.config.i18n.MessageFactory.createStaticMessage;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_DISPOSITION;
+import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_ID;
 import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_TYPE;
+import static org.mule.module.http.internal.HttpParser.getContentTypeParameter;
+import org.mule.api.MuleRuntimeException;
 import org.mule.module.http.internal.HttpParser;
 import org.mule.module.http.internal.domain.MultipartHttpEntity;
 import org.mule.util.IOUtils;
@@ -29,10 +33,30 @@ public class HttpMultipartEncoder
 
     private static final String FORM_DATA = "form-data";
 
-    public static MimeMultipart createMultpartContent(MultipartHttpEntity body, String contentType)
+    private static final String RELATED = "related";
+
+    public static final String MANDATORY_TYPE_ERROR_MESSAGE = "Type parameter is not present in multipart/related content type, but it is mandatory.";
+
+    public static final String AMBIGUOUS_TYPE_ERROR_MESSAGE = "Type parameter and root body part content type must be the same.";
+
+
+    private HttpMultipartEncoder()
     {
+    }
+
+    public static MimeMultipart createContent(MultipartHttpEntity body, String contentType)
+    {
+
         String contentTypeSubType = HttpParser.getContentTypeSubType(contentType);
-        MimeMultipart mimeMultipartContent = new HttpMimeMultipart(contentType, contentTypeSubType);
+        MimeMultipart mimeMultipartContent ;
+
+        if (contentTypeSubType.equals(RELATED) && getContentTypeParameter(contentType, "type") == null)
+        {
+            throw new MuleRuntimeException(createStaticMessage(MANDATORY_TYPE_ERROR_MESSAGE));
+        }
+
+        mimeMultipartContent = new HttpMimeMultipart(contentType, contentTypeSubType);
+
         final Collection<HttpPart> parts = body.getParts();
 
         for (HttpPart part : parts)
@@ -50,6 +74,12 @@ public class HttpMultipartEncoder
             {
                 internetHeaders.addHeader(CONTENT_DISPOSITION, getContentDisposition(part));
             }
+
+            if (contentTypeSubType.equals(RELATED) && part.getName() != null)
+            {
+                internetHeaders.addHeader(CONTENT_ID, part.getName());
+            }
+
             if (internetHeaders.getHeader(CONTENT_TYPE) == null && part.getContentType() != null)
             {
                 internetHeaders.addHeader(CONTENT_TYPE, part.getContentType());
@@ -57,13 +87,32 @@ public class HttpMultipartEncoder
             try
             {
                 final byte[] partContent = IOUtils.toByteArray(part.getInputStream());
-                mimeMultipartContent.addBodyPart(new MimeBodyPart(internetHeaders, partContent));
+                String rootContentId = getContentTypeParameter(contentType, "start");
+
+                if (contentTypeSubType.equals(RELATED) && part.getName() != null && part.getName().equals(rootContentId))
+                {
+                    mimeMultipartContent.addBodyPart(new MimeBodyPart(internetHeaders, partContent), 0);
+                }
+                else
+                {
+                    mimeMultipartContent.addBodyPart(new MimeBodyPart(internetHeaders, partContent));
+                }
             }
             catch (Exception e)
             {
                 throw new RuntimeException(e);
             }
         }
+
+        try
+        {
+            verifyNoAmbiguousMultipartRelatedType(contentTypeSubType, contentType, mimeMultipartContent);
+        }
+        catch (MessagingException e)
+        {
+            throw new RuntimeException(e);
+        }
+
         return mimeMultipartContent;
     }
 
@@ -85,10 +134,22 @@ public class HttpMultipartEncoder
 
     public static byte[] createMultipartContent(MultipartHttpEntity multipartEntity, String contentType) throws IOException, MessagingException
     {
-        MimeMultipart mimeMultipartContent = HttpMultipartEncoder.createMultpartContent(multipartEntity, contentType);
+        MimeMultipart mimeMultipartContent = HttpMultipartEncoder.createContent(multipartEntity, contentType);
         final ByteArrayOutputStream byteArrayOutputStream;
         byteArrayOutputStream = new ByteArrayOutputStream();
         mimeMultipartContent.writeTo(byteArrayOutputStream);
         return byteArrayOutputStream.toByteArray();
+    }
+
+    private static void verifyNoAmbiguousMultipartRelatedType(String subContentType, String contentType, MimeMultipart mimeMultipartContent) throws MessagingException
+    {
+        if (subContentType.equals(RELATED) && mimeMultipartContent.getCount() > 0)
+        {
+            String rootBodyPartContentType = mimeMultipartContent.getBodyPart(0).getContentType();
+            if(rootBodyPartContentType != null && (!rootBodyPartContentType.equals(getContentTypeParameter(contentType, "type"))))
+            {
+                throw new MuleRuntimeException(createStaticMessage(AMBIGUOUS_TYPE_ERROR_MESSAGE));
+            }
+        }
     }
 }

--- a/modules/http/src/test/java/org/mule/module/http/internal/multipart/HttpMultipartEncoderTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/multipart/HttpMultipartEncoderTestCase.java
@@ -41,7 +41,6 @@ public class HttpMultipartEncoderTestCase extends AbstractMuleTestCase
 
     private static final String FORTH_PART_CONTENT = "{ \"test\" : \"forth-part-test\"}";
 
-
     private final List<HttpPart> httpParts = new ArrayList<>();
 
     private final MultipartHttpEntity multipartHttpEntity = mock(MultipartHttpEntity.class);
@@ -64,7 +63,7 @@ public class HttpMultipartEncoderTestCase extends AbstractMuleTestCase
     @Test
     public void createMultipartRelatedContentWithStartParameter() throws Exception
     {
-        MimeMultipart mimeMultipart = createContent(multipartHttpEntity, "multipart/related; type=\"text/plain\"; start=thirdPart");
+        MimeMultipart mimeMultipart = createContent(multipartHttpEntity, "multipart/related; boundary= \"MIMEBoundary\"; type=\"text/plain\"; start=thirdPart");
         verifyBodyPart(mimeMultipart.getBodyPart(0), THIRD_PART_CONTENT, "thirdPart");
         verifyBodyPart(mimeMultipart.getBodyPart(1), FIRST_PART_CONTENT, "firstPart");
         verifyBodyPart(mimeMultipart.getBodyPart(2), SECOND_PART_CONTENT, "secondPart");
@@ -74,7 +73,7 @@ public class HttpMultipartEncoderTestCase extends AbstractMuleTestCase
     @Test
     public void createMultipartRelatedContentWithoutStartParameter() throws Exception
     {
-        MimeMultipart mimeMultipart = createContent(multipartHttpEntity, "multipart/related; type=\"text/plain\"; boundary= \"MIMEBoundary\"");
+        MimeMultipart mimeMultipart = createContent(multipartHttpEntity, "multipart/related; boundary=\"MIMEBoundary\"; type=\"text/plain\";");
         verifyBodyPart(mimeMultipart.getBodyPart(0), FIRST_PART_CONTENT, "firstPart");
         verifyBodyPart(mimeMultipart.getBodyPart(1), SECOND_PART_CONTENT, "secondPart");
         verifyBodyPart(mimeMultipart.getBodyPart(2), THIRD_PART_CONTENT, "thirdPart");
@@ -86,9 +85,8 @@ public class HttpMultipartEncoderTestCase extends AbstractMuleTestCase
     {
         try
         {
-            createContent(multipartHttpEntity, "multipart/related");
+            createContent(multipartHttpEntity, "multipart/related; boundary=\"MIMEBoundary\"");
             fail("Exception caused by no present type should be triggered");
-
         }
         catch(Exception e)
         {
@@ -103,7 +101,7 @@ public class HttpMultipartEncoderTestCase extends AbstractMuleTestCase
         httpParts.add(forthPart);
         try
         {
-            createContent(multipartHttpEntity, "multipart/related; type=\"text/plain\"; start=forthPart");
+            createContent(multipartHttpEntity, "multipart/related; boundary=\"MIMEBoundary\"; type=\"text/plain\"; start=forthPart");
             fail("Exception caused by ambiguous type should be triggered");
         }
         catch(Exception e)

--- a/modules/http/src/test/java/org/mule/module/http/internal/multipart/HttpMultipartEncoderTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/multipart/HttpMultipartEncoderTestCase.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.http.internal.multipart;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.module.http.api.HttpHeaders.Names.CONTENT_ID;
+import static org.mule.module.http.internal.multipart.HttpMultipartEncoder.AMBIGUOUS_TYPE_ERROR_MESSAGE;
+import static org.mule.module.http.internal.multipart.HttpMultipartEncoder.MANDATORY_TYPE_ERROR_MESSAGE;
+import static org.mule.module.http.internal.multipart.HttpMultipartEncoder.createContent;
+
+import org.mule.module.http.internal.domain.MultipartHttpEntity;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.mail.BodyPart;
+import javax.mail.internet.MimeMultipart;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpMultipartEncoderTestCase extends AbstractMuleTestCase
+{
+
+    private static final String FIRST_PART_CONTENT = "first-part-test";
+
+    private static final String SECOND_PART_CONTENT = "second-part-test";
+
+    private static final String THIRD_PART_CONTENT = "third-part-test";
+
+    private static final String FORTH_PART_CONTENT = "{ \"test\" : \"forth-part-test\"}";
+
+
+    private final List<HttpPart> httpParts = new ArrayList<>();
+
+    private final MultipartHttpEntity multipartHttpEntity = mock(MultipartHttpEntity.class);
+
+    @Before
+    public void setUp() throws Exception
+    {
+        HttpPart firstPart = new HttpPart("firstPart", FIRST_PART_CONTENT.getBytes(), "text/plain", FIRST_PART_CONTENT.getBytes().length);
+        httpParts.add(firstPart);
+
+        HttpPart secondPart = new HttpPart("secondPart", SECOND_PART_CONTENT.getBytes(), "text/plain", SECOND_PART_CONTENT.getBytes().length);
+        httpParts.add(secondPart);
+
+        HttpPart thirdPart = new HttpPart("thirdPart", THIRD_PART_CONTENT.getBytes(), "text/plain", THIRD_PART_CONTENT.getBytes().length);
+        httpParts.add(thirdPart);
+
+        when(multipartHttpEntity.getParts()).thenReturn(httpParts);
+    }
+
+    @Test
+    public void createMultipartRelatedContentWithStartParameter() throws Exception
+    {
+        MimeMultipart mimeMultipart = createContent(multipartHttpEntity, "multipart/related; type=\"text/plain\"; start=thirdPart");
+        verifyBodyPart(mimeMultipart.getBodyPart(0), THIRD_PART_CONTENT, "thirdPart");
+        verifyBodyPart(mimeMultipart.getBodyPart(1), FIRST_PART_CONTENT, "firstPart");
+        verifyBodyPart(mimeMultipart.getBodyPart(2), SECOND_PART_CONTENT, "secondPart");
+        assertThat(mimeMultipart.getContentType(), containsString("type=\"text/plain\""));
+    }
+
+    @Test
+    public void createMultipartRelatedContentWithoutStartParameter() throws Exception
+    {
+        MimeMultipart mimeMultipart = createContent(multipartHttpEntity, "multipart/related; type=\"text/plain\"; boundary= \"MIMEBoundary\"");
+        verifyBodyPart(mimeMultipart.getBodyPart(0), FIRST_PART_CONTENT, "firstPart");
+        verifyBodyPart(mimeMultipart.getBodyPart(1), SECOND_PART_CONTENT, "secondPart");
+        verifyBodyPart(mimeMultipart.getBodyPart(2), THIRD_PART_CONTENT, "thirdPart");
+        assertThat(mimeMultipart.getContentType(), containsString("type=\"text/plain\""));
+    }
+
+    @Test
+    public void createMultipartRelatedContentWithoutMandatoryTypeParameter() throws Exception
+    {
+        try
+        {
+            createContent(multipartHttpEntity, "multipart/related");
+            fail("Exception caused by no present type should be triggered");
+
+        }
+        catch(Exception e)
+        {
+            assertThat(e.getMessage(), is(MANDATORY_TYPE_ERROR_MESSAGE));
+        }
+    }
+
+    @Test
+    public void createMultipartRelatedContentWithAmbiguousType() throws Exception
+    {
+        HttpPart forthPart = new HttpPart("forthPart", FORTH_PART_CONTENT.getBytes(), "application/json", FORTH_PART_CONTENT.getBytes().length);
+        httpParts.add(forthPart);
+        try
+        {
+            createContent(multipartHttpEntity, "multipart/related; type=\"text/plain\"; start=forthPart");
+            fail("Exception caused by ambiguous type should be triggered");
+        }
+        catch(Exception e)
+        {
+            assertThat(e.getMessage(), is(AMBIGUOUS_TYPE_ERROR_MESSAGE));
+        }
+    }
+
+    private void verifyBodyPart(BodyPart bodyPart, String content, String name) throws Exception
+    {
+        assertThat((String) bodyPart.getContent(), is(content));
+        assertThat(bodyPart.getHeader(CONTENT_ID)[0] , is(name));
+    }
+
+}


### PR DESCRIPTION
… response.

According to [this RFC article](https://tools.ietf.org/html/rfc2387), in multipart/related content type:

The start parameter, if given, is the content-ID of the compound object's "root".
If not present the "root" is the first body part in the Multipart/Related entity.

Additionally, we shoud also honor the following restrictions:
- Type parameter is mandatory in multipart/related.
- The value of the content-type parameter must be the same that the root body part's content-type.