### PR TITLE
MULE-14833: SFTP tests filing due to error during login in 3.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <smackVersion>3.4.1</smackVersion>
         <springOsgiVersion>1.0.2</springOsgiVersion>
         <springVersion>4.1.9.RELEASE</springVersion>
-        <sshCoreVersion>1.4.0</sshCoreVersion>
+        <sshCoreVersion>1.2.0</sshCoreVersion>
         <springForkVersion>4.1.9.RELEASE-MULE-001</springForkVersion>
         <springSecurityVersion>4.2.3.RELEASE</springSecurityVersion>
         <springLdapVersion>2.3.2.RELEASE</springLdapVersion>


### PR DESCRIPTION
- Downgrading Apache's sshd-core libs version to 1.2.0 due to lack of support for JDK7 as stated in https://github.com/apache/mina-sshd#core-requirements