### PR TITLE
MULE-12321: When an app with OAuth Client Credentials can't connect at

### DIFF
--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/message/request/DefaultHttpRequest.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/message/request/DefaultHttpRequest.java
@@ -6,12 +6,13 @@
  */
 package org.mule.runtime.http.api.domain.message.request;
 
-import org.mule.runtime.http.api.domain.HttpProtocol;
+import static java.lang.System.lineSeparator;
+
 import org.mule.runtime.api.util.MultiMap;
+import org.mule.runtime.http.api.domain.HttpProtocol;
 import org.mule.runtime.http.api.domain.entity.HttpEntity;
 import org.mule.runtime.http.api.domain.message.BaseHttpMessage;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -55,17 +56,11 @@ class DefaultHttpRequest extends BaseHttpMessage implements HttpRequest {
 
   @Override
   public Collection<String> getHeaderNames() {
-    if (headers == null) {
-      return new ArrayList<>();
-    }
     return headers.keySet();
   }
 
   @Override
   public String getHeaderValue(String headerName) {
-    if (headers == null) {
-      return null;
-    }
     return headers.get(headerName);
   }
 
@@ -84,8 +79,20 @@ class DefaultHttpRequest extends BaseHttpMessage implements HttpRequest {
     return uri;
   }
 
+  @Override
   public MultiMap<String, String> getQueryParams() {
     return queryParams;
+  }
+
+  @Override
+  public String toString() {
+    return "DefaultHttpRequest {" + lineSeparator()
+        + "  uri: " + uri + "," + lineSeparator()
+        + "  path: " + path + "," + lineSeparator()
+        + "  method: " + method + "," + lineSeparator()
+        + "  headers: " + headers.toString() + "," + lineSeparator()
+        + "  queryParams: " + queryParams.toString() + lineSeparator()
+        + "}";
   }
 
 }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/message/response/DefaultHttpResponse.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/message/response/DefaultHttpResponse.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.http.api.domain.message.response;
 
+import static java.lang.System.lineSeparator;
+
 import org.mule.runtime.api.util.MultiMap;
 import org.mule.runtime.http.api.domain.entity.HttpEntity;
 import org.mule.runtime.http.api.domain.message.BaseHttpMessage;
@@ -55,6 +57,14 @@ class DefaultHttpResponse extends BaseHttpMessage implements HttpResponse {
   @Override
   public String getReasonPhrase() {
     return this.responseStatus.getReasonPhrase();
+  }
+
+  @Override
+  public String toString() {
+    return "DefaultHttpResponse {" + lineSeparator()
+        + "  responseStatus: " + responseStatus.getStatusCode() + " (" + responseStatus.getReasonPhrase() + ")," + lineSeparator()
+        + "  headers: " + headers.toString() + lineSeparator()
+        + "}";
   }
 
 }

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/exception/TokenNotFoundException.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/exception/TokenNotFoundException.java
@@ -7,9 +7,11 @@
 package org.mule.runtime.oauth.api.exception;
 
 import static java.lang.String.format;
+import static java.lang.System.lineSeparator;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 
 import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 
 /**
  * It was not possible to retrieve the access token or the refresh token from the token URL response
@@ -18,9 +20,11 @@ public class TokenNotFoundException extends MuleException {
 
   private static final long serialVersionUID = -4527896867466127563L;
 
-  public TokenNotFoundException(Object tokenUrlResponseBody) {
-    super(createStaticMessage(format("Could not extract access token or refresh token from token URL response: %s",
-                                     tokenUrlResponseBody)));
+  public TokenNotFoundException(String tokenUrl, HttpResponse response, String body) {
+    super(createStaticMessage(format("Could not extract access token or refresh token from token URL '%s'. Response was:"
+        + lineSeparator() + "%s"
+        + lineSeparator() + "%s",
+                                     tokenUrl, response.toString(), body)));
   }
 
 }

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/exception/TokenUrlResponseException.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/exception/TokenUrlResponseException.java
@@ -7,9 +7,13 @@
 package org.mule.runtime.oauth.api.exception;
 
 import static java.lang.String.format;
+import static java.lang.System.lineSeparator;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 
 import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.http.api.domain.message.response.HttpResponse;
+
+import java.io.IOException;
 
 /**
  * There was a problem with the call to the tokenUrl.
@@ -18,13 +22,16 @@ public class TokenUrlResponseException extends MuleException {
 
   private static final long serialVersionUID = 201036315336735350L;
 
-  public TokenUrlResponseException(String tokenUrl) {
-    super(createStaticMessage(format("Exception when calling token URL %s", tokenUrl)));
+  public TokenUrlResponseException(String tokenUrl, HttpResponse response, String body) throws IOException {
+    super(createStaticMessage(format("Error response when calling token URL '%s'. Response was:"
+        + lineSeparator() + "%s"
+        + lineSeparator() + "%s",
+                                     tokenUrl, response.toString(), body)));
 
   }
 
   public TokenUrlResponseException(String tokenUrl, Exception cause) {
-    super(createStaticMessage(format("Exception when calling token URL %s", tokenUrl)), cause);
+    super(createStaticMessage(format("Exception when calling token URL '%s'.", tokenUrl)), cause);
 
   }
 }


### PR DESCRIPTION
deployment it doesn't show the HTTP requester response as in 3.x