### PR TITLE
MULE-15187: Fix core tests in Windows

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/api/message/ErrorBuilderTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/message/ErrorBuilderTestCase.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.internal.message.ErrorBuilder.builder;
-import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalIgnoringLineBreaks;
+import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalToIgnoringLineBreaks;
 
 import org.mule.runtime.api.exception.ComposedErrorException;
 import org.mule.runtime.api.exception.DefaultMuleException;
@@ -112,7 +112,7 @@ public class ErrorBuilderTestCase extends AbstractMuleTestCase {
         .build();
 
     assertThat(error.toString(),
-               is(equalIgnoringLineBreaks("\norg.mule.runtime.core.internal.message.ErrorBuilder$ErrorImplementation\n"
+               is(equalToIgnoringLineBreaks("\norg.mule.runtime.core.internal.message.ErrorBuilder$ErrorImplementation\n"
                    + "{\n"
                    + "  description=message\n"
                    + "  detailedDescription=message\n"

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/DefaultExpressionManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/DefaultExpressionManagerTestCase.java
@@ -38,7 +38,7 @@ import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUG
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_EXPRESSION_LANGUAGE;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
-import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalIgnoringLineBreaks;
+import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalToIgnoringLineBreaks;
 import static org.mule.test.allure.AllureConstants.ExpressionLanguageFeature.EXPRESSION_LANGUAGE;
 import static org.mule.test.allure.AllureConstants.ExpressionLanguageFeature.ExpressionLanguageStory.SUPPORT_MVEL_DW;
 
@@ -258,10 +258,10 @@ public class DefaultExpressionManagerTestCase extends AbstractMuleContextTestCas
             + "\n  payload=test\n  mediaType=*/*\n  attributes=<not set>\n  attributesMediaType=*/*\n}";
     assertThat(expressionManager.parseLogTemplate("current message is #[mel:message]", testEvent(), TEST_CONNECTOR_LOCATION,
                                                   NULL_BINDING_CONTEXT),
-               is(equalIgnoringLineBreaks(expectedOutput)));
+               is(equalToIgnoringLineBreaks(expectedOutput)));
     assertThat(expressionManager.parseLogTemplate("current message is #[message]", testEvent(), TEST_CONNECTOR_LOCATION,
                                                   NULL_BINDING_CONTEXT),
-               is(equalIgnoringLineBreaks(expectedOutput)));
+               is(equalToIgnoringLineBreaks(expectedOutput)));
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/message/DefaultMuleMessageTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/message/DefaultMuleMessageTestCase.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mule.runtime.api.metadata.DataType.JSON_STRING;
 import static org.mule.runtime.api.metadata.MediaType.TEXT;
-import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalIgnoringLineBreaks;
+import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalToIgnoringLineBreaks;
 
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
@@ -135,7 +135,7 @@ public class DefaultMuleMessageTestCase extends AbstractMuleContextTestCase {
         .mediaType(TEXT)
         .build();
 
-    assertThat(message.toString(), is(equalIgnoringLineBreaks("\n" +
+    assertThat(message.toString(), is(equalToIgnoringLineBreaks("\n" +
         "org.mule.runtime.core.internal.message.DefaultMessageBuilder$MessageImplementation\n"
         + "{\n"
         + "  payload=test\n"
@@ -156,7 +156,7 @@ public class DefaultMuleMessageTestCase extends AbstractMuleContextTestCase {
         .exceptionPayload(new DefaultExceptionPayload(new NullPointerException("error")))
         .build();
 
-    assertThat(message.toString(), is(equalIgnoringLineBreaks("\n"
+    assertThat(message.toString(), is(equalToIgnoringLineBreaks("\n"
         + "org.mule.runtime.core.internal.message.DefaultMessageBuilder$MessageImplementation\n"
         + "{\n"
         + "  payload=test\n"

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/model/internal/config/FileConfigurationPropertiesProviderTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/model/internal/config/FileConfigurationPropertiesProviderTestCase.java
@@ -9,6 +9,7 @@ package org.mule.runtime.config.dsl.model.internal.config;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
+import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalToIgnoringLineBreaks;
 import static org.mule.test.allure.AllureConstants.ConfigurationProperties.CONFIGURATION_PROPERTIES;
 import static org.mule.test.allure.AllureConstants.ConfigurationProperties.ComponentConfigurationAttributesStory.CONFIGURATION_PROPERTIES_RESOLVER_STORY;
 
@@ -45,7 +46,8 @@ public class FileConfigurationPropertiesProviderTestCase extends AbstractMuleTes
 
   @Test
   public void fileIsResolved() {
-    assertThat(resolver.resolveValue("${file::dummy.xml}"), is("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<foo/>\n"));
+    assertThat((String) resolver.resolveValue("${file::dummy.xml}"),
+               is(equalToIgnoringLineBreaks("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<foo/>\n")));
   }
 
   @Test

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/ClassLoaderResourceProviderTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/ClassLoaderResourceProviderTestCase.java
@@ -11,16 +11,15 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.mule.tck.junit4.AbstractMuleTestCase;
 
 public class ClassLoaderResourceProviderTestCase extends AbstractMuleTestCase {
 

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/ClassLoaderResourceProviderTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/ClassLoaderResourceProviderTestCase.java
@@ -33,17 +33,17 @@ public class ClassLoaderResourceProviderTestCase extends AbstractMuleTestCase {
 
   @Test
   public void sameJarResourceGetsLoaded() {
-    verifyResourceGetsLoadedSuccessfully(Paths.get("META-INF", "mule-core.xsd").toString());
+    verifyResourceGetsLoadedSuccessfully("META-INF/mule-core.xsd");
   }
 
   @Test
   public void differentJarResourceGetsLoaded() {
-    verifyResourceGetsLoadedSuccessfully(Paths.get("javax", "inject", "Inject.class").toString());
+    verifyResourceGetsLoadedSuccessfully("javax/inject/Inject.class");
   }
 
   @Test
   public void absolutePathResourceGetsLoaded() {
-    File file = FileUtils.toFile(getClass().getClassLoader().getResource(Paths.get("META-INF", "mule-core.xsd").toString()));
+    File file = FileUtils.toFile(getClass().getClassLoader().getResource("META-INF/mule-core.xsd"));
     verifyResourceGetsLoadedSuccessfully(file.getAbsolutePath());
   }
 

--- a/tests/unit/src/main/java/org/mule/tck/junit4/matcher/IsEqualIgnoringLineBreaks.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/matcher/IsEqualIgnoringLineBreaks.java
@@ -41,11 +41,11 @@ public class IsEqualIgnoringLineBreaks extends TypeSafeMatcher<String> {
   }
 
   public void describeTo(Description description) {
-    description.appendText("equalIgnoringLineBreaks(").appendValue(this.string).appendText(")");
+    description.appendText("equalToIgnoringLineBreaks(").appendValue(this.string).appendText(")");
   }
 
   @Factory
-  public static Matcher<String> equalIgnoringLineBreaks(String expectedString) {
+  public static Matcher<String> equalToIgnoringLineBreaks(String expectedString) {
     return new IsEqualIgnoringLineBreaks(expectedString);
   }
 }


### PR DESCRIPTION
- FileConfigurationPropertiesProviderTestCase: Fixing string comparison
by ignoring system-dependent line-breaks

- ClassLoaderResourceProviderTestCase: Removing system-dependent path
construction since Java classloaders work with " '/'-separated paths "

- Renaming matcher that ignores linebreak to make it follow Hamcrest
naming style.