### PR TITLE
MULE-14135: getFullStackTrace has to be added to ExceptionUtils to guarantee retrocompatibility.

### DIFF
--- a/core/src/main/java/org/mule/util/ExceptionUtils.java
+++ b/core/src/main/java/org/mule/util/ExceptionUtils.java
@@ -79,5 +79,17 @@ public class ExceptionUtils extends org.apache.commons.lang3.exception.Exception
 
         return builder.toString();
     }
+    
+    /**
+     * This method is intended to keep the method getFullStackTrace to guarantee retrocompatibility
+     * after upgrading commons lang library. 
+     * 
+     * @param throwable the throwable to inspect, may be <code>null</code>
+     * @return the stack trace as a string. Empty string if throwable was <code>null</code>
+     */
+    public static String getFullStackTrace(Throwable throwable)
+    {
+        return getStackTrace(throwable);
+    }
 
 }

--- a/core/src/test/java/org/mule/util/ExceptionUtilsTestCase.java
+++ b/core/src/test/java/org/mule/util/ExceptionUtilsTestCase.java
@@ -7,7 +7,6 @@
 package org.mule.util;
 
 import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
-import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -16,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mule.util.ExceptionUtils.containsType;
 import static org.mule.util.ExceptionUtils.getDeepestOccurenceOfType;
 import static org.mule.util.ExceptionUtils.getFullStackTraceWithoutMessages;
+import static org.mule.util.ExceptionUtils.getFullStackTrace;
 
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;


### PR DESCRIPTION
guarantee retrocompatibility.