### PR TITLE
MULE-12183: AbstractAsyncRequestReplyRequester should not add correlation sequence to correlationID

### DIFF
--- a/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
+++ b/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
@@ -48,9 +48,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.buffer.BoundedFifoBuffer;
 
 public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterceptingMessageProcessorBase
-        implements RequestReplyRequesterMessageProcessor, FlowConstructAware, Initialisable, Startable, Stoppable, Disposable
+    implements RequestReplyRequesterMessageProcessor, FlowConstructAware, Initialisable, Startable, Stoppable, Disposable
 {
-
     public static final int MAX_PROCESSED_GROUPS = 50000;
     public static final int UNCLAIMED_TIME_TO_LIVE = 60000;
     public static int UNCLAIMED_INTERVAL = 60000;
@@ -98,7 +97,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
                     event.getSession().merge(resultEvent.getSession());
                 }
                 resultEvent = org.mule.RequestContext.setEvent(new DefaultMuleEvent(resultEvent.getMessage(),
-                                                                                    event));
+                    event));
             }
             return resultEvent;
         }
@@ -147,10 +146,10 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
     public void initialise() throws InitialisationException
     {
         name = String.format(NAME_TEMPLATE, storePrefix, ThreadNameHelper.getPrefix(muleContext),
-                             flowConstruct == null ? "" : flowConstruct.getName());
+            flowConstruct == null ? "" : flowConstruct.getName());
         store = ((ObjectStoreManager) muleContext.getRegistry().
-                get(MuleProperties.OBJECT_STORE_MANAGER)).
-                getObjectStore(name, false, MAX_PROCESSED_GROUPS, UNCLAIMED_TIME_TO_LIVE, UNCLAIMED_INTERVAL);
+            get(MuleProperties.OBJECT_STORE_MANAGER)).
+            getObjectStore(name, false, MAX_PROCESSED_GROUPS, UNCLAIMED_TIME_TO_LIVE, UNCLAIMED_INTERVAL);
     }
 
     @Override
@@ -177,7 +176,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
             try
             {
                 ((ObjectStoreManager) muleContext.getRegistry().
-                        get(MuleProperties.OBJECT_STORE_MANAGER)).disposeStore(store);
+                    get(MuleProperties.OBJECT_STORE_MANAGER)).disposeStore(store);
             }
             catch (ObjectStoreException e)
             {
@@ -286,12 +285,12 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
             if (failOnTimeout)
             {
                 event.getMuleContext()
-                        .fireNotification(
-                                new RoutingNotification(event.getMessage(), null,
-                                                        RoutingNotification.ASYNC_REPLY_TIMEOUT));
+                    .fireNotification(
+                        new RoutingNotification(event.getMessage(), null,
+                            RoutingNotification.ASYNC_REPLY_TIMEOUT));
 
                 throw new ResponseTimeoutException(CoreMessages.responseTimedOutWaitingForId((int) timeout,
-                                                                                             asyncReplyCorrelationId), event, null);
+                    asyncReplyCorrelationId), event, null);
             }
             else
             {
@@ -327,7 +326,6 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
 
     class InternalAsyncReplyMessageProcessor implements MessageProcessor
     {
-
         @Override
         public MuleEvent process(MuleEvent event) throws MuleException
         {
@@ -366,7 +364,6 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
 
     private class AsyncReplyMonitoringThread extends EventProcessingThread
     {
-
         AsyncReplyMonitoringThread(String name)
         {
             super(name, 100);

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/JMSRequestReplyInForEachTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/JMSRequestReplyInForEachTestCase.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.usecases.routing.response;
+
+public class JMSRequestReplyInForEachTestCase extends RequestReplyInForEachTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/usecases/routing/response/jms-request-reply-in-for-each.xml";
+    }
+
+}

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/RequestReplyInForEachTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/RequestReplyInForEachTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.usecases.routing.response;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import org.mule.DefaultMuleMessage;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.MuleClient;
+import org.mule.tck.junit4.FunctionalTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class RequestReplyInForEachTestCase extends FunctionalTestCase
+{
+
+    private final List<String> values = new ArrayList<>();
+
+    @Before
+    public void setUp() throws Exception
+    {
+        values.add("value1");
+        values.add("value2");
+        values.add("value3");
+    }
+
+    @Test
+    public void testRequestReplyWithForEach() throws Exception
+    {
+        MuleClient client = muleContext.getClient();
+        MuleMessage message = new DefaultMuleMessage(values, mock(Map.class) , muleContext);
+        client.dispatch("vm://foreach", message);
+        for(String value : values )
+        {
+            assertResult(client, value + "-processed", "test-foreach-reply");
+        }
+    }
+
+    @Test
+    public void testRequestReplyInSequenceCall() throws Exception
+    {
+        MuleClient client = muleContext.getClient();
+        MuleMessage message = new DefaultMuleMessage("test", mock(Map.class) , muleContext);
+        client.dispatch("vm://sequence-call", message);
+        assertResult(client, "first-call-processed", "test-sequence-reply");
+        assertResult(client, "second-call-processed", "test-sequence-reply");
+    }
+
+    private void assertResult(MuleClient client, String payload, String queueName) throws Exception
+    {
+        MuleMessage reply = client.request("vm://" + queueName, 1000);
+        assertThat(reply, is(notNullValue()));
+        assertThat(reply.getPayloadAsString(), is(payload));
+    }
+
+}

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/VMRequestReplyInForEachTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/VMRequestReplyInForEachTestCase.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.usecases.routing.response;
+
+public class VMRequestReplyInForEachTestCase extends RequestReplyInForEachTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml";
+    }
+
+}

--- a/tests/integration/src/test/resources/foreach-test.xml
+++ b/tests/integration/src/test/resources/foreach-test.xml
@@ -346,7 +346,7 @@
 
     <flow name="request-reply-meddle" processingStrategy="synchronous">
         <vm:inbound-endpoint path="middle" exchange-pattern="one-way"/>
-        <vm:outbound-endpoint path="in" exchange-pattern="one-way"/>
+        <echo-component/>
     </flow>
     
     <flow name="foreachWithAsync">

--- a/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/jms-request-reply-in-for-each.xml
+++ b/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/jms-request-reply-in-for-each.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns:test="http://www.mulesoft.org/schema/mule/test"
+        xmlns:jms="http://www.mulesoft.org/schema/mule/jms"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+        http://www.mulesoft.org/schema/mule/jms http://www.mulesoft.org/schema/mule/jms/current/mule-jms.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
+
+    <vm:connector name="default"/>
+    <jms:activemq-connector name="jms-connector" />
+
+
+    <flow name="forEachCaseFlow">
+        <vm:inbound-endpoint path="foreach" connector-ref="default"/>
+        <foreach collection="#[payload]" >
+            <request-reply storePrefix="foo">
+                <jms:outbound-endpoint queue="request" connector-ref="jms-connector"/>
+                <jms:inbound-endpoint queue="foreach-reply" connector-ref="jms-connector"/>
+            </request-reply>
+            <vm:outbound-endpoint path="test-foreach-reply" connector-ref="default"/>
+        </foreach>
+    </flow>
+
+    <flow name="sequenceCaseFlow">
+        <vm:inbound-endpoint path="sequence-call" connector-ref="default"/>
+        <set-payload value="first-call"/>
+        <flow-ref name="request-reply-flow"/>
+        <set-payload value="second-call"/>
+        <flow-ref name="request-reply-flow"/>
+    </flow>
+
+    <flow name="request-reply">
+        <jms:inbound-endpoint queue="request" connector-ref="jms-connector"/>
+        <test:component appendString="-processed"/>
+    </flow>
+
+    <flow name="request-reply-flow" processingStrategy="synchronous">
+        <request-reply>
+            <jms:outbound-endpoint queue="request" connector-ref="jms-connector"/>
+            <jms:inbound-endpoint queue="reply" connector-ref="jms-connector"/>
+        </request-reply>
+        <vm:outbound-endpoint path="test-sequence-reply" connector-ref="default"/>
+    </flow>
+
+</mule>

--- a/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml
+++ b/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml
@@ -32,7 +32,7 @@
         <flow-ref name="request-reply-flow"/>
     </flow>
 
-    <flow name="request-reply">
+    <flow name="request-reply" processingStrategy="synchronous">
         <vm:inbound-endpoint path="request" connector-ref="default"/>
         <test:component appendString="-processed"/>
     </flow>

--- a/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml
+++ b/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns:test="http://www.mulesoft.org/schema/mule/test"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
+
+    <vm:connector name="default"/>
+
+    <flow name="forEachCaseFlow">
+        <vm:inbound-endpoint path="foreach" connector-ref="default"/>
+        <foreach collection="#[payload]" >
+            <request-reply storePrefix="foo">
+                <vm:outbound-endpoint path="request" connector-ref="default"/>
+                <vm:inbound-endpoint path="foreach-reply" connector-ref="default"/>
+            </request-reply>
+            <vm:outbound-endpoint path="test-foreach-reply" connector-ref="default"/>
+        </foreach>
+    </flow>
+
+    <flow name="sequenceCaseFlow">
+        <vm:inbound-endpoint path="sequence-call" connector-ref="default"/>
+        <set-payload value="first-call"/>
+        <flow-ref name="request-reply-flow"/>
+        <set-payload value="second-call"/>
+        <flow-ref name="request-reply-flow"/>
+    </flow>
+
+    <flow name="request-reply">
+        <vm:inbound-endpoint path="request" connector-ref="default"/>
+        <test:component appendString="-processed"/>
+    </flow>
+
+    <flow name="request-reply-flow" processingStrategy="synchronous">
+        <request-reply>
+            <vm:outbound-endpoint path="request" connector-ref="default"/>
+            <vm:inbound-endpoint path="reply" connector-ref="default"/>
+        </request-reply>
+        <vm:outbound-endpoint path="test-sequence-reply" connector-ref="default"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
If request reply is inside a component that adds correlation sequence (e.g. for each), then the replied message cannot be recieved, because it is expecting the message without the correlation sequence added.