### PR TITLE
MULE-14983: Missing default value for `maxRedeliveryCount` in

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
@@ -704,7 +704,8 @@ public class CoreComponentBuildingDefinitionProvider implements ComponentBuildin
 
     componentBuildingDefinitions.add(baseDefinition.withIdentifier(REDELIVERY_POLICY_ELEMENT_IDENTIFIER)
         .withTypeDefinition(fromType(IdempotentRedeliveryPolicy.class))
-        .withSetterParameterDefinition("maxRedeliveryCount", fromSimpleParameter("maxRedeliveryCount").build())
+        .withSetterParameterDefinition("maxRedeliveryCount",
+                                       fromSimpleParameter("maxRedeliveryCount").withDefaultValue(5).build())
         .withSetterParameterDefinition("useSecureHash", fromSimpleParameter("useSecureHash").build())
         .withSetterParameterDefinition("messageDigestAlgorithm", fromSimpleParameter("messageDigestAlgorithm").build())
         .withSetterParameterDefinition("idExpression", fromSimpleParameter("idExpression").build())


### PR DESCRIPTION
`idempotent-redelivery-policy`