### PR TITLE
MULE-14033: Log a threaddump when a test fails due to timeout for

### DIFF
--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleTestCase.java
@@ -30,6 +30,8 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.util.StringUtils;
 import org.mule.runtime.core.api.util.SystemUtils;
 import org.mule.tck.junit4.rule.WarningTimeout;
+import org.mule.tck.report.ThreadDumpOnTimeOut;
+import org.mule.tck.report.ThreadDumper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,6 +46,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
@@ -98,7 +101,9 @@ public abstract class AbstractMuleTestCase {
   public TestName name = new TestName();
 
   @Rule
-  public TestRule globalTimeout = createTestTimeoutRule();
+  public final TestRule chain = RuleChain
+      .outerRule(new ThreadDumpOnTimeOut())
+      .around(createTestTimeoutRule());
 
   /**
    * Creates the timeout rule that will be used to run the test.
@@ -278,8 +283,8 @@ public abstract class AbstractMuleTestCase {
   }
 
   /**
-   * Create a new {@link CoreEvent} for each invocation. Useful if multiple distinct event instances are needed in a single
-   * test method.
+   * Create a new {@link CoreEvent} for each invocation. Useful if multiple distinct event instances are needed in a single test
+   * method.
    *
    * @return new test event.
    * @throws MuleException

--- a/tests/unit/src/main/java/org/mule/tck/probe/PollingProber.java
+++ b/tests/unit/src/main/java/org/mule/tck/probe/PollingProber.java
@@ -6,10 +6,17 @@
  */
 package org.mule.tck.probe;
 
+import static org.mule.tck.report.ThreadDumper.logThreadDump;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.core.api.util.func.CheckedFunction;
 import org.mule.runtime.core.api.util.func.CheckedSupplier;
 
+import org.slf4j.Logger;
+
 public class PollingProber implements Prober {
+
+  private static final Logger LOGGER = getLogger(PollingProber.class);
 
   public static final long DEFAULT_TIMEOUT = 1000;
   public static final long DEFAULT_POLLING_INTERVAL = 100;
@@ -59,6 +66,8 @@ public class PollingProber implements Prober {
   @Override
   public void check(Probe probe) {
     if (!poll(probe)) {
+      LOGGER.error("test timed out. Maybe due to a deadlock?");
+      logThreadDump();
       throw new AssertionError(probe.describeFailure());
     }
   }

--- a/tests/unit/src/main/java/org/mule/tck/report/ThreadDumpOnTimeOut.java
+++ b/tests/unit/src/main/java/org/mule/tck/report/ThreadDumpOnTimeOut.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tck.report;
+
+import static org.mule.tck.report.ThreadDumper.logThreadDump;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runners.model.TestTimedOutException;
+import org.slf4j.Logger;
+
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Rule that generates a heap dump on failure.
+ * <p>
+ * Useful for troubleshooting failures in memory leak prevention tests.
+ *
+ * @since 4.1
+ */
+public class ThreadDumpOnTimeOut extends TestWatcher {
+
+  private static final Logger LOGGER = getLogger(ThreadDumpOnTimeOut.class);
+
+  @Override
+  protected void failed(Throwable e, Description description) {
+    super.failed(e, description);
+
+    if (e instanceof TestTimedOutException || e instanceof TimeoutException) {
+      LOGGER.error("test timed out. Maybe due to a deadlock?");
+      logThreadDump();
+    }
+  }
+}

--- a/tests/unit/src/main/java/org/mule/tck/report/ThreadDumper.java
+++ b/tests/unit/src/main/java/org/mule/tck/report/ThreadDumper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tck.report;
+
+import static java.lang.System.lineSeparator;
+import static java.lang.management.ManagementFactory.getThreadMXBean;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.slf4j.Logger;
+
+import java.lang.management.ThreadMXBean;
+
+/**
+ * Provides a way to generate thread dumps in order to troubleshoot tests.
+ *
+ * @since 4.1
+ */
+public class ThreadDumper {
+
+  private static final ThreadMXBean tmx = getThreadMXBean();
+
+  private static final Logger LOGGER = getLogger(ThreadDumper.class);
+
+  /**
+   * Call this method from your application whenever you want to log a thread dump.
+   */
+  public static void logThreadDump() {
+    LOGGER
+        .error(lineSeparator() + stream(tmx.dumpAllThreads(true, true)).map(Object::toString).collect(joining(lineSeparator())));
+  }
+
+}


### PR DESCRIPTION
troubleshooting