### PR TITLE
MULE-12663: In Message Filter, When unaccepted events are handled, ex…

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/AbstractFilteringMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/AbstractFilteringMessageProcessor.java
@@ -7,7 +7,9 @@
 package org.mule.runtime.core.privileged.processor;
 
 import static org.mule.runtime.core.api.processor.MessageProcessors.processToApply;
+import static org.mule.runtime.core.internal.util.rx.Operators.requestUnbounded;
 import static reactor.core.publisher.Flux.error;
+import static reactor.core.publisher.Flux.empty;
 import static reactor.core.publisher.Flux.from;
 import static reactor.core.publisher.Flux.just;
 
@@ -75,7 +77,9 @@ public abstract class AbstractFilteringMessageProcessor extends AbstractIntercep
           if (accept(event, builder)) {
             return just(event).transform(applyNext());
           } else {
-            return just(event).transform(unacceptedMessageProcessor);
+            just(event).transform(unacceptedMessageProcessor).subscribe(requestUnbounded());
+            event.getContext().success();
+            return empty();
           }
         } catch (Exception ex) {
           return error(filterFailureException(builder.build(), ex));


### PR DESCRIPTION
…ecution of flow caller is not stopped.

In a subflow with a filter, if the filter condition is not satisfied and the unaccepted event is handled, then the flow that called this subflow must stop its execution.