### PR TITLE
MULE-13831 Use shared reactor stream(s) rather than once per event fo…

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/connector/SourceWithCorrelationIdTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/connector/SourceWithCorrelationIdTestCase.java
@@ -17,16 +17,11 @@ import org.junit.Test;
 
 public class SourceWithCorrelationIdTestCase extends AbstractExtensionFunctionalTestCase {
 
-  private static String correlationId;
+  private static volatile String correlationId;
 
   @Override
   protected String getConfigFile() {
     return "source-with-correlation-id-config.xml";
-  }
-
-  @Before
-  public void setUp() {
-    correlationId = null;
   }
 
   @Override


### PR DESCRIPTION
…r performance and back-pressure. Avoid race condition where source fires before setup method sets correlationId null.