### PR TITLE
MULE-13978: SFTP logging does not mask credentials when special regex

### DIFF
--- a/core/src/main/java/org/mule/api/util/CredentialsMaskUtil.java
+++ b/core/src/main/java/org/mule/api/util/CredentialsMaskUtil.java
@@ -99,7 +99,7 @@ public class CredentialsMaskUtil
         Matcher matcher = pattern.matcher(input);
         if (matcher.find() && matcher.groupCount() > 0)
         {
-            input = input.replaceAll(prefix + matcher.group(1), prefix + mask);
+            input = input.replace(prefix + matcher.group(1), prefix + mask);
         }
         return input;
 

--- a/core/src/test/java/org/mule/api/execution/LocationExecutionContextProviderTestCase.java
+++ b/core/src/test/java/org/mule/api/execution/LocationExecutionContextProviderTestCase.java
@@ -52,6 +52,15 @@ public class LocationExecutionContextProviderTestCase extends AbstractMuleTestCa
         assertThat(sanitized, equalTo("<sftp:config username=\"user\" password=\"<<credentials>>\" />"));
 
     }
+    
+    @Test
+    public void sanitizedPasswordAttributeWhenUsingRegExpCharactersInPassword()
+    {
+        withXmlElement(annotatedObject, "<sftp:config username=\"user\" password=\"pass^word\" />");
+        String sanitized = getSourceXML(annotatedObject);
+        assertThat(sanitized, equalTo("<sftp:config username=\"user\" password=\"<<credentials>>\" />"));
+
+    }
 
     private void withXmlElement(AnnotatedObject annotatedObject, String value)
     {


### PR DESCRIPTION
chars in password.