### PR TITLE
MULE-12327: ArtifactClassLoaderRunner - Application URLs are also

### DIFF
--- a/core-tests/pom.xml
+++ b/core-tests/pom.xml
@@ -36,7 +36,16 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${project.version}</version>
-
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-service-http-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-weave</artifactId>
+            <classifier>mule-service</classifier>
         </dependency>
 
         <dependency>

--- a/modules/artifact/pom.xml
+++ b/modules/artifact/pom.xml
@@ -32,6 +32,18 @@
             <artifactId>aether-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-service-http-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-weave</artifactId>
+            <classifier>mule-service</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-unit</artifactId>
             <version>${project.version}</version>

--- a/modules/deployment-model-impl/pom.xml
+++ b/modules/deployment-model-impl/pom.xml
@@ -48,12 +48,10 @@
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-maven-client-api</artifactId>
-            <version>${muleMavenClientApi}</version>
         </dependency>
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-maven-client-impl</artifactId>
-            <version>${muleMavenClientImpl}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -143,6 +141,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-weave</artifactId>
+            <classifier>mule-service</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-extensions-spring-support</artifactId>
             <version>${project.version}</version>
@@ -186,7 +190,6 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>${commonsCollectionsVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/extensions-spring-support/pom.xml
+++ b/modules/extensions-spring-support/pom.xml
@@ -111,6 +111,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-runner</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
             <scope>test</scope>

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/ContentTypeHandlingTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/ContentTypeHandlingTestCase.java
@@ -14,7 +14,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
 
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.core.api.Event;

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/DynamicConfigExpirationTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/DynamicConfigExpirationTestCase.java
@@ -8,7 +8,8 @@ package org.mule.test.module.extension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import org.mule.functional.junit4.FlowRunner;
+
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.runtime.core.api.Event;
 import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/OperationExecutionTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/OperationExecutionTestCase.java
@@ -27,7 +27,7 @@ import static org.mule.test.heisenberg.extension.model.HealthStatus.HEALTHY;
 import static org.mule.test.heisenberg.extension.model.KnockeableDoor.knock;
 import static org.mule.test.heisenberg.extension.model.Ricin.RICIN_KILL_MESSAGE;
 
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;

--- a/modules/extensions-support/pom.xml
+++ b/modules/extensions-support/pom.xml
@@ -85,6 +85,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-weave</artifactId>
+            <classifier>mule-service</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-unit</artifactId>
             <version>${project.version}</version>

--- a/modules/extensions-xml-support/pom.xml
+++ b/modules/extensions-xml-support/pom.xml
@@ -81,6 +81,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-functional</artifactId>
             <version>${project.version}</version>

--- a/modules/extensions-xml-support/pom.xml
+++ b/modules/extensions-xml-support/pom.xml
@@ -87,6 +87,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-unit</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <scope>test</scope>

--- a/modules/spring-config/pom.xml
+++ b/modules/spring-config/pom.xml
@@ -117,6 +117,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-service-http-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-weave</artifactId>
+            <classifier>mule-service</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>

--- a/modules/tls/pom.xml
+++ b/modules/tls/pom.xml
@@ -49,5 +49,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-unit</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/tls/pom.xml
+++ b/modules/tls/pom.xml
@@ -44,6 +44,19 @@
 
         <!-- test dependencies -->
         <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-runner</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-functional</artifactId>
             <version>${project.version}</version>

--- a/tests/component-plugin/pom.xml
+++ b/tests/component-plugin/pom.xml
@@ -28,6 +28,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${project.version}</version>
@@ -51,12 +56,13 @@
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-unit</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mule.runtime</groupId>
-                    <artifactId>mule-core</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-service-http-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/component/ResponseAssertionMessageProcessor.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/component/ResponseAssertionMessageProcessor.java
@@ -12,10 +12,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mule.functional.api.component.FlowAssert.addAssertion;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.setFlowConstructIfNeeded;
+import static org.mule.tck.junit4.AbstractMuleContextTestCase.RECEIVE_TIMEOUT;
+import static org.mule.tck.processor.FlowAssert.addAssertion;
 import static reactor.core.Exceptions.propagate;
 import static reactor.core.publisher.Flux.from;
+
 import org.mule.runtime.api.el.ValidationResult;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -28,11 +30,12 @@ import org.mule.runtime.core.api.expression.InvalidExpressionException;
 import org.mule.runtime.core.api.processor.InterceptingMessageProcessor;
 import org.mule.runtime.core.api.processor.Processor;
 
-import com.eaio.uuid.UUID;
-
 import java.util.concurrent.CountDownLatch;
 
 import org.reactivestreams.Publisher;
+
+import com.eaio.uuid.UUID;
+
 import reactor.core.publisher.Flux;
 
 public class ResponseAssertionMessageProcessor extends AssertionMessageProcessor
@@ -40,7 +43,7 @@ public class ResponseAssertionMessageProcessor extends AssertionMessageProcessor
 
   private static final ThreadLocal<String> taskTokenInThread = new ThreadLocal<>();
 
-  protected String responseExpression = "#[mel:true]";
+  protected String responseExpression = "#[true]";
   private int responseCount = 1;
   private boolean responseSameTask = true;
 
@@ -183,7 +186,7 @@ public class ResponseAssertionMessageProcessor extends AssertionMessageProcessor
    * @throws InterruptedException
    */
   synchronized private boolean isResponseProcessesCountCorrect() throws InterruptedException {
-    boolean countReached = responseLatch.await(timeout, MILLISECONDS);
+    boolean countReached = responseLatch.await(RECEIVE_TIMEOUT, MILLISECONDS);
     if (needToMatchCount) {
       return responseCount == responseInvocationCount;
     } else {

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/component/TestNonBlockingProcessor.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/component/TestNonBlockingProcessor.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.tck.processor;
+package org.mule.functional.api.component;
 
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE_ASYNC;
 import static org.mule.runtime.core.api.scheduler.SchedulerConfig.config;

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/flow/FlowConstructRunner.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/flow/FlowConstructRunner.java
@@ -4,11 +4,12 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.functional.junit4;
+package org.mule.functional.api.flow;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.fail;
+
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.MediaType;

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/flow/FlowRunner.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/flow/FlowRunner.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.functional.junit4;
+package org.mule.functional.api.flow;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.fail;
@@ -16,17 +16,16 @@ import org.mule.runtime.api.streaming.Cursor;
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.Flow;
+import org.mule.runtime.core.api.exception.MessagingException;
 import org.mule.runtime.core.api.execution.ExecutionCallback;
 import org.mule.runtime.core.api.execution.ExecutionTemplate;
+import org.mule.runtime.core.api.transaction.MuleTransactionConfig;
 import org.mule.runtime.core.api.transaction.TransactionConfig;
 import org.mule.runtime.core.api.transaction.TransactionFactory;
 import org.mule.tck.processor.FlowAssert;
-import org.mule.runtime.core.api.exception.MessagingException;
-import org.mule.runtime.core.api.transaction.MuleTransactionConfig;
 
 import java.util.concurrent.ExecutionException;
-
-import org.apache.commons.collections.Transformer;
+import java.util.function.Function;
 
 import reactor.core.publisher.MonoProcessor;
 
@@ -41,7 +40,7 @@ public class FlowRunner extends FlowConstructRunner<FlowRunner> implements Dispo
 
   private ExecutionTemplate<Event> txExecutionTemplate = callback -> callback.process();
 
-  private Transformer responseEventTransformer = input -> input;
+  private Function<Event, Event> responseEventTransformer = input -> input;
 
   private Scheduler scheduler;
 
@@ -148,7 +147,7 @@ public class FlowRunner extends FlowConstructRunner<FlowRunner> implements Dispo
       }
     }
     verify(flowNamesToVerify);
-    return (Event) responseEventTransformer.transform(response);
+    return responseEventTransformer.apply(response);
   }
 
   /**
@@ -208,9 +207,10 @@ public class FlowRunner extends FlowConstructRunner<FlowRunner> implements Dispo
 
   /**
    * Verifies asserts on flowNamesToVerify
+   * 
    * @param flowNamesToVerify
    * @throws Exception
-   * */
+   */
   private void verify(String... flowNamesToVerify) throws Exception {
     for (String flowNameToVerify : flowNamesToVerify) {
       FlowAssert.verify(flowNameToVerify);

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/flow/TransactionConfigEnum.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/flow/TransactionConfigEnum.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.functional.junit4;
+package org.mule.functional.api.flow;
 
 import org.mule.runtime.core.api.transaction.TransactionConfig;
 

--- a/tests/component-plugin/src/main/java/org/mule/functional/config/TestComponentBuildingDefinitionProvider.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/config/TestComponentBuildingDefinitionProvider.java
@@ -25,12 +25,12 @@ import org.mule.functional.api.component.ResponseAssertionMessageProcessor;
 import org.mule.functional.api.component.SharedConfig;
 import org.mule.functional.api.component.SharedSource;
 import org.mule.functional.api.component.SkeletonSource;
+import org.mule.functional.api.component.TestNonBlockingProcessor;
 import org.mule.functional.api.component.ThrowProcessor;
 import org.mule.functional.client.QueueWriterMessageProcessor;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinitionProvider;
-import org.mule.tck.processor.TestNonBlockingProcessor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/tests/component-plugin/src/main/resources/META-INF/mule-artifact/mule-artifact.json
+++ b/tests/component-plugin/src/main/resources/META-INF/mule-artifact/mule-artifact.json
@@ -8,10 +8,10 @@
         "org.mule.functional.api.component",
         "org.mule.functional.api.exception",
         "org.mule.functional.api.notification",
-        "org.mule.functional.config",
         "org.mule.functional.client"
       ],
       "exportedResources": [
+        "META-INF/spring.schemas",
         "META-INF/mule-test.xsd"
       ]
     }

--- a/tests/component-plugin/src/main/resources/META-INF/mule-artifact/mule-artifact.json
+++ b/tests/component-plugin/src/main/resources/META-INF/mule-artifact/mule-artifact.json
@@ -7,8 +7,8 @@
       "exportedPackages": [
         "org.mule.functional.api.component",
         "org.mule.functional.api.exception",
-        "org.mule.functional.api.notification",
-        "org.mule.functional.client"
+        "org.mule.functional.api.flow",
+        "org.mule.functional.api.notification"
       ],
       "exportedResources": [
         "META-INF/spring.schemas",

--- a/tests/component-plugin/src/test/java/org/mule/test/tck/ResponseAssertionMessageProcessorTestCase.java
+++ b/tests/component-plugin/src/test/java/org/mule/test/tck/ResponseAssertionMessageProcessorTestCase.java
@@ -14,9 +14,9 @@ import static org.mule.runtime.api.meta.AbstractAnnotatedObject.LOCATION_KEY;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
 
 import org.mule.functional.api.component.ResponseAssertionMessageProcessor;
+import org.mule.functional.api.component.TestNonBlockingProcessor;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.tck.SensingNullMessageProcessor;
-import org.mule.tck.processor.TestNonBlockingProcessor;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -17,12 +17,6 @@
     <dependencies>
         <dependency>
             <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-core</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-spring-config</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -37,16 +31,28 @@
 
         <dependency>
             <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-extensions-soap-support</artifactId>
+            <artifactId>mule-module-artifact</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-artifact</artifactId>
+            <artifactId>mule-module-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-service</artifactId>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -55,25 +61,24 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-service</artifactId>
-            <type>test-jar</type>
-            <version>${project.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-artifact</artifactId>
             <type>test-jar</type>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-runner</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.tests.plugin</groupId>
@@ -83,51 +88,11 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- needed for org.springframework.beans.factory.FactoryBean interface -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-aop</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-net</groupId>
-            <artifactId>commons-net</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-dbutils</groupId>
-            <artifactId>commons-dbutils</artifactId>
-            <version>${commonsDbUtilsVersion}</version>
-        </dependency>
-
-        <!-- Needed for ExtensionsFunctionalTestCase -->
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-        </dependency>
-
         <!-- Unit tests -->
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-unit</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <!-- required for ConfigurationBuilders at runtime -->
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-builders</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -44,6 +44,12 @@
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-service-http-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-service</artifactId>
             <type>test-jar</type>
             <version>${project.version}</version>

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -19,35 +19,41 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-spring-config</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-extensions-support</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-extensions-soap-support</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-artifact</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-container</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -74,6 +80,7 @@
             <artifactId>mule-tests-component-plugin</artifactId>
             <version>${project.version}</version>
             <classifier>mule-plugin</classifier>
+            <scope>provided</scope>
         </dependency>
 
         <!-- needed for org.springframework.beans.factory.FactoryBean interface -->

--- a/tests/functional/src/main/java/org/mule/functional/junit4/FlowRunner.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/FlowRunner.java
@@ -10,7 +10,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.fail;
 import static org.mule.runtime.core.api.execution.TransactionalExecutionTemplate.createTransactionalExecutionTemplate;
 
-import org.mule.functional.api.component.FlowAssert;
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.api.streaming.Cursor;
@@ -21,6 +20,7 @@ import org.mule.runtime.core.api.execution.ExecutionCallback;
 import org.mule.runtime.core.api.execution.ExecutionTemplate;
 import org.mule.runtime.core.api.transaction.TransactionConfig;
 import org.mule.runtime.core.api.transaction.TransactionFactory;
+import org.mule.tck.processor.FlowAssert;
 import org.mule.runtime.core.api.exception.MessagingException;
 import org.mule.runtime.core.api.transaction.MuleTransactionConfig;
 

--- a/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
@@ -9,6 +9,7 @@ package org.mule.functional.junit4;
 import static java.util.Collections.emptyMap;
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
 
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.runtime.config.spring.SpringXmlConfigurationBuilder;
 import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
 import org.mule.runtime.core.api.Event;

--- a/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
@@ -8,7 +8,7 @@ package org.mule.functional.junit4;
 
 import static java.util.Collections.emptyMap;
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
-import org.mule.functional.api.component.FlowAssert;
+
 import org.mule.runtime.config.spring.SpringXmlConfigurationBuilder;
 import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
 import org.mule.runtime.core.api.Event;
@@ -19,6 +19,7 @@ import org.mule.runtime.core.api.processor.MessageProcessorChain;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.processor.FlowAssert;
 
 import org.junit.After;
 

--- a/tests/functional/src/main/java/org/mule/functional/junit4/MuleArtifactFunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/MuleArtifactFunctionalTestCase.java
@@ -16,12 +16,28 @@ import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
  * @since 4.0
  */
 @ArtifactClassLoaderRunnerConfig(
-    providedExclusions = {"org.mule.tests:*:*:*:*", "com.mulesoft.compatibility.tests:*:*:*:*"},
-    testExclusions = {"org.mule.runtime:*:*:*:*", "org.mule.modules*:*:*:*:*", "org.mule.transports:*:*:*:*",
-        "org.mule.mvel:*:*:*:*", "org.mule.extensions:*:*:*:*", "com.mulesoft.mule.runtime*:*:*:*:*",
+    providedExclusions = {
+        "org.mule.tests:*:*:*:*",
+        "com.mulesoft.compatibility.tests:*:*:*:*"
+    },
+    testExclusions = {
+        "org.mule.runtime:*:*:*:*",
+        "org.mule.modules*:*:*:*:*",
+        "org.mule.transports:*:*:*:*",
+        "org.mule.mvel:*:*:*:*",
+        "org.mule.extensions:*:*:*:*",
+        "org.mule.connectors:*:*:*:*",
+        "org.mule.tests.plugin:*:*:*:*",
+        "com.mulesoft.mule.runtime*:*:*:*:*",
         "com.mulesoft.licm:*:*:*:*"
     },
-    testInclusions = {"*:*:jar:tests:*"})
+    testInclusions = {
+        "*:*:jar:tests:*",
+        "*:*:test-jar:*:*"
+    },
+    sharedRuntimeLibs = {
+        "org.mule.tests:mule-tests-unit"
+    })
 public abstract class MuleArtifactFunctionalTestCase extends ArtifactFunctionalTestCase {
 
 }

--- a/tests/infrastructure/pom.xml
+++ b/tests/infrastructure/pom.xml
@@ -21,20 +21,23 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-launcher</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-launcher</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-functional</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mule.tests</groupId>
+        <artifactId>mule-tests</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>mule-tests-simple-integration</artifactId>
+    <name>Mule Runtime Integration Tests</name>
+
+    <properties>
+        <formatterConfigPath>../../formatter.xml</formatterConfigPath>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-launcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-infrastructure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-deployment-model-impl</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+            <dependency>
+            <groupId>org.mule.services</groupId>
+            <artifactId>mule-service-http</artifactId>
+            <version>${muleHttpServiceTestVersion}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/src/test/java/org/mule/runtime/module/launcher/logging/ConnectorLevelMessageDispatchingTestCase.java
+++ b/tests/integration/src/test/java/org/mule/runtime/module/launcher/logging/ConnectorLevelMessageDispatchingTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.launcher.logging;
+
+import static java.lang.String.format;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.runtime.http.api.HttpConstants.Method.GET;
+
+import org.mule.functional.listener.FlowExecutionListener;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.registry.RegistrationException;
+import org.mule.runtime.http.api.domain.entity.ByteArrayHttpEntity;
+import org.mule.runtime.http.api.domain.message.request.HttpRequest;
+import org.mule.runtime.module.launcher.logging.rule.UseMuleLog4jContextFactory;
+import org.mule.service.http.TestHttpClient;
+import org.mule.tck.junit4.rule.DynamicPort;
+import org.mule.tck.junit4.rule.SystemProperty;
+import org.mule.test.infrastructure.deployment.AbstractFakeMuleServerTestCase;
+import org.mule.test.infrastructure.deployment.FakeMuleServer;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.qameta.allure.Issue;
+
+@Ignore("MULE-10633, also, this uses FakeMuleServer which does not support loading extensions")
+@Issue("MULE-10633")
+public class ConnectorLevelMessageDispatchingTestCase extends AbstractFakeMuleServerTestCase {
+
+  public static final String HELLO_WORLD_APP = "hello-world";
+  public static final String HELLO_MULE_APP = "hello-mule";
+  @Rule
+  public DynamicPort dynamicPort = new DynamicPort("port1");
+  @Rule
+  public SystemProperty endpointScheme = new SystemProperty("scheme", "http");
+  @Rule
+  public UseMuleLog4jContextFactory muleLogging = new UseMuleLog4jContextFactory();
+
+  @Rule
+  public TestHttpClient httpClient = new TestHttpClient.Builder().build();
+
+  @Test
+  public void verifyClassLoaderIsAppClassLoader() throws Exception {
+    muleServer.deployDomainFromClasspathFolder("domain/deployable-domains/http-domain-listener", "domain");
+    muleServer.deployAppFromClasspathFolder("domain/deployable-apps/hello-world-app", HELLO_WORLD_APP);
+    muleServer.deployAppFromClasspathFolder("domain/deployable-apps/hello-mule-app", HELLO_MULE_APP);
+    muleServer.start();
+    verifyAppProcessMessageWithAppClassLoader(muleServer, HELLO_MULE_APP, "http://localhost:%d/service/helloMule");
+    verifyAppProcessMessageWithAppClassLoader(muleServer, HELLO_WORLD_APP, "http://localhost:%d/service/helloWorld");
+  }
+
+  private void verifyAppProcessMessageWithAppClassLoader(FakeMuleServer fakeMuleServer, String appName, String requestUrl)
+      throws IOException, TimeoutException, RegistrationException {
+    MuleContext applicationContext = fakeMuleServer.findApplication(appName).getMuleContext();
+
+    final AtomicReference<ClassLoader> executionClassLoader = new AtomicReference<>();
+    FlowExecutionListener flowExecutionListener = new FlowExecutionListener(applicationContext);
+    flowExecutionListener.addListener(source -> executionClassLoader.set(Thread.currentThread().getContextClassLoader()));
+    HttpRequest request =
+        HttpRequest.builder().uri(format(requestUrl, dynamicPort.getNumber())).method(GET)
+            .entity(new ByteArrayHttpEntity("test-data".getBytes())).build();
+    httpClient.send(request, DEFAULT_TEST_TIMEOUT_SECS, false, null);
+    flowExecutionListener.waitUntilFlowIsComplete();
+    assertThat(executionClassLoader.get(), is(applicationContext.getExecutionClassLoader()));
+  }
+
+
+}

--- a/tests/integration/src/test/java/org/mule/runtime/module/launcher/logging/LogConfigurationTestCase.java
+++ b/tests/integration/src/test/java/org/mule/runtime/module/launcher/logging/LogConfigurationTestCase.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.launcher.logging;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_SIMPLE_LOG;
+
+import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.module.deployment.impl.internal.builder.ApplicationFileBuilder;
+import org.mule.runtime.module.deployment.impl.internal.builder.DomainFileBuilder;
+import org.mule.runtime.module.launcher.logging.rule.UseMuleLog4jContextFactory;
+import org.mule.test.infrastructure.deployment.AbstractFakeMuleServerTestCase;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Checks log4j configuration for application and domains
+ */
+public class LogConfigurationTestCase extends AbstractFakeMuleServerTestCase {
+
+  public static final String APP_NAME = "app1";
+  public static final String DOMAIN_NAME = "domain";
+
+  @Rule
+  public UseMuleLog4jContextFactory muleLogging = new UseMuleLog4jContextFactory();
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    // here we're trying to test log separation so we need to
+    // disable this default property of the fake mule server
+    // in order to test that
+    System.clearProperty(MULE_SIMPLE_LOG);
+  }
+
+  @Test
+  public void defaultAppLoggingConfigurationOnlyLogsOnApplicationLogFile() throws Exception {
+    muleServer.start();
+    ApplicationFileBuilder applicationFileBuilder = new ApplicationFileBuilder(APP_NAME).definedBy("log/empty-config.xml");
+    muleServer.deploy(applicationFileBuilder.getArtifactFile().toURI().toURL(), APP_NAME);
+    ensureOnlyDefaultAppender();
+  }
+
+  @Test
+  public void defaultAppInDomainLoggingConfigurationOnlyLogsOnApplicationLogFile() throws Exception {
+    muleServer.start();
+    File domainFile =
+        new DomainFileBuilder(DOMAIN_NAME).definedBy("log/empty-domain/empty-domain-config.xml").getArtifactFile();
+    muleServer.deployDomainFile(domainFile);
+
+    ApplicationFileBuilder applicationFileBuilder =
+        new ApplicationFileBuilder(APP_NAME).definedBy("log/empty-config.xml").deployedWith("domain", "domain");
+    muleServer.deploy(applicationFileBuilder.getArtifactFile().toURI().toURL(), APP_NAME);
+    ensureOnlyDefaultAppender();
+  }
+
+  @Test
+  public void honorLog4jConfigFileForApp() throws Exception {
+    muleServer.start();
+    ApplicationFileBuilder applicationFileBuilder = new ApplicationFileBuilder(APP_NAME).definedBy("log/empty-config.xml")
+        .usingResource("log/log4j-config.xml", "log4j2-test.xml");
+    muleServer.deploy(applicationFileBuilder.getArtifactFile().toURI().toURL(), APP_NAME);
+    ensureArtifactAppender("consoleForApp", ConsoleAppender.class);
+  }
+
+  @Test
+  public void honorLog4jConfigFileForAppInDomain() throws Exception {
+    muleServer.start();
+
+    File domainFile = new DomainFileBuilder(DOMAIN_NAME)
+        .definedBy("log/empty-domain-with-log4j/empty-domain-config.xml")
+        .containingResource("log/empty-domain-with-log4j/log4j2-test.xml", "classes/log4j2-test.xml")
+        .getArtifactFile();
+    muleServer.deployDomainFile(domainFile);
+
+    ApplicationFileBuilder applicationFileBuilder = new ApplicationFileBuilder(APP_NAME)
+        .definedBy("log/empty-config.xml").deployedWith("domain", "domain");
+    muleServer.deploy(applicationFileBuilder.getArtifactFile().toURI().toURL(), APP_NAME);
+    ensureArtifactAppender("ConsoleForDomain", ConsoleAppender.class);
+  }
+
+  private void ensureOnlyDefaultAppender() throws Exception {
+    assertThat(1, equalTo(appendersCount(APP_NAME)));
+    assertThat(1, equalTo(selectByClass(APP_NAME, RollingFileAppender.class).size()));
+
+    RollingFileAppender fileAppender = (RollingFileAppender) selectByClass(APP_NAME, RollingFileAppender.class).get(0);
+    assertThat("defaultFileAppender", equalTo(fileAppender.getName()));
+    assertThat(fileAppender.getFileName(), containsString(String.format("mule-app-%s.log", APP_NAME)));
+  }
+
+  private void ensureArtifactAppender(final String appenderName, final Class<? extends Appender> appenderClass) throws Exception {
+    withAppClassLoader(APP_NAME, () -> {
+      Logger logger = getRootLoggerForApp(APP_NAME);
+      assertThat(Level.WARN, equalTo(logger.getLevel()));
+      assertThat(true, equalTo(loggerHasAppender(APP_NAME, logger, appenderName)));
+
+
+      assertThat(1, equalTo(appendersCount(APP_NAME)));
+      assertThat(1, equalTo(selectByClass(APP_NAME, appenderClass).size()));
+      assertThat(appenderName, equalTo(selectByClass(APP_NAME, appenderClass).get(0).getName()));
+
+      return null;
+    });
+  }
+
+  private boolean loggerHasAppender(String appName, Logger logger, String appenderName) throws Exception {
+    return getContext(appName).getConfiguration().getLoggerConfig(logger.getName()).getAppenders().containsKey(appenderName);
+  }
+
+  private Logger getRootLoggerForApp(String appName) throws Exception {
+    return getContext(appName).getLogger("");
+  }
+
+  private LoggerContext getContext(final String appName) throws Exception {
+    return withAppClassLoader(appName, () -> {
+      Application app = muleServer.findApplication(appName);
+      ClassLoader classLoader = app.getMuleContext().getExecutionClassLoader();
+      return (LoggerContext) LogManager.getContext(classLoader, false);
+    });
+  }
+
+  private <T> T withAppClassLoader(String appName, Callable<T> closure) throws Exception {
+    Application app = muleServer.findApplication(appName);
+    ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+    ClassLoader classLoader = app.getMuleContext().getExecutionClassLoader();
+    Thread.currentThread().setContextClassLoader(classLoader);
+    try {
+      return closure.call();
+    } finally {
+      Thread.currentThread().setContextClassLoader(currentClassLoader);
+    }
+  }
+
+  private List<Appender> selectByClass(String appName, Class<?> appenderClass) throws Exception {
+    LoggerContext context = getContext(appName);
+    List<Appender> filteredAppenders = new LinkedList<>();
+    for (Appender appender : context.getConfiguration().getAppenders().values()) {
+      if (appenderClass.isAssignableFrom(appender.getClass())) {
+        filteredAppenders.add(appender);
+      }
+    }
+
+    return filteredAppenders;
+  }
+
+  private int appendersCount(String appName) throws Exception {
+    return selectByClass(appName, Appender.class).size();
+  }
+}

--- a/tests/integration/src/test/java/org/mule/runtime/module/launcher/logging/rule/UseMuleLog4jContextFactory.java
+++ b/tests/integration/src/test/java/org/mule/runtime/module/launcher/logging/rule/UseMuleLog4jContextFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.launcher.logging.rule;
+
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.module.launcher.log4j2.MuleLog4jContextFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
+import org.junit.rules.ExternalResource;
+
+/**
+ * Allows tests to use the mule logging infrastructure without initializing a {@link MuleContext}.
+ */
+public class UseMuleLog4jContextFactory extends ExternalResource {
+
+  private static MuleLog4jContextFactory muleLog4jContextFactory = new MuleLog4jContextFactory();
+
+  private LoggerContextFactory originalLog4jContextFactory;
+
+  @Override
+  protected void before() throws Throwable {
+    originalLog4jContextFactory = LogManager.getFactory();
+    LogManager.setFactory(muleLog4jContextFactory);
+  }
+
+  @Override
+  protected void after() {
+    // We can safely force a removal of the old logger contexts instead of waiting for the reaper thread to do it.
+    ((MuleLog4jContextFactory) LogManager.getFactory()).dispose();
+    LogManager.setFactory(originalLog4jContextFactory);
+  }
+}

--- a/tests/integration/src/test/resources/log/empty-config.xml
+++ b/tests/integration/src/test/resources/log/empty-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <description>Empty Mule Application</description>
+</mule>

--- a/tests/integration/src/test/resources/log/empty-domain-with-log4j/empty-domain-config.xml
+++ b/tests/integration/src/test/resources/log/empty-domain-with-log4j/empty-domain-config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
+
+
+</mule-domain>

--- a/tests/integration/src/test/resources/log/empty-domain-with-log4j/log4j2-test.xml
+++ b/tests/integration/src/test/resources/log/empty-domain-with-log4j/log4j2-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration shutdownHook="disable">
+    <Appenders>
+        <Console name="ConsoleForDomain" target="SYSTEM_OUT">
+            <PatternLayout pattern="%-5p %d [%t] %c: %m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+
+        <!-- CXF is used heavily by Mule for web services -->
+        <AsyncLogger name="org.apache.cxf" level="WARN"/>
+
+        <!-- Apache Commons tend to make a lot of noise which can clutter the log-->
+        <AsyncLogger name="org.apache" level="WARN"/>
+
+        <!-- Reduce startup noise -->
+        <AsyncLogger name="org.springframework.beans.factory" level="WARN"/>
+
+        <!-- Mule classes -->
+        <AsyncLogger name="org.mule" level="WARN"/>
+        <AsyncLogger name="com.mulesoft" level="WARN"/>
+
+        <AsyncRoot level="WARN" >
+            <AppenderRef ref="ConsoleForDomain"/>
+        </AsyncRoot>
+    </Loggers>
+
+</Configuration>

--- a/tests/integration/src/test/resources/log/empty-domain/empty-domain-config.xml
+++ b/tests/integration/src/test/resources/log/empty-domain/empty-domain-config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule-domain xmlns="http://www.mulesoft.org/schema/mule/domain"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.mulesoft.org/schema/mule/domain http://www.mulesoft.org/schema/mule/domain/current/mule-domain.xsd">
+
+
+</mule-domain>

--- a/tests/integration/src/test/resources/log/log4j-config.xml
+++ b/tests/integration/src/test/resources/log/log4j-config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="consoleForApp" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%d{MM-dd HH:mm:ss}] %-5p %c{1} [%t]: %m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+
+        <AsyncRoot level="WARN">
+            <AppenderRef ref="consoleForApp"/>
+        </AsyncRoot>
+    </Loggers>
+
+</Configuration>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -26,6 +26,7 @@
         <module>test-policies</module>
         <module>test-services</module>
         <module>runner</module>
+        <module>integration</module>
     </modules>
 
     <build>

--- a/tests/runner/.gitignore
+++ b/tests/runner/.gitignore
@@ -1,0 +1,1 @@
+/dependency-reduced-pom.xml

--- a/tests/runner/pom.xml
+++ b/tests/runner/pom.xml
@@ -15,6 +15,33 @@
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <minimizeJar>true</minimizeJar>
+                    <artifactSet>
+                        <includes>
+                            <!-- Shade spring so it doesn't end as libraries in the APP for testing -->
+                            <include>org.springframework:*</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- Maven Client dependencies -->
         <dependency>

--- a/tests/runner/pom.xml
+++ b/tests/runner/pom.xml
@@ -58,26 +58,31 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-extensions-support</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-extensions-soap-support</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-service</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-container</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-deployment-model</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- 3rd party dependencies -->

--- a/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
@@ -25,25 +25,14 @@ import static org.eclipse.aether.util.filter.DependencyFilterUtils.classpathFilt
 import static org.eclipse.aether.util.filter.DependencyFilterUtils.orFilter;
 import static org.mule.runtime.api.util.Preconditions.checkNotNull;
 import static org.mule.runtime.core.api.util.PropertiesUtils.loadProperties;
-import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_PLUGIN_CLASSIFIER;
 import static org.mule.test.runner.api.ArtifactClassificationType.APPLICATION;
 import static org.mule.test.runner.api.ArtifactClassificationType.MODULE;
 import static org.mule.test.runner.api.ArtifactClassificationType.PLUGIN;
+
 import org.mule.runtime.extension.api.annotation.Extension;
 import org.mule.runtime.module.artifact.classloader.ArtifactClassLoader;
 import org.mule.test.runner.classification.PatternExclusionsDependencyFilter;
 import org.mule.test.runner.classification.PatternInclusionsDependencyFilter;
-
-import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.resolution.ArtifactDescriptorException;
-import org.eclipse.aether.resolution.ArtifactResolutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -61,6 +50,17 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Creates the {@link ArtifactUrlClassification} based on the Maven dependencies declared by the rootArtifact using Eclipse
@@ -91,6 +91,7 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
   private static final String TESTS_JAR = "-tests.jar";
   private static final String SERVICE_PROPERTIES_FILE_NAME = "service.properties";
   private static final String SERVICE_PROVIDER_CLASS_NAME = "service.className";
+  private static final String MULE_PLUGIN_CLASSIFIER = "mule-plugin";
   private static final String MULE_SERVICE_CLASSIFIER = "mule-service";
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -169,8 +170,8 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
   }
 
   /**
-   * Finds direct dependencies declared with classifier {@value #MULE_SERVICE_CLASSIFIER}. Creates a
-   * List of {@link ArtifactUrlClassification} for each service including their {@code compile} scope dependencies.
+   * Finds direct dependencies declared with classifier {@value #MULE_SERVICE_CLASSIFIER}. Creates a List of
+   * {@link ArtifactUrlClassification} for each service including their {@code compile} scope dependencies.
    * <p/>
    * {@value #SERVICE_PROVIDER_CLASS_NAME} will be used as {@link ArtifactClassLoader#getArtifactId()}
    * <p/>
@@ -762,6 +763,7 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
    * <p/>
    * If the application artifact has not been classified as plugin its going to be resolved as {@value #JAR_EXTENSION} in order to
    * include this its compiled classes classification.
+   * 
    * @param context {@link ClassPathClassifierContext} with settings for the classification process
    * @param directDependencies {@link List} of {@link Dependency} with direct dependencies for the rootArtifact
    * @param rootArtifactType {@link ArtifactClassificationType} for rootArtifact @return {@link URL}s for application class loader
@@ -802,7 +804,10 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
             // TODO MULE-11332 Review other manifestations of this bug and add unit tests
             return toTransform.setScope(COMPILE);
           }
-          if (PLUGIN.equals(rootArtifactType) && toTransform.getScope().equals(COMPILE)) {
+          if ((PLUGIN.equals(rootArtifactType)
+              || MULE_PLUGIN_CLASSIFIER.equals(toTransform.getArtifact().getClassifier())
+              || MULE_SERVICE_CLASSIFIER.equals(toTransform.getArtifact().getClassifier()))
+              && toTransform.getScope().equals(COMPILE)) {
             // TODO MULE-11332 Review other manifestations of this bug and add unit tests
             return toTransform.setScope(PROVIDED);
           }

--- a/tests/runner/src/main/java/org/mule/test/runner/classloader/IsolatedClassLoaderFactory.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/classloader/IsolatedClassLoaderFactory.java
@@ -19,6 +19,7 @@ import static org.mule.runtime.container.internal.ContainerClassLoaderFactory.SY
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_LOG_VERBOSE_CLASSLOADING;
 import static org.mule.runtime.deployment.model.internal.DefaultRegionPluginClassLoadersFactory.getArtifactPluginId;
 import static org.mule.runtime.module.artifact.classloader.ParentFirstLookupStrategy.PARENT_FIRST;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.container.api.MuleModule;
@@ -66,7 +67,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Factory that creates a class loader hierarchy to emulate the one used in a mule standalone container.
@@ -84,9 +84,10 @@ import org.slf4j.LoggerFactory;
  */
 public class IsolatedClassLoaderFactory {
 
+  private static final Logger LOGGER = getLogger(IsolatedClassLoaderFactory.class);
+
   private static final String APP_NAME = "app";
 
-  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
   private ClassLoaderFilterFactory classLoaderFilterFactory = new ArtifactClassLoaderFilterFactory();
   private PluginLookPolicyFactory pluginLookupPolicyGenerator = new PluginLookPolicyFactory();
 
@@ -413,7 +414,7 @@ public class IsolatedClassLoaderFactory {
     }).collect(toSet());
     if (!containerProvidedPackages.isEmpty()) {
       exportedPackages.removeAll(containerProvidedPackages);
-      logger
+      LOGGER
           .warn("Exported packages from plugin '" + pluginUrlClassification.getName() + "' are provided by parent class loader: "
               + containerProvidedPackages);
     }
@@ -422,7 +423,7 @@ public class IsolatedClassLoaderFactory {
         parentExportedPackages.stream().filter(p -> exportedPackages.contains(p)).collect(toSet());
     if (!appProvidedPackages.isEmpty()) {
       exportedPackages.removeAll(appProvidedPackages);
-      logger.warn("Exported packages from plugin '" + pluginUrlClassification.getName() + "' are provided by the artifact owner: "
+      LOGGER.warn("Exported packages from plugin '" + pluginUrlClassification.getName() + "' are provided by the artifact owner: "
           + appProvidedPackages);
     }
     return exportedPackages;
@@ -471,9 +472,9 @@ public class IsolatedClassLoaderFactory {
    */
   private void logClassLoadingTrace(String message) {
     if (isVerboseClassLoading()) {
-      logger.info(message);
+      LOGGER.info(message);
     } else {
-      logger.debug(message);
+      LOGGER.debug(message);
     }
   }
 

--- a/tests/test-policies/pom.xml
+++ b/tests/test-policies/pom.xml
@@ -49,5 +49,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-unit</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/tests/test-policies/pom.xml
+++ b/tests/test-policies/pom.xml
@@ -44,6 +44,19 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>${project.version}</version>
+            <classifier>mule-plugin</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-runner</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-functional</artifactId>
             <version>${project.version}</version>

--- a/tests/unit/pom.xml
+++ b/tests/unit/pom.xml
@@ -20,12 +20,14 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-service-http-api</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -45,16 +47,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.services</groupId>
-            <artifactId>mule-service-weave</artifactId>
-            <classifier>mule-service</classifier>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-service-soap-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/tests/unit/src/main/java/org/mule/tck/processor/FlowAssert.java
+++ b/tests/unit/src/main/java/org/mule/tck/processor/FlowAssert.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.functional.api.component;
+package org.mule.tck.processor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,11 +13,11 @@ import java.util.TreeMap;
 
 public class FlowAssert {
 
-  private static Map<String, List<AssertionMessageProcessor>> assertions = new TreeMap<>();
+  private static Map<String, List<FlowAssertion>> assertions = new TreeMap<>();
 
   public static void verify() throws Exception {
-    for (List<AssertionMessageProcessor> flowAssertions : assertions.values()) {
-      for (AssertionMessageProcessor assertion : flowAssertions) {
+    for (List<FlowAssertion> flowAssertions : assertions.values()) {
+      for (FlowAssertion assertion : flowAssertions) {
         assertion.verify();
       }
     }
@@ -25,25 +25,25 @@ public class FlowAssert {
 
   public static void verify(String flowName) throws Exception {
 
-    List<AssertionMessageProcessor> flowAssertions = assertions.get(flowName);
+    List<FlowAssertion> flowAssertions = assertions.get(flowName);
     if (flowAssertions != null) {
-      for (AssertionMessageProcessor assertion : flowAssertions) {
+      for (FlowAssertion assertion : flowAssertions) {
         assertion.verify();
       }
     }
   }
 
-  static void addAssertion(String flowName, AssertionMessageProcessor assertion) {
+  public static void addAssertion(String flowName, FlowAssertion assertion) {
     synchronized (assertions) {
       if (assertions.get(flowName) == null) {
-        assertions.put(flowName, new ArrayList<AssertionMessageProcessor>());
+        assertions.put(flowName, new ArrayList<FlowAssertion>());
       }
       assertions.get(flowName).add(assertion);
     }
   }
 
   public static void reset() {
-    assertions = new TreeMap<String, List<AssertionMessageProcessor>>();
+    assertions = new TreeMap<String, List<FlowAssertion>>();
   }
 
 }

--- a/tests/unit/src/main/java/org/mule/tck/processor/FlowAssertion.java
+++ b/tests/unit/src/main/java/org/mule/tck/processor/FlowAssertion.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tck.processor;
+
+public interface FlowAssertion {
+
+  void verify() throws InterruptedException;
+
+}


### PR DESCRIPTION
including transitive dependencies from filter ones
* Bring back integration tests that don't need isolation or extensions
to this repo
* Cleanup test artifact dependencies so no unwanted transitive
dependencies en up in the APP classloader for tests