### PR TITLE
MULE-14666: CredentialsMaskUtils uses replaceAll instead of replace a…

### DIFF
--- a/core/src/main/java/org/mule/api/util/CredentialsMaskUtil.java
+++ b/core/src/main/java/org/mule/api/util/CredentialsMaskUtil.java
@@ -44,9 +44,8 @@ public class CredentialsMaskUtil
         Matcher matcher = PASSWORD_PATTERN.matcher(input);
         if (matcher.find() && matcher.groupCount() > 0)
         {
-            input = input.replaceAll(maskPasswordAttribute(matcher.group(1)), maskPasswordAttribute(PASSWORD_MASK));
+            input = input.replace(maskPasswordAttribute(matcher.group(1)), maskPasswordAttribute(PASSWORD_MASK));
         }
-        input = maskUrlPassword(input, PASSWORD_PATTERN);
 
         return input;
     }

--- a/core/src/test/java/org/mule/api/execution/LocationExecutionContextProviderTestCase.java
+++ b/core/src/test/java/org/mule/api/execution/LocationExecutionContextProviderTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.api.execution;
 
+import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -56,10 +57,14 @@ public class LocationExecutionContextProviderTestCase extends AbstractMuleTestCa
     @Test
     public void sanitizedPasswordAttributeWhenUsingRegExpCharactersInPassword()
     {
-        withXmlElement(annotatedObject, "<sftp:config username=\"user\" password=\"pass^word\" />");
-        String sanitized = getSourceXML(annotatedObject);
-        assertThat(sanitized, equalTo("<sftp:config username=\"user\" password=\"<<credentials>>\" />"));
-
+        String [] specialCharacters = new String[]{"^", ")"};
+        String input = "<sftp:config username=\"user\" password=\"pass%sword\" />";
+        for(String specialCharacter : specialCharacters)
+        {
+            withXmlElement(annotatedObject, format(input, specialCharacter));
+            String sanitized = getSourceXML(annotatedObject);
+            assertThat(sanitized, equalTo("<sftp:config username=\"user\" password=\"<<credentials>>\" />"));
+        }
     }
 
     private void withXmlElement(AnnotatedObject annotatedObject, String value)


### PR DESCRIPTION
…nd fails with regex reserved characters.