### PR TITLE
MULE-13605: Studio distro in CE includes a lot of jars in the lib/use…

### DIFF
--- a/distributions/studio/assembly.xml
+++ b/distributions/studio/assembly.xml
@@ -51,6 +51,12 @@
             <outputDirectory>lib/user</outputDirectory>
             <scope>runtime</scope>
             <fileMode>0644</fileMode>
+            <useStrictFiltering>true</useStrictFiltering>
+            <includes>
+                <include>junit:junit</include>
+                <include>xmlunit:xmlunit</include>
+                <include>org.mule.tests:mule-tests-functional</include>
+            </includes>
         </dependencySet>
     </dependencySets>
 


### PR DESCRIPTION
…r folder which should not be included