### PR TITLE
MULE-14492: Fix errors in the revapi validation in changes in the api

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChainBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChainBuilder.java
@@ -45,6 +45,7 @@ public abstract class AbstractMessageProcessorChainBuilder implements MessagePro
     this.name = name;
   }
 
+  @Override
   public void setProcessingStrategy(ProcessingStrategy processingStrategy) {
     this.processingStrategy = processingStrategy;
   }

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
@@ -123,7 +123,10 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
     mockMuleContext.getInjector().inject(this);
 
     when(locator.find(any(Location.class))).thenReturn(of(mock(Flow.class)));
+    when(locator.find(Location.builder().globalName("flow").build())).thenReturn(of(callerFlow));
     when(callerFlow.getProcessingStrategy()).thenReturn(callerFlowProcessingStrategy);
+
+    when(callerFlowProcessingStrategy.onProcessor(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArguments()[0]);
   }
 
   @Test


### PR DESCRIPTION
already ignored in 4.1.x
* Fix flow-ref tests

Apparently the visibility change of AbstractMessageProcessorChainBuilder exposed some behavior in Mockito that failed the tests. On further examination, it was the tests that were wrong.