### PR TITLE
MULE-11876: Provide a standard way to build a BindingContext from an

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/routing/IdempotentMessageValidatorMule6079TestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/routing/IdempotentMessageValidatorMule6079TestCase.java
@@ -12,12 +12,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.core.api.Event;
-import org.mule.runtime.core.api.EventContext;
-import org.mule.runtime.core.api.routing.ValidationException;
 import org.mule.runtime.api.store.ObjectAlreadyExistsException;
 import org.mule.runtime.api.store.ObjectStore;
 import org.mule.runtime.api.store.ObjectStoreException;
+import org.mule.runtime.core.api.Event;
+import org.mule.runtime.core.api.EventContext;
+import org.mule.runtime.core.api.routing.ValidationException;
 import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
@@ -67,7 +67,7 @@ public class IdempotentMessageValidatorMule6079TestCase extends AbstractMuleCont
     public void run() {
       Message okMessage = InternalMessage.builder().payload("OK").build();
       EventContext context = mock(EventContext.class);
-      when(context.getId()).thenReturn("1");
+      when(context.getCorrelationId()).thenReturn("1");
       Event event = Event.builder(context).message(okMessage).build();
 
       try {

--- a/core-tests/src/test/java/org/mule/runtime/core/routing/IdempotentMessageValidatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/routing/IdempotentMessageValidatorTestCase.java
@@ -37,7 +37,7 @@ public class IdempotentMessageValidatorTestCase extends AbstractMuleContextTestC
     idempotent.setObjectStore(new InMemoryObjectStore<String>());
 
     final EventContext contextA = mock(EventContext.class);
-    when(contextA.getId()).thenReturn("1");
+    when(contextA.getCorrelationId()).thenReturn("1");
 
     Message okMessage = InternalMessage.builder().payload("OK").build();
     Event event = Event.builder(contextA).message(okMessage).build();
@@ -47,7 +47,7 @@ public class IdempotentMessageValidatorTestCase extends AbstractMuleContextTestC
     assertThat(processedEvent, sameInstance(event));
 
     final EventContext contextB = mock(EventContext.class);
-    when(contextB.getId()).thenReturn("1");
+    when(contextB.getCorrelationId()).thenReturn("1");
 
     // This will not process, because the ID is a duplicate
     event = Event.builder(contextB).message(okMessage).build();

--- a/core/src/main/java/org/mule/runtime/core/el/BindingContextUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/el/BindingContextUtils.java
@@ -32,7 +32,6 @@ public class BindingContextUtils {
   public static final String DATA_TYPE = "dataType";
   public static final String ATTRIBUTES = "attributes";
   public static final String ERROR = "error";
-  public static final String ID = "id";
   public static final String CORRELATION_ID = "correlationId";
   public static final String VARIABLES = "variables";
   public static final String PROPERTIES = "properties";
@@ -78,7 +77,6 @@ public class BindingContextUtils {
                               new TypedValue<>(unmodifiableMap(event.getParameters()),
                                                fromType(event.getParameters().getClass())));
 
-    contextBuilder.addBinding(ID, new TypedValue<>(event.getContext().getId(), STRING));
     contextBuilder.addBinding(CORRELATION_ID, new TypedValue<>(event.getContext().getCorrelationId(), STRING));
 
     Message message = event.getMessage();

--- a/core/src/main/java/org/mule/runtime/core/routing/IdempotentMessageValidator.java
+++ b/core/src/main/java/org/mule/runtime/core/routing/IdempotentMessageValidator.java
@@ -15,6 +15,7 @@ import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_PREFIX;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.el.BindingContextUtils.CORRELATION_ID;
 import static org.mule.runtime.core.el.BindingContextUtils.NULL_BINDING_CONTEXT;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -58,8 +59,8 @@ public class IdempotentMessageValidator extends AbstractAnnotatedObject
   protected volatile ObjectStore<String> store;
   protected String storePrefix;
 
-  protected String idExpression = format("%sid%s", DEFAULT_EXPRESSION_PREFIX, DEFAULT_EXPRESSION_POSTFIX);
-  protected String valueExpression = format("%sid%s", DEFAULT_EXPRESSION_PREFIX, DEFAULT_EXPRESSION_POSTFIX);
+  protected String idExpression = format("%s%s%s", DEFAULT_EXPRESSION_PREFIX, CORRELATION_ID, DEFAULT_EXPRESSION_POSTFIX);
+  protected String valueExpression = format("%s%s%s", DEFAULT_EXPRESSION_PREFIX, CORRELATION_ID, DEFAULT_EXPRESSION_POSTFIX);
 
   @Override
   public void setMuleContext(MuleContext context) {


### PR DESCRIPTION
InterceptionEvent
* Remove `id` binding