### PR TITLE
MULE-13941: Dynamic flow reference from a For-Each causes ConcurrentModificationException.

### DIFF
--- a/core/src/main/java/org/mule/api/processor/DefaultMessageProcessorPathElement.java
+++ b/core/src/main/java/org/mule/api/processor/DefaultMessageProcessorPathElement.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 public class DefaultMessageProcessorPathElement implements MessageProcessorPathElement
 {
 
@@ -41,7 +43,7 @@ public class DefaultMessageProcessorPathElement implements MessageProcessorPathE
     @Override
     public List<MessageProcessorPathElement> getChildren()
     {
-        return Collections.unmodifiableList(children);
+        return ImmutableList.copyOf(children);
     }
 
     @Override


### PR DESCRIPTION
Even thought getChildren() returned an unmodifiableList, this type of list only wraps the given list with one that only support get operations. If the underlying list is changed while iterating the unmodifiableList, the ConcurrentModificationException will be thrown.

This is why the ImmutableList was chosen :

A high-performance, immutable, random-access List implementation.
Does not permit null elements.

Unlike Collections.unmodifiableList, which is a view of a separate collection that can still change, an instance of ImmutableList contains its own private data and will never change.
ImmutableList is convenient for public static final lists ("constant lists") and also lets you easily make a "defensive copy" of a list provided to your class by a caller.