### PR TITLE
MULE-10948

### DIFF
--- a/modules/cxf/src/test/java/org/mule/module/cxf/WsdlCallTestCase.java
+++ b/modules/cxf/src/test/java/org/mule/module/cxf/WsdlCallTestCase.java
@@ -100,4 +100,18 @@ public class WsdlCallTestCase extends AbstractServiceAndFlowTestCase
         assertEquals(location, ((Element) nodes.get(0)).attribute("location").getStringValue());
     }
 
+    @Test
+    public void testRequestJaxwsWsdlWithHttp() throws Exception
+    {
+        String location = "http://localhost:" + httpPort.getNumber() + "/cxfJaxwsService";
+        InputStream wsdlStream = new URL(location + "?wsdl").openStream();
+        
+        Document document = new SAXReader().read(wsdlStream);
+        List nodes = document.selectNodes("//wsdl:definitions/wsdl:service");
+        assertEquals(((Element) nodes.get(0)).attribute("name").getStringValue(), "CallableService");
+        
+        nodes = document.selectNodes("//wsdl:definitions/wsdl:service/wsdl:port/soap:address");
+        assertEquals(location, ((Element) nodes.get(0)).attribute("location").getStringValue());
+    }
+    
 }

--- a/modules/cxf/src/test/resources/wsdl-conf-flow-httpn.xml
+++ b/modules/cxf/src/test/resources/wsdl-conf-flow-httpn.xml
@@ -29,4 +29,11 @@
         <test:component />
     </flow>
 
+    <flow name="cxfJaxwsService">
+        <http:listener config-ref="httpConfig" path="cxfJaxwsService"/>
+        <cxf:jaxws-service serviceClass="org.mule.api.lifecycle.Callable" />
+
+        <test:component />
+    </flow>
+
 </mule>

--- a/modules/cxf/src/test/resources/wsdl-conf-flow.xml
+++ b/modules/cxf/src/test/resources/wsdl-conf-flow.xml
@@ -29,4 +29,14 @@
         <test:component />
     </flow>
 
+    <flow name="cxfJaxwsService">
+
+        <inbound-endpoint address="http://localhost:${httpPort}/cxfJaxwsService"
+            exchange-pattern="request-response">
+            <cxf:jaxws-service serviceClass="org.mule.api.lifecycle.Callable" />
+        </inbound-endpoint>
+
+        <test:component />
+    </flow>
+
 </mule>

--- a/modules/cxf/src/test/resources/wsdl-conf-service.xml
+++ b/modules/cxf/src/test/resources/wsdl-conf-service.xml
@@ -28,5 +28,14 @@
             </inbound>
             <test:component/>
         </service>
+        
+        <service name="cxfJaxwsService">
+            <inbound>
+                <inbound-endpoint address="http://localhost:${httpPort}/cxfJaxwsService" exchange-pattern="request-response">
+                    <cxf:jaxws-service serviceClass="org.mule.api.lifecycle.Callable" />
+                </inbound-endpoint>
+            </inbound>
+            <test:component/>
+        </service>
     </model>
 </mule>


### PR DESCRIPTION
cxf:jaxws-service does not retrieve WSDL file with the new http
extension.
* Add test case