### PR TITLE
EE-6098: Fix distro tests that fail on windows because mule can’t be installed twice on same host

### DIFF
--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/AbstractOSController.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/AbstractOSController.java
@@ -7,6 +7,7 @@
 
 package org.mule.test.infrastructure.process;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.HashMap;
@@ -129,9 +130,9 @@ public abstract class AbstractOSController {
     for (Map.Entry<String, String> it : env.entrySet()) {
       newEnv.put(it.getKey(), it.getValue());
     }
-    newEnv.put(MULE_HOME_VARIABLE, muleHome);
 
-    if (muleAppName != null && muleAppLongName != null) {
+    newEnv.put(MULE_HOME_VARIABLE, muleHome);
+    if (isNotEmpty(muleAppName) && isNotEmpty(muleAppLongName)) {
       newEnv.put(MULE_APP_VARIABLE, muleAppName);
       newEnv.put(MULE_APP_LONG_VARIABLE, muleAppLongName);
     }


### PR DESCRIPTION
- Bug fix. When the controller isn't being used in cluster mode the
application name is therefore null, this causes that the status method
always returned true because when the windows service control is queried
without any service name it returns the information of all services and
there will always be one of those services with running status that will
be taken as if it were the Mule one.