### PR TITLE
 MULE-8207: Fix ConcurrentModificationException in FileMessageReceiver.

### DIFF
--- a/transports/file/src/main/java/org/mule/transport/file/FileMessageReceiver.java
+++ b/transports/file/src/main/java/org/mule/transport/file/FileMessageReceiver.java
@@ -63,7 +63,6 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
     public static final String COMPARATOR_CLASS_NAME_PROPERTY = "comparator";
     public static final String COMPARATOR_REVERSE_ORDER_PROPERTY = "reverseOrder";
     public static final String MULE_TRANSPORT_FILE_SINGLEPOLLINSTANCE = "mule.transport.file.singlepollinstance";
-    private static final List<File> NO_FILES = new ArrayList<File>();
 
     private FileConnector fileConnector = null;
     private String readDir = null;
@@ -699,7 +698,7 @@ public class FileMessageReceiver extends AbstractPollingMessageReceiver
         {
             List<File> files = new ArrayList<File>();
             this.basicListFiles(readDirectory, files);
-            return (files.isEmpty() ? NO_FILES : files);
+            return (files.isEmpty() ? Collections.<File>emptyList() : files);
         }
         catch (Exception e)
         {

--- a/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
+++ b/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.transport.file;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mule.util.FileUtils.openDirectory;
+
+import org.mule.api.exception.RollbackSourceCallback;
+import org.mule.api.exception.SystemExceptionHandler;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.util.concurrent.Latch;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class FilePollEmptyResultTestCase extends FunctionalTestCase
+{
+
+    private static long TEST_TIMEOUT = 5000;
+
+    private Latch latch = new Latch();
+
+    private static Throwable concurrentException;
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "file-poll-empty-config.xml";
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        openDirectory(getFileInsideWorkingDirectory("test").getAbsolutePath());
+        openDirectory(getFileInsideWorkingDirectory("test2").getAbsolutePath());
+        muleContext.setExceptionListener(new TestExceptionHandler());
+    }
+
+    @Test
+    public void testNoConcurrentExceptionWhenEmptyPollResult() throws InterruptedException
+    {
+        assertThat(latch.await(TEST_TIMEOUT, MILLISECONDS), is(false));
+        assertThat(concurrentException, is(nullValue()));
+    }
+
+    private class TestExceptionHandler implements SystemExceptionHandler
+    {
+
+        @Override
+        public void handleException(Exception exception, RollbackSourceCallback rollbackMethod)
+        {
+
+        }
+
+        @Override
+        public void handleException(Exception exception)
+        {
+            concurrentException = exception;
+            latch.countDown();
+        }
+    }
+
+
+}

--- a/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
+++ b/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
@@ -68,5 +68,4 @@ public class FilePollEmptyResultTestCase extends FunctionalTestCase
         }
     }
 
-
 }

--- a/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
+++ b/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
@@ -26,9 +26,10 @@ public class FilePollEmptyResultTestCase extends FunctionalTestCase
 
     private static long TEST_TIMEOUT = 5000;
 
+    private static Throwable concurrentException;
+
     private Latch latch = new Latch();
 
-    private static Throwable concurrentException;
 
     @Override
     protected String getConfigFile()

--- a/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
+++ b/transports/file/src/test/java/org/mule/transport/file/FilePollEmptyResultTestCase.java
@@ -24,11 +24,11 @@ import org.junit.Test;
 public class FilePollEmptyResultTestCase extends FunctionalTestCase
 {
 
-    private static long TEST_TIMEOUT = 5000;
+    private static final long TEST_TIMEOUT = 5000;
 
     private static Throwable concurrentException;
 
-    private Latch latch = new Latch();
+    private final Latch latch = new Latch();
 
 
     @Override

--- a/transports/file/src/test/resources/file-poll-empty-config.xml
+++ b/transports/file/src/test/resources/file-poll-empty-config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:file="http://www.mulesoft.org/schema/mule/file"
+      xsi:schemaLocation="
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/file http://www.mulesoft.org/schema/mule/file/current/mule-file.xsd">
+
+    <file:connector name="fileConnector" pollingFrequency="1"/>
+
+    <flow name="firstFileFlow">
+        <file:inbound-endpoint path="${workingDirectory}/test" connector-ref="fileConnector" comparator="org.mule.transport.file.comparator.OlderFirstComparator"/>
+        <echo-component/>
+    </flow>
+
+    <flow name="secondFileFlow">
+        <file:inbound-endpoint path="${workingDirectory}/test2"  connector-ref="fileConnector" comparator="org.mule.transport.file.comparator.OlderFirstComparator"/>
+        <echo-component/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
When no files are found in FileMessageReceiver polling, an empty list is returned.
However this empty list is mutable (an instance of ArrayList).
We should return an immutable list instead for avoiding Concurrent Exceptions in heavy load.