### PR TITLE
MULE-12663: In Message Filter, When unaccepted events are handled, ex…

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/routing/MessageFilterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/routing/MessageFilterTestCase.java
@@ -73,13 +73,9 @@ public class MessageFilterTestCase extends AbstractReactiveProcessorTestCase {
     SensingNullMessageProcessor out = getSensingNullMessageProcessor();
     mp.setMuleContext(muleContext);
     mp.setListener(out);
-
     Event inEvent = eventBuilder().message(of(TEST_MESSAGE)).build();
-
-    Event resultEvent = process(mp, inEvent);
-
+    process(mp, inEvent);
     assertNull(out.event);
-    assertSame(inEvent, resultEvent);
     assertNotNull(unaccepted.event);
   }
 }


### PR DESCRIPTION
…ecution of flow caller is not stopped.

In a subflow with a filter, if the filter condition is not satisfied and the unaccepted event is handled, then the flow that called this subflow must stop its execution.