### PR TITLE
MULE-13773: XmlExtensionModelProperty should be public

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/extension/xml/property/XmlExtensionModelProperty.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/extension/xml/property/XmlExtensionModelProperty.java
@@ -45,6 +45,6 @@ public class XmlExtensionModelProperty implements ModelProperty {
 
   @Override
   public boolean isPublic() {
-    return false;
+    return true;
   }
 }


### PR DESCRIPTION
* Needed in order to use serialized version of ExtensionModel from Tooling but also this model property has to be included (public) as the macro expansion looks for this in order to build the application model expanded for smart connectors when resolving DataSense