### PR TITLE
MULE-13419: Avoid exporting exception mappings and property editor

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/util/CompositeClassLoader.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/CompositeClassLoader.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.core.internal.util;
 
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,8 +36,10 @@ public class CompositeClassLoader extends ClassLoader {
 
   public CompositeClassLoader(ClassLoader first, ClassLoader... others) {
     delegates = new ArrayList<>();
-    delegates.add(first);
-    delegates.addAll(asList(others));
+    if (first != null) {
+      delegates.add(first);
+    }
+    delegates.addAll(asList(others).stream().filter(o -> o != null).collect(toList()));
   }
 
   @Override

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoader.java
@@ -11,8 +11,12 @@ import static java.lang.String.format;
 import static java.lang.System.getProperty;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_LOG_VERBOSE_CLASSLOADING;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.core.api.util.ClassUtils;
 import org.mule.runtime.module.artifact.api.classloader.exception.CompositeClassNotFoundException;
+
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -25,8 +29,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import sun.misc.CompoundEnumeration;
 import sun.net.www.protocol.jar.Handler;
 
@@ -43,7 +45,7 @@ public class FineGrainedControlClassLoader extends URLClassLoader
     registerAsParallelCapable();
   }
 
-  protected Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger LOGGER = getLogger(FineGrainedControlClassLoader.class);
 
   private final ClassLoaderLookupPolicy lookupPolicy;
   private final boolean verboseLogging;
@@ -52,11 +54,11 @@ public class FineGrainedControlClassLoader extends URLClassLoader
     super(urls, parent, new NonCachingURLStreamHandlerFactory());
     checkArgument(lookupPolicy != null, "Lookup policy cannot be null");
     this.lookupPolicy = lookupPolicy;
-    verboseLogging = logger.isDebugEnabled() || isVerboseLoggingEnabled();
+    verboseLogging = LOGGER.isDebugEnabled() || isVerboseLoggingEnabled();
   }
 
   private boolean isVerboseLoggingEnabled() {
-    return logger.isInfoEnabled() && valueOf(getProperty(MULE_LOG_VERBOSE_CLASSLOADING));
+    return LOGGER.isInfoEnabled() && valueOf(getProperty(MULE_LOG_VERBOSE_CLASSLOADING));
   }
 
   @Override
@@ -123,10 +125,10 @@ public class FineGrainedControlClassLoader extends URLClassLoader
   }
 
   private void doVerboseLogging(String message) {
-    if (logger.isDebugEnabled()) {
-      logger.debug(message);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(message);
     } else {
-      logger.info(message);
+      LOGGER.info(message);
     }
   }
 

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
@@ -12,9 +12,12 @@ import static java.lang.System.identityHashCode;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.api.util.IOUtils.closeQuietly;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
+
+import org.slf4j.Logger;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -29,6 +32,8 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
   static {
     registerAsParallelCapable();
   }
+
+  private static final Logger LOGGER = getLogger(MuleArtifactClassLoader.class);
 
   private static final String DEFAULT_RESOURCE_RELEASER_CLASS_LOCATION =
       "/org/mule/module/artifact/classloader/DefaultResourceReleaser.class";
@@ -89,7 +94,7 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
     try {
       createResourceReleaserInstance().release();
     } catch (Exception e) {
-      logger.error("Cannot create resource releaser instance", e);
+      LOGGER.error("Cannot create resource releaser instance", e);
     }
     super.dispose();
     shutdownListeners();
@@ -100,7 +105,7 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
       try {
         listener.execute();
       } catch (Exception e) {
-        logger.error("Error executing shutdown listener", e);
+        LOGGER.error("Error executing shutdown listener", e);
       }
     }
 
@@ -150,7 +155,7 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
     try {
       createCustomInstance(getErrorHooksClassLocation());
     } catch (Exception e) {
-      logger.error("Cannot configure error hooks", e);
+      LOGGER.error("Cannot configure error hooks", e);
     }
   }
 

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoaderTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoaderTestCase.java
@@ -35,18 +35,18 @@ import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.util.EnumerationMatcher;
 
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class RegionClassLoaderTestCase extends AbstractMuleTestCase {
 
@@ -259,7 +259,7 @@ public class RegionClassLoaderTestCase extends AbstractMuleTestCase {
 
     regionClassLoader.addClassLoader(appClassLoader, new DefaultArtifactClassLoaderFilter(singleton(PACKAGE_NAME), emptySet()));
     expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage(duplicatePackageMappingError(PACKAGE_NAME));
+    expectedException.expectMessage(duplicatePackageMappingError(PACKAGE_NAME, appClassLoader, pluginClassLoader));
     regionClassLoader.addClassLoader(pluginClassLoader,
                                      new DefaultArtifactClassLoaderFilter(singleton(PACKAGE_NAME), emptySet()));
   }

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/domain/MuleSharedDomainClassLoader.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/domain/MuleSharedDomainClassLoader.java
@@ -9,11 +9,15 @@ package org.mule.runtime.deployment.model.internal.domain;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getDomainFolder;
 import static org.mule.runtime.deployment.model.internal.domain.DomainClassLoaderFactory.getDomainId;
 import static org.mule.runtime.module.reboot.api.MuleContainerBootstrapUtils.getMuleConfDir;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.module.artifact.api.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
+
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -28,6 +32,8 @@ public class MuleSharedDomainClassLoader extends MuleDeployableArtifactClassLoad
   static {
     registerAsParallelCapable();
   }
+
+  private static final Logger LOGGER = getLogger(MuleSharedDomainClassLoader.class);
 
   public MuleSharedDomainClassLoader(ArtifactDescriptor artifactDescriptor, ClassLoader parent,
                                      ClassLoaderLookupPolicy lookupPolicy, List<URL> urls,
@@ -45,7 +51,7 @@ public class MuleSharedDomainClassLoader extends MuleDeployableArtifactClassLoad
         try {
           resource = file.toURI().toURL();
         } catch (MalformedURLException e) {
-          logger.debug("Failure looking for resource", e);
+          LOGGER.debug("Failure looking for resource", e);
         }
       }
     }


### PR DESCRIPTION
resources
* Fix: test-runner was including transitive test dependencies as plugins
* Improve classloader logging for troubleshooting