### PR TITLE
MULE-13718: ClusterCoreExtensions are not being loaded as domain deployment listeners

### DIFF
--- a/modules/launcher/src/main/java/org/mule/module/launcher/AbstractArtifactDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/AbstractArtifactDeploymentListener.java
@@ -8,6 +8,11 @@ package org.mule.module.launcher;
 
 import org.mule.api.MuleContext;
 
+/**
+ * Default implementation of {@link ArtifactDeploymentListener}).
+ * Extending this abstract class, it is possible to implement the ArtifactDeploymentListener interface
+ * without having to override all methods.
+ */
 public class AbstractArtifactDeploymentListener implements ArtifactDeploymentListener
 {
 

--- a/modules/launcher/src/main/java/org/mule/module/launcher/AbstractArtifactDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/AbstractArtifactDeploymentListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher;
+
+import org.mule.api.MuleContext;
+
+public class AbstractArtifactDeploymentListener implements ArtifactDeploymentListener
+{
+
+    @Override
+    public void onDeploymentStart(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onDeploymentSuccess(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onDeploymentFailure(String artifactName, Throwable cause)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onUndeploymentStart(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onUndeploymentSuccess(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onUndeploymentFailure(String artifactName, Throwable cause)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onMuleContextCreated(String artifactName, MuleContext context)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onMuleContextInitialised(String artifactName, MuleContext context)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onMuleContextConfigured(String artifactName, MuleContext context)
+    {
+        //No-op default
+    }
+
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/AbstractDomainDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/AbstractDomainDeploymentListener.java
@@ -8,6 +8,11 @@ package org.mule.module.launcher;
 
 import org.mule.api.MuleContext;
 
+/**
+ * Default implementation of {@link DomainDeploymentListener}).
+ * Extending this abstract class, it is possible to implement the DomainDeploymentListener interface
+ * without having to override all methods.
+ */
 public class AbstractDomainDeploymentListener implements DomainDeploymentListener
 {
 

--- a/modules/launcher/src/main/java/org/mule/module/launcher/AbstractDomainDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/AbstractDomainDeploymentListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher;
+
+import org.mule.api.MuleContext;
+
+public class AbstractDomainDeploymentListener implements DomainDeploymentListener
+{
+
+    @Override
+    public void onDeploymentStart(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onDeploymentSuccess(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onDeploymentFailure(String artifactName, Throwable cause)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onUndeploymentStart(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onUndeploymentSuccess(String artifactName)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onUndeploymentFailure(String artifactName, Throwable cause)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onMuleContextCreated(String artifactName, MuleContext context)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onMuleContextInitialised(String artifactName, MuleContext context)
+    {
+        //No-op default
+    }
+
+    @Override
+    public void onMuleContextConfigured(String artifactName, MuleContext context)
+    {
+        //No-op default
+    }
+
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/ArtifactDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/ArtifactDeploymentListener.java
@@ -7,7 +7,7 @@
 package org.mule.module.launcher;
 
 /**
- * Marker interface for deployment events from all Mule Artifacts.
+ * Defines a listener for deployment events for all Mule artifacts.
  */
 public interface ArtifactDeploymentListener extends DeploymentListener
 {

--- a/modules/launcher/src/main/java/org/mule/module/launcher/ArtifactDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/ArtifactDeploymentListener.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher;
+
+/**
+ * Marker interface for deployment events from all Mule Artifacts.
+ */
+public interface ArtifactDeploymentListener extends DeploymentListener
+{
+
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DomainDeploymentListener.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DomainDeploymentListener.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher;
+
+/**
+ * Defines a listener for deployment events for Mule domains.
+ */
+public interface DomainDeploymentListener extends DeploymentListener
+{
+
+}

--- a/modules/launcher/src/main/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManager.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/coreextension/DefaultMuleCoreExtensionManager.java
@@ -11,9 +11,11 @@ import org.mule.MuleCoreExtension;
 import org.mule.api.DefaultMuleException;
 import org.mule.api.MuleException;
 import org.mule.api.lifecycle.InitialisationException;
+import org.mule.module.launcher.ArtifactDeploymentListener;
 import org.mule.module.launcher.DeploymentListener;
 import org.mule.module.launcher.DeploymentService;
 import org.mule.module.launcher.DeploymentServiceAware;
+import org.mule.module.launcher.DomainDeploymentListener;
 import org.mule.module.launcher.PluginClassLoaderManager;
 import org.mule.module.launcher.PluginClassLoaderManagerAware;
 
@@ -124,9 +126,20 @@ public class DefaultMuleCoreExtensionManager implements MuleCoreExtensionManager
                 ((DeploymentServiceAware) extension).setDeploymentService(deploymentService);
             }
 
-            if (extension instanceof DeploymentListener)
+            if (extension instanceof DeploymentListener && ! (extension instanceof DomainDeploymentListener) && ! (extension instanceof ArtifactDeploymentListener))
             {
                 deploymentService.addDeploymentListener((DeploymentListener) extension);
+            }
+
+            if (extension instanceof DomainDeploymentListener)
+            {
+                deploymentService.addDomainDeploymentListener((DeploymentListener) extension);
+            }
+
+            if (extension instanceof ArtifactDeploymentListener)
+            {
+                deploymentService.addDeploymentListener((DeploymentListener) extension);
+                deploymentService.addDomainDeploymentListener((DeploymentListener) extension);
             }
 
             if (extension instanceof PluginClassLoaderManagerAware)


### PR DESCRIPTION
This issue was found out since domain vm connectors aren't being clustered as expected.
ClusterCoreExtension is only loaded as an applicationDeploymentListener and thus only vm connectors defined at application level are being clustered.
In order to fix this issue we should add an ArtifactDeploymentListener for deployment events from all mule artifacts (app and domains).