### PR TITLE
MULE-14588: Deployment failed due to NoSuchMethodError: Error creatin…

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/MuleArtifactContext.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/MuleArtifactContext.java
@@ -427,7 +427,6 @@ public class MuleArtifactContext extends AbstractRefreshableConfigApplicationCon
     if (isRunning()) {
       super.close();
     }
-    beanDefinitionFactory.destroy();
   }
 
   public static Resource[] convert(ConfigResource[] resources) {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/BeanDefinitionFactory.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/BeanDefinitionFactory.java
@@ -459,8 +459,4 @@ public class BeanDefinitionFactory {
     return wrapperIdentifierAndTypeMap;
   }
 
-  /**
-   * Release resources from the bean factory.
-   */
-  public void destroy() {}
 }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/BeanDefinitionFactory.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/BeanDefinitionFactory.java
@@ -462,7 +462,5 @@ public class BeanDefinitionFactory {
   /**
    * Release resources from the bean factory.
    */
-  public void destroy() {
-    objectFactoryClassRepository.destroy();
-  }
+  public void destroy() {}
 }

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/spring/ObjectFactoryClassRepositoryTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/spring/ObjectFactoryClassRepositoryTestCase.java
@@ -7,8 +7,8 @@
 package org.mule.runtime.config.dsl.spring;
 
 import static java.util.Optional.empty;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import org.mule.runtime.config.internal.dsl.spring.ObjectFactoryClassRepository;
 import org.mule.runtime.dsl.api.component.AbstractComponentFactory;
@@ -43,7 +43,7 @@ public class ObjectFactoryClassRepositoryTestCase {
     objectFactory = objectFactoryClass.newInstance();
     assertThat(((SmartFactoryBean) objectFactory).isSingleton(), is(true));
 
-    assertThat(firstProxyGenerated, equalTo(objectFactory.getClass()));
+    assertThat(firstProxyGenerated, sameInstance(objectFactory.getClass()));
   }
 
   public Class<ObjectFactory> getObjectFactoryClass() {

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/spring/ObjectFactoryClassRepositoryTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/spring/ObjectFactoryClassRepositoryTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.dsl.spring;
+
+import static java.util.Optional.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import org.mule.runtime.config.internal.dsl.spring.ObjectFactoryClassRepository;
+import org.mule.runtime.dsl.api.component.AbstractComponentFactory;
+import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition;
+import org.mule.runtime.dsl.api.component.ObjectFactory;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.SmartFactoryBean;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ObjectFactoryClassRepositoryTestCase {
+
+  @Mock
+  private ComponentBuildingDefinition componentBuildingDefinition;
+
+  @Test
+  public void cacheEnableForCGLib()
+      throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+    Class<ObjectFactory> objectFactoryClass = getObjectFactoryClass();
+
+    // First we create the objectFactory that will create an Enhancer with the callback registered and using internal cache
+    ObjectFactory objectFactory = objectFactoryClass.newInstance();
+    assertThat(((SmartFactoryBean) objectFactory).isSingleton(), is(true));
+    Class firstProxyGenerated = objectFactory.getClass();
+
+    objectFactoryClass = getObjectFactoryClass();
+    objectFactory = objectFactoryClass.newInstance();
+    assertThat(((SmartFactoryBean) objectFactory).isSingleton(), is(true));
+
+    assertThat(firstProxyGenerated, equalTo(objectFactory.getClass()));
+  }
+
+  public Class<ObjectFactory> getObjectFactoryClass() {
+    ObjectFactoryClassRepository objectFactoryClassRepository = new ObjectFactoryClassRepository();
+    return objectFactoryClassRepository.getObjectFactoryClass(componentBuildingDefinition,
+                                                              FakeObjectConnectionProviderObjectFactory.class,
+                                                              FakeObject.class, () -> false, empty());
+  }
+
+
+  public static class FakeObjectConnectionProviderObjectFactory extends AbstractComponentFactory {
+
+    @Override
+    public Object doGetObject() throws Exception {
+      return new FakeObject();
+    }
+
+  }
+
+  public static class FakeObject {
+  }
+
+}


### PR DESCRIPTION
…g bean with name 'http_request' when running parallel deployments

The cache added to this factory holds also references to proxies created for Mule (container) componentBuildingDefinitions but this cache is being tied to the application lifecycle, therefore at some point the proxies has unregistered the callbacks but still the Enhancer has enabled the useCache (in order to avoid OOM and creating of classes for the container that are not needed) and the NoSuchMethod is thrown.
As cglib already has the cache managed internally and always returns the same class (when create class is invoked) and only for those cases where classes are created for the application context the cache is set to false) we can just remove this cache that introduced this issues.