### PR TITLE
MULE-12698: Changes on Mule Maven Client API

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/api/DependencyResolver.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/DependencyResolver.java
@@ -70,7 +70,7 @@ public class DependencyResolver {
     this.resolutionContext = new AetherResolutionContext(mavenConfiguration);
     this.repositoryState =
         new AetherRepositoryState(this.resolutionContext.getLocalRepositoryLocation(), workspaceReader, false,
-                                  true, resolutionContext.getAuthenticatorSelector(), true);
+                                  false, resolutionContext.getAuthenticatorSelector(), true);
     if (logger.isDebugEnabled()) {
       resolutionContext.getAuthenticatorSelector()
           .ifPresent(selector -> logger.debug("Using authenticator selector: " + ReflectionToStringBuilder.toString(selector)));


### PR DESCRIPTION
Revert wrong parameter value to enable repositories on pom files (true means they will be ignored).