### PR TITLE
MULE-13068: Dispose through tooling client does not call onUndeployme…

### DIFF
--- a/distributions/embedded/embedded-impl/src/main/java/org/mule/runtime/module/embedded/impl/EmbeddedController.java
+++ b/distributions/embedded/embedded-impl/src/main/java/org/mule/runtime/module/embedded/impl/EmbeddedController.java
@@ -121,7 +121,7 @@ public class EmbeddedController {
             artifactResourcesRegistry.getApplicationDescriptorFactory().create(deploymentApplicationLocation);
         artifactResourcesRegistry.getDomainFactory().createArtifact(createDefaultDomainDir());
 
-        this.application = artifactResourcesRegistry.getApplicationFactory().createAppFrom(applicationDescriptor);
+        this.application = artifactResourcesRegistry.getApplicationFactory().createArtifact(applicationDescriptor);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
…ntSuccess causing a Memory leak on the Metaspace.