### PR TITLE
MULE-14005: Core extensions disposed before flows finish

### DIFF
--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/MuleContainer.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/MuleContainer.java
@@ -14,6 +14,7 @@ import static org.mule.runtime.core.api.config.i18n.CoreMessages.fatalErrorWhile
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 import static org.mule.runtime.core.api.util.StringMessageUtils.getBoilerPlate;
 import static org.mule.runtime.module.deployment.internal.MuleDeploymentService.findSchedulerService;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.i18n.I18nMessage;
@@ -43,14 +44,14 @@ import org.mule.runtime.module.service.api.manager.ServiceManager;
 import org.mule.runtime.module.tooling.api.ToolingService;
 import org.mule.runtime.module.tooling.internal.DefaultToolingService;
 
+import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.logging.log4j.LogManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MuleContainer {
 
@@ -277,19 +278,19 @@ public class MuleContainer {
   public void stop() throws MuleException {
     MuleContainerBootstrap.dispose();
 
-    coreExtensionManager.stop();
-
     if (deploymentService != null) {
       deploymentService.stop();
+    }
+
+    if (extensionModelLoaderManager != null) {
+      extensionModelLoaderManager.stop();
     }
 
     if (serviceManager != null) {
       serviceManager.stop();
     }
 
-    if (extensionModelLoaderManager != null) {
-      extensionModelLoaderManager.stop();
-    }
+    coreExtensionManager.stop();
 
     coreExtensionManager.dispose();
     if (LogManager.getFactory() instanceof MuleLog4jContextFactory) {

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/coreextension/DefaultMuleCoreExtensionManagerServer.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/coreextension/DefaultMuleCoreExtensionManagerServer.java
@@ -8,6 +8,8 @@ package org.mule.runtime.module.launcher.coreextension;
 
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.DOMAIN;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.container.api.ArtifactClassLoaderManagerAware;
@@ -25,15 +27,14 @@ import org.mule.runtime.module.repository.api.RepositoryServiceAware;
 import org.mule.runtime.module.tooling.api.ToolingService;
 import org.mule.runtime.module.tooling.api.ToolingServiceAware;
 
+import org.slf4j.Logger;
+
 import java.util.LinkedList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class DefaultMuleCoreExtensionManagerServer implements MuleCoreExtensionManagerServer {
 
-  protected static final Logger logger = LoggerFactory.getLogger(DefaultMuleCoreExtensionManagerServer.class);
+  private static final Logger LOGGER = getLogger(DefaultMuleCoreExtensionManagerServer.class);
 
   private final MuleCoreExtensionDiscoverer coreExtensionDiscoverer;
   private final MuleCoreExtensionDependencyResolver coreExtensionDependencyResolver;
@@ -52,11 +53,13 @@ public class DefaultMuleCoreExtensionManagerServer implements MuleCoreExtensionM
 
   @Override
   public void dispose() {
+    LOGGER.info("Disposing core extensions");
     for (MuleCoreExtension extension : coreExtensions) {
       try {
         extension.dispose();
+        LOGGER.info("Core extension '{}' disposed", extension.toString());
       } catch (Exception ex) {
-        logger.error("Error disposing core extension " + extension.getName(), ex);
+        LOGGER.error("Error disposing core extension " + extension.getName(), ex);
       }
     }
   }
@@ -77,9 +80,10 @@ public class DefaultMuleCoreExtensionManagerServer implements MuleCoreExtensionM
 
   @Override
   public void start() throws MuleException {
-    logger.info("Starting core extensions");
+    LOGGER.info("Starting core extensions");
     for (MuleCoreExtension extension : orderedCoreExtensions) {
       extension.start();
+      LOGGER.info("Core extension '{}' started", extension.toString());
     }
   }
 
@@ -89,19 +93,21 @@ public class DefaultMuleCoreExtensionManagerServer implements MuleCoreExtensionM
       return;
     }
 
+    LOGGER.info("Stopping core extensions");
     for (int i = orderedCoreExtensions.size() - 1; i >= 0; i--) {
       MuleCoreExtension extension = orderedCoreExtensions.get(i);
 
       try {
         extension.stop();
+        LOGGER.info("Core extension '{}' stopped", extension.toString());
       } catch (Throwable e) {
-        logger.warn("Error stopping core extension: " + extension.getName(), e);
+        LOGGER.warn("Error stopping core extension: " + extension.getName(), e);
       }
     }
   }
 
   private void initializeCoreExtensions() throws MuleException {
-    logger.info("Initializing core extensions");
+    LOGGER.info("Initializing core extensions");
 
     for (MuleCoreExtension extension : orderedCoreExtensions) {
       if (extension instanceof DeploymentServiceAware) {
@@ -135,6 +141,7 @@ public class DefaultMuleCoreExtensionManagerServer implements MuleCoreExtensionM
       }
 
       extension.initialise();
+      LOGGER.info("Core extension '{}' initialized", extension.toString());
     }
   }
 
@@ -148,6 +155,7 @@ public class DefaultMuleCoreExtensionManagerServer implements MuleCoreExtensionM
     this.repositoryService = repositoryService;
   }
 
+  @Override
   public void setToolingService(ToolingService toolingService) {
     this.toolingService = toolingService;
   }

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/MuleContainerTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/MuleContainerTestCase.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mule.runtime.container.api.MuleFoldersUtil.getExecutionFolder;
+
 import org.mule.runtime.core.api.config.MuleProperties;
 import org.mule.runtime.module.deployment.api.DeploymentService;
 import org.mule.runtime.module.extension.internal.loader.ExtensionModelLoaderManager;
@@ -93,13 +94,13 @@ public class MuleContainerTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  public void stopsCoreExtensionsBeforeDeploymentService() throws Exception {
+  public void stopsCoreExtensionsAfterDeploymentService() throws Exception {
     container.start(false);
     container.stop();
 
     InOrder inOrder = inOrder(coreExtensionManager, deploymentService);
-    inOrder.verify(coreExtensionManager).stop();
     inOrder.verify(deploymentService).stop();
+    inOrder.verify(coreExtensionManager).stop();
   }
 
   @Test


### PR DESCRIPTION
Making `MuleContainer#stop` call the inverse methods on the objects in the reverse order as they are called in `MuleContainer#start`.

Otherwise a situation occurs where the core extensions are stopped before the applications/flows. If for instance a flow uses a VM connector and the runtime is clustered, this will cause the cluster support to be stopped first, leaving the queues used by the VM connector in an unusable state.

The proper way to do things is to stop applications/flows first. This PR fixes that.