### PR TITLE
MULE-11659: Add tool to ensure that Mule API is backward compatible o…

### DIFF
--- a/core/api-ignored.json
+++ b/core/api-ignored.json
@@ -1,0 +1,301 @@
+{
+  "revapi": {
+    "ignore": [
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundAttachment(java.lang.String, javax.activation.DataHandler)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundAttachment(java.lang.String, javax.activation.DataHandler)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundProperty(java.lang.String, java.io.Serializable)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundProperty(java.lang.String, java.io.Serializable)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundAttachment(java.lang.String, javax.activation.DataHandler)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundAttachment(java.lang.String, javax.activation.DataHandler)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundProperty(java.lang.String, java.io.Serializable)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundProperty(java.lang.String, java.io.Serializable)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::attributes(org.mule.runtime.api.metadata.TypedValue<?>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::attributes(org.mule.runtime.api.metadata.TypedValue<?>)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::attributesMediaType(org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::attributesMediaType(org.mule.runtime.api.metadata.MediaType)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::attributesValue(java.lang.Object)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::attributesValue(java.lang.Object)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::exceptionPayload(org.mule.runtime.core.api.message.ExceptionPayload)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::exceptionPayload(org.mule.runtime.core.api.message.ExceptionPayload)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::inboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::inboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::inboundProperties(java.util.Map<java.lang.String, java.io.Serializable>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::inboundProperties(java.util.Map<java.lang.String, java.io.Serializable>)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method org.mule.runtime.core.api.processor.strategy.ProcessingStrategy org.mule.runtime.core.api.construct.FlowConstruct::getProcessingStrategy() @ org.mule.runtime.core.api.policy.DefaultPolicyInstance",
+        "new": "method org.mule.runtime.core.api.policy.DefaultPolicyInstance.PolicyProcessingStrategy org.mule.runtime.core.api.policy.DefaultPolicyInstance::getProcessingStrategy()",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::mediaType(org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::mediaType(org.mule.runtime.api.metadata.MediaType)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::nullAttributesValue()",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::nullAttributesValue()",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::outboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::outboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::outboundProperties(java.util.Map<java.lang.String, java.io.Serializable>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::outboundProperties(java.util.Map<java.lang.String, java.io.Serializable>)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeInboundAttachment(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeInboundAttachment(java.lang.String)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeInboundProperty(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeInboundProperty(java.lang.String)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeOutboundAttachment(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeOutboundAttachment(java.lang.String)",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeOutboundProperty(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.DefaultMessageBuilder::removeOutboundProperty(java.lang.String)",
+        "oldType": "org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addInboundAttachment(java.lang.String, javax.activation.DataHandler)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addInboundAttachment(java.lang.String, javax.activation.DataHandler) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addInboundProperty(java.lang.String, java.io.Serializable)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addInboundProperty(java.lang.String, java.io.Serializable) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addInboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addOutboundAttachment(java.lang.String, javax.activation.DataHandler)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addOutboundAttachment(java.lang.String, javax.activation.DataHandler) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addOutboundProperty(java.lang.String, java.io.Serializable)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addOutboundProperty(java.lang.String, java.io.Serializable) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.DataType) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::addOutboundProperty(java.lang.String, java.io.Serializable, org.mule.runtime.api.metadata.MediaType) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::attributes(org.mule.runtime.api.metadata.TypedValue<?>)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::attributes(org.mule.runtime.api.metadata.TypedValue<?>) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::attributesMediaType(org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::attributesMediaType(org.mule.runtime.api.metadata.MediaType) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::attributesValue(java.lang.Object)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::attributesValue(java.lang.Object) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::build()",
+        "new": "method org.mule.runtime.api.message.Message org.mule.runtime.api.message.Message.Builder::build() @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::exceptionPayload(org.mule.runtime.core.api.message.ExceptionPayload)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::exceptionPayload(org.mule.runtime.core.api.message.ExceptionPayload) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::inboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::inboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::inboundProperties(java.util.Map<java.lang.String, java.io.Serializable>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::inboundProperties(java.util.Map<java.lang.String, java.io.Serializable>) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::itemMediaType(org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.api.message.Message.CollectionBuilder org.mule.runtime.api.message.Message.CollectionBuilder::itemMediaType(org.mule.runtime.api.metadata.MediaType) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::mediaType(org.mule.runtime.api.metadata.MediaType)",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::mediaType(org.mule.runtime.api.metadata.MediaType) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::nullAttributesValue()",
+        "new": "method org.mule.runtime.api.message.Message.Builder org.mule.runtime.api.message.Message.Builder::nullAttributesValue() @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::outboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::outboundAttachments(java.util.Map<java.lang.String, javax.activation.DataHandler>) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::outboundProperties(java.util.Map<java.lang.String, java.io.Serializable>)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::outboundProperties(java.util.Map<java.lang.String, java.io.Serializable>) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::removeInboundAttachment(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::removeInboundAttachment(java.lang.String) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::removeInboundProperty(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::removeInboundProperty(java.lang.String) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::removeOutboundAttachment(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::removeOutboundAttachment(java.lang.String) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder::removeOutboundProperty(java.lang.String)",
+        "new": "method org.mule.runtime.core.internal.message.InternalMessage.Builder org.mule.runtime.core.internal.message.InternalMessage.Builder::removeOutboundProperty(java.lang.String) @ org.mule.runtime.core.internal.message.InternalMessage.CollectionBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.class.nonPublicPartOfAPI",
+        "old": "class org.mule.runtime.core.privileged.processor.chain.AbstractMessageProcessorChainBuilder",
+        "new": "class org.mule.runtime.core.privileged.processor.chain.AbstractMessageProcessorChainBuilder",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method void org.mule.runtime.core.privileged.processor.chain.MessageProcessorChainBuilder::setProcessingStrategy(org.mule.runtime.core.api.processor.strategy.ProcessingStrategy)",
+        "package": "org.mule.runtime.core.privileged.processor.chain",
+        "justification": "MULE-14279: API broken by MULE-14171"
+      }
+    ]
+  }
+}

--- a/modules/dsl-api/pom.xml
+++ b/modules/dsl-api/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
+        <oldMuleArtifactVersion>1.0.0</oldMuleArtifactVersion>
     </properties>
 
     <dependencies>
@@ -40,5 +41,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/modules/http-api/api-ignored.json
+++ b/modules/http-api/api-ignored.json
@@ -1,0 +1,11 @@
+{
+  "revapi": {
+    "ignore": [
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method org.mule.runtime.http.api.domain.request.ServerConnection org.mule.runtime.http.api.domain.request.HttpRequestContext::getServerConnection()",
+        "justification": "MULE-14281: API broken by MULE-10912"
+      }
+    ]
+  }
+}

--- a/modules/http-policy-api/pom.xml
+++ b/modules/http-policy-api/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
+        <oldMuleArtifactVersion>1.0.0</oldMuleArtifactVersion>
     </properties>
 
     <dependencies>
@@ -23,6 +24,4 @@
             <artifactId>mule-module-policy-api</artifactId>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/modules/license-api/pom.xml
+++ b/modules/license-api/pom.xml
@@ -11,7 +11,6 @@
 
     <groupId>org.mule.runtime</groupId>
     <artifactId>mule-module-license-api</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Mule Runtime License API</name>
     <description>This module provides an API for license verification</description>

--- a/modules/policy-api/pom.xml
+++ b/modules/policy-api/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
+        <oldMuleArtifactVersion>1.0.0</oldMuleArtifactVersion>
     </properties>
 
     <dependencies>
@@ -23,5 +24,4 @@
             <artifactId>mule-api</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,7 @@
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <formatterGoal>validate</formatterGoal>
+        <oldMuleArtifactVersion>4.0.0</oldMuleArtifactVersion>
     </properties>
 
     <dependencies>
@@ -1752,12 +1753,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.mule.tools.maven</groupId>
-                    <artifactId>mule-module-maven-plugin</artifactId>
-                    <version>${mule.module.maven.plugin.version}</version>
-                    <extensions>true</extensions>
-                </plugin>
-                <plugin>
                     <groupId>org.mule.runtime.plugins</groupId>
                     <artifactId>mule-plugin-maven-plugin</artifactId>
                     <version>${mule.app.plugins.maven.plugin.version}</version>
@@ -1811,19 +1806,6 @@
                     <timestampFormat>{0,date,yyyy-MMM-dd HH:mm:ss}</timestampFormat>
                     <shortRevisionLength>8</shortRevisionLength>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.mule.tools.maven</groupId>
-                <artifactId>mule-module-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>analyze</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>analyze</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>com.marvinformatics.formatter</groupId>
@@ -2146,6 +2128,82 @@
                                     </rules>
                                     <skip>${skipNoSnapshotsEnforcerPluginRule}</skip>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>mule-module</id>
+            <activation>
+                <file>
+                    <exists>target/classes/META-INF/mule-module.properties</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.mule.tools.maven</groupId>
+                        <artifactId>mule-module-maven-plugin</artifactId>
+                        <version>${mule.module.maven.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <executions>
+                            <execution>
+                                <id>analyze</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>analyze</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.revapi</groupId>
+                        <artifactId>revapi-maven-plugin</artifactId>
+                        <version>0.9.5</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.mule.tools.maven</groupId>
+                                <artifactId>mule-revapi-extension</artifactId>
+                                <version>1.0.0-SNAPSHOT</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <oldVersion>${oldMuleArtifactVersion}</oldVersion>
+                            <failOnUnresolvedArtifacts>true</failOnUnresolvedArtifacts>
+                            <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+                            <analysisConfiguration><![CDATA[
+                                {
+                                    "revapi" : {
+                                        "java" : {
+                                            "missing-classes" : {
+                                                "behavior" : "report"
+                                            }
+                                        },
+                                        "semver": {
+                                          "ignore": {
+                                            "enabled": true,
+                                            "versionIncreaseAllows" : {
+                                              "major" : "breaking",
+                                              "minor" : "nonBreaking",
+                                              "patch" : "equivalent"
+                                            }
+                                          }
+                                        }
+                                    }
+                                }
+                            ]]></analysisConfiguration>
+                            <analysisConfigurationFiles combine.children="append">
+                                <configurationFile>
+                                    <path>api-ignored.json</path>
+                                </configurationFile>
+                            </analysisConfigurationFiles>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>api-check</id>
+                                <goals><goal>check</goal></goals>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
…n each release

_ Adding profile to run the Mule module and Revapi plugins only when a Mule module is declared.
_ Adding Revapi exclusions to temporarily ignore broken API