### PR TITLE
MULE-14972: Fix Resource not found when equivalent path than the one …

### DIFF
--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoader.java
@@ -12,6 +12,7 @@ import static java.lang.String.format;
 import static java.lang.System.identityHashCode;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.io.FilenameUtils.normalize;
 import static org.apache.commons.lang3.ClassUtils.getPackageName;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -123,12 +124,8 @@ public class RegionClassLoader extends MuleDeployableArtifactClassLoader {
       });
 
       for (String exportedResource : filter.getExportedResources()) {
-        List<ArtifactClassLoader> classLoaders = resourceMapping.get(exportedResource);
-
-        if (classLoaders == null) {
-          classLoaders = new ArrayList<>();
-          resourceMapping.put(exportedResource, classLoaders);
-        }
+        List<ArtifactClassLoader> classLoaders =
+            resourceMapping.computeIfAbsent(normalize(exportedResource), k -> new ArrayList<>());
 
         classLoaders.add(artifactClassLoader);
       }
@@ -221,10 +218,11 @@ public class RegionClassLoader extends MuleDeployableArtifactClassLoader {
   @Override
   public final URL findResource(final String name) {
     URL resource = null;
-    final List<ArtifactClassLoader> artifactClassLoaders = resourceMapping.get(name);
+    String normalizedName = normalize(name);
+    final List<ArtifactClassLoader> artifactClassLoaders = resourceMapping.get(normalizedName);
     if (artifactClassLoaders != null) {
       for (ArtifactClassLoader artifactClassLoader : artifactClassLoaders) {
-        resource = artifactClassLoader.findResource(name);
+        resource = artifactClassLoader.findResource(normalizedName);
         if (resource != null) {
           break;
         }
@@ -236,13 +234,14 @@ public class RegionClassLoader extends MuleDeployableArtifactClassLoader {
 
   @Override
   public final Enumeration<URL> findResources(final String name) throws IOException {
-    final List<ArtifactClassLoader> artifactClassLoaders = resourceMapping.get(name);
+    String normalizedName = normalize(name);
+    final List<ArtifactClassLoader> artifactClassLoaders = resourceMapping.get(normalizedName);
     List<Enumeration<URL>> enumerations = new ArrayList<>(registeredClassLoaders.size());
 
     if (artifactClassLoaders != null) {
       for (ArtifactClassLoader artifactClassLoader : artifactClassLoaders) {
 
-        final Enumeration<URL> partialResources = artifactClassLoader.findResources(name);
+        final Enumeration<URL> partialResources = artifactClassLoader.findResources(normalizedName);
         if (partialResources.hasMoreElements()) {
           enumerations.add(partialResources);
         }

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoaderTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoaderTestCase.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -371,6 +372,23 @@ public class RegionClassLoaderTestCase extends AbstractMuleTestCase {
     regionClassLoader.addClassLoader(pluginClassLoader, NULL_CLASSLOADER_FILTER);
 
     assertThat(regionClassLoader.getArtifactPluginClassLoaders(), contains(pluginClassLoader));
+  }
+
+  @Test
+  public void getResourceUsingNotNormalizedPath() {
+    final ClassLoader parentClassLoader = mock(ClassLoader.class);
+    RegionClassLoader regionClassLoader = new RegionClassLoader(ARTIFACT_ID, artifactDescriptor, parentClassLoader, lookupPolicy);
+    createClassLoaders(parentClassLoader);
+    pluginClassLoader.addResource(RESOURCE_NAME, PLUGIN_LOADED_RESOURCE);
+
+    when(lookupPolicy.getPackageLookupStrategy(PACKAGE_NAME)).thenReturn(CHILD_FIRST);
+
+    regionClassLoader.addClassLoader(pluginClassLoader,
+                                     new DefaultArtifactClassLoaderFilter(singleton(PACKAGE_NAME), singleton(RESOURCE_NAME)));
+
+    URL resource = regionClassLoader.findResource("root/../dummy.txt");
+
+    assertThat(resource, notNullValue());
   }
 
   public static class TestApplicationClassLoader extends TestArtifactClassLoader {


### PR DESCRIPTION
…exported in mule-artifact.json is used