### PR TITLE
MULE-14070: Upgrade log4j to 2.9.1

### DIFF
--- a/modules/extensions-xml-support/pom.xml
+++ b/modules/extensions-xml-support/pom.xml
@@ -52,6 +52,7 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>

--- a/modules/logging/src/main/resources/META-INF/mule-module.properties
+++ b/modules/logging/src/main/resources/META-INF/mule-module.properties
@@ -47,8 +47,10 @@ artifact.export.optionalPackages=javax.mail,\
                                  javax.mail.internet,\
                                  com.beust.jcommander,\
                                  com.conversantmedia.util.concurrent,\
+                                 com.fasterxml.jackson.annotation,\
                                  com.fasterxml.jackson.core,\
                                  com.fasterxml.jackson.databind,\
+                                 com.fasterxml.jackson.dataformat.xml.annotation,\
                                  org.apache.commons.csv,\
                                  org.dom4j,\
                                  org.fusesource.jansi,\

--- a/pom.xml
+++ b/pom.xml
@@ -203,8 +203,8 @@
         <jschVersion>0.1.53</jschVersion>
         <jsonVersion>20140107</jsonVersion>
         <junitVersion>4.12</junitVersion>
-        <log4jVersion>2.8.2</log4jVersion>
-        <disruptorVersion>3.3.0</disruptorVersion>
+        <log4jVersion>2.10.0</log4jVersion>
+        <disruptorVersion>3.3.7</disruptorVersion>
         <mockitoVersion>1.10.19</mockitoVersion>
         <multithreadedtcVersion>1.01</multithreadedtcVersion>
         <muleMvelVersion>2.1.9-MULE-013</muleMvelVersion>

--- a/tests/runner/pom.xml
+++ b/tests/runner/pom.xml
@@ -96,6 +96,7 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- 3rd party dependencies -->


### PR DESCRIPTION
_ Upgrading log4j to 2.10.0
_ Upgrading disruptor to 3.3.7
_ Fixing test runner issue with context classloader