### PR TITLE
EE-6024: Fix Distribution Tests in windows that fail for wrong use of…

### DIFF
--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractArtifactFileBuilder.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractArtifactFileBuilder.java
@@ -191,7 +191,7 @@ public abstract class AbstractArtifactFileBuilder<T extends AbstractArtifactFile
         buildBrokenJarFile(tempFile);
       } else {
         final List<ZipResource> zipResources = new LinkedList<>(resources);
-        zipResources.add(new ZipResource(getArtifactPomFile().getAbsolutePath(), getArtifactFileBundledPomPath()));
+        zipResources.add(new ZipResource(getArtifactPomFile().getAbsolutePath(), getArtifactFileBundledPomPartialUrl()));
         zipResources.addAll(getCustomResources());
         compress(tempFile, zipResources.toArray(new ZipResource[0]));
       }

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractDependencyFileBuilder.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractDependencyFileBuilder.java
@@ -254,8 +254,7 @@ public abstract class AbstractDependencyFileBuilder<T extends AbstractDependency
    * @return the path within the artifact file where the pom file is bundled
    */
   public String getArtifactFileBundledPomPartialUrl() {
-    return new StringBuilder(5).append("META-INF/maven/").append(getGroupId()).append("/").append(getArtifactId())
-        .append("/pom.xml").toString();
+    return "META-INF/maven/" + getGroupId() + "/" + getArtifactId() + "/pom.xml";
   }
 
   /**

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractDependencyFileBuilder.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractDependencyFileBuilder.java
@@ -253,8 +253,9 @@ public abstract class AbstractDependencyFileBuilder<T extends AbstractDependency
   /**
    * @return the path within the artifact file where the pom file is bundled
    */
-  public String getArtifactFileBundledPomPath() {
-    return Paths.get("META-INF", "maven", getGroupId(), getArtifactId(), "pom.xml").toString();
+  public String getArtifactFileBundledPomPartialUrl() {
+    return new StringBuilder(5).append("META-INF/maven/").append(getGroupId()).append("/").append(getArtifactId())
+        .append("/pom.xml").toString();
   }
 
   /**


### PR DESCRIPTION
… URLs and paths

 - Changing the way how the `ArtifactFileBundledPom` location is built,
 now it uses forward slashes to mimic a partial URL. The reasons for this
 changes are the following ones:

 1. The location of other zip resources like the `mule-artifact.json` added
 to the plugin jar by the `ArtifactPluginFileBuilder` are also treated
 as URLs

 2. Another set of methods like
 `org.mule.runtime.module.deployment.impl.internal.maven.MavenUtils#getPomUrlFromJar`
 that will be dealing at a later time with the pom.xml location, could
 fail in Windows Systems if the pom.xml file is retrieved as a jar entry
 with backslashed because it’s expecting to deal just with URL, which
 uses forward slashes