### PR TITLE
EE-6076: Windows binary doesn't follow its Unix counterpart regarding the exit statuses

### DIFF
--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/WindowsController.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/WindowsController.java
@@ -30,6 +30,9 @@ public class WindowsController extends AbstractOSController {
   public void start(String... args) {
     install(args);
     super.start(args);
+    if (status() != 0) {
+      throw new MuleControllerException("The mule instance couldn't be started");
+    }
   }
 
   @Override


### PR DESCRIPTION
- Adding status check to the Windows process controller start method
since we can't rely on the exit status of service wrapper batch file in
the same way as we do for Unix systems. This is mainly due to the
particularities of service wrapper execution as a Windows service