### PR TITLE
MULE-15316: Long processor chains generate StackOverflowError

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/api/processor/MessageProcessorsTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/processor/MessageProcessorsTestCase.java
@@ -55,6 +55,7 @@ public class MessageProcessorsTestCase extends AbstractMuleContextTestCase {
   public ExpectedException thrown = ExpectedException.none();
 
   private RuntimeException exception = new IllegalArgumentException();
+  private OnErrorPropagateHandler exceptionHandler;
   private BaseEventContext eventContext;
   private CoreEvent input;
   private CoreEvent output;
@@ -65,7 +66,7 @@ public class MessageProcessorsTestCase extends AbstractMuleContextTestCase {
   @Before
   public void setup() throws MuleException {
     flow = mock(Flow.class, RETURNS_DEEP_STUBS);
-    OnErrorPropagateHandler exceptionHandler = new OnErrorPropagateHandler();
+    exceptionHandler = new OnErrorPropagateHandler();
     exceptionHandler.setMuleContext(muleContext);
     exceptionHandler
         .setNotificationFirer(((MuleContextWithRegistry) muleContext).getRegistry().lookupObject(NotificationDispatcher.class));
@@ -84,6 +85,7 @@ public class MessageProcessorsTestCase extends AbstractMuleContextTestCase {
       flow.stop();
       flow.dispose();
     }
+    exceptionHandler.dispose();
   }
 
   private InternalReactiveProcessor map = publisher -> from(publisher).map(in -> output);

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/enricher/MessageEnricherTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/enricher/MessageEnricherTestCase.java
@@ -18,9 +18,11 @@ import static org.junit.rules.ExpectedException.none;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
@@ -66,9 +68,13 @@ public class MessageEnricherTestCase extends AbstractReactiveProcessorTestCase {
         .message(InternalMessage.builder(event.getMessage()).value(TEST_PAYLOAD).build()).build());
     initialiseIfNeeded(enricher, muleContext);
 
-    Message result = process(enricher, testEvent()).getMessage();
-    assertEquals(TEST_PAYLOAD, ((InternalMessage) result).getOutboundProperty("myHeader"));
-    assertEquals(TEST_PAYLOAD, result.getPayload().getValue());
+    try {
+      Message result = process(enricher, testEvent()).getMessage();
+      assertEquals(TEST_PAYLOAD, ((InternalMessage) result).getOutboundProperty("myHeader"));
+      assertEquals(TEST_PAYLOAD, result.getPayload().getValue());
+    } finally {
+      disposeIfNeeded(enricher, getLogger(getClass()));
+    }
   }
 
   private MessageEnricher createEnricher() {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
@@ -57,6 +57,7 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -642,6 +643,17 @@ public class DefaultEventContextTestCase extends AbstractMuleContextTestCase {
     eventContext.error(new NullPointerException());
 
     assertThat(callbacks, contains("onResponse", "onComplete", "onTerminated"));
+  }
+
+  @Test
+  public void deepNesting() {
+    BaseEventContext lastContext = context.get();
+
+    expectedException.expect(EventContextDeepNestingException.class);
+
+    while (true) {
+      lastContext = DefaultEventContext.child(lastContext, Optional.empty());
+    }
   }
 
   private void assertParent(Matcher<Object> eventMatcher, Matcher<Object> errorMatcher, boolean complete, boolean terminated) {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
@@ -22,13 +22,14 @@ import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
 
-import java.util.Collection;
-
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
 
 @RunWith(Parameterized.class)
 public abstract class AbstractErrorHandlerTestCase extends AbstractMuleContextTestCase {
@@ -61,5 +62,10 @@ public abstract class AbstractErrorHandlerTestCase extends AbstractMuleContextTe
 
     context = create(flow, TEST_CONNECTOR_LOCATION);
     muleEvent = InternalEvent.builder(context).message(of("")).build();
+  }
+
+  @After
+  public void after() {
+    flow.dispose();
   }
 }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorTestCase.java
@@ -81,6 +81,8 @@ public class AsyncDelegateMessageProcessorTestCase extends AbstractReactiveProce
   protected void doTearDown() throws Exception {
     messageProcessor.stop();
     messageProcessor.dispose();
+
+    flow.dispose();
     super.doTearDown();
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/processor/PipelineMessageNotificationTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/processor/PipelineMessageNotificationTestCase.java
@@ -25,9 +25,11 @@ import static org.mule.runtime.api.notification.PipelineMessageNotification.PROC
 import static org.mule.runtime.api.notification.PipelineMessageNotification.PROCESS_END;
 import static org.mule.runtime.api.notification.PipelineMessageNotification.PROCESS_START;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.runtime.core.api.processor.strategy.AsyncProcessingStrategyFactory.DEFAULT_MAX_CONCURRENCY;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
@@ -123,6 +125,7 @@ public class PipelineMessageNotificationTestCase extends AbstractReactiveProcess
   @After
   public void after() throws MuleException {
     stopIfNeeded(pipeline);
+    disposeIfNeeded(pipeline, getLogger(getClass()));
     stopIfNeeded(muleContext.getSchedulerService());
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
@@ -13,9 +13,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.management.stats.RouterStatistics.TYPE_OUTBOUND;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.event.CoreEvent;
@@ -24,6 +26,7 @@ import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.tck.junit4.AbstractReactiveProcessorTestCase;
 import org.mule.tck.testmodels.mule.TestMessageProcessor;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -45,6 +48,11 @@ public class ChoiceRouterTestCase extends AbstractReactiveProcessorTestCase {
     choiceRouter = new ChoiceRouter();
     choiceRouter.setAnnotations(singletonMap(LOCATION_KEY, TEST_CONNECTOR_LOCATION));
     choiceRouter.setExpressionManager(muleContext.getExpressionManager());
+  }
+
+  @After
+  public void after() {
+    disposeIfNeeded(choiceRouter, getLogger(getClass()));
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/requestreply/AsyncRequestReplyRequesterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/requestreply/AsyncRequestReplyRequesterTestCase.java
@@ -34,6 +34,7 @@ import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.api.store.SimpleMemoryObjectStore;
 import org.mule.runtime.api.util.concurrent.Latch;
 import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.message.GroupCorrelation;
 import org.mule.runtime.core.api.processor.Processor;
@@ -70,6 +71,8 @@ public class AsyncRequestReplyRequesterTestCase extends AbstractMuleContextTestC
 
   private TestAsyncRequestReplyRequester asyncReplyMP;
 
+  private Flow flow;
+
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
     Map<String, Object> objects = new HashMap<>();
@@ -85,11 +88,12 @@ public class AsyncRequestReplyRequesterTestCase extends AbstractMuleContextTestC
   protected void doSetUp() throws Exception {
     super.doSetUp();
     scheduler = muleContext.getSchedulerService().cpuIntensiveScheduler();
-    createAndRegisterFlow(muleContext, APPLE_FLOW, componentLocator);
+    flow = createAndRegisterFlow(muleContext, APPLE_FLOW, componentLocator);
   }
 
   @Override
   protected void doTearDown() throws Exception {
+    disposeIfNeeded(flow, LOGGER);
     scheduler.stop();
     if (asyncReplyMP != null) {
       asyncReplyMP.stop();
@@ -118,8 +122,7 @@ public class AsyncRequestReplyRequesterTestCase extends AbstractMuleContextTestC
   public void testSingleEventNoTimeoutAsync() throws Exception {
     asyncReplyMP = new TestAsyncRequestReplyRequester(muleContext);
     SensingNullMessageProcessor target = getSensingNullMessageProcessor();
-    AsyncDelegateMessageProcessor asyncMP = createAsyncMessageProcessor(target);
-    initialiseIfNeeded(asyncMP, true, muleContext);
+    asyncMP = createAsyncMessageProcessor(target);
     asyncMP.start();
     asyncReplyMP.setListener(asyncMP);
     asyncReplyMP.setReplySource(target.getMessageSource());
@@ -138,8 +141,7 @@ public class AsyncRequestReplyRequesterTestCase extends AbstractMuleContextTestC
     asyncReplyMP.setTimeout(1);
     SensingNullMessageProcessor target = getSensingNullMessageProcessor();
     target.setWaitTime(30000);
-    AsyncDelegateMessageProcessor asyncMP = createAsyncMessageProcessor(target);
-    initialiseIfNeeded(asyncMP, true, muleContext);
+    asyncMP = createAsyncMessageProcessor(target);
     asyncMP.start();
     asyncReplyMP.setListener(asyncMP);
     asyncReplyMP.setReplySource(target.getMessageSource());
@@ -208,7 +210,7 @@ public class AsyncRequestReplyRequesterTestCase extends AbstractMuleContextTestC
     asyncReplyMP = new TestAsyncRequestReplyRequester(muleContext);
     SensingNullMessageProcessor target = getSensingNullMessageProcessor();
     target.setWaitTime(50);
-    AsyncDelegateMessageProcessor asyncMP = createAsyncMessageProcessor(target);
+    asyncMP = createAsyncMessageProcessor(target);
     asyncMP.initialise();
     asyncReplyMP.setListener(asyncMP);
     asyncReplyMP.setReplySource(target.getMessageSource());

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/ExpressionTransformerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/ExpressionTransformerTestCase.java
@@ -53,7 +53,11 @@ public class ExpressionTransformerTestCase extends AbstractMuleContextTestCase {
       }
     });
 
-    assertFalse((Boolean) transformer.transform("test"));
+    try {
+      assertFalse((Boolean) transformer.transform("test"));
+    } finally {
+      transformer.dispose();
+    }
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainTestCase.java
@@ -37,6 +37,7 @@ import static org.mule.runtime.api.notification.MessageProcessorNotification.MES
 import static org.mule.runtime.api.notification.MessageProcessorNotification.MESSAGE_PROCESSOR_PRE_INVOKE;
 import static org.mule.runtime.core.api.construct.Flow.builder;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_INTENSIVE;
@@ -46,6 +47,7 @@ import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
 import static org.mule.tck.MuleTestUtils.createAndRegisterFlow;
 import static org.mule.tck.junit4.AbstractReactiveProcessorTestCase.Mode.BLOCKING;
 import static org.mule.tck.junit4.AbstractReactiveProcessorTestCase.Mode.NON_BLOCKING;
+import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Flux.from;
 
 import org.mule.runtime.api.component.AbstractComponent;
@@ -731,8 +733,12 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     choiceRouter.addRoute("true", newChain(empty(), getAppendingMP("3")));
     initialiseIfNeeded(choiceRouter, muleContext);
 
-    assertThat(process(newChain(empty(), choiceRouter), getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
-               equalTo("01"));
+    try {
+      assertThat(process(newChain(empty(), choiceRouter), getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+                 equalTo("01"));
+    } finally {
+      disposeIfNeeded(choiceRouter, getLogger(getClass()));
+    }
   }
 
   @Test

--- a/core/api-changes.json
+++ b/core/api-changes.json
@@ -45,6 +45,25 @@
           "methodName": "resolveTypedValue",
           "elementKind": "method",
           "justification": "Added for performance"
+        },
+        {
+          "code": "java.method.added",
+          "new": "method void org.mule.runtime.core.privileged.client.MuleClientFlowConstruct::dispose()",
+          "package": "org.mule.runtime.core.privileged.client",
+          "classSimpleName": "MuleClientFlowConstruct",
+          "methodName": "dispose",
+          "elementKind": "method",
+          "justification": "Lifecycle fix"
+        },
+        {
+          "code": "java.class.nowImplementsInterface",
+          "old": "class org.mule.runtime.core.privileged.client.MuleClientFlowConstruct",
+          "new": "class org.mule.runtime.core.privileged.client.MuleClientFlowConstruct",
+          "interface": "org.mule.runtime.api.lifecycle.Disposable",
+          "package": "org.mule.runtime.core.privileged.client",
+          "classSimpleName": "MuleClientFlowConstruct",
+          "elementKind": "class",
+          "justification": "Lifecycle fix"
         }
       ]
     }

--- a/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractMessageTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractMessageTransformer.java
@@ -10,6 +10,7 @@ import static java.lang.String.format;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.privileged.transformer.TransformerUtils.checkTransformerReturnClass;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
 
@@ -18,12 +19,12 @@ import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.privileged.client.MuleClientFlowConstruct;
 import org.mule.runtime.core.api.config.i18n.CoreMessages;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.util.StringMessageUtils;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.internal.message.InternalMessage;
+import org.mule.runtime.core.privileged.client.MuleClientFlowConstruct;
 
 import java.nio.charset.Charset;
 
@@ -162,4 +163,10 @@ public abstract class AbstractMessageTransformer extends AbstractTransformer imp
    * Transform the message
    */
   public abstract Object transformMessage(CoreEvent event, Charset outputEncoding) throws MessageTransformerException;
+
+  @Override
+  public void dispose() {
+    super.dispose();
+    disposeIfNeeded(flowConstruct, logger);
+  }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventContext.java
@@ -69,7 +69,8 @@ public final class DefaultEventContext extends AbstractEventContext implements S
    */
   public static BaseEventContext child(BaseEventContext parent, Optional<ComponentLocation> componentLocation,
                                        FlowExceptionHandler exceptionHandler) {
-    BaseEventContext child = new ChildEventContext(parent, componentLocation.orElse(null), exceptionHandler);
+    BaseEventContext child =
+        new ChildEventContext(parent, componentLocation.orElse(null), exceptionHandler, parent.getDepthLevel() + 1);
     if (parent instanceof AbstractEventContext) {
       ((AbstractEventContext) parent).addChildContext(child);
     }
@@ -166,7 +167,7 @@ public final class DefaultEventContext extends AbstractEventContext implements S
    */
   public DefaultEventContext(FlowConstruct flow, FlowExceptionHandler exceptionHandler, ComponentLocation location,
                              String correlationId, Optional<CompletableFuture<Void>> externalCompletion) {
-    super(exceptionHandler, externalCompletion);
+    super(exceptionHandler, 0, externalCompletion);
     this.id = flow.getUniqueIdString();
     this.serverId = flow.getServerId();
     this.location = location;
@@ -193,7 +194,7 @@ public final class DefaultEventContext extends AbstractEventContext implements S
    */
   public DefaultEventContext(String id, String serverId, ComponentLocation location, String correlationId,
                              Optional<CompletableFuture<Void>> externalCompletion, FlowExceptionHandler exceptionHandler) {
-    super(exceptionHandler, externalCompletion);
+    super(exceptionHandler, 0, externalCompletion);
     this.id = id;
     this.serverId = serverId;
     this.location = location;
@@ -225,8 +226,8 @@ public final class DefaultEventContext extends AbstractEventContext implements S
     private final String id;
 
     private ChildEventContext(BaseEventContext parent, ComponentLocation componentLocation,
-                              FlowExceptionHandler messagingExceptionHandler) {
-      super(messagingExceptionHandler, empty());
+                              FlowExceptionHandler messagingExceptionHandler, int depthLevel) {
+      super(messagingExceptionHandler, depthLevel, empty());
       this.flowCallStack = parent.getFlowCallStack().clone();
       this.parent = parent;
       this.componentLocation = componentLocation;

--- a/core/src/main/java/org/mule/runtime/core/internal/event/EventContextDeepNestingException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/EventContextDeepNestingException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.event;
+
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+
+import org.mule.runtime.api.exception.MuleRuntimeException;
+
+/**
+ * Indicates that there are many nested event contexts.
+ * <p>
+ * This would be an equivalent of the {@link StackOverflowError} for Java in Mule.
+ *
+ * @since 4.2.0
+ */
+public class EventContextDeepNestingException extends MuleRuntimeException {
+
+  private static final long serialVersionUID = 9171026572161838000L;
+
+  public EventContextDeepNestingException(String message) {
+    super(createStaticMessage(message));
+  }
+
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorTypeLocatorFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorTypeLocatorFactory.java
@@ -22,8 +22,8 @@ import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Ha
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.UNKNOWN;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.VALIDATION;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Unhandleable.FATAL;
-import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Unhandleable.OVERLOAD;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Unhandleable.FLOW_BACK_PRESSURE;
+import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Unhandleable.OVERLOAD;
 
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
@@ -40,6 +40,7 @@ import org.mule.runtime.core.api.retry.policy.RetryPolicyExhaustedException;
 import org.mule.runtime.core.api.transformer.MessageTransformerException;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.internal.construct.FlowBackPressureException;
+import org.mule.runtime.core.internal.event.EventContextDeepNestingException;
 import org.mule.runtime.core.internal.routing.DuplicateMessageException;
 import org.mule.runtime.core.internal.routing.ValidationException;
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
@@ -84,6 +85,7 @@ public class ErrorTypeLocatorFactory {
             .addExceptionMapping(MessageRedeliveredException.class,
                                  errorTypeRepository.lookupErrorType(REDELIVERY_EXHAUSTED).get())
             .addExceptionMapping(Exception.class, unknown)
+            .addExceptionMapping(EventContextDeepNestingException.class, errorTypeRepository.getCriticalErrorType())
             .addExceptionMapping(Error.class, errorTypeRepository.getCriticalErrorType())
             .addExceptionMapping(StreamingBufferSizeExceededException.class,
                                  errorTypeRepository.lookupErrorType(STREAM_MAXIMUM_SIZE_EXCEEDED).get())

--- a/core/src/main/java/org/mule/runtime/core/privileged/client/MuleClientFlowConstruct.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/client/MuleClientFlowConstruct.java
@@ -8,10 +8,14 @@
 package org.mule.runtime.core.privileged.client;
 
 import static java.util.Optional.empty;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
-import org.mule.runtime.api.exception.MuleRuntimeException;
-import org.mule.runtime.api.lifecycle.InitialisationException;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.component.AbstractComponent;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.lifecycle.Disposable;
+import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.exception.FlowExceptionHandler;
@@ -19,10 +23,14 @@ import org.mule.runtime.core.api.lifecycle.LifecycleState;
 import org.mule.runtime.core.api.management.stats.FlowConstructStatistics;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
+import org.slf4j.Logger;
+
 /**
  * Placeholder class which makes the default exception handler available.
  */
-public final class MuleClientFlowConstruct extends AbstractComponent implements FlowConstruct {
+public final class MuleClientFlowConstruct extends AbstractComponent implements FlowConstruct, Disposable {
+
+  private static final Logger LOGGER = getLogger(MuleClientFlowConstruct.class);
 
   MuleContext muleContext;
   FlowExceptionHandler exceptionHandler;
@@ -76,5 +84,10 @@ public final class MuleClientFlowConstruct extends AbstractComponent implements 
 
   public MessageProcessorChain getMessageProcessorChain() {
     return null;
+  }
+
+  @Override
+  public void dispose() {
+    disposeIfNeeded(exceptionHandler, LOGGER);
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/privileged/event/BaseEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/event/BaseEventContext.java
@@ -14,10 +14,10 @@ import org.mule.runtime.core.api.context.notification.ProcessorsTrace;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.management.stats.ProcessingTime;
 
+import org.reactivestreams.Publisher;
+
 import java.util.Optional;
 import java.util.function.BiConsumer;
-
-import org.reactivestreams.Publisher;
 
 /**
  * Context representing a message that is received by a Mule Runtime via a connector source. This context is immutable and
@@ -189,5 +189,12 @@ public interface BaseEventContext extends EventContext {
   default String getServerId() {
     return null;
   }
+
+  /**
+   * @return the distance of this eventContext to its root ,counting one for every ancestor.
+   *
+   * @since 4.1.3
+   */
+  int getDepthLevel();
 
 }

--- a/core/src/main/java/org/mule/runtime/core/privileged/routing/outbound/AbstractOutboundRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/routing/outbound/AbstractOutboundRouter.java
@@ -10,6 +10,7 @@ import static com.google.common.cache.CacheBuilder.newBuilder;
 import static java.util.Collections.emptyList;
 import static org.mule.runtime.core.api.config.i18n.CoreMessages.objectIsNull;
 import static org.mule.runtime.core.api.execution.TransactionalExecutionTemplate.createTransactionalExecutionTemplate;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.util.StringMessageUtils.truncate;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.getProcessingStrategy;
@@ -224,7 +225,8 @@ public abstract class AbstractOutboundRouter extends AbstractMessageProcessorOwn
       super.dispose();
       routes = emptyList();
       initialised.set(false);
-      processorChainCache.invalidateAll();;
+      processorChainCache.asMap().values().forEach(chain -> disposeIfNeeded(chain, logger));
+      processorChainCache.invalidateAll();
     }
   }
 


### PR DESCRIPTION
* change in AMPC to reduce stack size when applying interceptors
* validate max child context nesting depth
* fix lifecycle issues in some components and unit tests