### PR TITLE
MULE-13729: Collection Aggregator does not honor the arrival order.

### DIFF
--- a/core/src/main/java/org/mule/routing/EventGroup.java
+++ b/core/src/main/java/org/mule/routing/EventGroup.java
@@ -233,7 +233,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
 
             if (sortByArrival)
             {
-                WrapperOrderEvent [] wrapperEventArray = new WrapperOrderEvent[keys.size()];
+                WrapperOrderEvent[] wrapperEventArray = new WrapperOrderEvent[keys.size()];
 
                 for (int i = 0; i < keys.size(); i++)
                 {
@@ -242,7 +242,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
 
                 Arrays.sort(wrapperEventArray, new ArrivalOrderEventComparator());
 
-                for(int i = 0 ; i < wrapperEventArray.length ; i ++)
+                for (int i = 0; i < wrapperEventArray.length; i++)
                 {
                     eventArray[i] = wrapperEventArray[i].event;
                 }

--- a/core/src/main/java/org/mule/routing/EventGroup.java
+++ b/core/src/main/java/org/mule/routing/EventGroup.java
@@ -532,8 +532,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
         {
             if (!key.equals(lastStoredEventKey))
             {
-                MuleEvent event = eventsObjectStore.retrieve(key, eventsPartitionKey).event;
-                addAndOverrideSessionProperties(session, event);
+                addAndOverrideSessionProperties(session, eventsObjectStore.retrieve(key, eventsPartitionKey).event);
             }
         }
         addAndOverrideSessionProperties(session, lastStoredEvent);

--- a/core/src/main/java/org/mule/routing/EventGroup.java
+++ b/core/src/main/java/org/mule/routing/EventGroup.java
@@ -25,7 +25,6 @@ import org.mule.util.store.DeserializationPostInitialisable;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -49,7 +48,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
     public static final String MULE_ARRIVAL_ORDER_PROPERTY = MuleProperties.PROPERTY_PREFIX + "ARRIVAL_ORDER";
 
     private final Object groupId;
-    private transient PartitionableObjectStore<MuleEvent> eventsObjectStore;
+    private transient PartitionableObjectStore<WrapperOrderEvent> eventsObjectStore;
     private final String storePrefix;
     private final String eventsPartitionKey;
     private final long created;
@@ -229,14 +228,32 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
                 return EMPTY_EVENTS_ARRAY;
             }
             List<Serializable> keys = eventsObjectStore.allKeys(eventsPartitionKey);
-            MuleEvent[] eventArray = new MuleEvent[keys.size()];
-            for (int i = 0; i < keys.size(); i++)
-            {
-                eventArray[i] = eventsObjectStore.retrieve(keys.get(i), eventsPartitionKey);
-            }
+
+            MuleEvent[] eventArray = new MuleEvent[keys.size()];;
+
             if (sortByArrival)
             {
-                Arrays.sort(eventArray, new ArrivalOrderEventComparator());
+                WrapperOrderEvent [] wrapperEventArray = new WrapperOrderEvent[keys.size()];
+
+                for (int i = 0; i < keys.size(); i++)
+                {
+                    wrapperEventArray[i] = eventsObjectStore.retrieve(keys.get(i), eventsPartitionKey);
+                }
+
+                Arrays.sort(wrapperEventArray, new ArrivalOrderEventComparator());
+
+                for(int i = 0 ; i < wrapperEventArray.length ; i ++)
+                {
+                    eventArray[i] = wrapperEventArray[i].event;
+                }
+
+            }
+            else
+            {
+                for (int i = 0; i < keys.size(); i++)
+                {
+                    eventArray[i] = eventsObjectStore.retrieve(keys.get(i), eventsPartitionKey).event;
+                }
             }
             return eventArray;
         }
@@ -255,9 +272,8 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
             //Using both event ID and CorrelationSequence since in certain instances
             //when an event is split up, the same event IDs are used.
             Serializable key= getEventKey(event);
-            event.getMessage().setInvocationProperty(MULE_ARRIVAL_ORDER_PROPERTY, ++arrivalOrderCounter);
             lastStoredEventKey = key;
-            eventsObjectStore.store(key, event, eventsPartitionKey);
+            eventsObjectStore.store(key, new WrapperOrderEvent(event, ++arrivalOrderCounter), eventsPartitionKey);
 
             if (!hasNoCommonRootId)
             {
@@ -376,7 +392,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
                     while (i.hasNext())
                     {
                         Serializable id = i.next();
-                        buf.append(eventsObjectStore.retrieve(id, eventsPartitionKey).getMessage().getUniqueId());
+                        buf.append(eventsObjectStore.retrieve(id, eventsPartitionKey).event.getMessage().getUniqueId());
                         if (i.hasNext())
                         {
                             buf.append(", ");
@@ -404,21 +420,40 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
     public MuleMessageCollection toMessageCollection(boolean sortByArrival) throws ObjectStoreException
     {
         DefaultMessageCollection col = new DefaultMessageCollection(muleContext);
-        List<MuleMessage> messages = new ArrayList<MuleMessage>();
+        List<Serializable> keys = eventsObjectStore.allKeys(eventsPartitionKey);
+        List<MuleMessage> messages = new ArrayList<>(keys.size());
 
         synchronized (this)
         {
-            for (Serializable id : eventsObjectStore.allKeys(eventsPartitionKey))
+            if (sortByArrival)
             {
-                MuleMessage message = eventsObjectStore.retrieve(id, eventsPartitionKey).getMessage();
-                messages.add(message);
+                WrapperOrderEvent[] wrapperEventArray = new WrapperOrderEvent[keys.size()];
+
+                for (int i = 0; i < keys.size(); i++)
+                {
+                    wrapperEventArray[i] = eventsObjectStore.retrieve(keys.get(i), eventsPartitionKey);
+                }
+
+                Arrays.sort(wrapperEventArray, new ArrivalOrderEventComparator());
+
+                for (int i = 0; i < wrapperEventArray.length; i++)
+                {
+                    messages.add(wrapperEventArray[i].event.getMessage());
+                }
+
+            }
+            else
+            {
+
+                for (Serializable id : keys)
+                {
+                    MuleMessage message = eventsObjectStore.retrieve(id, eventsPartitionKey).event.getMessage();
+                    messages.add(message);
+                }
+
             }
         }
 
-        if (sortByArrival)
-        {
-            Collections.sort(messages, new ArrivalOrderMessageComparator());
-        }
         col.addMessages(messages);
         return col;
     }
@@ -465,7 +500,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
                 lastStoredEventKey = findLastStoredEventKey();
             }
 
-            return eventsObjectStore.retrieve(lastStoredEventKey, eventsPartitionKey);
+            return eventsObjectStore.retrieve(lastStoredEventKey, eventsPartitionKey).event;
         }
     }
 
@@ -478,7 +513,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
         {
             if (!key.equals(lastStoredEventKey))
             {
-                MuleEvent event = eventsObjectStore.retrieve(key, eventsPartitionKey);
+                MuleEvent event = eventsObjectStore.retrieve(key, eventsPartitionKey).event;
                 addAndOverrideSessionProperties(session, event);
             }
         }
@@ -499,7 +534,7 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
         this.muleContext = context;
     }
 
-    public void initEventsStore(PartitionableObjectStore<MuleEvent> events) throws ObjectStoreException
+    public void initEventsStore(PartitionableObjectStore<WrapperOrderEvent> events) throws ObjectStoreException
     {
         this.eventsObjectStore = events;
         events.open(eventsPartitionKey);
@@ -536,27 +571,17 @@ public class EventGroup implements Comparable<EventGroup>, Serializable, Deseria
         return muleContext != null;
     }
 
-    public final class ArrivalOrderMessageComparator implements Comparator<MuleMessage>
+
+    public final class ArrivalOrderEventComparator implements Comparator<WrapperOrderEvent>
     {
         @Override
-        public int compare(MuleMessage message1, MuleMessage message2)
+        public int compare(WrapperOrderEvent wrapperOrderEvent1, WrapperOrderEvent wrapperOrderEvent2)
         {
-            int val1 = message1.getInvocationProperty(MULE_ARRIVAL_ORDER_PROPERTY, -1);
-            int val2 = message2.getInvocationProperty(MULE_ARRIVAL_ORDER_PROPERTY, -1);
+            int val1 = wrapperOrderEvent1.arrivalOrder;
+            int val2 = wrapperOrderEvent2.arrivalOrder;
 
             return val1 - val2;
         }
     }
 
-    public final class ArrivalOrderEventComparator implements Comparator<MuleEvent>
-    {
-        @Override
-        public int compare(MuleEvent event1, MuleEvent event2)
-        {
-            int val1 = event1.getMessage().getInvocationProperty(MULE_ARRIVAL_ORDER_PROPERTY, -1);
-            int val2 = event2.getMessage().getInvocationProperty(MULE_ARRIVAL_ORDER_PROPERTY, -1);
-
-            return val1 - val2;
-        }
-    }
 }

--- a/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
+++ b/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
@@ -10,7 +10,7 @@ package org.mule.routing;
 import org.mule.api.MuleEvent;
 import java.io.Serializable;
 
-class WrapperOrderEvent implements Serializable
+public class WrapperOrderEvent implements Serializable
 {
     final MuleEvent event ;
     final int arrivalOrder ;
@@ -21,4 +21,13 @@ class WrapperOrderEvent implements Serializable
         this.arrivalOrder = arrivalOrder;
     }
 
+    public MuleEvent getEvent()
+    {
+        return event;
+    }
+
+    public int getArrivalOrder()
+    {
+        return arrivalOrder;
+    }
 }

--- a/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
+++ b/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
@@ -8,12 +8,14 @@
 package org.mule.routing;
 
 import org.mule.api.MuleEvent;
+
 import java.io.Serializable;
 
 public class WrapperOrderEvent implements Serializable
 {
-    final MuleEvent event ;
-    final int arrivalOrder ;
+
+    final MuleEvent event;
+    final int arrivalOrder;
 
     public WrapperOrderEvent(MuleEvent event, int arrivalOrder)
     {

--- a/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
+++ b/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
@@ -7,11 +7,16 @@
 
 package org.mule.routing;
 
+import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
+import org.mule.util.store.DeserializationPostInitialisable;
 
 import java.io.Serializable;
 
-public class WrapperOrderEvent implements Serializable
+/**
+ * Wraps the {@link MuleEvent} and saves the arrivalOrder of this to an {@link EventGroup}.
+ */
+class WrapperOrderEvent implements Serializable, DeserializationPostInitialisable
 {
 
     final MuleEvent event;
@@ -32,4 +37,11 @@ public class WrapperOrderEvent implements Serializable
     {
         return arrivalOrder;
     }
+
+    @SuppressWarnings({"unused"})
+    private void initAfterDeserialisation(MuleContext muleContext) throws Exception
+    {
+        DeserializationPostInitialisable.Implementation.init(event, muleContext);
+    }
+
 }

--- a/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
+++ b/core/src/main/java/org/mule/routing/WrapperOrderEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.routing;
+
+import org.mule.api.MuleEvent;
+import java.io.Serializable;
+
+class WrapperOrderEvent implements Serializable
+{
+    final MuleEvent event ;
+    final int arrivalOrder ;
+
+    public WrapperOrderEvent(MuleEvent event, int arrivalOrder)
+    {
+        this.event = event;
+        this.arrivalOrder = arrivalOrder;
+    }
+
+}

--- a/core/src/main/java/org/mule/util/store/PersistentObjectStorePartition.java
+++ b/core/src/main/java/org/mule/util/store/PersistentObjectStorePartition.java
@@ -25,6 +25,7 @@ import org.mule.api.store.ObjectStoreNotAvaliableException;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.config.i18n.Message;
 import org.mule.config.i18n.MessageFactory;
+import org.mule.routing.WrapperOrderEvent;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -437,6 +438,10 @@ public class PersistentObjectStorePartition<T extends Serializable>
             if (storedValue.getValue() instanceof DeserializationPostInitialisable)
             {
                 DeserializationPostInitialisable.Implementation.init(storedValue.getValue(), muleContext);
+            }
+            if (storedValue.getValue() instanceof WrapperOrderEvent)
+            {
+                DeserializationPostInitialisable.Implementation.init(((WrapperOrderEvent) storedValue.getValue()).getEvent(), muleContext);
             }
             return storedValue;
         }

--- a/core/src/main/java/org/mule/util/store/PersistentObjectStorePartition.java
+++ b/core/src/main/java/org/mule/util/store/PersistentObjectStorePartition.java
@@ -438,7 +438,6 @@ public class PersistentObjectStorePartition<T extends Serializable>
             {
                 DeserializationPostInitialisable.Implementation.init(storedValue.getValue(), muleContext);
             }
-
             return storedValue;
         }
         catch (FileNotFoundException e)

--- a/core/src/main/java/org/mule/util/store/PersistentObjectStorePartition.java
+++ b/core/src/main/java/org/mule/util/store/PersistentObjectStorePartition.java
@@ -25,7 +25,6 @@ import org.mule.api.store.ObjectStoreNotAvaliableException;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.config.i18n.Message;
 import org.mule.config.i18n.MessageFactory;
-import org.mule.routing.WrapperOrderEvent;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -439,10 +438,7 @@ public class PersistentObjectStorePartition<T extends Serializable>
             {
                 DeserializationPostInitialisable.Implementation.init(storedValue.getValue(), muleContext);
             }
-            if (storedValue.getValue() instanceof WrapperOrderEvent)
-            {
-                DeserializationPostInitialisable.Implementation.init(((WrapperOrderEvent) storedValue.getValue()).getEvent(), muleContext);
-            }
+
             return storedValue;
         }
         catch (FileNotFoundException e)

--- a/core/src/test/java/org/mule/routing/EventGroupTestCase.java
+++ b/core/src/test/java/org/mule/routing/EventGroupTestCase.java
@@ -26,9 +26,11 @@ import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.util.UUID;
 import org.mule.util.store.DefaultObjectStoreFactoryBean;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.collections.IteratorUtils;
@@ -214,7 +216,7 @@ public class EventGroupTestCase extends AbstractMuleContextTestCase
         assertTrue(es.contains(firstId));
         assertTrue(es.contains(secondId));
     }
-    
+
     @Test
     public void mergedSessions() throws Exception
     {
@@ -222,23 +224,23 @@ public class EventGroupTestCase extends AbstractMuleContextTestCase
         eg.initEventsStore(objectStore);
         assertFalse(eg.iterator().hasNext());
 
-        MuleEvent event1 = getTestEvent("foo1"); 
-        MuleEvent event2 = getTestEvent("foo2"); 
-        MuleEvent event3 = getTestEvent("foo3"); 
-        
+        MuleEvent event1 = getTestEvent("foo1");
+        MuleEvent event2 = getTestEvent("foo2");
+        MuleEvent event3 = getTestEvent("foo3");
+
         event1.getSession().setProperty("key1", "value1");
         event1.getSession().setProperty("key2", "value2");
         event2.getSession().setProperty("KEY2", "value2NEW");
         event2.getSession().setProperty("key3", "value3");
         event3.getSession().setProperty("key4", "value4");
-        
+
         eg.addEvent(event1);
         System.out.println(event1.getSession());
         eg.addEvent(event2);
         System.out.println(event2.getSession());
         eg.addEvent(event3);
         System.out.println(event3.getSession());
-        
+
         MuleEvent result = eg.getMessageCollectionEvent();
         assertEquals("value1", result.getSession().getProperty("key1"));
         // Cannot assert this because the ordering of events aren't ordered. See MULE-5998
@@ -253,23 +255,29 @@ public class EventGroupTestCase extends AbstractMuleContextTestCase
     {
         EventGroup eventGroup = new EventGroup(UUID.getUUID(),muleContext);
         eventGroup.initEventsStore(objectStore);
-
-        MuleEvent event1 = getTestEvent("foo1");
-        MuleEvent event2 = getTestEvent("foo2");
-        MuleEvent event3 = getTestEvent("foo3");
-
-        eventGroup.addEvent(event1);
-        eventGroup.addEvent(event2);
-        eventGroup.addEvent(event3);
-
+        addMuleEventsWithSharedFlowVarsToEventGroup(eventGroup);
         MuleEvent result = eventGroup.getMessageCollectionEvent();
         DefaultMessageCollection messageCollection = (DefaultMessageCollection) result.getMessage();
         MuleMessage messages [] =  messageCollection.getMessagesAsArray();
 
         assertThat(messages.length, is(3));
-        assertThat(messages[0].getPayloadAsString(), is("foo1"));
-        assertThat(messages[1].getPayloadAsString(), is("foo2"));
-        assertThat(messages[2].getPayloadAsString(), is("foo3"));
+        assertThat(messages[0].getPayloadAsString(), is("foo0"));
+        assertThat(messages[1].getPayloadAsString(), is("foo1"));
+        assertThat(messages[2].getPayloadAsString(), is("foo2"));
+    }
+
+    private void addMuleEventsWithSharedFlowVarsToEventGroup(EventGroup group) throws Exception
+    {
+        MuleEvent testEvent = getTestEvent(null);
+
+        for (int i = 0; i < 3; i++)
+        {
+            MuleMessage messageCopy = new DefaultMuleMessage(testEvent.getMessage());
+            messageCopy.setPayload("foo" + i);
+            messageCopy.setCorrelationSequence(i);
+            group.addEvent(new DefaultMuleEvent(messageCopy, testEvent, true, true));
+        }
+
     }
 
     private static class MyEventGroup extends EventGroup


### PR DESCRIPTION
This issue occurs since arrival order is being saved as an invocation property which causes that the arrivalOrder is always overrode by the last value in all the messages to aggregate (because all they have the same reference to the flow var list).
A good solution is to replace the current logic, saving the arrivalOrder in an object that wraps the muleEvent.