### PR TITLE
MULE-9563: Support nonProxyHosts in http:proxy (DO NOT MERGE)

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/NtlmProxyConfigBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/NtlmProxyConfigBuilder.java
@@ -78,4 +78,14 @@ public class NtlmProxyConfigBuilder
         return this;
     }
 
+    /**
+     * @param nonProxyHosts A list of hosts separated by |, which specifies that the proxy must not be used
+     * @return the builder
+     */
+    public NtlmProxyConfigBuilder setNonProxyHosts(String nonProxyHosts)
+    {
+        ntlmProxyConfig.setNonProxyHosts(nonProxyHosts);
+        return this;
+    }
+
 }

--- a/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/ProxyConfig.java
+++ b/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/ProxyConfig.java
@@ -38,7 +38,7 @@ public interface ProxyConfig
     public String getPassword();
 
     /**
-     * @return A list of hosts, which are separated by |, which a proxy must not be used
+     * @return A list of hosts separated by |, which specifies that the proxy must not be used
      */
     public String getNonProxyHosts();
 

--- a/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/ProxyConfig.java
+++ b/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/ProxyConfig.java
@@ -37,4 +37,9 @@ public interface ProxyConfig
      */
     public String getPassword();
 
+    /**
+     * @return A list of hosts, which are separated by |, which a proxy must not be used
+     */
+    public String getNonProxyHosts();
+
 }

--- a/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/ProxyConfigBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/api/requester/proxy/ProxyConfigBuilder.java
@@ -47,6 +47,12 @@ public class ProxyConfigBuilder
         return this;
     }
 
+    public ProxyConfigBuilder setNonProxyHosts(String nonProxyHosts)
+    {
+        proxyConfig.setNonProxyHosts(nonProxyHosts);
+        return this;
+    }
+
     public ProxyConfig build()
     {
         Preconditions.checkArgument(proxyConfig.getHost() != null, "Host must be not null");

--- a/modules/http/src/main/java/org/mule/module/http/internal/request/DefaultProxyConfig.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/DefaultProxyConfig.java
@@ -19,6 +19,7 @@ public class DefaultProxyConfig implements ProxyConfig
     private int port = Integer.MAX_VALUE;
     private String username;
     private String password;
+    private String nonProxyHosts;
 
     public String getName()
     {
@@ -68,6 +69,14 @@ public class DefaultProxyConfig implements ProxyConfig
     public void setPassword(String password)
     {
         this.password = password;
+    }
+
+    public String getNonProxyHosts() {
+        return nonProxyHosts;
+    }
+
+    public void setNonProxyHosts(String nonProxyHosts) {
+        this.nonProxyHosts = nonProxyHosts;
     }
 
 }

--- a/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
@@ -234,6 +234,12 @@ public class GrizzlyHttpClient implements HttpClient
         {
             proxyServer = new ProxyServer(proxyConfig.getHost(),proxyConfig.getPort());
         }
+
+        if (proxyConfig.getNonProxyHosts() != null && !proxyConfig.getNonProxyHosts().isEmpty()) {
+            for (final String host : proxyConfig.getNonProxyHosts().split("\\|")) {
+                proxyServer.addNonProxyHost(host);
+            }
+        }
         return proxyServer;
     }
 

--- a/modules/http/src/main/resources/META-INF/mule-httpn.xsd
+++ b/modules/http/src/main/resources/META-INF/mule-httpn.xsd
@@ -891,6 +891,7 @@
                 <xsd:attribute name="port" type="mule:substitutableInt" />
                 <xsd:attribute name="username" type="xsd:string" use="optional" />
                 <xsd:attribute name="password" type="xsd:string" use="optional" />
+                <xsd:attribute name="nonProxyHosts" type="xsd:string" use="optional" />
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/modules/http/src/test/java/org/mule/module/http/api/requester/proxy/NtlmProxyConfigBuilderTest.java
+++ b/modules/http/src/test/java/org/mule/module/http/api/requester/proxy/NtlmProxyConfigBuilderTest.java
@@ -61,7 +61,7 @@ public class NtlmProxyConfigBuilderTest extends AbstractMuleTestCase
     public void fullConfig()
     {
         NtlmProxyConfig config = (NtlmProxyConfig) ntlmProxyConfigBuilder
-                .setHost(HOST).setPort(PORT).setNtlmDomain(NTLM_DOMAIN).setUsername(USERNAME).setPassword(PASSWORD).build();
+                .setHost(HOST).setPort(PORT).setNtlmDomain(NTLM_DOMAIN).setUsername(USERNAME).setPassword(PASSWORD).setNonProxyHosts(NON_PROXY_HOST).build();
         assertThat(config.getHost(), is(HOST));
         assertThat(config.getPort(), is(PORT));
         assertThat(config.getNtlmDomain(), is(NTLM_DOMAIN));

--- a/modules/http/src/test/java/org/mule/module/http/api/requester/proxy/NtlmProxyConfigBuilderTest.java
+++ b/modules/http/src/test/java/org/mule/module/http/api/requester/proxy/NtlmProxyConfigBuilderTest.java
@@ -23,6 +23,7 @@ public class NtlmProxyConfigBuilderTest extends AbstractMuleTestCase
     public static final String NTLM_DOMAIN = "DOMAIN";
     public static final String USERNAME = "username";
     public static final String PASSWORD = "password";
+    public static final String NON_PROXY_HOST = "host1|host2";
 
     private NtlmProxyConfigBuilder ntlmProxyConfigBuilder = new NtlmProxyConfigBuilder();
 
@@ -66,5 +67,6 @@ public class NtlmProxyConfigBuilderTest extends AbstractMuleTestCase
         assertThat(config.getNtlmDomain(), is(NTLM_DOMAIN));
         assertThat(config.getPassword(), is(PASSWORD));
         assertThat(config.getUsername(), is(USERNAME));
+        assertThat(config.getNonProxyHosts(), is(NON_PROXY_HOST));
     }
 }

--- a/modules/http/src/test/java/org/mule/module/http/api/requester/proxy/ProxyConfigBuilderTest.java
+++ b/modules/http/src/test/java/org/mule/module/http/api/requester/proxy/ProxyConfigBuilderTest.java
@@ -21,6 +21,7 @@ public class ProxyConfigBuilderTest extends AbstractMuleTestCase
     public static final int PORT = 8080;
     public static final String USERNAME = "username";
     public static final String PASSWORD = "password";
+    public static final String NON_PROXY_HOSTS = "host1|host2";
 
     private ProxyConfigBuilder proxyConfigBuilder = new ProxyConfigBuilder();
 
@@ -51,10 +52,11 @@ public class ProxyConfigBuilderTest extends AbstractMuleTestCase
     public void fullConfig()
     {
         ProxyConfig config = proxyConfigBuilder
-                .setHost(HOST).setPort(PORT).setUsername(USERNAME).setPassword(PASSWORD).build();
+                .setHost(HOST).setPort(PORT).setUsername(USERNAME).setPassword(PASSWORD).setNonProxyHosts(NON_PROXY_HOSTS).build();
         assertThat(config.getHost(), is(HOST));
         assertThat(config.getPort(), is(PORT));
         assertThat(config.getPassword(), is(PASSWORD));
         assertThat(config.getUsername(), is(USERNAME));
+        assertThat(config.getNonProxyHosts(), is(NON_PROXY_HOSTS));
     }
 }

--- a/modules/http/src/test/java/org/mule/module/http/internal/request/grizzly/ProxyParamsTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/request/grizzly/ProxyParamsTestCase.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.http.internal.request.grizzly;
+
+import org.apache.commons.io.IOUtils;
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mule.api.MuleException;
+import org.mule.module.http.internal.ParameterMap;
+import org.mule.module.http.internal.domain.request.DefaultHttpRequest;
+import org.mule.module.http.internal.domain.request.HttpRequest;
+import org.mule.module.http.internal.request.DefaultProxyConfig;
+import org.mule.module.http.internal.request.HttpClientConfiguration;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.eclipse.jetty.http.HttpMethod.GET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class ProxyParamsTestCase extends AbstractMuleTestCase
+{
+
+    public DynamicPort dynamicPort = new DynamicPort("port");
+    public DynamicPort proxyPort = new DynamicPort("proxyPort");
+
+    private static final String EXPECTED_RESULT = "result";
+    private static final String PROTOCOL = "http";
+    private static final String HOST = "localhost";
+    private static final String PATH = "retrieve";
+    private static final int TIMEOUT = -1;
+    private static final Boolean FOLLOW_REDIRECTS = Boolean.TRUE;
+    private MockServer server = new MockServer(dynamicPort.getNumber());
+    private GrizzlyHttpClient httpClient;
+
+    @Parameterized.Parameter()
+    public String nonProxyHosts;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> parameters()
+    {
+        return Arrays.asList(new Object[][] {
+                {""},
+                {"localhost"},
+                {"other|localhost"}
+        });
+    }
+    
+    @After
+    public void after() throws Exception
+    {
+        server.stop();
+        httpClient.stop();
+    }
+
+    @Test
+    public void testProxyNonProxyParams() throws Exception {
+        createProxyAndClient(nonProxyHosts);
+
+        final HttpRequest request = new DefaultHttpRequest(
+                PROTOCOL + "://" + HOST + ":" + dynamicPort.getNumber() + "/" + PATH, null, GET.asString(),
+                new ParameterMap(), new ParameterMap(), null);
+
+        if (nonProxyHosts != null && !nonProxyHosts.isEmpty()) {
+            // as we set the nonProxyHosts to localhost, the proxy will not block this request
+            InputStream responseStream = httpClient.sendAndReceiveInputStream(request, TIMEOUT, FOLLOW_REDIRECTS, null);
+            assertNotNull(responseStream);
+            assertEquals(EXPECTED_RESULT, IOUtils.toString(responseStream));
+        } else {
+            try {
+                httpClient.sendAndReceiveInputStream(request, TIMEOUT, FOLLOW_REDIRECTS, null);
+                fail("Request must be blocked by proxy when nonProxyHosts are configured");
+            } catch (Exception ignore) {}
+        }
+    }
+
+    private void createProxyAndClient(final String nonProxyHosts) throws MuleException
+    {
+        // create proxy config
+        DefaultProxyConfig defaultProxyConfig = new DefaultProxyConfig();
+        defaultProxyConfig.setName("testProxy");
+        defaultProxyConfig.setHost(HOST);
+        defaultProxyConfig.setPort(proxyPort.getNumber());
+        if (nonProxyHosts != null) defaultProxyConfig.setNonProxyHosts(nonProxyHosts);
+
+        HttpClientConfiguration configuration = new HttpClientConfiguration.Builder().setUsePersistentConnections(true)
+                                                                                     .setMaxConnections(1)
+                                                                                     .setStreaming(false)
+                                                                                     .setConnectionIdleTimeout(-1)
+                                                                                     .setProxyConfig(defaultProxyConfig)
+                                                                                     .build();
+
+        httpClient = new GrizzlyHttpClient(configuration);
+        httpClient.start();
+    }
+
+    /**
+     * Implementation of an http fake server
+     */
+    private static class MockServer
+    {
+
+        private int serverPort;
+        private HttpServer server;
+
+        MockServer(int serverPort)
+        {
+            try
+            {
+                this.serverPort = serverPort;
+                start();
+            }
+            catch (Exception e)
+            {
+                fail("Could not construct mock server");
+            }
+        }
+
+        public void start() throws IOException
+        {
+            server = HttpServer.createSimpleServer("/", serverPort);
+            server.getServerConfiguration().addHttpHandler(new HttpHandler()
+            {
+                public void service(Request request, Response response) throws Exception
+                {
+//                    response.setContentType(APPLICATION_XML_UTF_8.toString());
+                    String contents = EXPECTED_RESULT;
+                    response.setContentLength(contents.length());
+                    response.getWriter().write(contents);
+                }
+            }, "/" + PATH);
+
+            server.start();
+        }
+
+        public void stop() throws Exception
+        {
+            server.shutdownNow();
+        }
+
+    }
+
+}

--- a/transports/http/src/main/resources/META-INF/mule-http.xsd
+++ b/transports/http/src/main/resources/META-INF/mule-http.xsd
@@ -111,6 +111,13 @@
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
+                <xsd:attribute name="nonProxyHosts" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            A list of hosts, which are separated by |, which a proxy must not be used
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/transports/http/src/main/resources/META-INF/mule-http.xsd
+++ b/transports/http/src/main/resources/META-INF/mule-http.xsd
@@ -111,13 +111,6 @@
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="nonProxyHosts" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:documentation>
-                            A list of hosts, which are separated by |, which a proxy must not be used
-                        </xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>


### PR DESCRIPTION
Add support for Proxy Param "nonProxyHosts".
Indicates the hosts that should be accessed without going through the proxy.

[MULE Issue](https://www.mulesoft.org/jira/browse/MULE-9563)