### PR TITLE
MULE-14833: SFTP tests filing due to error during login in 3.8.x

### DIFF
--- a/transports/sftp/pom.xml
+++ b/transports/sftp/pom.xml
@@ -98,6 +98,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.54</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-http</artifactId>
             <version>${project.version}</version>

--- a/transports/sftp/src/test/java/org/mule/transport/sftp/SftpKnownHostsTestCase.java
+++ b/transports/sftp/src/test/java/org/mule/transport/sftp/SftpKnownHostsTestCase.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 public class SftpKnownHostsTestCase extends AbstractSftpFunctionalTestCase
 {
 
-    private static final String TEST_ERROR_MESSAGE = "Error during login to muletest1@localhost: UnknownHostKey: localhost. RSA key fingerprint is ";
+    private static final String TEST_ERROR_MESSAGE = "Error during login to muletest1@localhost: UnknownHostKey: localhost. DSA key fingerprint is ";
 
     @Override
     protected String getConfigFile()


### PR DESCRIPTION
 - Bouncy Castle version downgrade for SFTP tests due to the login errors that show up again after downgrading sshd-core lib, which was necessary due to its incompatibility with JDK7