### PR TITLE
MULE-13819: MuleDeployableArtifactClassLoader not registered as

### DIFF
--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleDeployableArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleDeployableArtifactClassLoader.java
@@ -22,6 +22,10 @@ public class MuleDeployableArtifactClassLoader extends MuleArtifactClassLoader {
 
   private final List<ArtifactClassLoader> artifactPluginClassLoaders;
 
+  static {
+    registerAsParallelCapable();
+  }
+
   /**
    * Creates a {@link MuleDeployableArtifactClassLoader} with the provided configuration.
    *


### PR DESCRIPTION
parallelCapable