### PR TITLE
MULE-14803: forbid the use of any type of configuration properties wi…

### DIFF
--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/api/loader/xml/XmlExtensionModelLoader.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/api/loader/xml/XmlExtensionModelLoader.java
@@ -17,6 +17,7 @@ import org.mule.runtime.extension.api.loader.ExtensionModelLoader;
 import org.mule.runtime.extension.api.loader.ExtensionModelValidator;
 import org.mule.runtime.extension.internal.loader.XmlExtensionLoaderDelegate;
 import org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator;
+import org.mule.runtime.extension.internal.loader.validator.ForbiddenConfigurationPropertiesValidator;
 import org.mule.runtime.extension.internal.loader.validator.GlobalElementNamesValidator;
 import org.mule.runtime.module.extension.internal.loader.enricher.stereotypes.StereotypesDeclarationEnricher;
 
@@ -34,7 +35,8 @@ public class XmlExtensionModelLoader extends ExtensionModelLoader {
   private final List<DeclarationEnricher> customEnrichers = unmodifiableList(asList(new StereotypesDeclarationEnricher()));
 
   private final List<ExtensionModelValidator> customValidators = unmodifiableList(asList(new CorrectPrefixesValidator(),
-                                                                                         new GlobalElementNamesValidator()));
+                                                                                         new GlobalElementNamesValidator(),
+                                                                                         new ForbiddenConfigurationPropertiesValidator()));
 
   /**
    * Attribute to look for in the parametrized attributes picked up from the descriptor.

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/XmlExtensionLoaderDelegate.java
@@ -26,6 +26,7 @@ import static org.mule.runtime.api.meta.model.parameter.ParameterRole.BEHAVIOUR;
 import static org.mule.runtime.config.api.XmlConfigurationDocumentLoader.schemaValidatingDocumentLoader;
 import static org.mule.runtime.config.internal.dsl.model.extension.xml.MacroExpansionModuleModel.TNS_PREFIX;
 import static org.mule.runtime.config.internal.dsl.model.extension.xml.MacroExpansionModulesModel.getUsedNamespaces;
+import static org.mule.runtime.config.internal.model.ApplicationModel.GLOBAL_PROPERTY;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.ANY;
 import static org.mule.runtime.core.internal.processor.chain.ModuleOperationMessageProcessorChainBuilder.MODULE_CONNECTION_GLOBAL_ELEMENT_NAME;
 import static org.mule.runtime.extension.api.util.XmlModelUtils.createXmlLanguageModel;
@@ -57,27 +58,34 @@ import org.mule.runtime.api.meta.model.display.LayoutModel;
 import org.mule.runtime.api.meta.model.error.ErrorModelBuilder;
 import org.mule.runtime.api.meta.model.parameter.ParameterRole;
 import org.mule.runtime.config.api.XmlConfigurationDocumentLoader;
-import org.mule.runtime.config.internal.model.ComponentModel;
+import org.mule.runtime.config.api.dsl.model.properties.ConfigurationPropertiesProvider;
+import org.mule.runtime.config.api.dsl.model.properties.ConfigurationProperty;
 import org.mule.runtime.config.api.dsl.processor.ConfigLine;
 import org.mule.runtime.config.api.dsl.processor.xml.XmlApplicationParser;
+import org.mule.runtime.config.internal.dsl.model.ClassLoaderResourceProvider;
 import org.mule.runtime.config.internal.dsl.model.ComponentModelReader;
+import org.mule.runtime.config.internal.dsl.model.config.ConfigurationPropertiesResolver;
 import org.mule.runtime.config.internal.dsl.model.config.DefaultConfigurationPropertiesResolver;
+import org.mule.runtime.config.internal.dsl.model.config.DefaultConfigurationProperty;
 import org.mule.runtime.config.internal.dsl.model.config.EnvironmentPropertiesConfigurationProvider;
+import org.mule.runtime.config.internal.dsl.model.config.FileConfigurationPropertiesProvider;
+import org.mule.runtime.config.internal.dsl.model.config.GlobalPropertyConfigurationPropertiesProvider;
+import org.mule.runtime.config.internal.dsl.model.config.PropertyNotFoundException;
 import org.mule.runtime.config.internal.dsl.model.extension.xml.MacroExpansionModuleModel;
 import org.mule.runtime.config.internal.dsl.model.extension.xml.MacroExpansionModulesModel;
 import org.mule.runtime.config.internal.dsl.model.extension.xml.property.GlobalElementComponentModelModelProperty;
 import org.mule.runtime.config.internal.dsl.model.extension.xml.property.OperationComponentModelModelProperty;
 import org.mule.runtime.config.internal.dsl.model.extension.xml.property.TestConnectionGlobalElementModelProperty;
+import org.mule.runtime.config.internal.model.ComponentModel;
 import org.mule.runtime.config.internal.util.NoOpXmlErrorHandler;
-import org.mule.runtime.core.api.registry.SpiServiceRegistry;
 import org.mule.runtime.extension.api.annotation.param.display.Placement;
 import org.mule.runtime.extension.api.dsl.syntax.resolver.DslSyntaxResolver;
 import org.mule.runtime.extension.api.exception.IllegalModelDefinitionException;
 import org.mule.runtime.extension.api.exception.IllegalParameterModelDefinitionException;
 import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
 import org.mule.runtime.extension.api.loader.xml.declaration.DeclarationOperation;
-import org.mule.runtime.extension.api.property.ClassLoaderModelProperty;
 import org.mule.runtime.extension.api.property.XmlExtensionModelProperty;
+import org.mule.runtime.extension.internal.loader.validator.ForbiddenConfigurationPropertiesValidator;
 import org.mule.runtime.extension.internal.property.NoReconnectionStrategyModelProperty;
 import org.mule.runtime.internal.dsl.NullDslResolvingContext;
 
@@ -88,7 +96,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -348,10 +355,44 @@ public final class XmlExtensionLoaderDelegate {
       // This happens in org.mule.runtime.config.dsl.processor.xml.XmlApplicationParser.configLineFromElement()
       throw new IllegalArgumentException(format("There was an issue trying to read the stream of '%s'", resource.getFile()));
     }
-    ComponentModelReader componentModelReader =
-        new ComponentModelReader(new DefaultConfigurationPropertiesResolver(empty(),
-                                                                            new EnvironmentPropertiesConfigurationProvider()));
-    return componentModelReader.extractComponentDefinitionModel(parseModule.get(), modulePath);
+    final ConfigLine configLine = parseModule.get();
+    final ConfigurationPropertiesResolver externalPropertiesResolver = getConfigurationPropertiesResolver(configLine);
+    final ComponentModelReader componentModelReader = new ComponentModelReader(externalPropertiesResolver);
+    return componentModelReader.extractComponentDefinitionModel(configLine, modulePath);
+  }
+
+  private ConfigurationPropertiesResolver getConfigurationPropertiesResolver(ConfigLine configLine) {
+    // <mule:global-property ... /> properties reader
+    final ConfigurationPropertiesResolver globalPropertiesConfigurationPropertiesResolver =
+        new DefaultConfigurationPropertiesResolver(of(new XmlExtensionConfigurationPropertiesResolver()),
+                                                   createProviderFromGlobalProperties(configLine, modulePath));
+    // system properties, such as "file.separator" properties reader
+    final ConfigurationPropertiesResolver systemPropertiesResolver =
+        new DefaultConfigurationPropertiesResolver(of(globalPropertiesConfigurationPropertiesResolver),
+                                                   new EnvironmentPropertiesConfigurationProvider());
+    // "file::" properties reader
+    final String description = format("External files for smart connector '%s'", modulePath);
+    final FileConfigurationPropertiesProvider externalPropertiesConfigurationProvider =
+        new FileConfigurationPropertiesProvider(new ClassLoaderResourceProvider(currentThread().getContextClassLoader()),
+                                                description);
+    return new DefaultConfigurationPropertiesResolver(of(systemPropertiesResolver),
+                                                      externalPropertiesConfigurationProvider);
+  }
+
+  private ConfigurationPropertiesProvider createProviderFromGlobalProperties(ConfigLine moduleLine, String modulePath) {
+    final Map<String, ConfigurationProperty> globalProperties = new HashMap<>();
+    moduleLine.getChildren().stream()
+        .filter(configLine -> GLOBAL_PROPERTY.equals(configLine.getIdentifier()))
+        .forEach(configLine -> {
+          final String key = configLine.getConfigAttributes().get("name").getValue();
+          final String rawValue = configLine.getConfigAttributes().get("value").getValue();
+          globalProperties.put(key,
+                               new DefaultConfigurationProperty(format("global-property - file: %s - lineNumber %s",
+                                                                       modulePath, configLine.getLineNumber()),
+                                                                key, rawValue));
+
+        });
+    return new GlobalPropertyConfigurationPropertiesProvider(globalProperties);
   }
 
   private void loadModuleExtension(ExtensionDeclarer declarer, URL resource, Document moduleDocument,
@@ -842,5 +883,24 @@ public final class XmlExtensionLoaderDelegate {
               .withParent(ErrorModelBuilder.newError(ANY).build())
               .build());
         }));
+  }
+
+  /**
+   * Utility class to read the XML module entirely so that if there's any usage of configurations properties, such as
+   * "${someProperty}", the {@link ForbiddenConfigurationPropertiesValidator} can show the errors consistently,
+   * Without this dull implementation, the {@link ComponentModelReader#extractComponentDefinitionModel(ConfigLine, String)} method
+   * fails while reading ANY parametrization throwing a {@link PropertyNotFoundException} eagerly.
+   */
+  private class XmlExtensionConfigurationPropertiesResolver implements ConfigurationPropertiesResolver {
+
+    @Override
+    public Object resolveValue(String value) {
+      return value;
+    }
+
+    @Override
+    public Object resolvePlaceholderKeyValue(String placeholderKey) {
+      return placeholderKey;
+    }
   }
 }

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.extension.internal.loader.validator;
+
+import static java.lang.String.format;
+import org.mule.runtime.api.component.ComponentIdentifier;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.api.meta.model.config.ConfigurationModel;
+import org.mule.runtime.api.meta.model.util.ExtensionWalker;
+import org.mule.runtime.config.api.dsl.model.properties.ConfigurationPropertiesProviderFactory;
+import org.mule.runtime.config.internal.dsl.model.extension.xml.property.GlobalElementComponentModelModelProperty;
+import org.mule.runtime.extension.api.loader.ExtensionModelValidator;
+import org.mule.runtime.extension.api.loader.Problem;
+import org.mule.runtime.extension.api.loader.ProblemsReporter;
+
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * {@link ExtensionModelValidator} which applies to {@link ExtensionModel}s which are XML based, as those that contain usages of
+ * configuration properties. If the developer wants to use constants, then it must rely on <mule:global-property/>'s than in the
+ * properties file.
+ *
+ * @since 4.1.2
+ */
+public class ForbiddenConfigurationPropertiesValidator implements ExtensionModelValidator {
+
+  public static final String CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE =
+      "Configuration properties is not supported, either use <mule:global-property ../>, ${file::file.txt} or <module:property/> instead. Offending global element '%s'";
+
+  @Override
+  public void validate(ExtensionModel extensionModel, ProblemsReporter problemsReporter) {
+    new ExtensionWalker() {
+
+      @Override
+      protected void onConfiguration(ConfigurationModel model) {
+        model.getModelProperty(GlobalElementComponentModelModelProperty.class).ifPresent(modelProperty -> {
+          final Set<ComponentIdentifier> configurationPropertiesCollection = getConfigurationPropertiesIdentifiers();
+          modelProperty.getGlobalElements().forEach(globalElementComponentModel -> {
+            if (configurationPropertiesCollection.contains(globalElementComponentModel.getIdentifier())) {
+              problemsReporter.addError(new Problem(model, format(
+                                                                  CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE,
+                                                                  globalElementComponentModel.getIdentifier())));
+            }
+          });
+        });
+      }
+
+      private Set<ComponentIdentifier> getConfigurationPropertiesIdentifiers() {
+        final ServiceLoader<ConfigurationPropertiesProviderFactory> providerFactories =
+            ServiceLoader.load(ConfigurationPropertiesProviderFactory.class);
+        return StreamSupport.stream(providerFactories.spliterator(), false)
+            .map(ConfigurationPropertiesProviderFactory::getSupportedComponentIdentifier)
+            .collect(Collectors.toSet());
+      }
+    }.walk(extensionModel);
+  }
+}

--- a/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/validation/DefaultModelValidatorTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/validation/DefaultModelValidatorTestCase.java
@@ -13,6 +13,7 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mule.runtime.api.dsl.DslResolvingContext.getDefault;
 import static org.mule.runtime.config.api.dsl.CoreDslConstants.RAISE_ERROR_IDENTIFIER;
+import static org.mule.runtime.config.api.dsl.model.properties.DefaultConfigurationPropertiesProviderFactory.CONFIGURATION_PROPERTIES;
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.CORE_ERROR_NS;
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.TARGET_TYPE;
 import static org.mule.runtime.config.internal.model.ApplicationModel.ERROR_MAPPING_IDENTIFIER;
@@ -20,11 +21,11 @@ import static org.mule.runtime.extension.api.loader.xml.XmlExtensionModelLoader.
 import static org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator.EMPTY_TYPE_FORMAT_MESSAGE;
 import static org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator.TYPE_RAISE_ERROR_ATTRIBUTE;
 import static org.mule.runtime.extension.internal.loader.validator.CorrectPrefixesValidator.WRONG_VALUE_FORMAT_MESSAGE;
+import static org.mule.runtime.extension.internal.loader.validator.ForbiddenConfigurationPropertiesValidator.CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE;
 import static org.mule.runtime.extension.internal.loader.validator.GlobalElementNamesValidator.ILLEGAL_GLOBAL_ELEMENT_NAME_FORMAT_MESSAGE;
 import static org.mule.runtime.extension.internal.loader.validator.GlobalElementNamesValidator.REPEATED_GLOBAL_ELEMENT_NAME_FORMAT_MESSAGE;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.TYPE_PROPERTY_NAME;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.VERSION;
-
 import org.mule.runtime.api.dsl.DslResolvingContext;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.extension.api.exception.IllegalModelDefinitionException;
@@ -36,11 +37,12 @@ import org.mule.tck.size.SmallTest;
 import org.mule.test.heisenberg.extension.HeisenbergExtension;
 import org.mule.test.petstore.extension.PetStoreConnector;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.maven.model.validation.ModelValidator;
 import org.junit.Before;
 import org.junit.Rule;
@@ -190,6 +192,12 @@ public class DefaultModelValidatorTestCase extends AbstractMuleTestCase {
                                                         "ilegal-petstore-config-name_lal[\\{#a",
                                                         ""))));
     getExtensionModelFrom("validation/module-repeated-global-elements.xml", getDependencyExtensions());
+  }
+
+  @Test
+  public void forbiddenConfigurationPropertiesThrowsException() {
+    exception.expectMessage(format(CONFIGURATION_PROPERTY_NOT_SUPPORTED_FORMAT_MESSAGE, CONFIGURATION_PROPERTIES.toString()));
+    getExtensionModelFrom("validation/module-configuration-property-file.xml");
   }
 
   private ExtensionModel getExtensionModelFrom(String modulePath) {

--- a/modules/extensions-xml-support/src/test/java/org/mule/test/functional/ModuleWithPropertiesTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/test/functional/ModuleWithPropertiesTestCase.java
@@ -6,13 +6,13 @@
  */
 package org.mule.test.functional;
 
+import static java.lang.Thread.currentThread;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-
-import org.mule.runtime.core.api.event.CoreEvent;
-
 import org.junit.Test;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.util.IOUtils;
 
 public class ModuleWithPropertiesTestCase extends AbstractXmlExtensionMuleArtifactFunctionalTestCase {
 
@@ -66,5 +66,28 @@ public class ModuleWithPropertiesTestCase extends AbstractXmlExtensionMuleArtifa
   public void testSetPayloadConfigOptionalProperty() throws Exception {
     CoreEvent muleEvent = flowRunner("testSetPayloadConfigOptionalProperty").run();
     assertThat(muleEvent.getMessage().getPayload().getValue(), is(nullValue()));
+  }
+
+  @Test
+  public void testSetPayloadHardcodedGlobalProperty() throws Exception {
+    CoreEvent muleEvent = flowRunner("testSetPayloadHardcodedGlobalProperty").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), is("a-constant-global-value"));
+  }
+
+  @Test
+  public void testSetPayloadHardcodedSystemProperty() throws Exception {
+    final String expected_value = System.getProperty("user.home");
+    CoreEvent muleEvent = flowRunner("testSetPayloadHardcodedSystemProperty").run();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), is(expected_value));
+  }
+
+  @Test
+  public void testSetPayloadHardcodedFileProperty() throws Exception {
+    CoreEvent muleEvent = flowRunner("testSetPayloadHardcodedFileProperty").run();
+    final String expectedContent =
+        IOUtils.toString(currentThread().getContextClassLoader().getResourceAsStream("modules/module-properties-file.txt"))
+            .trim();
+    assertThat(muleEvent.getMessage().getPayload().getValue(), is(
+                                                                  expectedContent));
   }
 }

--- a/modules/extensions-xml-support/src/test/resources/flows/flows-using-module-properties.xml
+++ b/modules/extensions-xml-support/src/test/resources/flows/flows-using-module-properties.xml
@@ -35,4 +35,16 @@
     <flow name="testSetPayloadConfigOptionalProperty">
         <module-properties:set-payload-config-optional-property config-ref="instantiatedConfig"/>
     </flow>
+
+    <flow name="testSetPayloadHardcodedGlobalProperty">
+        <module-properties:set-payload-hardcoded-global-property config-ref="instantiatedConfig"/>
+    </flow>
+
+    <flow name="testSetPayloadHardcodedSystemProperty">
+        <module-properties:set-payload-hardcoded-system-property config-ref="instantiatedConfig"/>
+    </flow>
+
+    <flow name="testSetPayloadHardcodedFileProperty">
+        <module-properties:set-payload-hardcoded-file-property config-ref="instantiatedConfig"/>
+    </flow>
 </mule>

--- a/modules/extensions-xml-support/src/test/resources/modules/module-properties-file.txt
+++ b/modules/extensions-xml-support/src/test/resources/modules/module-properties-file.txt
@@ -1,0 +1,1 @@
+content of the payload from the file

--- a/modules/extensions-xml-support/src/test/resources/modules/module-properties.xml
+++ b/modules/extensions-xml-support/src/test/resources/modules/module-properties.xml
@@ -7,6 +7,8 @@
            http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
+    <mule:global-property name="mule-global-property" value="a-constant-global-value" />
+
     <property name="configParam" type="string"/>
     <property name="defaultConfigParam" defaultValue="some default-config-value-parameter" type="string"/>
     <property name="optionalProperty" use="OPTIONAL" type="string"/>
@@ -65,6 +67,28 @@
             <mule:set-payload value="a value"/>
             <!-- will override payload with the null 'optionalProperty' parameter-->
             <mule:set-payload value="#[vars.optionalProperty]"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-hardcoded-global-property">
+        <body>
+            <mule:set-payload value="${mule-global-property}"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-hardcoded-system-property">
+        <body>
+            <mule:set-payload value="${user.home}"/>
+        </body>
+        <output type="string"/>
+    </operation>
+
+    <operation name="set-payload-hardcoded-file-property">
+        <body>
+            <!-- notice we need to add the folder modules to be sure it will be loaded in the context of the running test -->
+            <mule:set-payload value="${file::modules/module-properties-file.txt}"/>
         </body>
         <output type="string"/>
     </operation>

--- a/modules/extensions-xml-support/src/test/resources/validation/module-configuration-property-file.xml
+++ b/modules/extensions-xml-support/src/test/resources/validation/module-configuration-property-file.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="module-configuration-property-file"
+        
+        xmlns="http://www.mulesoft.org/schema/mule/module"
+        xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+           http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
+           http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <mule:configuration-properties file="config.properties" />
+
+    <operation name="op">
+        <body>
+            <!-- smart connectors do not support configuration properties, it will fail during validation phase-->
+            <mule:set-payload value="${aProperty}"/>
+        </body>
+        <output type="string"/>
+    </operation>
+</module>


### PR DESCRIPTION
…thin smart connectors, but allow file::filename, and global-property

(cherry picked from commit 65d6058)