### PR TITLE
MULE-13240: remove VOID as a primitive type 

### DIFF
--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
@@ -326,8 +326,8 @@ final class XmlExtensionLoaderDelegate {
 
     operationDeclarer.withModelProperty(new OperationComponentModelModelProperty(operationModel, bodyComponentModel));
     operationDeclarer.describedAs(getDescription(operationModel));
-    extractOperationParameters(operationDeclarer, operationModel);
-    extractOutputType(operationDeclarer, operationModel);
+    extractOutputType(operationDeclarer.withOutput(), OPERATION_OUTPUT_IDENTIFIER, operationModel);
+    extractOutputType(operationDeclarer.withOutputAttributes(), OPERATION_OUTPUT_ATTRIBUTES_IDENTIFIER, operationModel);
   }
 
   // TODO MULE-12619: until the internals of ExtensionModel doesn't validate or corrects the name, this is the custom validation
@@ -404,43 +404,12 @@ final class XmlExtensionLoaderDelegate {
             .defaultingTo(parameterDefaultValue);
   }
 
-  private void extractOutputType(OperationDeclarer operationDeclarer, ComponentModel componentModel) {
-    // output processing
-    extractOutputType(operationDeclarer.withOutput(), OPERATION_OUTPUT_IDENTIFIER, componentModel);
-    //    ComponentModel outputComponentModel = componentModel.getInnerComponents()
-    //        .stream()
-    //        .filter(child -> child.getIdentifier().equals(OPERATION_OUTPUT_IDENTIFIER)).findFirst()
-    //        .orElseThrow(() -> new IllegalArgumentException("Having an operation without <output> is not supported"));
-    //
-    //    String receivedOutputType = outputComponentModel.getParameters().get(TYPE_ATTRIBUTE);
-    //    MetadataType outputType = extractType(receivedOutputType);
-    //    operationDeclarer.withOutput().describedAs(getDescription(outputComponentModel))
-    //        .ofType(outputType);
-
-    // output attribute processing
-    extractOutputType(operationDeclarer.withOutputAttributes(), OPERATION_OUTPUT_ATTRIBUTES_IDENTIFIER, componentModel);
-    //    Optional<ComponentModel> outputAttributesComponentModel = componentModel.getInnerComponents()
-    //        .stream()
-    //        .filter(child -> child.getIdentifier().equals(OPERATION_OUTPUT_ATTRIBUTES_IDENTIFIER)).findFirst();
-    //    OutputDeclarer outputAttributesDeclarer = operationDeclarer.withOutputAttributes();
-    //
-    //    if (outputAttributesComponentModel.isPresent()) {
-    //      String receivedOutputAttributeType = outputAttributesComponentModel.get().getParameters().get(TYPE_ATTRIBUTE);
-    //      final MetadataType metadataType = extractType(receivedOutputAttributeType);
-    //      outputAttributesDeclarer.describedAs(getDescription(outputAttributesComponentModel.get()))
-    //          .ofType(metadataType);
-    //    } else {
-    //      outputAttributesDeclarer.ofType(BaseTypeBuilder.create(JAVA).voidType().build());
-    //    }
-  }
-
   private void extractOutputType(OutputDeclarer outputDeclarer, ComponentIdentifier componentIdentifier,
-                                 ComponentModel componentModel) {
-
-    Optional<ComponentModel> outputAttributesComponentModel = componentModel.getInnerComponents()
+                                 ComponentModel operationModel) {
+    Optional<ComponentModel> outputAttributesComponentModel = operationModel.getInnerComponents()
         .stream()
         .filter(child -> child.getIdentifier().equals(componentIdentifier)).findFirst();
-
+    //if tye element is absent, it will default to the VOID type
     if (outputAttributesComponentModel.isPresent()) {
       String receivedOutputAttributeType = outputAttributesComponentModel.get().getParameters().get(TYPE_ATTRIBUTE);
       final MetadataType metadataType = extractType(receivedOutputAttributeType);

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
@@ -326,6 +326,7 @@ final class XmlExtensionLoaderDelegate {
 
     operationDeclarer.withModelProperty(new OperationComponentModelModelProperty(operationModel, bodyComponentModel));
     operationDeclarer.describedAs(getDescription(operationModel));
+    extractOperationParameters(operationDeclarer, operationModel);
     extractOutputType(operationDeclarer.withOutput(), OPERATION_OUTPUT_IDENTIFIER, operationModel);
     extractOutputType(operationDeclarer.withOutputAttributes(), OPERATION_OUTPUT_ATTRIBUTES_IDENTIFIER, operationModel);
   }

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
@@ -26,7 +26,7 @@ import static org.mule.runtime.api.meta.model.parameter.ParameterRole.BEHAVIOUR;
 import static org.mule.runtime.config.spring.api.XmlConfigurationDocumentLoader.schemaValidatingDocumentLoader;
 import static org.mule.runtime.extension.api.util.XmlModelUtils.createXmlLanguageModel;
 import static org.mule.runtime.extension.internal.loader.catalog.loader.common.XmlMatcher.match;
-
+import com.google.common.collect.ImmutableMap;
 import org.mule.metadata.api.builder.BaseTypeBuilder;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.catalog.api.TypeResolver;
@@ -63,8 +63,8 @@ import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
 import org.mule.runtime.extension.internal.loader.catalog.loader.common.XmlMatcher;
 import org.mule.runtime.extension.internal.loader.catalog.loader.xml.TypesCatalogXmlLoader;
 import org.mule.runtime.extension.internal.loader.catalog.model.TypesCatalog;
-
-import com.google.common.collect.ImmutableMap;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import java.io.IOException;
 import java.net.URL;
@@ -75,9 +75,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 /**
  * Describes an {@link ExtensionModel} by scanning an XML provided in the constructor
@@ -409,29 +406,48 @@ final class XmlExtensionLoaderDelegate {
 
   private void extractOutputType(OperationDeclarer operationDeclarer, ComponentModel componentModel) {
     // output processing
-    ComponentModel outputComponentModel = componentModel.getInnerComponents()
-        .stream()
-        .filter(child -> child.getIdentifier().equals(OPERATION_OUTPUT_IDENTIFIER)).findFirst()
-        .orElseThrow(() -> new IllegalArgumentException("Having an operation without <output> is not supported"));
-
-    String receivedOutputType = outputComponentModel.getParameters().get(TYPE_ATTRIBUTE);
-    MetadataType outputType = extractType(receivedOutputType);
-    operationDeclarer.withOutput().describedAs(getDescription(outputComponentModel))
-        .ofType(outputType);
+    extractOutputType(operationDeclarer.withOutput(), OPERATION_OUTPUT_IDENTIFIER, componentModel);
+    //    ComponentModel outputComponentModel = componentModel.getInnerComponents()
+    //        .stream()
+    //        .filter(child -> child.getIdentifier().equals(OPERATION_OUTPUT_IDENTIFIER)).findFirst()
+    //        .orElseThrow(() -> new IllegalArgumentException("Having an operation without <output> is not supported"));
+    //
+    //    String receivedOutputType = outputComponentModel.getParameters().get(TYPE_ATTRIBUTE);
+    //    MetadataType outputType = extractType(receivedOutputType);
+    //    operationDeclarer.withOutput().describedAs(getDescription(outputComponentModel))
+    //        .ofType(outputType);
 
     // output attribute processing
+    extractOutputType(operationDeclarer.withOutputAttributes(), OPERATION_OUTPUT_ATTRIBUTES_IDENTIFIER, componentModel);
+    //    Optional<ComponentModel> outputAttributesComponentModel = componentModel.getInnerComponents()
+    //        .stream()
+    //        .filter(child -> child.getIdentifier().equals(OPERATION_OUTPUT_ATTRIBUTES_IDENTIFIER)).findFirst();
+    //    OutputDeclarer outputAttributesDeclarer = operationDeclarer.withOutputAttributes();
+    //
+    //    if (outputAttributesComponentModel.isPresent()) {
+    //      String receivedOutputAttributeType = outputAttributesComponentModel.get().getParameters().get(TYPE_ATTRIBUTE);
+    //      final MetadataType metadataType = extractType(receivedOutputAttributeType);
+    //      outputAttributesDeclarer.describedAs(getDescription(outputAttributesComponentModel.get()))
+    //          .ofType(metadataType);
+    //    } else {
+    //      outputAttributesDeclarer.ofType(BaseTypeBuilder.create(JAVA).voidType().build());
+    //    }
+  }
+
+  private void extractOutputType(OutputDeclarer outputDeclarer, ComponentIdentifier componentIdentifier,
+                                 ComponentModel componentModel) {
+
     Optional<ComponentModel> outputAttributesComponentModel = componentModel.getInnerComponents()
         .stream()
-        .filter(child -> child.getIdentifier().equals(OPERATION_OUTPUT_ATTRIBUTES_IDENTIFIER)).findFirst();
-    OutputDeclarer outputAttributesDeclarer = operationDeclarer.withOutputAttributes();
+        .filter(child -> child.getIdentifier().equals(componentIdentifier)).findFirst();
 
     if (outputAttributesComponentModel.isPresent()) {
       String receivedOutputAttributeType = outputAttributesComponentModel.get().getParameters().get(TYPE_ATTRIBUTE);
       final MetadataType metadataType = extractType(receivedOutputAttributeType);
-      outputAttributesDeclarer.describedAs(getDescription(outputAttributesComponentModel.get()))
+      outputDeclarer.describedAs(getDescription(outputAttributesComponentModel.get()))
           .ofType(metadataType);
     } else {
-      outputAttributesDeclarer.ofType(BaseTypeBuilder.create(JAVA).voidType().build());
+      outputDeclarer.ofType(BaseTypeBuilder.create(JAVA).voidType().build());
     }
   }
 

--- a/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderTestCase.java
@@ -53,7 +53,7 @@ public class XmlExtensionLoaderTestCase extends AbstractMuleTestCase {
     Optional<OperationModel> operationModelOptional = extensionModel.getOperationModel("set-payload-concat-params-values");
     assertThat(operationModelOptional.isPresent(), is(true));
     final OperationModel operationModel = operationModelOptional.get();
-    assertThat(operationModel.getAllParameterModels().size(), is(3));
+    assertThat(operationModel.getAllParameterModels().size(), is(4));
     assertThat(operationModel.getAllParameterModels().get(0).getName(), is("value1"));
     assertThat(operationModel.getAllParameterModels().get(1).getName(), is("value2"));
     assertThat(operationModel.getAllParameterModels().get(2).getName(), is(TARGET_PARAMETER_NAME));

--- a/modules/extensions-xml-support/src/test/resources/modules/module-simple.xml
+++ b/modules/extensions-xml-support/src/test/resources/modules/module-simple.xml
@@ -56,6 +56,7 @@
 
     <operation name="do-nothing">
         <body>
+            <mule:set-variable variableName="variableBeforeCalling" value="this value will be written within this scope, but won't be propagated" />
             <mule:set-payload value="despite writing the payload, it won't be propagated because of the void return type" />
         </body>
     </operation>

--- a/modules/extensions-xml-support/src/test/resources/modules/module-simple.xml
+++ b/modules/extensions-xml-support/src/test/resources/modules/module-simple.xml
@@ -58,7 +58,6 @@
         <body>
             <mule:set-payload value="despite writing the payload, it won't be propagated because of the void return type" />
         </body>
-        <output type="void"/>
     </operation>
 
     <operation name="set-payload-param-value-appender">

--- a/modules/extensions-xml-support/src/test/resources/modules/module-using-jms.xml
+++ b/modules/extensions-xml-support/src/test/resources/modules/module-using-jms.xml
@@ -26,7 +26,6 @@
                 </jms:message>
             </jms:publish>
         </body>
-        <output type="void"/>
     </operation>
 
     <operation name="do-consume">

--- a/modules/extensions-xml-support/src/test/resources/modules/nested/module-simple-proxy.xml
+++ b/modules/extensions-xml-support/src/test/resources/modules/nested/module-simple-proxy.xml
@@ -56,7 +56,6 @@
         <body>
             <simple-prefix:do-nothing/>
         </body>
-        <output type="void"/>
     </operation>
 
     <operation name="set-payload-param-value-appender">

--- a/modules/spring-config/src/main/resources/META-INF/mule-module.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule-module.xsd
@@ -54,7 +54,7 @@
                             </xsd:sequence>
                         </xsd:complexType>
                     </xsd:element>
-                    <xsd:element ref="output" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element ref="output" minOccurs="0" maxOccurs="1"/>
                     <xsd:element ref="output-attributes" minOccurs="0" maxOccurs="1"/>
                 </xsd:sequence>
                 <xsd:attribute name="name" use="required">


### PR DESCRIPTION
the type will "be" VOID implicitly if `<output>` is absent, same goes for `<output-attributess>`

depends on https://github.com/mulesoft/metadata-model-api/pull/93