### PR TITLE
MULE-13974: ObjectToJMSMessage does not register source types.

### DIFF
--- a/transports/jms/src/main/java/org/mule/transport/jms/transformers/ObjectToJMSMessage.java
+++ b/transports/jms/src/main/java/org/mule/transport/jms/transformers/ObjectToJMSMessage.java
@@ -8,6 +8,7 @@ package org.mule.transport.jms.transformers;
 
 import org.mule.api.MuleMessage;
 import org.mule.api.transformer.TransformerException;
+import org.mule.api.transport.OutputHandler;
 import org.mule.transformer.types.DataTypeFactory;
 import org.mule.util.ClassUtils;
 
@@ -38,6 +39,10 @@ public class ObjectToJMSMessage extends AbstractJmsTransformer
     @Override
     protected void declareInputOutputClasses()
     {
+        this.registerSourceType(DataTypeFactory.OBJECT);
+        this.registerSourceType(DataTypeFactory.INPUT_STREAM);
+        this.registerSourceType(DataTypeFactory.STRING);
+        this.registerSourceType(DataTypeFactory.create(OutputHandler.class));
         setReturnDataType(DataTypeFactory.create(Message.class));
     }
 


### PR DESCRIPTION
ObjectToJMSMessage does not register source types. This causes an error on resolving transformers as it gets a higher priority than ObjectToString depending on the ordering of the environment when the datatypes are less specific.