### PR TITLE
MULE-13969: SFTP receiver reconnection is invoking exceptionListener …

### DIFF
--- a/transports/sftp/src/main/java/org/mule/transport/sftp/SftpMessageReceiver.java
+++ b/transports/sftp/src/main/java/org/mule/transport/sftp/SftpMessageReceiver.java
@@ -147,7 +147,6 @@ public class SftpMessageReceiver extends AbstractPollingMessageReceiver
         catch (Exception e)
         {
             logger.error("Error in poll", e);
-            getEndpoint().getMuleContext().getExceptionListener().handleException(e);
             throw e;
         }
     }


### PR DESCRIPTION
…twice.

SftpMessageReceiver is calling the exception listener to handle connection exceptions and after propagating the exception to the superclass.
However, the PollingReceiverWorker invokes the exception listener too, causing lifecycles errors because Connector#stop and Connector#start are called twice per reconnection.
