### PR TITLE
MULE-14675: Cannot destroy thread groups that have commons-pool evictor

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/TransactionalDelegateSink.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/TransactionalDelegateSink.java
@@ -8,16 +8,20 @@ package org.mule.runtime.core.internal.processor.strategy;
 
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTransactionActive;
-import static org.slf4j.helpers.NOPLogger.NOP_LOGGER;
 
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.Sink;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Delegate {@link Sink} that uses one of two {@link Sink}'s depending on if a transaction is in context or not.
  */
 final class TransactionalDelegateSink implements Sink, Disposable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TransactionalDelegateSink.class);
 
   private final Sink transactionalSink;
   private final Sink sink;
@@ -47,7 +51,7 @@ final class TransactionalDelegateSink implements Sink, Disposable {
 
   @Override
   public void dispose() {
-    disposeIfNeeded(transactionalSink, NOP_LOGGER);
-    disposeIfNeeded(sink, NOP_LOGGER);
+    disposeIfNeeded(transactionalSink, LOGGER);
+    disposeIfNeeded(sink, LOGGER);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <commonsLangVersion>3.6</commonsLangVersion>
         <commonsNetVersion>3.5</commonsNetVersion>
         <commonsPoolVersion>1.6</commonsPoolVersion>
-        <commonsPool2Version>2.4.2</commonsPool2Version>
+        <commonsPool2Version>2.5.0</commonsPool2Version>
         <derbyVersion>10.13.1.1</derbyVersion>
         <dom4jVersion>1.6.1</dom4jVersion>
         <eaioUuidVersion>3.4.0</eaioUuidVersion>

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/component/FunctionalTestProcessor.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/component/FunctionalTestProcessor.java
@@ -6,6 +6,7 @@
  */
 package org.mule.functional.api.component;
 
+import static java.lang.Thread.currentThread;
 import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR;
 import static org.mule.functional.api.notification.FunctionalTestNotification.EVENT_RECEIVED;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
@@ -267,6 +268,7 @@ public class FunctionalTestProcessor extends AbstractComponent implements Proces
       try {
         Thread.sleep(waitTime);
       } catch (InterruptedException e) {
+        currentThread().interrupt();
         LOGGER.info("FunctionalTestProcessor waitTime was interrupted");
       }
     }


### PR DESCRIPTION
threads
* Improve processing strategy dispose
* Fix in test component
* Upgrade commons-pool. Previous version used a `TimerThread` while the new one uses a `ScheduledExecutor`