### PR TITLE
MULE-9142: Transformation service must always update message once pay…

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/SetPayloadTransformerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/SetPayloadTransformerTestCase.java
@@ -21,7 +21,7 @@ import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.InternalEvent;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.el.ExtendedExpressionManager;
-import org.mule.runtime.core.api.transformer.TransformerException;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -53,11 +53,11 @@ public class SetPayloadTransformerTestCase extends AbstractMuleTestCase {
     when(mockMuleEvent.getMessage()).thenReturn(mockMuleMessage);
     when(mockMuleContext.getExpressionManager()).thenReturn(mockExpressionManager);
     when(mockExpressionManager.parse(anyString(), any(InternalEvent.class), any(ComponentLocation.class)))
-        .thenAnswer(invocation -> (String) invocation.getArguments()[0]);
+        .thenAnswer(invocation -> invocation.getArguments()[0]);
   }
 
   @Test
-  public void testSetPayloadTransformerNulValue() throws InitialisationException, TransformerException {
+  public void testSetPayloadTransformerNulValue() throws InitialisationException, MessageTransformerException {
     setPayloadTransformer.setValue(null);
     setPayloadTransformer.initialise();
 
@@ -66,7 +66,7 @@ public class SetPayloadTransformerTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  public void testSetPayloadTransformerPlainText() throws InitialisationException, TransformerException {
+  public void testSetPayloadTransformerPlainText() throws InitialisationException, MessageTransformerException {
     setPayloadTransformer.setValue(PLAIN_TEXT);
     setPayloadTransformer.initialise();
 
@@ -77,7 +77,7 @@ public class SetPayloadTransformerTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  public void testSetPayloadTransformerExpression() throws InitialisationException, TransformerException {
+  public void testSetPayloadTransformerExpression() throws InitialisationException, MessageTransformerException {
     setPayloadTransformer.setValue(EXPRESSION);
     when(mockExpressionManager.isExpression(EXPRESSION)).thenReturn(true);
     setPayloadTransformer.initialise();

--- a/core/src/main/java/org/mule/runtime/core/api/InternalEvent.java
+++ b/core/src/main/java/org/mule/runtime/core/api/InternalEvent.java
@@ -11,14 +11,14 @@ import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Error;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
-import org.mule.runtime.core.api.security.SecurityContext;
 import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
 import org.mule.runtime.core.api.connector.ReplyToHandler;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.context.notification.FlowCallStack;
 import org.mule.runtime.core.api.message.GroupCorrelation;
+import org.mule.runtime.core.api.security.SecurityContext;
 import org.mule.runtime.core.api.source.MessageSource;
-import org.mule.runtime.core.api.transformer.TransformerException;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.internal.message.DefaultEventBuilder;
 import org.mule.runtime.core.internal.processor.chain.ModuleOperationMessageProcessorChainBuilder;
 
@@ -97,26 +97,12 @@ public interface InternalEvent extends Serializable, Event {
    * @param outputType The requested output type.
    * @param muleContext the Mule node.
    * @return the message transformed into it's recognized or expected format.
-   * @throws TransformerException if a failure occurs in the transformer
+   * @throws MessageTransformerException if a failure occurs in the transformer
    * @see org.mule.runtime.core.api.transformer.Transformer if the transform fails or the outputtype is null
    * @deprecated TODO MULE-10013 Move message serialization logic from within the message to an external service
    */
   @Deprecated
-  <T> T transformMessage(Class<T> outputType, MuleContext muleContext) throws TransformerException;
-
-  /**
-   * Transforms the message into the requested format. The transformer used is the one configured on the endpoint through which
-   * this event was received.
-   * 
-   * @param outputType The requested output type.
-   * @param muleContext the Mule node.
-   * @return the message transformed into it's recognized or expected format.
-   * @throws TransformerException if a failure occurs in the transformer
-   * @see org.mule.runtime.core.api.transformer.Transformer if the transform fails or the outputtype is null
-   * @deprecated TODO MULE-10013 Move message serialization logic from within the message to an external service
-   */
-  @Deprecated
-  Object transformMessage(DataType outputType, MuleContext muleContext) throws TransformerException;
+  Object transformMessage(DataType outputType, MuleContext muleContext) throws MessageTransformerException;
 
   /**
    * Returns the message transformed into it's recognized or expected format and then into a String. The transformer used is the
@@ -125,12 +111,12 @@ public interface InternalEvent extends Serializable, Event {
    * 
    * @param muleContext the Mule node.
    * @return the message transformed into it's recognized or expected format as a Strings.
-   * @throws TransformerException if a failure occurs in the transformer
+   * @throws MessageTransformerException if a failure occurs in the transformer
    * @see org.mule.runtime.core.api.transformer.Transformer
    * @deprecated TODO MULE-10013 Move message serialization logic from within the message to an external service
    */
   @Deprecated
-  String transformMessageToString(MuleContext muleContext) throws TransformerException;
+  String transformMessageToString(MuleContext muleContext) throws MessageTransformerException;
 
   /**
    * Returns the message contents as a string If necessary this will use the encoding set on the event

--- a/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractMessageTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractMessageTransformer.java
@@ -90,8 +90,7 @@ public abstract class AbstractMessageTransformer extends AbstractTransformer imp
         return src;
       } else {
         I18nMessage msg = CoreMessages.transformOnObjectUnsupportedTypeOfEndpoint(getName(), src.getClass());
-        /// FIXME
-        throw new MessageTransformerException(msg, this);
+        throw new MessageTransformerException(msg, this, event.getMessage());
       }
     }
     if (logger.isDebugEnabled()) {
@@ -111,7 +110,7 @@ public abstract class AbstractMessageTransformer extends AbstractTransformer imp
       message = of(src);
     } else {
       if (event == null) {
-        throw new MessageTransformerException(CoreMessages.noCurrentEventForTransformer(), this);
+        throw new MessageTransformerException(CoreMessages.noCurrentEventForTransformer(), this, null);
       }
       message = event.getMessage();
     }
@@ -124,11 +123,8 @@ public abstract class AbstractMessageTransformer extends AbstractTransformer imp
       ComponentLocation location = getLocation() != null ? getLocation() : fromSingleComponent("AbstractMessageTransformer");
       event = InternalEvent.builder(create(flowConstruct, location)).message(message).flow(flowConstruct).build();
     }
-    try {
-      result = transformMessage(event, enc);
-    } catch (TransformerException e) {
-      throw new MessageTransformerException(e.getI18nMessage(), this, e);
-    }
+
+    result = transformMessage(event, enc);
 
     if (logger.isDebugEnabled()) {
       logger.debug(String.format("Object after transform: %s", StringMessageUtils.toString(result)));
@@ -151,7 +147,8 @@ public abstract class AbstractMessageTransformer extends AbstractTransformer imp
     if (getReturnDataType() != null) {
       DataType dt = DataType.fromObject(object);
       if (!getReturnDataType().isCompatibleWith(dt)) {
-        throw new MessageTransformerException(CoreMessages.transformUnexpectedType(dt, getReturnDataType()), this);
+        throw new MessageTransformerException(CoreMessages.transformUnexpectedType(dt, getReturnDataType()), this,
+                                              event.getMessage());
       }
     }
 
@@ -165,5 +162,5 @@ public abstract class AbstractMessageTransformer extends AbstractTransformer imp
   /**
    * Transform the message
    */
-  public abstract Object transformMessage(InternalEvent event, Charset outputEncoding) throws TransformerException;
+  public abstract Object transformMessage(InternalEvent event, Charset outputEncoding) throws MessageTransformerException;
 }

--- a/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractTransformer.java
@@ -79,8 +79,10 @@ public abstract class AbstractTransformer extends AbstractAnnotatedObject implem
       try {
         return InternalEvent.builder(event)
             .message(muleContext.getTransformationService().applyTransformers(event.getMessage(), event, this)).build();
+      } catch (MessageTransformerException e) {
+        throw e;
       } catch (Exception e) {
-        throw new MessageTransformerException(this, e);
+        throw new MessageTransformerException(this, e, event.getMessage());
       }
     }
     return event;

--- a/core/src/main/java/org/mule/runtime/core/api/transformer/MessageTransformerException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/transformer/MessageTransformerException.java
@@ -6,34 +6,52 @@
  */
 package org.mule.runtime.core.api.transformer;
 
+import org.mule.runtime.api.exception.ErrorMessageAwareException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.i18n.I18nMessage;
+import org.mule.runtime.api.message.Message;
 
 /**
  * An exception that occurred while transforming a message, thrown by {@link MessageTransformer}s.
  *
  * @since 4.0
  */
-public class MessageTransformerException extends MuleException {
+public class MessageTransformerException extends MuleException implements ErrorMessageAwareException {
 
   private transient Transformer transformer;
+  private final Message message;
 
-  public MessageTransformerException(I18nMessage message, Transformer transformer) {
+  public MessageTransformerException(I18nMessage message, Transformer transformer,
+                                     Message muleMessage) {
     super(message);
     this.transformer = transformer;
+    this.message = muleMessage;
   }
 
-  public MessageTransformerException(I18nMessage message, Transformer transformer, Throwable cause) {
+  public MessageTransformerException(I18nMessage message, Transformer transformer, Throwable cause,
+                                     Message muleMessage) {
     super(message, cause);
     this.transformer = transformer;
+    this.message = muleMessage;
   }
 
-  public MessageTransformerException(Transformer transformer, Throwable cause) {
+  public MessageTransformerException(Transformer transformer, Throwable cause, Message message) {
     super(cause);
     this.transformer = transformer;
+    this.message = message;
   }
 
   public Transformer getTransformer() {
     return transformer;
+  }
+
+  @Override
+  public Message getErrorMessage() {
+    return message;
+  }
+
+  @Override
+  public Throwable getRootCause() {
+    return this;
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/el/context/MessageContext.java
+++ b/core/src/main/java/org/mule/runtime/core/el/context/MessageContext.java
@@ -10,6 +10,7 @@ import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.InternalEvent;
 import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.api.transformer.TransformerException;
 
 import java.io.Serializable;
@@ -82,9 +83,9 @@ public class MessageContext {
    *
    * @param dataType the DatType to transform the current message payload to
    * @return the transformed payload
-   * @throws TransformerException if there is an error during transformation
+   * @throws MessageTransformerException if there is an error during transformation
    */
-  public Object payloadAs(DataType dataType) throws TransformerException {
+  public Object payloadAs(DataType dataType) throws MessageTransformerException {
     eventBuilder.message(muleContext.getTransformationService().internalTransform(event.getMessage(), dataType));
     event = eventBuilder.build();
     return event.getMessage().getPayload().getValue();

--- a/core/src/main/java/org/mule/runtime/core/internal/message/DefaultEventBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/message/DefaultEventBuilder.java
@@ -14,8 +14,8 @@ import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static org.mule.runtime.api.el.BindingContextUtils.NULL_BINDING_CONTEXT;
 import static org.mule.runtime.api.el.BindingContextUtils.addEventBindings;
+import static org.mule.runtime.core.api.config.i18n.CoreMessages.objectIsNull;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
-
 import org.mule.runtime.api.el.BindingContext;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Error;
@@ -39,12 +39,9 @@ import org.mule.runtime.core.api.message.GroupCorrelation;
 import org.mule.runtime.core.api.security.SecurityContext;
 import org.mule.runtime.core.api.session.DefaultMuleSession;
 import org.mule.runtime.core.api.store.DeserializationPostInitialisable;
-import org.mule.runtime.core.api.transformer.TransformerException;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.internal.context.notification.DefaultFlowCallStack;
 import org.mule.runtime.core.internal.util.CopyOnWriteCaseInsensitiveMap;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -53,6 +50,9 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultEventBuilder implements InternalEvent.Builder {
 
@@ -379,14 +379,9 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
     }
 
     @Override
-    public <T> T transformMessage(Class<T> outputType, MuleContext muleContext) throws TransformerException {
-      return (T) transformMessage(DataType.fromType(outputType), muleContext);
-    }
-
-    @Override
-    public Object transformMessage(DataType outputType, MuleContext muleContext) throws TransformerException {
+    public Object transformMessage(DataType outputType, MuleContext muleContext) throws MessageTransformerException {
       if (outputType == null) {
-        throw new TransformerException(CoreMessages.objectIsNull("outputType"));
+        throw new MessageTransformerException(objectIsNull("outputType"), null, message);
       }
 
       Message transformedMessage = muleContext.getTransformationService().internalTransform(message, outputType);
@@ -405,7 +400,7 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
      * @see org.mule.runtime.core.api.transformer.Transformer
      */
     @Override
-    public String transformMessageToString(MuleContext muleContext) throws TransformerException {
+    public String transformMessageToString(MuleContext muleContext) throws MessageTransformerException {
       final DataType dataType = DataType.builder(getMessage().getPayload().getDataType()).type(String.class).build();
       return (String) transformMessage(dataType, muleContext);
     }

--- a/core/src/main/java/org/mule/runtime/core/internal/transformer/expression/ExpressionTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transformer/expression/ExpressionTransformer.java
@@ -7,10 +7,9 @@
 package org.mule.runtime.core.internal.transformer.expression;
 
 import static org.mule.runtime.core.api.config.i18n.CoreMessages.expressionReturnedNull;
-
 import org.mule.runtime.core.api.InternalEvent;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
-import org.mule.runtime.core.api.transformer.TransformerException;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 
 import java.nio.charset.Charset;
 import java.util.Iterator;
@@ -38,7 +37,7 @@ public class ExpressionTransformer extends AbstractExpressionTransformer {
   private boolean returnSourceIfNull = false;
 
   @Override
-  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws TransformerException {
+  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws MessageTransformerException {
     Object results[] = new Object[arguments.size()];
     int i = 0;
     for (Iterator<ExpressionArgument> iterator = arguments.iterator(); iterator.hasNext(); i++) {
@@ -46,11 +45,12 @@ public class ExpressionTransformer extends AbstractExpressionTransformer {
       try {
         results[i] = argument.evaluate(event);
       } catch (ExpressionRuntimeException e) {
-        throw new TransformerException(this, e);
+        throw new MessageTransformerException(this, e, event.getMessage());
       }
 
       if (!argument.isOptional() && results[i] == null) {
-        throw new TransformerException(expressionReturnedNull(argument.getExpressionConfig().getExpression()), this);
+        throw new MessageTransformerException(expressionReturnedNull(argument.getExpressionConfig().getExpression()), this,
+                                              event.getMessage());
       }
 
     }

--- a/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/AutoTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/AutoTransformer.java
@@ -10,15 +10,15 @@ import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.InternalEvent;
 import org.mule.runtime.core.api.config.i18n.CoreMessages;
-import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.api.transformer.AbstractMessageTransformer;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 
 import java.nio.charset.Charset;
 
 /**
  * A transformer that uses the transform discovery mechanism to convert the message payload. This transformer works much better
  * when transforming custom object types rather that java types since there is less chance for ambiguity. If an exact match cannot
- * be made an execption will be thrown.
+ * be made an exception will be thrown.
  */
 public class AutoTransformer extends AbstractMessageTransformer {
 
@@ -37,7 +37,7 @@ public class AutoTransformer extends AbstractMessageTransformer {
   }
 
   @Override
-  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws TransformerException {
+  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws MessageTransformerException {
     return muleContext.getTransformationService()
         .internalTransform(event.getMessage(), DataType.fromType(getReturnDataType().getType()))
         .getPayload().getValue();

--- a/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/SetPayloadTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transformer/simple/SetPayloadTransformer.java
@@ -7,11 +7,11 @@
 package org.mule.runtime.core.internal.transformer.simple;
 
 
+import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.InternalEvent;
-import org.mule.runtime.api.lifecycle.InitialisationException;
-import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.api.transformer.AbstractMessageTransformer;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.api.util.AttributeEvaluator;
 
 import java.nio.charset.Charset;
@@ -35,7 +35,7 @@ public class SetPayloadTransformer extends AbstractMessageTransformer {
   }
 
   @Override
-  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws TransformerException {
+  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws MessageTransformerException {
     if (valueEvaluator.getRawValue() == null) {
       return null;
     }

--- a/core/src/main/java/org/mule/runtime/core/privileged/transformer/CompositeConverter.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transformer/CompositeConverter.java
@@ -134,8 +134,10 @@ public class CompositeConverter extends AbstractAnnotatedObject implements Conve
       try {
         event = InternalEvent.builder(event)
             .message(muleContext.getTransformationService().applyTransformers(event.getMessage(), event, this)).build();
+      } catch (MessageTransformerException e) {
+        throw e;
       } catch (Exception e) {
-        throw new MessageTransformerException(this, e);
+        throw new MessageTransformerException(this, e, event.getMessage());
       }
     }
 

--- a/core/src/main/java/org/mule/runtime/core/privileged/transformer/TransformerTemplate.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transformer/TransformerTemplate.java
@@ -9,6 +9,7 @@ package org.mule.runtime.core.privileged.transformer;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.InternalEvent;
 import org.mule.runtime.core.api.transformer.AbstractMessageTransformer;
+import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.api.transformer.TransformerException;
 
 import java.nio.charset.Charset;
@@ -23,13 +24,15 @@ public class TransformerTemplate extends AbstractMessageTransformer {
   }
 
   @Override
-  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws TransformerException {
+  public Object transformMessage(InternalEvent event, Charset outputEncoding) throws MessageTransformerException {
     try {
       return callback.doTransform(event.getMessage());
+    } catch (MessageTransformerException e) {
+      throw e;
     } catch (TransformerException e) {
-      throw new TransformerException(e.getI18nMessage(), this, e);
+      throw new MessageTransformerException(e.getI18nMessage(), this, e, event.getMessage());
     } catch (Exception e) {
-      throw new TransformerException(this, e);
+      throw new MessageTransformerException(this, e, event.getMessage());
     }
   }
 


### PR DESCRIPTION
_ Making message transformation to throw MessageTransformationException instead of TransformationException
_ Implementing ErrorMessageAwareException on MessageTransformationException in order to propagate the modified message payload when an error occurs during a transformation