### PR TITLE
MULE-14803: forbid the use of any type of configuration properties wi…

### DIFF
--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/loader/validator/ForbiddenConfigurationPropertiesValidator.java
@@ -25,7 +25,7 @@ import java.util.stream.StreamSupport;
  * configuration properties. If the developer wants to use constants, then it must rely on <mule:global-property/>'s than in the
  * properties file.
  *
- * @since 4.2
+ * @since 4.1.2
  */
 public class ForbiddenConfigurationPropertiesValidator implements ExtensionModelValidator {
 


### PR DESCRIPTION
…thin smart connectors, but allow file::filename, and global-property, bumping since