### PR TITLE
MULE-13127: Implement support for multi-valued "requiredAuthorities" …

### DIFF
--- a/modules/spring-security/src/main/java/org/mule/module/spring/security/AuthorizationFilter.java
+++ b/modules/spring-security/src/main/java/org/mule/module/spring/security/AuthorizationFilter.java
@@ -23,10 +23,11 @@ import org.mule.security.AbstractSecurityFilter;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.mule.util.StringUtils;
 import org.springframework.security.core.GrantedAuthority;
 
 /**
@@ -35,7 +36,7 @@ import org.springframework.security.core.GrantedAuthority;
 public class AuthorizationFilter extends AbstractSecurityFilter
 {
     protected final Log logger = LogFactory.getLog(getClass());
-    private Collection<String> requiredAuthorities = new HashSet<String>();
+    private Collection<String> requiredAuthorities = new LinkedHashSet<String>();
 
     public void doFilter(MuleEvent event)
         throws SecurityException, UnknownAuthenticationTypeException, CryptoFailureException,
@@ -73,6 +74,7 @@ public class AuthorizationFilter extends AbstractSecurityFilter
                 if (requiredAuthorities.contains(authority.getAuthority()))
                 {
                     authorized = true;
+                    break; // no need to proceed with loop any longer
                 }
             }
         }
@@ -85,13 +87,16 @@ public class AuthorizationFilter extends AbstractSecurityFilter
         }
     }
 
-    public Collection<String> getRequiredAuthorities()
+    public String getRequiredAuthorities()
     {
-        return requiredAuthorities;
+        return StringUtils.join(this.requiredAuthorities, ", ");
     }
 
-    public void setRequiredAuthorities(Collection<String> requiredAuthorities)
+    public void setRequiredAuthorities(String requiredAuthorities)
     {
-        this.requiredAuthorities = requiredAuthorities;
+        if (requiredAuthorities != null)
+        {
+            this.requiredAuthorities = new LinkedHashSet<>(Arrays.asList(StringUtils.splitAndTrim(requiredAuthorities, ",")));
+        }
     }
 }

--- a/modules/spring-security/src/test/java/org/mule/module/spring/security/AuthorizationFilterTestCase.java
+++ b/modules/spring-security/src/test/java/org/mule/module/spring/security/AuthorizationFilterTestCase.java
@@ -79,6 +79,30 @@ public class AuthorizationFilterTestCase extends FunctionalTestCase
         doRequest(null, "localhost", "ross", "ross", getUrl(), false, 200);
     }
 
+    @Test
+    public void testAuthorizedAny() throws Exception
+    {
+        doRequest("mule-realm", "localhost", "max", "max", getUrl() + "any", false, 200);
+    }
+
+    @Test
+    public void testNotAuthorizedAny() throws Exception
+    {
+        doRequest("mule-realm", "localhost", "anon", "anon", getUrl() + "any", false, 403);
+    }
+
+    @Test
+    public void testAuthorizedAll() throws Exception
+    {
+        doRequest("mule-realm", "localhost", "ubermax", "ubermax", getUrl() + "all", false, 200);
+    }
+
+    @Test
+    public void testNotAuthorizedAll() throws Exception
+    {
+        doRequest("mule-realm", "localhost", "max", "max", getUrl() + "all", false, 403);
+    }
+
     protected String getUrl()
     {
         return "http://localhost:" + port1.getNumber() + "/authorize";

--- a/modules/spring-security/src/test/java/org/mule/module/spring/security/HttpFilterFunctionalTestCase.java
+++ b/modules/spring-security/src/test/java/org/mule/module/spring/security/HttpFilterFunctionalTestCase.java
@@ -8,7 +8,6 @@ package org.mule.module.spring.security;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.mule.tck.AbstractServiceAndFlowTestCase;
 import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.transport.http.HttpConstants;
@@ -87,7 +86,7 @@ public class HttpFilterFunctionalTestCase extends FunctionalTestCase
         doRequest(null, "localhost", "anonX", "anonX", getUrl(), false, 401);
     }
 
-    @Ignore // TODO Realm validataion seems to be completely ignored
+    @Ignore // TODO Realm validation seems to be completely ignored
     @Test
     public void testAuthenticationFailureBadRealm() throws Exception
     {
@@ -106,7 +105,7 @@ public class HttpFilterFunctionalTestCase extends FunctionalTestCase
         doRequest(null, "localhost", "anon", "anon", getUrl(), true, 200);
     }
 
-    @Ignore // TODO Realm validataion seems to be completely ignored
+    @Ignore // TODO Realm validation seems to be completely ignored
     @Test
     public void testAuthenticationAuthorisedWithHandshakeAndBadRealm() throws Exception
     {

--- a/modules/spring-security/src/test/resources/http-module-filter-test.xml
+++ b/modules/spring-security/src/test/resources/http-module-filter-test.xml
@@ -18,6 +18,8 @@
                 <ss:user-service id="userService">
                     <ss:user name="ross" password="ross" authorities="ROLE_ADMIN" />
                     <ss:user name="anon" password="anon" authorities="ROLE_ANONYMOUS" />
+                    <ss:user name="max" password="max" authorities="ROLE_CONTRIBUTOR" />
+                    <ss:user name="ubermax" password="ubermax" authorities="ROLE_ADMIN,ROLE_CONTRIBUTOR" />
                 </ss:user-service>
             </ss:authentication-provider>
         </ss:authentication-manager>
@@ -40,5 +42,20 @@
         <http:basic-security-filter realm="mule-realm"/>
         <mule-ss:authorization-filter requiredAuthorities="ROLE_ADMIN"/>
         <component class="org.mule.component.simple.EchoComponent"/>
+    </flow>
+
+    <flow name="authorizeAny">
+        <http:listener config-ref="listenerConfig" path="authorizeany"/>
+        <http:basic-security-filter realm="mule-realm"/>
+        <mule-ss:authorization-filter requiredAuthorities="ROLE_ADMIN, ROLE_CONTRIBUTOR"/>
+        <logger/>
+    </flow>
+
+    <flow name="authorizeAll">
+        <http:listener config-ref="listenerConfig" path="authorizeall"/>
+        <http:basic-security-filter realm="mule-realm"/>
+        <mule-ss:authorization-filter requiredAuthorities="ROLE_CONTRIBUTOR"/>
+        <mule-ss:authorization-filter requiredAuthorities="ROLE_ADMIN"/>
+        <logger/>
     </flow>
 </mule>

--- a/modules/spring-security/src/test/resources/http-transport-filter-test.xml
+++ b/modules/spring-security/src/test/resources/http-transport-filter-test.xml
@@ -18,6 +18,8 @@
                 <ss:user-service id="userService">
                     <ss:user name="ross" password="ross" authorities="ROLE_ADMIN" />
                     <ss:user name="anon" password="anon" authorities="ROLE_ANONYMOUS" />
+                    <ss:user name="max" password="max" authorities="ROLE_CONTRIBUTOR" />
+                    <ss:user name="ubermax" password="ubermax" authorities="ROLE_ADMIN,ROLE_CONTRIBUTOR" />
                 </ss:user-service>
             </ss:authentication-provider>
         </ss:authentication-manager>
@@ -38,5 +40,20 @@
         <http:basic-security-filter realm="mule-realm"/>
         <mule-ss:authorization-filter requiredAuthorities="ROLE_ADMIN"/>
         <component class="org.mule.component.simple.EchoComponent"/>
+    </flow>
+
+    <flow name="authorizeAny">
+        <inbound-endpoint address="http://localhost:${port1}/authorizeany" exchange-pattern="request-response"/>
+        <http:basic-security-filter realm="mule-realm"/>
+        <mule-ss:authorization-filter requiredAuthorities="ROLE_ADMIN, ROLE_CONTRIBUTOR"/>
+        <logger/>
+    </flow>
+
+    <flow name="authorizeAll">
+        <inbound-endpoint address="http://localhost:${port1}/authorizeall" exchange-pattern="request-response"/>
+        <http:basic-security-filter realm="mule-realm"/>
+        <mule-ss:authorization-filter requiredAuthorities="ROLE_CONTRIBUTOR"/>
+        <mule-ss:authorization-filter requiredAuthorities="ROLE_ADMIN"/>
+        <logger/>
     </flow>
 </mule>


### PR DESCRIPTION
Implemented support for handling a CSV string value as the value of the "requiredAuthorities" property in org.mule.module.spring.security.AuthorizationFilter.  Added some tests to verify functionality.