### PR TITLE
MULE-9669: Added a toString to DefaultHttpListenerConfig to detect the port used if the listener fails to start

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
@@ -338,4 +338,15 @@ public class DefaultHttpListenerConfig extends AbstractAnnotatedObject implement
     {
         this.connectionIdleTimeout = connectionIdleTimeout;
     }
+    
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder();
+        buf.append("org.mule.module.http.internal.listener.DefaultHttpListenerConfig{name=")
+           .append(name)
+           .append(", url=")
+           .append(listenerUrl())
+           .append("}");
+        return buf.toString();
+    }
 }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
@@ -342,7 +342,8 @@ public class DefaultHttpListenerConfig extends AbstractAnnotatedObject implement
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        buf.append("DefaultHttpListenerConfig{name=")
+        buf.append(getClass().getSimpleName())
+           .append("{name=")
            .append(name)
            .append(", url=")
            .append(listenerUrl())

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/DefaultHttpListenerConfig.java
@@ -342,7 +342,7 @@ public class DefaultHttpListenerConfig extends AbstractAnnotatedObject implement
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        buf.append("org.mule.module.http.internal.listener.DefaultHttpListenerConfig{name=")
+        buf.append("DefaultHttpListenerConfig{name=")
            .append(name)
            .append(", url=")
            .append(listenerUrl())


### PR DESCRIPTION
Added a toString to DefaultHttpListenerConfig to detect the port used if the listener fails to start