### PR TITLE
MULE-14607: Using the interception API with an operation that fails,

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -18,7 +18,6 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNee
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.runtime.core.api.rx.Exceptions.checkedFunction;
-import static org.mule.runtime.core.api.rx.Exceptions.unwrap;
 import static org.mule.runtime.core.internal.interception.DefaultInterceptionEvent.INTERCEPTION_RESOLVED_CONTEXT;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
 import static org.mule.runtime.extension.api.ExtensionConstants.TARGET_PARAMETER_NAME;
@@ -48,6 +47,7 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
+import org.mule.runtime.core.api.rx.Exceptions;
 import org.mule.runtime.core.api.streaming.CursorProviderFactory;
 import org.mule.runtime.core.internal.context.notification.DefaultFlowCallStack;
 import org.mule.runtime.core.internal.exception.MessagingException;
@@ -172,7 +172,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
         ExecutionContextAdapter<T> operationContext = getPrecalculatedContext(event);
         configuration = operationContext.getConfiguration();
 
-        operationExecutionFunction = (parameters, operationEvent) -> doProcess(operationEvent, operationContext);
+        operationExecutionFunction = (parameters, operationEvent) -> doProcessWithErrorMapping(operationEvent, operationContext);
       } else {
         // Otherwise, generate the context as usual.
         configuration = getConfiguration(event);
@@ -184,7 +184,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
           } catch (MuleException e) {
             return error(e);
           }
-          return doProcess(operationEvent, operationContext);
+          return doProcessWithErrorMapping(operationEvent, operationContext);
         };
       }
       if (getLocation() != null) {
@@ -202,6 +202,19 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
     }));
   }
 
+  /**
+   * While a hook in reactor is used to map Throwable to MessagingException when an error occurs this does not cover the case
+   * where an error is explicitly triggered via a Sink such as such as when using Mono.create in ReactorCompletionCallback rather
+   * than being thrown by a reactor operator. Although changes could be made to Mule to cater for this in
+   * AbstractMessageProcessorChain, this is not trivial given processor interceptors and a potent performance overhead associated
+   * with the addition of many additional flatMaps. It would be slightly clearer to create the MessagingException in
+   * ReactorCompletionCallback where Mono.error is used but we don't have a reference to the processor there.
+   */
+  private Publisher<CoreEvent> doProcessWithErrorMapping(CoreEvent operationEvent, ExecutionContextAdapter<T> operationContext) {
+    return doProcess(operationEvent, operationContext)
+        .onErrorMap(e -> !(e instanceof MessagingException), e -> new MessagingException(operationEvent, e, this));
+  }
+
   private PrecalculatedExecutionContextAdapter<T> getPrecalculatedContext(CoreEvent event) {
     return (PrecalculatedExecutionContextAdapter) (((InternalEvent) event).getInternalParameters()
         .get(INTERCEPTION_RESOLVED_CONTEXT));
@@ -211,14 +224,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
     return executeOperation(operationContext)
         .map(value -> asReturnValue(operationContext, value))
         .switchIfEmpty(fromCallable(() -> asReturnValue(operationContext, null)))
-        // While a hook in reactor is used to map Throwable to MessagingException when an error occurs this does not cover
-        // the case where an error is explicitly triggered via a Sink such as such as when using Mono.create in
-        // ReactorCompletionCallback rather than being thrown by a reactor operator. Although changes could be made to Mule
-        // to cater for this in AbstractMessageProcessorChain, this is not trivial given processor interceptors and a potent
-        // performance overhead associated with the addition of many additional flatMaps. It would be slightly clearer to
-        // create the MessagingException in ReactorCompletionCallback where Mono.error is used but we don't have a reference
-        // to the processor there.
-        .onErrorMap(e -> !(unwrap(e) instanceof MessagingException), e -> new MessagingException(event, unwrap(e), this));
+        .onErrorMap(Exceptions::unwrap);
   }
 
   private CoreEvent asReturnValue(ExecutionContextAdapter<T> operationContext, Object value) {


### PR DESCRIPTION
throws an exception and keeps looping indefenitely (continuously calling
before method).
* Fix oauth tests