### PR TITLE
MULE-13472: Migrate Transactional Tests from JMS transport to JMS Extension

### DIFF
--- a/tests/unit/src/main/java/org/mule/tck/junit4/rule/SystemProperty.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/rule/SystemProperty.java
@@ -13,9 +13,10 @@ import org.junit.rules.ExternalResource;
  */
 public class SystemProperty extends ExternalResource {
 
+  protected boolean initialized;
+  protected String value;
+
   private final String name;
-  private String value;
-  private boolean initialized;
   private String oldValue;
 
   public SystemProperty(String name) {

--- a/tests/unit/src/main/java/org/mule/tck/junit4/rule/SystemPropertyLambda.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/rule/SystemPropertyLambda.java
@@ -22,6 +22,9 @@ public class SystemPropertyLambda extends SystemProperty {
 
   @Override
   public String getValue() {
-    return propertySupplier.get();
+    if (!initialized) {
+      value = propertySupplier.get();
+    }
+    return super.getValue();
   }
 }


### PR DESCRIPTION
- Refactoring SystemPropery and SystemPropertyLambda classes for not triggering the value supplier once property has been initialized