### PR TITLE
EE-6047: Fix distribution tests in Windows

### DIFF
--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/Controller.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/Controller.java
@@ -237,6 +237,10 @@ public class Controller {
     return new File(appsDir, appName + ANCHOR_SUFFIX).exists();
   }
 
+  protected boolean isUndeployed(String appName) {
+    return !(new File(appsDir, appName + ANCHOR_SUFFIX).exists() || new File(appsDir, appName).exists());
+  }
+
   protected boolean isDomainDeployed(String domainName) {
     return new File(domainsDir, domainName + ANCHOR_SUFFIX).exists();
   }

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/MuleProcessController.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/MuleProcessController.java
@@ -81,6 +81,10 @@ public class MuleProcessController {
     return getController().isDeployed(appName);
   }
 
+  public boolean isUndeployed(String appName) {
+    return getController().isUndeployed(appName);
+  }
+
   public File getArtifactInternalRepository(String artifactName) {
     return getController().getArtifactInternalRepository(artifactName);
   }


### PR DESCRIPTION
- Improving the way how a successful un-deployment is detected because in some cases it's not enough to rely on the anchor file.