### PR TITLE
MULE-13968: Replace log4j-jul and log4j-jcl with jul-to-slf4j and

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/transformer/Converter.java
+++ b/core/src/main/java/org/mule/runtime/core/api/transformer/Converter.java
@@ -37,8 +37,7 @@ public interface Converter extends Transformer {
 
   @Override
   default ProcessingType getProcessingType() {
-    if (getReturnDataType().isStreamType()
-        || getSourceDataTypes().stream().filter(dataType -> !dataType.isStreamType()).count() > 0) {
+    if (getReturnDataType().isStreamType() || getSourceDataTypes().stream().anyMatch(dataType -> !dataType.isStreamType())) {
       return IO_RW;
     } else {
       return CPU_LITE;

--- a/core/src/main/java/org/mule/runtime/core/api/util/IOUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/api/util/IOUtils.java
@@ -7,9 +7,11 @@
 package org.mule.runtime.core.api.util;
 
 import static org.apache.commons.lang3.math.NumberUtils.toInt;
+import static org.mule.runtime.core.api.config.MuleProperties.MULE_STREAMING_BUFFER_SIZE;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
-import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.core.api.config.i18n.CoreMessages;
 import org.mule.runtime.core.api.message.ds.ByteArrayDataSource;
 import org.mule.runtime.core.api.message.ds.InputStreamDataSource;
@@ -34,17 +36,16 @@ import java.security.PrivilegedAction;
 import javax.activation.DataHandler;
 import javax.activation.FileDataSource;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
 
 /**
  * Mule input/output utilities.
  */
 public class IOUtils {
 
-  private static final Log logger = LogFactory.getLog(IOUtils.class);
+  private static final Logger logger = getLogger(IOUtils.class);
 
-  protected static int bufferSize = toInt(System.getProperty(MuleProperties.MULE_STREAMING_BUFFER_SIZE), 4 * 1024);
+  protected static int bufferSize = toInt(System.getProperty(MULE_STREAMING_BUFFER_SIZE), 4 * 1024);
 
   /**
    * Attempts to load a resource from the file system, from a URL, or from the classpath, in that order.

--- a/core/src/main/java/org/mule/runtime/core/internal/util/xmlsecurity/DefaultXMLSecureFactories.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/xmlsecurity/DefaultXMLSecureFactories.java
@@ -11,6 +11,7 @@ import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
 import static javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET;
 import static javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES;
 import static javax.xml.stream.XMLInputFactory.SUPPORT_DTD;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
@@ -20,8 +21,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
 
 /**
  * Create different XML factories configured through the same interface for disabling vulnerabilities.
@@ -47,7 +47,7 @@ public class DefaultXMLSecureFactories {
   private Boolean externalEntities;
   private Boolean expandEntities;
 
-  private final static Log logger = LogFactory.getLog(DefaultXMLSecureFactories.class);
+  private final static Logger logger = getLogger(DefaultXMLSecureFactories.class);
 
   public DefaultXMLSecureFactories(Boolean externalEntities, Boolean expandEntities) {
     this.externalEntities = externalEntities;

--- a/modules/logging/pom.xml
+++ b/modules/logging/pom.xml
@@ -44,16 +44,12 @@
             <artifactId>log4j-1.2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jcl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jul</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/modules/reboot/pom.xml
+++ b/modules/reboot/pom.xml
@@ -41,17 +41,20 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-logging</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>tanukisoft</groupId>
             <artifactId>wrapper</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-unit</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/MuleContainerBootstrap.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/MuleContainerBootstrap.java
@@ -21,6 +21,7 @@ import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.tanukisoftware.wrapper.WrapperManager;
 
 /**
@@ -39,6 +40,13 @@ public class MuleContainerBootstrap {
       {"version", "false", "Show product and version information"}};
 
   public static void main(String[] args) throws Exception {
+    // Optionally remove existing handlers attached to j.u.l root logger
+    SLF4JBridgeHandler.removeHandlersForRootLogger(); // (since SLF4J 1.6.5)
+
+    // add SLF4JBridgeHandler to j.u.l's root logger, should be done once during
+    // the initialization phase of your application
+    SLF4JBridgeHandler.install();
+
     // Parse any command line options based on the list above.
     CommandLine commandLine = parseCommandLine(args);
     // Any unrecognized arguments get passed through to the next class (e.g., to the OSGi Framework).

--- a/pom.xml
+++ b/pom.xml
@@ -749,19 +749,14 @@
                 <version>${log4jVersion}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-jcl</artifactId>
-                <version>${log4jVersion}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4jVersion}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-jul</artifactId>
-                <version>${log4jVersion}</version>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4jVersion}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
jcl-over-slf4j

Checking if a log level is enabled using the JUL api has different
processing times depending on the bridge used.
Benchmarking showed that jul-to-slf4j outperforms log4j-jul in a 1:10
ratio. Since this check using the jul api is used heavily by grizzly,
making this change should improve the performance of the http service.

Also, change the bridge of JCL for consistency. Benchmarking didn't show
any degradation