### PR TITLE
EE-6098: Fix distro tests that fail on windows because mule can’t be installed twice on same host

### DIFF
--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
@@ -337,9 +337,7 @@ public class MuleDeployment extends MuleInstallation {
         mule.addConfProperty(format("-D%s=%s", MULE_REMOTE_REPOSITORIES_PROPERTY, REMOTE_REPOSITORIES));
       }
       resolvePropertiesUsingLambdas();
-      mule.start(addAll(toArray(parameters), toArray(properties)));
-      domains.forEach((domain) -> checkDomainIsDeployed(getName(domain)));
-      applications.forEach((application) -> checkAppIsDeployed(getName(application)));
+      startMule();
       logger.info("Deployment successful");
     }
   }
@@ -418,11 +416,23 @@ public class MuleDeployment extends MuleInstallation {
     removeShutdownHooks();
   }
 
-  private void stopMule() {
+  public void startMule() {
+    if (!mule.isRunning()) {
+      mule.start(addAll(toArray(parameters), toArray(properties)));
+      domains.forEach((domain) -> checkDomainIsDeployed(getName(domain)));
+      applications.forEach((application) -> checkAppIsDeployed(getName(application)));
+    } else {
+      logger.warn("Mule Server was already running");
+    }
+  }
+
+  public void stopMule() {
     if (mule.isRunning()) {
       logger.info("Stopping Mule Server");
       mule.stop();
       prober.check(isNotRunning(mule));
+    } else {
+      logger.warn("Mule Server was not running");
     }
   }
 


### PR DESCRIPTION
- Exposing the stop method and creating a new public start method on the
Mule Deployment.

- This change is performed for the particular case of Mule instances
clustered on Windows OS because it's the most convenient place where we
have an adequately instantiated Mule process controller, otherwise,
we'll need to modify the process controller testing infrastructure for
enabling the instantiation in this particular case and this could end in
a non-intuitive or cumbersome API.