### PR TITLE
MULE-12706: Source errors should not be available in on-error-continue

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/exception/ErrorTypeRepository.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/ErrorTypeRepository.java
@@ -77,8 +77,8 @@ public class ErrorTypeRepository {
 
   public ErrorTypeRepository() {
     this.errorTypes.put(ANY, ANY_ERROR_TYPE);
-    this.errorTypes.put(SOURCE, SOURCE_ERROR_TYPE);
     this.errorTypes.put(SOURCE_RESPONSE, SOURCE_RESPONSE_ERROR_TYPE);
+    this.internalErrorTypes.put(SOURCE, SOURCE_ERROR_TYPE);
     this.internalErrorTypes.put(CRITICAL, CRITICAL_ERROR_TYPE);
     this.internalErrorTypes.put(UNKNOWN, UNKNOWN_ERROR_TYPE);
   }

--- a/core/src/main/java/org/mule/runtime/core/api/exception/Errors.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/Errors.java
@@ -21,7 +21,11 @@ import static org.mule.runtime.core.api.exception.Errors.Identifiers.ROUTING_ERR
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.SECURITY_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.SERVER_SECURITY_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.SOURCE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.exception.Errors.Identifiers.SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.exception.Errors.Identifiers.SOURCE_ERROR_RESPONSE_SEND_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.SOURCE_RESPONSE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.exception.Errors.Identifiers.SOURCE_RESPONSE_GENERATE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.exception.Errors.Identifiers.SOURCE_RESPONSE_SEND_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.STREAM_MAXIMUM_SIZE_EXCEEDED_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.TRANSFORMATION_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.UNKNOWN_ERROR_IDENTIFIER;
@@ -97,6 +101,21 @@ public abstract class Errors {
     public static final String SERVER_SECURITY_ERROR_IDENTIFIER = "SERVER_SECURITY";
 
     /**
+     * Indicates that an error occurred in the source of the flow processing a successful response.
+     */
+    public static final String SOURCE_RESPONSE_ERROR_IDENTIFIER = "SOURCE_RESPONSE";
+
+    /**
+     * Indicates that an error occurred in the source of the flow sending a successful response.
+     */
+    public static final String SOURCE_RESPONSE_SEND_ERROR_IDENTIFIER = "SOURCE_RESPONSE_SEND";
+
+    /**
+     * Indicates that an error occurred in the source of the flow generating the parameters of a successful response.
+     */
+    public static final String SOURCE_RESPONSE_GENERATE_ERROR_IDENTIFIER = "SOURCE_RESPONSE_GENERATE";
+
+    /**
      * Wild card that matches with any error
      */
     public static final String ANY_IDENTIFIER = "ANY";
@@ -116,9 +135,14 @@ public abstract class Errors {
     public static final String SOURCE_ERROR_IDENTIFIER = "SOURCE";
 
     /**
-     * Indicates that an error occurred in the source of the flow processing a successful response.
+     * Indicates that an error occurred in the source of the flow sending an error response.
      */
-    public static final String SOURCE_RESPONSE_ERROR_IDENTIFIER = "SOURCE_RESPONSE";
+    public static final String SOURCE_ERROR_RESPONSE_SEND_ERROR_IDENTIFIER = "SOURCE_ERROR_RESPONSE_SEND";
+
+    /**
+     * Indicates that an error occurred in the source of the flow generating the parameters of an error response.
+     */
+    public static final String SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER = "SOURCE_ERROR_RESPONSE_GENERATE";
 
     /**
      * Indicates that a severe error occurred. Cannot be handled. Other unhandleable errors should go under it.
@@ -172,13 +196,13 @@ public abstract class Errors {
     public static final ComponentIdentifier SOURCE_RESPONSE =
         builder().withNamespace(CORE_NAMESPACE_NAME).withName(SOURCE_RESPONSE_ERROR_IDENTIFIER).build();
     public static final ComponentIdentifier SOURCE_RESPONSE_GENERATE =
-        builder().withNamespace(CORE_NAMESPACE_NAME).withName("SOURCE_RESPONSE_GENERATE").build();
+        builder().withNamespace(CORE_NAMESPACE_NAME).withName(SOURCE_RESPONSE_GENERATE_ERROR_IDENTIFIER).build();
     public static final ComponentIdentifier SOURCE_RESPONSE_SEND =
-        builder().withNamespace(CORE_NAMESPACE_NAME).withName("SOURCE_RESPONSE_SEND").build();
+        builder().withNamespace(CORE_NAMESPACE_NAME).withName(SOURCE_RESPONSE_SEND_ERROR_IDENTIFIER).build();
     public static final ComponentIdentifier SOURCE_ERROR_RESPONSE_GENERATE =
-        builder().withNamespace(CORE_NAMESPACE_NAME).withName("SOURCE_ERROR_RESPONSE_GENERATE").build();
+        builder().withNamespace(CORE_NAMESPACE_NAME).withName(SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER).build();
     public static final ComponentIdentifier SOURCE_ERROR_RESPONSE_SEND =
-        builder().withNamespace(CORE_NAMESPACE_NAME).withName("SOURCE_ERROR_RESPONSE_SEND").build();
+        builder().withNamespace(CORE_NAMESPACE_NAME).withName(SOURCE_ERROR_RESPONSE_SEND_ERROR_IDENTIFIER).build();
 
     public static final ComponentIdentifier STREAM_MAXIMUM_SIZE_EXCEEDED =
         builder().withNamespace(CORE_NAMESPACE_NAME).withName(STREAM_MAXIMUM_SIZE_EXCEEDED_ERROR_IDENTIFIER).build();

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorTypeRepositoryFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorTypeRepositoryFactory.java
@@ -61,8 +61,8 @@ public class ErrorTypeRepositoryFactory {
     final ErrorType sourceErrorType = errorTypeRepository.getSourceErrorType();
     errorTypeRepository.addErrorType(SOURCE_RESPONSE_GENERATE, errorTypeRepository.getSourceResponseErrorType());
     errorTypeRepository.addErrorType(SOURCE_RESPONSE_SEND, errorTypeRepository.getSourceResponseErrorType());
-    errorTypeRepository.addErrorType(SOURCE_ERROR_RESPONSE_GENERATE, sourceErrorType);
-    errorTypeRepository.addErrorType(SOURCE_ERROR_RESPONSE_SEND, sourceErrorType);
+    errorTypeRepository.addInternalErrorType(SOURCE_ERROR_RESPONSE_GENERATE, sourceErrorType);
+    errorTypeRepository.addInternalErrorType(SOURCE_ERROR_RESPONSE_SEND, sourceErrorType);
 
     return errorTypeRepository;
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/TemplateOnErrorHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/TemplateOnErrorHandler.java
@@ -55,10 +55,11 @@ public abstract class TemplateOnErrorHandler extends AbstractExceptionListener
   private MessageProcessorChain configuredMessageProcessors;
   private Processor replyToMessageProcessor = new ReplyToPropertyRequestReplyReplier();
 
-  private String errorType = null;
-  private ErrorTypeMatcher errorTypeMatcher = null;
   private String when;
   private boolean handleException;
+
+  protected String errorType = null;
+  protected ErrorTypeMatcher errorTypeMatcher = null;
 
   @Override
   final public Event handleException(MessagingException exception, Event event) {

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/source/HeisenbergMessageSourceTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/source/HeisenbergMessageSourceTestCase.java
@@ -6,9 +6,11 @@
  */
 package org.mule.test.module.extension.source;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.SOURCE_ERROR_RESPONSE_GENERATE;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.SOURCE_ERROR_RESPONSE_SEND;
 import static org.mule.tck.junit4.matcher.ErrorTypeMatcher.errorType;
@@ -20,7 +22,6 @@ import static org.mule.test.heisenberg.extension.HeisenbergSource.TerminateStatu
 import static org.mule.test.heisenberg.extension.HeisenbergSource.TerminateStatus.ERROR_INVOKE;
 import static org.mule.test.heisenberg.extension.HeisenbergSource.TerminateStatus.SUCCESS;
 import static org.mule.test.heisenberg.extension.exception.HeisenbergConnectionExceptionEnricher.ENRICHED_MESSAGE;
-
 import org.mule.runtime.api.message.Error;
 import org.mule.runtime.core.api.construct.Flow;
 import org.mule.test.heisenberg.extension.HeisenbergSource;
@@ -37,6 +38,8 @@ public class HeisenbergMessageSourceTestCase extends AbstractExtensionFunctional
 
   public static final int TIMEOUT_MILLIS = 50000;
   public static final int POLL_DELAY_MILLIS = 100;
+
+  private static final String OUT = "test://out";
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -117,6 +120,8 @@ public class HeisenbergMessageSourceTestCase extends AbstractExtensionFunctional
 
     assertThat(HeisenbergSource.terminateStatus, is(SUCCESS));
     assertThat(HeisenbergSource.error, empty());
+
+    assertThat(muleContext.getClient().request(OUT, RECEIVE_TIMEOUT).getRight().get(), hasPayload(equalTo("Expected.")));
   }
 
   @Test
@@ -128,6 +133,8 @@ public class HeisenbergMessageSourceTestCase extends AbstractExtensionFunctional
 
     assertThat(HeisenbergSource.terminateStatus, is(SUCCESS));
     assertThat(HeisenbergSource.error, empty());
+
+    assertThat(muleContext.getClient().request(OUT, RECEIVE_TIMEOUT).getRight().get(), hasPayload(equalTo("Expected.")));
   }
 
   @Test
@@ -161,7 +168,6 @@ public class HeisenbergMessageSourceTestCase extends AbstractExtensionFunctional
   public void failureInFlowCallsOnErrorDirectlyAndHandlesItCorrectly() throws Exception {
     startFlow("failureInFlowCallsOnErrorDirectly");
     probe(TIMEOUT_MILLIS, POLL_DELAY_MILLIS, () -> assertState(false, true, true));
-
   }
 
   @Test

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-source-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-source-config.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
       xmlns="http://www.mulesoft.org/schema/mule/core"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-               http://www.mulesoft.org/schema/mule/heisenberg http://www.mulesoft.org/schema/mule/heisenberg/current/mule-heisenberg.xsd">
+                          http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+                          http://www.mulesoft.org/schema/mule/heisenberg http://www.mulesoft.org/schema/mule/heisenberg/current/mule-heisenberg.xsd">
 
     <heisenberg:config name="heisenberg"
                        
@@ -91,6 +93,16 @@
         </heisenberg:listen-payments>
 
         <set-payload value="#[mel:java.lang.Long.valueOf('100')]"/>
+
+        <error-handler>
+            <on-error-propagate type="SOURCE_RESPONSE_GENERATE">
+                <set-payload value="Expected."/>
+                <test:queue name="out"/>
+            </on-error-propagate>
+            <on-error-propagate type="SOURCE, SOURCE_RESPONSE">
+                <test:queue name="out"/>
+            </on-error-propagate>
+        </error-handler>
     </flow>
 
     <flow name="sourceWithInvalidSuccessAndErrorParameters" initialState="stopped">
@@ -123,6 +135,7 @@
         </heisenberg:listen-payments>
 
         <set-payload value="#[hi ++]"/>
+
     </flow>
 
     <flow name="sourceFailsOnSuccessBodyCallsOnErrorAndOnTerminate" initialState="stopped">
@@ -139,6 +152,16 @@
         </heisenberg:listen-payments>
 
         <set-payload value="#[mel:java.lang.Long.valueOf('100')]"/>
+
+        <error-handler>
+            <on-error-propagate type="SOURCE_RESPONSE_SEND">
+                <set-payload value="Expected."/>
+                <test:queue name="out"/>
+            </on-error-propagate>
+            <on-error-propagate type="SOURCE_RESPONSE">
+                <test:queue name="out"/>
+            </on-error-propagate>
+        </error-handler>
     </flow>
 
     <flow name="failureInFlowCallsOnErrorDirectly" initialState="stopped">


### PR DESCRIPTION
 - Prevent using source error response types in all handlers
 - Prevent using and handling source response types in continue handler
 - Order errors
 - Add test cases