### PR TITLE
MULE-13296: SMTP Transformer is not overriding endpoints attributes i…

### DIFF
--- a/transports/email/src/main/java/org/mule/transport/email/SmtpConnector.java
+++ b/transports/email/src/main/java/org/mule/transport/email/SmtpConnector.java
@@ -24,6 +24,7 @@ public class SmtpConnector extends AbstractMailConnector
     public static final String DEFAULT_SMTP_HOST = "localhost";
     public static final int DEFAULT_SMTP_PORT = 25;
     public static final String DEFAULT_CONTENT_TYPE = "text/plain";
+    public static final String DEFAULT_SUBJECT_VALUE  = "[No Subject]";
 
     /**
      * Holds value of bcc addresses.
@@ -43,7 +44,7 @@ public class SmtpConnector extends AbstractMailConnector
     /**
      * Holds value of default subject
      */
-    private String defaultSubject = "[No Subject]";
+    private String defaultSubject = DEFAULT_SUBJECT_VALUE;
 
     /**
      * Holds value of the from address.

--- a/transports/email/src/main/java/org/mule/transport/email/transformers/StringToEmailMessage.java
+++ b/transports/email/src/main/java/org/mule/transport/email/transformers/StringToEmailMessage.java
@@ -161,7 +161,11 @@ public class StringToEmailMessage extends AbstractMessageTransformer
         String value = message.getOutboundProperty(propName);
         if (value == null)
         {
-            value = message.getInvocationProperty(propName, defaultValue);
+            value = (String) endpoint.getProperty(propName);
+            if (value == null)
+            {
+                value = defaultValue;
+            }
         }
         return evaluate(value, message);
     }

--- a/transports/email/src/test/java/org/mule/transport/email/functional/SmtpEndpointAttributesTestCase.java
+++ b/transports/email/src/test/java/org/mule/transport/email/functional/SmtpEndpointAttributesTestCase.java
@@ -6,6 +6,8 @@
  */
 package org.mule.transport.email.functional;
 
+import static javax.mail.Message.RecipientType.BCC;
+import static javax.mail.Message.RecipientType.CC;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -34,6 +36,7 @@ public class SmtpEndpointAttributesTestCase extends AbstractEmailFunctionalTestC
 
     private static final CountDownLatch latch = new CountDownLatch(3);
     private static final List<Message> processedMessages = new ArrayList<>();
+
     public SmtpEndpointAttributesTestCase(ConfigVariant variant, String configResources)
     {
         super(variant, STRING_MESSAGE, "smtp", configResources);
@@ -62,8 +65,8 @@ public class SmtpEndpointAttributesTestCase extends AbstractEmailFunctionalTestC
 
     private void assertMessage (Message message, String messageId) throws Exception
     {
-        Address[]  ccAddresses = message.getRecipients(Message.RecipientType.CC);
-        Address[]  bccAddresses = message.getRecipients(Message.RecipientType.BCC);
+        Address[]  ccAddresses = message.getRecipients(CC);
+        Address[]  bccAddresses = message.getRecipients(BCC);
         assertThat(message.getContent(), is((Object) (messageId + "-payload")));
         assertThat(ccAddresses[0].toString(), is (messageId + "-cc@example.com"));
         assertThat(bccAddresses[0].toString(), is(messageId + "-bcc@example.com" ));
@@ -73,8 +76,8 @@ public class SmtpEndpointAttributesTestCase extends AbstractEmailFunctionalTestC
 
     private void assertMessageWithNullValues(Message message, String messageId) throws Exception
     {
-        Address[]  ccAddresses = message.getRecipients(Message.RecipientType.CC);
-        Address[]  bccAddresses = message.getRecipients(Message.RecipientType.BCC);
+        Address[]  ccAddresses = message.getRecipients(CC);
+        Address[]  bccAddresses = message.getRecipients(BCC);
         assertThat(message.getContent(), is((Object) (messageId + "-payload")));
         assertThat(ccAddresses, is(nullValue()));
         assertThat(bccAddresses, is(nullValue()));

--- a/transports/email/src/test/java/org/mule/transport/email/functional/SmtpEndpointAttributesTestCase.java
+++ b/transports/email/src/test/java/org/mule/transport/email/functional/SmtpEndpointAttributesTestCase.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.email.functional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mule.transport.email.SmtpConnector.DEFAULT_SUBJECT_VALUE;
+import org.mule.api.MuleEvent;
+import org.mule.api.MuleException;
+import org.mule.api.endpoint.OutboundEndpoint;
+import org.mule.api.transport.MessageDispatcher;
+import org.mule.transport.email.SmtpMessageDispatcher;
+import org.mule.transport.email.SmtpMessageDispatcherFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import javax.mail.Address;
+import javax.mail.Message;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+
+public class SmtpEndpointAttributesTestCase extends AbstractEmailFunctionalTestCase
+{
+
+    private static final CountDownLatch latch = new CountDownLatch(3);
+    private static final List<Message> processedMessages = new ArrayList<>();
+    public SmtpEndpointAttributesTestCase(ConfigVariant variant, String configResources)
+    {
+        super(variant, STRING_MESSAGE, "smtp", configResources);
+    }
+
+    @Parameters
+    public static Collection<Object[]> parameters()
+    {
+        return Arrays.asList(new Object[][]{
+            {ConfigVariant.FLOW, "smtp-endpoint-attributes-config.xml"}
+        });
+    }      
+    
+    @Test
+    public void testSend() throws Exception
+    {
+        runFlow("endpointAttributesFlow");
+        latch.await();
+        Message firstMessage = processedMessages.get(0);
+        Message secondMessage = processedMessages.get(1);
+        Message thirdMessage = processedMessages.get(2);
+        assertMessage(firstMessage, "first");
+        assertMessage(secondMessage, "second");
+        assertMessageWithNullValues(thirdMessage, "third");
+    }
+
+    private void assertMessage (Message message, String messageId) throws Exception
+    {
+        Address[]  ccAddresses = message.getRecipients(Message.RecipientType.CC);
+        Address[]  bccAddresses = message.getRecipients(Message.RecipientType.BCC);
+        assertThat(message.getContent(), is((Object) (messageId + "-payload")));
+        assertThat(ccAddresses[0].toString(), is (messageId + "-cc@example.com"));
+        assertThat(bccAddresses[0].toString(), is(messageId + "-bcc@example.com" ));
+        assertThat(message.getReplyTo()[0].toString(), is(messageId + "-reply-to@example.com"));
+        assertThat(message.getSubject(), is(messageId + "-subject"));
+    }
+
+    private void assertMessageWithNullValues(Message message, String messageId) throws Exception
+    {
+        Address[]  ccAddresses = message.getRecipients(Message.RecipientType.CC);
+        Address[]  bccAddresses = message.getRecipients(Message.RecipientType.BCC);
+        assertThat(message.getContent(), is((Object) (messageId + "-payload")));
+        assertThat(ccAddresses, is(nullValue()));
+        assertThat(bccAddresses, is(nullValue()));
+        assertThat(message.getReplyTo(), is(nullValue()));
+        assertThat(message.getSubject(), is(DEFAULT_SUBJECT_VALUE));
+    }
+
+    private static class TestSmtpServiceDispatcher extends SmtpMessageDispatcher
+    {
+        private TestSmtpServiceDispatcher(OutboundEndpoint endpoint)
+        {
+            super(endpoint);
+        }
+
+        @Override
+        protected void doDispatch(MuleEvent event) throws Exception
+        {
+            processedMessages.add((Message) event.getMessage().getPayload());
+            latch.countDown();
+        }
+    }
+
+    public static class TestSmtpServiceDispatcherFactory extends SmtpMessageDispatcherFactory
+    {
+        @Override
+        public MessageDispatcher create(OutboundEndpoint endpoint) throws MuleException
+        {
+            return new TestSmtpServiceDispatcher(endpoint);
+        }
+    }
+
+}

--- a/transports/email/src/test/resources/smtp-endpoint-attributes-config.xml
+++ b/transports/email/src/test/resources/smtp-endpoint-attributes-config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:smtp="http://www.mulesoft.org/schema/mule/smtp"
+       xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/smtp http://www.mulesoft.org/schema/mule/smtp/current/mule-smtp.xsd">
+
+    <smtp:connector name="smtpConnector">
+        <service-overrides dispatcherFactory="org.mule.transport.email.functional.SmtpEndpointAttributesTestCase$TestSmtpServiceDispatcherFactory"/>
+    </smtp:connector>
+
+    <flow name="endpointAttributesFlow">
+        <set-payload value="first-payload"/>
+        <smtp:outbound-endpoint host="localhost" port="${port1}" to="first-to@example.com" cc="first-cc@example.com" bcc="first-bcc@example.com" replyTo="first-reply-to@example.com" subject="first-subject" connector-ref="smtpConnector"/>
+        <set-payload value="second-payload"/>
+        <smtp:outbound-endpoint host="localhost" port="${port1}" to="second-to@example.com" cc="second-cc@example.com" bcc="second-bcc@example.com" replyTo="second-reply-to@example.com" subject="second-subject" connector-ref="smtpConnector"/>
+        <set-payload value="third-payload"/>
+        <smtp:outbound-endpoint host="localhost" port="${port1}" to="third-to@example.com"  connector-ref="smtpConnector"/>
+    </flow>
+    
+</mule>


### PR DESCRIPTION
…n the same flow.

This issue ocurrs since StringToEmailMessage Transformer is creating the javax.mail.Message using the Mule Message invocation properties instead the endpoint properties.
