### PR TITLE
MULE-15187: Fix core tests in Windows

### DIFF
--- a/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/ModuleExtensionModelJsonTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/runtime/extension/internal/loader/ModuleExtensionModelJsonTestCase.java
@@ -87,7 +87,7 @@ public class ModuleExtensionModelJsonTestCase extends AbstractMuleTestCase {
 
     Function<String, Object[]> stringFunction = moduleName -> {
       String moduleModelPath = "modules" + separator + "model" + separator + moduleName + ".json";
-      String modulePath = "modules" + separator + moduleName + ".xml";
+      String modulePath = "modules/" + moduleName + ".xml";
 
       ClassLoader contextClassLoader = currentThread().getContextClassLoader();
       Map<String, Object> parameters = new HashMap<>();


### PR DESCRIPTION
- Adjusting path on ModuleExtensionModelJsonTestCase that is used for a
classloader and therefore requires to be in a "/" fashion regardless of
the OS. This was causing the TypesResolverBuilder to fail when trying to
resolve the types for module-json-custom-types.