### PR TITLE
MULE-13280: In File Endpoints, FileAge is not always honored.

### DIFF
--- a/transports/file/src/main/java/org/mule/transport/file/FileMessageReceiver.java
+++ b/transports/file/src/main/java/org/mule/transport/file/FileMessageReceiver.java
@@ -271,7 +271,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
         //TODO RM*: This can be put in a Filter. Also we can add an AndFileFilter/OrFileFilter to allow users to
         //combine file filters (since we can only pass a single filter to File.listFiles, we would need to wrap
         //the current And/Or filters to extend {@link FilenameFilter}
-        Long fileAge;
+        Long fileAge = null;
         if (this.endpoint.getProperties().containsKey(PROPERTY_FILE_AGE))
         {
             fileAge = (Long) endpoint.getProperties().get(PROPERTY_FILE_AGE);
@@ -281,7 +281,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
             fileAge = fileConnector.getFileAge();
         }
 
-        if (fileConnector.getCheckFileAge() && !isAgedFile(file, fileAge))
+        if (fileAge != null && !isAgedFile(file, fileAge))
         {
             removeProcessingMark(file.getAbsolutePath());
 

--- a/transports/file/src/test/java/org/mule/transport/file/FileAgeTestCase.java
+++ b/transports/file/src/test/java/org/mule/transport/file/FileAgeTestCase.java
@@ -9,9 +9,14 @@ package org.mule.transport.file;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static java.lang.Long.parseLong;
+import static org.mule.transport.file.FileTestUtils.createDataFile;
+import static org.mule.util.FileUtils.openDirectory;
 import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
 
+import java.io.File;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -19,8 +24,11 @@ import org.junit.Test;
 public class FileAgeTestCase extends FunctionalTestCase
 {
 
-    private static final String CONNECTOR_FILE_AGE= "60000";
-    private static final String ENDPOINT_FILE_AGE = "120000";
+    private static long DELTA_TIME = 1000;
+
+    private static final String CONNECTOR_FILE_AGE= "2000";
+
+    private static final String ENDPOINT_FILE_AGE = "3000";
 
     @Rule
     public SystemProperty fileAgeConnectorSystemProperty = new SystemProperty("fileAgeConnector", CONNECTOR_FILE_AGE);
@@ -28,10 +36,25 @@ public class FileAgeTestCase extends FunctionalTestCase
     @Rule
     public SystemProperty fileAgeEndpointSystemProperty = new SystemProperty("fileAgeEndpoint", ENDPOINT_FILE_AGE);
 
+    private File temporaryDirectory ;
+
+    private File secondTemporaryDirectory ;
+
+    private File thirdTemporaryDirectory ;
+
     @Override
     protected String getConfigFile()
     {
         return "file-age-config.xml";
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        openDirectory(getFileInsideWorkingDirectory("test").getAbsolutePath());
+        temporaryDirectory = openDirectory(getFileInsideWorkingDirectory("test").getAbsolutePath());
+        secondTemporaryDirectory = openDirectory(getFileInsideWorkingDirectory("test2").getAbsolutePath());
+        thirdTemporaryDirectory = openDirectory(getFileInsideWorkingDirectory("test3").getAbsolutePath());
     }
 
     @Test
@@ -39,6 +62,30 @@ public class FileAgeTestCase extends FunctionalTestCase
     {
         FileConnector fileConnector = muleContext.getRegistry().lookupObject("fileConnector");
         assertThat(fileConnector.getFileAge(), is(parseLong(CONNECTOR_FILE_AGE)));
+    }
+
+    @Test
+    public void fileAgeInheritedFromConnectorIsHonored() throws Exception
+    {
+        File createdFile = createDataFile(temporaryDirectory, TEST_MESSAGE, "UTF-8");
+        Thread.sleep(parseLong(CONNECTOR_FILE_AGE) - DELTA_TIME);
+        assertThat(createdFile.exists(), is(true));
+    }
+
+    @Test
+    public void overrodeFileAgeInEndpointIsHonored() throws Exception
+    {
+        File createdFile = createDataFile(secondTemporaryDirectory, TEST_MESSAGE, "UTF-8");
+        Thread.sleep(parseLong(ENDPOINT_FILE_AGE) - DELTA_TIME);
+        assertThat(createdFile.exists(), is(true));
+    }
+
+    @Test
+    public void fileAgeInEndpointIsHonoredWhenAbsentInReferredConnector() throws Exception
+    {
+        File createdFile = createDataFile(thirdTemporaryDirectory, TEST_MESSAGE, "UTF-8");
+        Thread.sleep(parseLong(ENDPOINT_FILE_AGE) - DELTA_TIME);
+        assertThat(createdFile.exists(), is(true));
     }
 
 }

--- a/transports/file/src/test/java/org/mule/transport/file/FileAgeTestCase.java
+++ b/transports/file/src/test/java/org/mule/transport/file/FileAgeTestCase.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.is;
 import static java.lang.Long.parseLong;
 import static org.mule.transport.file.FileTestUtils.createDataFile;
 import static org.mule.util.FileUtils.openDirectory;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
 
@@ -67,7 +68,7 @@ public class FileAgeTestCase extends FunctionalTestCase
     @Test
     public void fileAgeInheritedFromConnectorIsHonored() throws Exception
     {
-        File createdFile = createDataFile(temporaryDirectory, TEST_MESSAGE, "UTF-8");
+        File createdFile = createDataFile(temporaryDirectory, TEST_MESSAGE, UTF_8.name());
         Thread.sleep(parseLong(CONNECTOR_FILE_AGE) - DELTA_TIME);
         assertThat(createdFile.exists(), is(true));
     }
@@ -75,7 +76,7 @@ public class FileAgeTestCase extends FunctionalTestCase
     @Test
     public void overrodeFileAgeInEndpointIsHonored() throws Exception
     {
-        File createdFile = createDataFile(secondTemporaryDirectory, TEST_MESSAGE, "UTF-8");
+        File createdFile = createDataFile(secondTemporaryDirectory, TEST_MESSAGE, UTF_8.name());
         Thread.sleep(parseLong(ENDPOINT_FILE_AGE) - DELTA_TIME);
         assertThat(createdFile.exists(), is(true));
     }
@@ -83,7 +84,7 @@ public class FileAgeTestCase extends FunctionalTestCase
     @Test
     public void fileAgeInEndpointIsHonoredWhenAbsentInReferredConnector() throws Exception
     {
-        File createdFile = createDataFile(thirdTemporaryDirectory, TEST_MESSAGE, "UTF-8");
+        File createdFile = createDataFile(thirdTemporaryDirectory, TEST_MESSAGE, UTF_8.name());
         Thread.sleep(parseLong(ENDPOINT_FILE_AGE) - DELTA_TIME);
         assertThat(createdFile.exists(), is(true));
     }

--- a/transports/file/src/test/resources/file-age-config.xml
+++ b/transports/file/src/test/resources/file-age-config.xml
@@ -5,14 +5,22 @@
       xsi:schemaLocation="
        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
        http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd">
-    <file:connector name="fileConnector" fileAge="${fileAgeConnector}"/>
+    <file:connector name="fileConnector" fileAge="${fileAgeConnector}" autoDelete="true" streaming="false" pollingFrequency="500"/>
+    <file:connector name="fileConnectorWithAbsentFileAge" autoDelete="true" streaming="false" pollingFrequency="500"/>
 
-    <flow name="testageFlow">
-        <file:inbound-endpoint path="src/main/resources/Dir1" connector-ref="fileConnector"/>
+    <flow name="fileAgeInheritedFromConnectorHonorsFlow">
+        <file:inbound-endpoint path="${workingDirectory}/test" connector-ref="fileConnector"/>
         <echo-component/>
     </flow>
-    <flow name="testageFlow1">
-        <file:inbound-endpoint path="src/main/resources/Dir2"  fileAge="${fileAgeEndpoint}"/>
+
+    <flow name="overrodeFileAgeInEndpointIsHonoredFlow">
+        <file:inbound-endpoint path="${workingDirectory}/test2"  connector-ref="fileConnector" fileAge="${fileAgeEndpoint}"/>
         <echo-component/>
     </flow>
+
+    <flow name="fileAgeInEndpointIsHonoredWhenAbsentInReferredConnectorFlow">
+        <file:inbound-endpoint path="${workingDirectory}/test3"  connector-ref="fileConnectorWithAbsentFileAge" fileAge="${fileAgeEndpoint}"/>
+        <echo-component/>
+    </flow>
+
 </mule>


### PR DESCRIPTION
If I have an FileEndpoint that defines a FileAge and refers to a File Connector that doesn't define a fileAge, so the fileAge attribute is ignored.
