### PR TITLE
MULE-12183: AbstractAsyncRequestReplyRequester should not add correla…

### DIFF
--- a/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
+++ b/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
@@ -38,6 +38,7 @@ import org.mule.util.concurrent.ThreadNameHelper;
 import org.mule.util.store.DeserializationPostInitialisable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -56,14 +57,14 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
 
     public static final String NAME_TEMPLATE = "%s.%s.%s.asyncReplies";
     protected String name;
-    
+
     protected volatile long timeout = -1;
     protected volatile boolean failOnTimeout = true;
     protected MessageSource replyMessageSource;
     protected FlowConstruct flowConstruct;
     private final MessageProcessor internalAsyncReplyMessageProcessor = new InternalAsyncReplyMessageProcessor();
     private AsyncReplyMonitoringThread replyThread;
-    protected final Map<String, Latch> locks = new ConcurrentHashMap<String, Latch>();
+    protected final Map<String, RequestReplyLatch> locks = new ConcurrentHashMap<String, RequestReplyLatch>();
     private String storePrefix = "";
 
     protected final ConcurrentMap<String, MuleEvent> responseEvents = new ConcurrentHashMap<String, MuleEvent>();
@@ -82,8 +83,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
         }
         else
         {
-            locks.put(getAsyncReplyCorrelationId(event), createEventLock());
-
+            addLock(event);
             sendAsyncRequest(event);
 
             MuleEvent resultEvent = receiveAsyncReply(event);
@@ -110,6 +110,18 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
     protected Latch createEventLock()
     {
         return new Latch();
+    }
+
+    private void addLock(MuleEvent event)
+    {
+        String correlationId = getAsyncReplyCorrelationId(event);
+        locks.put(correlationId, new RequestReplyLatch(event.getMessage().getCorrelationGroupSize(), event.getMessage().getCorrelationSequence()));
+    }
+
+    private Latch getLatch(String correlationId)
+    {
+        RequestReplyLatch requestReplyLatch = locks.get(correlationId);
+        return requestReplyLatch.latch;
     }
 
     public void setTimeout(long timeout)
@@ -196,10 +208,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
         {
             correlationId = event.getFlowConstruct().getMessageInfoMapping().getCorrelationId(event.getMessage());
         }
-        if (event.getMessage().getCorrelationSequence() > 0)
-        {
-            correlationId += event.getMessage().getCorrelationSequence();
-        }
+
         return correlationId;
     }
 
@@ -211,7 +220,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
     protected MuleEvent receiveAsyncReply(MuleEvent event) throws MessagingException
     {
         String asyncReplyCorrelationId = getAsyncReplyCorrelationId(event);
-        Latch asyncReplyLatch = locks.get(asyncReplyCorrelationId);
+        Latch asyncReplyLatch = getLatch(asyncReplyCorrelationId);
         // flag for catching the interrupted status of the Thread waiting for a
         // result
         boolean interruptedWhileWaiting = false;
@@ -271,7 +280,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
         }
         else
         {
-            addProcessed(asyncReplyCorrelationId);
+            addProcessed(new ProcessedEvents(asyncReplyCorrelationId, EndReason.FINISHED_BY_TIMEOUT));
 
             if (failOnTimeout)
             {
@@ -321,7 +330,20 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
         public MuleEvent process(MuleEvent event) throws MuleException
         {
             String messageId = getAsyncReplyCorrelationId(event);
-            store.store(messageId, event);
+            RequestReplyLatch requestReplyLatch = locks.get(messageId);
+
+            if (requestReplyLatch != null && requestReplyLatch.isSequenceEvent() && store.contains(messageId))
+            {
+                MultipleEvent multipleEvent = (MultipleEvent) store.retrieve(messageId);
+                multipleEvent.addEvent(event);
+            }
+            else
+            {
+                MultipleEvent multipleEvent = new MultipleEvent();
+                multipleEvent.addEvent(event);
+                store.store(messageId, multipleEvent);
+            }
+
             replyThread.processNow();
             return null;
         }
@@ -359,16 +381,20 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
                     {
                         boolean deleteEvent = false;
                         String correlationId = (String) id;
+                        MultipleEvent multipleEvent = (MultipleEvent) store.retrieve(correlationId);
 
-                        if (isAlreadyProcessed(correlationId))
+                        if (isAlreadyProcessed(new ProcessedEvents(correlationId, EndReason.FINISHED_BY_TIMEOUT)))
                         {
                             deleteEvent = true;
-                            MuleEvent event = (MuleEvent) store.retrieve(correlationId);
+                            MuleEvent event;
+
+                            event = multipleEvent.getEvent();
+
                             if (logger.isDebugEnabled())
                             {
                                 logger.debug("An event was received for an event group that has already been processed, "
-                                    + "this is probably because the async-reply timed out. Correlation Id is: "
-                                    + correlationId + ". Dropping event");
+                                             + "this is because the async-reply timed out. Correlation Id is: "
+                                             + correlationId + ". Dropping event");
                             }
                             // Fire a notification to say we received this message
                             event.getMuleContext().fireNotification(
@@ -377,11 +403,10 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
                         }
                         else
                         {
-                            Latch l = locks.get(correlationId);
-                            if (l != null)
+                            RequestReplyLatch requestReplyLatch = locks.get(correlationId);
+                            if (requestReplyLatch != null)
                             {
                                 MuleEvent event = retrieveEvent(correlationId);
-
                                 MuleEvent previousResult = responseEvents.putIfAbsent(correlationId, event);
                                 if (previousResult != null)
                                 {
@@ -390,9 +415,22 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
                                     // processed. Can this actually happen?
                                     throw new IllegalStateException("Detected duplicate result message with id: " + correlationId);
                                 }
-                                addProcessed(correlationId);
-                                deleteEvent = true;
-                                l.countDown();
+                                if (requestReplyLatch.isSequenceEvent())
+                                {
+                                    if (requestReplyLatch.isLastEvent())
+                                    {
+                                        addProcessed(new ProcessedEvents(correlationId));
+                                        deleteEvent = true;
+                                    }
+                                }
+                                else
+                                {
+                                    addProcessed(new ProcessedEvents(correlationId));
+                                    deleteEvent = true;
+                                }
+
+                                requestReplyLatch.countDown();
+                                multipleEvent.removeEvent();
                             }
                         }
                         if (deleteEvent)
@@ -414,8 +452,8 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
 
         private MuleEvent retrieveEvent(String correlationId) throws ObjectStoreException, DefaultMuleException
         {
-            MuleEvent event = (MuleEvent) store.retrieve(correlationId);
-
+            MultipleEvent multipleEvent = (MultipleEvent) store.retrieve(correlationId);
+            MuleEvent event = multipleEvent.getEvent();
             if (event.getMuleContext() == null)
             {
                 try
@@ -427,8 +465,110 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
                     throw new DefaultMuleException(e);
                 }
             }
-
             return event;
         }
+    }
+
+    private class RequestReplyLatch
+    {
+
+        private final int groupSize;
+        private final int correlationSequence;
+        private final Latch latch = createEventLock();
+
+        private RequestReplyLatch(int groupSize, int correlationSequence)
+        {
+            this.groupSize = groupSize;
+            this.correlationSequence = correlationSequence;
+        }
+
+        private boolean isSequenceEvent()
+        {
+            return groupSize != -1;
+        }
+
+        private void countDown()
+        {
+            latch.countDown();
+        }
+
+        private boolean isLastEvent()
+        {
+            return groupSize == correlationSequence;
+        }
+    }
+
+    private class MultipleEvent implements Serializable
+    {
+
+        private final List<MuleEvent> muleEvents = new ArrayList<>();
+
+        private synchronized void addEvent(MuleEvent event)
+        {
+            muleEvents.add(event);
+        }
+
+        private synchronized void removeEvent()
+        {
+            muleEvents.remove(0);
+        }
+
+        private synchronized MuleEvent getEvent()
+        {
+            return muleEvents.get(0);
+        }
+    }
+
+    private class ProcessedEvents
+    {
+        private String id;
+        private EndReason endReason;
+
+        public ProcessedEvents(String id, EndReason endReason)
+        {
+            this.id = id;
+            this.endReason = endReason;
+        }
+
+        public ProcessedEvents(String id)
+        {
+            this.id = id;
+            this.endReason = EndReason.PROCESSED;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+
+            ProcessedEvents that = (ProcessedEvents) o;
+
+            if (!id.equals(that.id))
+            {
+                return false;
+            }
+            return endReason == that.endReason;
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = id.hashCode();
+            result = 31 * result + endReason.hashCode();
+            return result;
+        }
+    }
+
+    private enum EndReason
+    {
+        PROCESSED, FINISHED_BY_TIMEOUT
     }
 }

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/JMSRequestReplyInForEachTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/JMSRequestReplyInForEachTestCase.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.usecases.routing.response;
+
+public class JMSRequestReplyInForEachTestCase extends RequestReplyInForEachTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/usecases/routing/response/jms-request-reply-in-for-each.xml";
+    }
+
+}

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/RequestReplyInForEachTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/RequestReplyInForEachTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.usecases.routing.response;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import org.mule.DefaultMuleMessage;
+import org.mule.api.MuleMessage;
+import org.mule.api.client.MuleClient;
+import org.mule.tck.junit4.FunctionalTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class RequestReplyInForEachTestCase extends FunctionalTestCase
+{
+
+    private final List<String> values = new ArrayList<>();
+
+    @Before
+    public void setUp() throws Exception
+    {
+        values.add("value1");
+        values.add("value2");
+        values.add("value3");
+    }
+
+    @Test
+    public void testRequestReplyWithForEach() throws Exception
+    {
+        MuleClient client = muleContext.getClient();
+        MuleMessage message = new DefaultMuleMessage(values, mock(Map.class) , muleContext);
+        client.dispatch("vm://foreach", message);
+        for(String value : values )
+        {
+            assertResult(client, value + "-processed", "test-foreach-reply");
+        }
+    }
+
+    @Test
+    public void testRequestReplyInSequenceCall() throws Exception
+    {
+        MuleClient client = muleContext.getClient();
+        MuleMessage message = new DefaultMuleMessage("test", mock(Map.class) , muleContext);
+        client.dispatch("vm://sequence-call", message);
+        assertResult(client, "first-call-processed", "test-sequence-reply");
+        assertResult(client, "second-call-processed", "test-sequence-reply");
+    }
+
+    private void assertResult(MuleClient client, String payload, String queueName) throws Exception
+    {
+        MuleMessage reply = client.request("vm://" + queueName, 1000);
+        assertThat(reply, is(notNullValue()));
+        assertThat(reply.getPayloadAsString(), is(payload));
+    }
+
+}

--- a/tests/integration/src/test/java/org/mule/test/usecases/routing/response/VMRequestReplyInForEachTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/usecases/routing/response/VMRequestReplyInForEachTestCase.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.usecases.routing.response;
+
+public class VMRequestReplyInForEachTestCase extends RequestReplyInForEachTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml";
+    }
+
+}

--- a/tests/integration/src/test/resources/foreach-test.xml
+++ b/tests/integration/src/test/resources/foreach-test.xml
@@ -346,7 +346,7 @@
 
     <flow name="request-reply-meddle" processingStrategy="synchronous">
         <vm:inbound-endpoint path="middle" exchange-pattern="one-way"/>
-        <vm:outbound-endpoint path="in" exchange-pattern="one-way"/>
+        <echo-component/>
     </flow>
     
     <flow name="foreachWithAsync">

--- a/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/jms-request-reply-in-for-each.xml
+++ b/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/jms-request-reply-in-for-each.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns:test="http://www.mulesoft.org/schema/mule/test"
+        xmlns:jms="http://www.mulesoft.org/schema/mule/jms"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+        http://www.mulesoft.org/schema/mule/jms http://www.mulesoft.org/schema/mule/jms/current/mule-jms.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
+
+    <vm:connector name="default"/>
+    <jms:activemq-connector name="jms-connector" />
+
+
+    <flow name="forEachCaseFlow">
+        <vm:inbound-endpoint path="foreach" connector-ref="default"/>
+        <foreach collection="#[payload]" >
+            <request-reply storePrefix="foo">
+                <jms:outbound-endpoint queue="request" connector-ref="jms-connector"/>
+                <jms:inbound-endpoint queue="foreach-reply" connector-ref="jms-connector"/>
+            </request-reply>
+            <vm:outbound-endpoint path="test-foreach-reply" connector-ref="default"/>
+        </foreach>
+    </flow>
+
+    <flow name="sequenceCaseFlow">
+        <vm:inbound-endpoint path="sequence-call" connector-ref="default"/>
+        <set-payload value="first-call"/>
+        <flow-ref name="request-reply-flow"/>
+        <set-payload value="second-call"/>
+        <flow-ref name="request-reply-flow"/>
+    </flow>
+
+    <flow name="request-reply">
+        <jms:inbound-endpoint queue="request" connector-ref="jms-connector"/>
+        <test:component appendString="-processed"/>
+    </flow>
+
+    <flow name="request-reply-flow" processingStrategy="synchronous">
+        <request-reply>
+            <jms:outbound-endpoint queue="request" connector-ref="jms-connector"/>
+            <jms:inbound-endpoint queue="reply" connector-ref="jms-connector"/>
+        </request-reply>
+        <vm:outbound-endpoint path="test-sequence-reply" connector-ref="default"/>
+    </flow>
+
+</mule>

--- a/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml
+++ b/tests/integration/src/test/resources/org/mule/test/usecases/routing/response/vm-request-reply-in-for-each.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+        xmlns:http="http://www.mulesoft.org/schema/mule/http"
+        xmlns:test="http://www.mulesoft.org/schema/mule/test"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+        http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
+
+    <vm:connector name="default"/>
+
+    <flow name="forEachCaseFlow">
+        <vm:inbound-endpoint path="foreach" connector-ref="default"/>
+        <foreach collection="#[payload]" >
+            <request-reply storePrefix="foo">
+                <vm:outbound-endpoint path="request" connector-ref="default"/>
+                <vm:inbound-endpoint path="foreach-reply" connector-ref="default"/>
+            </request-reply>
+            <vm:outbound-endpoint path="test-foreach-reply" connector-ref="default"/>
+        </foreach>
+    </flow>
+
+    <flow name="sequenceCaseFlow">
+        <vm:inbound-endpoint path="sequence-call" connector-ref="default"/>
+        <set-payload value="first-call"/>
+        <flow-ref name="request-reply-flow"/>
+        <set-payload value="second-call"/>
+        <flow-ref name="request-reply-flow"/>
+    </flow>
+
+    <flow name="request-reply" processingStrategy="synchronous">
+        <vm:inbound-endpoint path="request" connector-ref="default"/>
+        <test:component appendString="-processed"/>
+    </flow>
+
+    <flow name="request-reply-flow" processingStrategy="synchronous">
+        <request-reply>
+            <vm:outbound-endpoint path="request" connector-ref="default"/>
+            <vm:inbound-endpoint path="reply" connector-ref="default"/>
+        </request-reply>
+        <vm:outbound-endpoint path="test-sequence-reply" connector-ref="default"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
…tion sequence to correlationID.

If request reply is inside a component that adds correlation sequence (e.g. for each), then the replied message cannot be recieved, because it is
expecting the message without the correlation sequence added.