### PR TITLE
MULE-14803: forbid the use of any type of configuration properties within smart

### DIFF
--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/api/loader/xml/XmlExtensionModelLoader.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/api/loader/xml/XmlExtensionModelLoader.java
@@ -18,6 +18,7 @@ import org.mule.runtime.extension.api.loader.ExtensionModelValidator;
 import org.mule.runtime.extension.internal.loader.XmlExtensionLoaderDelegate;
 import org.mule.runtime.extension.internal.loader.enricher.StereotypesDiscoveryDeclarationEnricher;
 import org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator;
+import org.mule.runtime.extension.internal.loader.validator.ForbiddenConfigurationPropertiesValidator;
 import org.mule.runtime.extension.internal.loader.validator.GlobalElementNamesValidator;
 import org.mule.runtime.module.extension.internal.loader.enricher.stereotypes.StereotypesDeclarationEnricher;
 
@@ -36,7 +37,8 @@ public class XmlExtensionModelLoader extends ExtensionModelLoader {
                                                                                     new StereotypesDiscoveryDeclarationEnricher()));
 
   private final List<ExtensionModelValidator> customValidators = unmodifiableList(asList(new CorrectPrefixesValidator(),
-                                                                                         new GlobalElementNamesValidator()));
+                                                                                         new GlobalElementNamesValidator(),
+                                                                                         new ForbiddenConfigurationPropertiesValidator()));
 
   /**
    * Attribute to look for in the parametrized attributes picked up from the descriptor.

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
@@ -506,16 +506,12 @@ public final class XmlExtensionLoaderDelegate {
     List<ComponentModel> configurationProperties = extractProperties(moduleModel);
     List<ComponentModel> connectionProperties = extractConnectionProperties(moduleModel);
     validateProperties(configurationProperties, connectionProperties);
-    //TODO lautaro aca
-    //TODO lautaro aca
-    //TODO lautaro aca
-    //TODO lautaro aca
-    //TODO lautaro aca
+
     if (!configurationProperties.isEmpty() || !connectionProperties.isEmpty() || !globalElementsComponentModel.isEmpty()) {
       declarer.withModelProperty(new NoReconnectionStrategyModelProperty());
       ConfigurationDeclarer configurationDeclarer = declarer.withConfig(CONFIG_NAME);
       configurationDeclarer.withModelProperty(new GlobalElementComponentModelModelProperty(globalElementsComponentModel));
-      configurationProperties.stream().forEach(param -> extractProperty(configurationDeclarer, param));
+      configurationProperties.forEach(param -> extractProperty(configurationDeclarer, param));
 
       addConnectionProvider(configurationDeclarer, connectionProperties, globalElementsComponentModel, extensions);
       return of(configurationDeclarer);

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.extension.internal.loader.validator;
+
+import static java.lang.String.format;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.api.meta.model.config.ConfigurationModel;
+import org.mule.runtime.api.meta.model.util.ExtensionWalker;
+import org.mule.runtime.config.api.dsl.model.properties.ConfigurationPropertiesProviderFactory;
+import org.mule.runtime.config.internal.dsl.model.extension.xml.property.GlobalElementComponentModelModelProperty;
+import org.mule.runtime.extension.api.loader.ExtensionModelValidator;
+import org.mule.runtime.extension.api.loader.Problem;
+import org.mule.runtime.extension.api.loader.ProblemsReporter;
+
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * {@link ExtensionModelValidator} which applies to {@link ExtensionModel}s which are XML based, as those that contain usages of
+ * configuration properties. If the developer wants to use constants, then it must rely on <mule:global-property/>'s than in the
+ * properties file.
+ *
+ * @since 4.2
+ */
+public class ForbiddenConfigurationPropertiesValidator implements ExtensionModelValidator {
+
+  public static final String CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE =
+      "Configuration properties is not supported, used <mule:global-property ../> or <module:property/> instead. Offending global element '%s'";
+
+  @Override
+  public void validate(ExtensionModel extensionModel, ProblemsReporter problemsReporter) {
+    new ExtensionWalker() {
+
+      @Override
+      protected void onConfiguration(ConfigurationModel model) {
+        model.getModelProperty(GlobalElementComponentModelModelProperty.class).ifPresent(modelProperty -> {
+          final Set<ComponentIdentifier> configurationPropertiesCollection = getConfigurationPropertiesIdentifiers();
+
+          modelProperty.getGlobalElements().forEach(globalElementComponentModel -> {
+            if (configurationPropertiesCollection.contains(globalElementComponentModel.getIdentifier())) {
+              problemsReporter.addError(new Problem(model, format(
+                                                                  CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE,
+                                                                  globalElementComponentModel.getIdentifier())));
+            }
+          });
+        });
+
+      }
+
+      private Set<ComponentIdentifier> getConfigurationPropertiesIdentifiers() {
+        final ServiceLoader<ConfigurationPropertiesProviderFactory> providerFactories =
+            ServiceLoader.load(ConfigurationPropertiesProviderFactory.class);
+        return StreamSupport.stream(providerFactories.spliterator(), false)
+            .map(ConfigurationPropertiesProviderFactory::getSupportedComponentIdentifier)
+            .collect(Collectors.toSet());
+      }
+    }.walk(extensionModel);
+  }
+}

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
@@ -32,7 +32,7 @@ import java.util.stream.StreamSupport;
 public class ForbiddenConfigurationPropertiesValidator implements ExtensionModelValidator {
 
   public static final String CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE =
-      "Configuration properties is not supported, used <mule:global-property ../> or <module:property/> instead. Offending global element '%s'";
+      "Configuration properties is not supported, either use <mule:global-property ../>, ${file::file.txt} or <module:property/> instead. Offending global element '%s'";
 
   @Override
   public void validate(ExtensionModel extensionModel, ProblemsReporter problemsReporter) {
@@ -42,7 +42,6 @@ public class ForbiddenConfigurationPropertiesValidator implements ExtensionModel
       protected void onConfiguration(ConfigurationModel model) {
         model.getModelProperty(GlobalElementComponentModelModelProperty.class).ifPresent(modelProperty -> {
           final Set<ComponentIdentifier> configurationPropertiesCollection = getConfigurationPropertiesIdentifiers();
-
           modelProperty.getGlobalElements().forEach(globalElementComponentModel -> {
             if (configurationPropertiesCollection.contains(globalElementComponentModel.getIdentifier())) {
               problemsReporter.addError(new Problem(model, format(
@@ -51,7 +50,6 @@ public class ForbiddenConfigurationPropertiesValidator implements ExtensionModel
             }
           });
         });
-
       }
 
       private Set<ComponentIdentifier> getConfigurationPropertiesIdentifiers() {

--- a/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderTestCase.java
@@ -137,9 +137,9 @@ public class XmlExtensionLoaderTestCase extends AbstractMuleTestCase {
     Optional<GlobalElementComponentModelModelProperty> globalElementComponentModelModelProperty =
         configurationModel.getModelProperty(GlobalElementComponentModelModelProperty.class);
     assertThat(globalElementComponentModelModelProperty.isPresent(), is(true));
-    assertThat(globalElementComponentModelModelProperty.get().getGlobalElements().size(), is(0));
+    assertThat(globalElementComponentModelModelProperty.get().getGlobalElements().size(), is(1));
 
-    assertThat(configurationModel.getOperationModels().size(), is(7));
+    assertThat(configurationModel.getOperationModels().size(), is(10));
 
     Optional<OperationModel> operationModel = configurationModel.getOperationModel("set-payload-add-param-and-property-values");
     assertThat(operationModel.isPresent(), is(true));

--- a/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/validation/DefaultModelValidatorTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/validation/DefaultModelValidatorTestCase.java
@@ -13,6 +13,7 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mule.runtime.api.dsl.DslResolvingContext.getDefault;
 import static org.mule.runtime.config.api.dsl.CoreDslConstants.RAISE_ERROR_IDENTIFIER;
+import static org.mule.runtime.config.api.dsl.model.properties.DefaultConfigurationPropertiesProviderFactory.CONFIGURATION_PROPERTIES;
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.CORE_ERROR_NS;
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.TARGET_TYPE;
 import static org.mule.runtime.config.internal.model.ApplicationModel.ERROR_MAPPING_IDENTIFIER;
@@ -20,6 +21,7 @@ import static org.mule.runtime.extension.api.loader.xml.XmlExtensionModelLoader.
 import static org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator.EMPTY_TYPE_FORMAT_MESSAGE;
 import static org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator.TYPE_RAISE_ERROR_ATTRIBUTE;
 import static org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator.WRONG_VALUE_FORMAT_MESSAGE;
+import static org.mule.runtime.extension.internal.loader.validator.ForbiddenConfigurationPropertiesValidator.CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE;
 import static org.mule.runtime.extension.internal.loader.validator.GlobalElementNamesValidator.ILLEGAL_GLOBAL_ELEMENT_NAME_FORMAT_MESSAGE;
 import static org.mule.runtime.extension.internal.loader.validator.GlobalElementNamesValidator.REPEATED_GLOBAL_ELEMENT_NAME_FORMAT_MESSAGE;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.TYPE_PROPERTY_NAME;
@@ -194,6 +196,12 @@ public class DefaultModelValidatorTestCase extends AbstractMuleTestCase {
                                                         "ilegal-petstore-config-name_lal[\\{#a",
                                                         ""))));
     getExtensionModelFrom("validation/module-repeated-global-elements.xml", getDependencyExtensions());
+  }
+
+  @Test
+  public void forbiddenConfigurationPropertiesThrowsException() {
+    exception.expectMessage(format(CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE, CONFIGURATION_PROPERTIES.toString()));
+    getExtensionModelFrom("validation/module-configuration-property-file.xml");
   }
 
   private ExtensionModel getExtensionModelFrom(String modulePath) {

--- a/modules/extensions-xml-support/src/test/java/org/mule/test/functional/ModuleWithPropertiesTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/test/functional/ModuleWithPropertiesTestCase.java
@@ -6,13 +6,13 @@
  */
 package org.mule.test.functional;
 
+import static java.lang.Thread.currentThread;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-
-import org.mule.runtime.core.api.event.CoreEvent;
-
 import org.junit.Test;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.util.IOUtils;
 
 public class ModuleWithPropertiesTestCase extends AbstractXmlExtensionMuleArtifactFunctionalTestCase {
 
@@ -66,5 +66,28 @@ public class ModuleWithPropertiesTestCase extends AbstractXmlExtensionMuleArtifa
   public void testSetPayloadConfigOptionalProperty() throws Exception {
     CoreEvent muleEvent = flowRunner("testSetPayloadConfigOptionalProperty").run();
     assertThat(muleEvent.getMessage().getPayload().getValue(), is(nullValue()));
+  }
+
+  @Test
+  public void testSetPayloadHardcodedGlobalProperty() throws Exception {
+    CoreEvent muleEvent = flowRunner("testSetPayloadHardcodedGlobalProperty").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), is("a-constant-global-value"));
+  }
+
+  @Test
+  public void testSetPayloadHardcodedSystemProperty() throws Exception {
+    final String expected_value = System.getProperty("user.home");
+    CoreEvent muleEvent = flowRunner("testSetPayloadHardcodedSystemProperty").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), is(expected_value));
+  }
+
+  @Test
+  public void testSetPayloadHardcodedFileProperty() throws Exception {
+    CoreEvent muleEvent = flowRunner("testSetPayloadHardcodedFileProperty").run();
+    final String expectedContent =
+        IOUtils.toString(currentThread().getContextClassLoader().getResourceAsStream("modules/module-properties-file.txt"))
+            .trim();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), is(
+                                                                  expectedContent));
   }
 }

--- a/modules/extensions-xml-support/src/test/resources/flows/flows-using-module-properties.xml
+++ b/modules/extensions-xml-support/src/test/resources/flows/flows-using-module-properties.xml
@@ -35,4 +35,16 @@
     <flow name="testSetPayloadConfigOptionalProperty">
         <module-properties:set-payload-config-optional-property config-ref="instantiatedConfig"/>
     </flow>
+
+    <flow name="testSetPayloadHardcodedGlobalProperty">
+        <module-properties:set-payload-hardcoded-global-property config-ref="instantiatedConfig"/>
+    </flow>
+
+    <flow name="testSetPayloadHardcodedSystemProperty">
+        <module-properties:set-payload-hardcoded-system-property config-ref="instantiatedConfig"/>
+    </flow>
+
+    <flow name="testSetPayloadHardcodedFileProperty">
+        <module-properties:set-payload-hardcoded-file-property config-ref="instantiatedConfig"/>
+    </flow>
 </mule>

--- a/modules/extensions-xml-support/src/test/resources/modules/module-properties-file.txt
+++ b/modules/extensions-xml-support/src/test/resources/modules/module-properties-file.txt
@@ -1,0 +1,1 @@
+content of the payload from the file

--- a/modules/extensions-xml-support/src/test/resources/modules/module-properties.xml
+++ b/modules/extensions-xml-support/src/test/resources/modules/module-properties.xml
@@ -7,6 +7,8 @@
            http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
+    <mule:global-property name="mule-global-property" value="a-constant-global-value" />
+
     <property name="configParam" type="string"/>
     <property name="defaultConfigParam" defaultValue="some default-config-value-parameter" type="string"/>
     <property name="optionalProperty" use="OPTIONAL" type="string"/>
@@ -65,6 +67,28 @@
             <mule:set-payload value="a value"/>
             <!-- will override payload with the null 'optionalProperty' parameter-->
             <mule:set-payload value="#[vars.optionalProperty]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-hardcoded-global-property">
+        <body>
+            <mule:set-payload value="${mule-global-property}"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-hardcoded-system-property">
+        <body>
+            <mule:set-payload value="${user.home}"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-hardcoded-file-property">
+        <body>
+            <!-- notice we need to add the folder modules to be sure it will be loaded in the context of the running test -->
+            <mule:set-payload value="${file::modules/module-properties-file.txt}"/>
         </body>
         <output type="string"/>
     </operation>

--- a/modules/extensions-xml-support/src/test/resources/validation/module-configuration-property-file.xml
+++ b/modules/extensions-xml-support/src/test/resources/validation/module-configuration-property-file.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-configuration-property-file"
+        
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <mule:configuration-properties file="config.properties" />
+
+    <operation name="op">
+        <body>
+            <!-- smart connectors do not support configuration properties, it will fail during validation phase-->
+            <mule:set-payload value="${aProperty}"/>
+        </body>
+        <output type="string"/>
+    </operation>
+</module>


### PR DESCRIPTION
 connectors, but allow file::filename, and global-property