### PR TITLE
MULE-14742: Memory leak on JMS transport tests with JDK 7 in 3.8.x

### DIFF
--- a/transports/jms/src/test/java/org/mule/transport/jms/JmsMessageDispatcherTestCase.java
+++ b/transports/jms/src/test/java/org/mule/transport/jms/JmsMessageDispatcherTestCase.java
@@ -40,9 +40,9 @@ import static org.mule.transport.jms.JmsConstants.PERSISTENT_DELIVERY_PROPERTY;
 import static org.mule.transport.jms.JmsConstants.PRIORITY_PROPERTY;
 import static org.mule.transport.jms.JmsConstants.TIME_TO_LIVE_PROPERTY;
 
-@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "org.mule.mvel2.*", "com.google.common.*", "org.apache.commons.*"})
 @PrepareForTest(JmsMessageDispatcher.class)
-@PowerMockIgnore("javax.management.*")
+@RunWith(PowerMockRunner.class)
 public class JmsMessageDispatcherTestCase extends AbstractMuleContextTestCase
 {
     final private boolean defaultPersistentDelivery = true;

--- a/transports/jms/src/test/java/org/mule/transport/jms/JmsTransformerTestCase.java
+++ b/transports/jms/src/test/java/org/mule/transport/jms/JmsTransformerTestCase.java
@@ -40,9 +40,9 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "org.mule.mvel2.*", "com.google.common.*", "org.apache.activemq.*"})
 @PrepareForTest(LogFactory.class)
-@PowerMockIgnore("javax.management.*")
+@RunWith(PowerMockRunner.class)
 public class JmsTransformerTestCase extends AbstractMuleContextTestCase
 {
 


### PR DESCRIPTION
MULE-14742: Memory leak on JMS transport tests with JDK 7 in 3.8.x

- Workaround to fix memory leak issue
- This workaround was tested for JDK 7 and 8
- This idea was derived from a well Kwon workaround found online (ignoring the appropriate packages that PowerMock's classloaders shouldn' be dealing with directly) and by several trial and error rounds based on a basic analysis of the classloading logs when the -verbose flag is set into the JVM
- Up to this point, I can't guarantee these are just the exact set of packages that should be ignored because they could perfectly be just a superset.
- I don't know if there's any drawback of ignoring that many packages.
- I can just guarantee that all JMS tests passed successfully in both JDK 7 and 8