### PR TITLE
MULE-15325: BindingContext look up is showing significant performance

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/el/DefaultBindingContextBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/DefaultBindingContextBuilder.java
@@ -6,12 +6,16 @@
  */
 package org.mule.runtime.core.internal.el;
 
-import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
+import static org.mule.runtime.api.el.BindingContextUtils.ATTRIBUTES;
+import static org.mule.runtime.api.el.BindingContextUtils.NULL_BINDING_CONTEXT;
+import static org.mule.runtime.api.el.BindingContextUtils.PAYLOAD;
+import static org.mule.runtime.api.el.BindingContextUtils.VARS;
 
 import org.mule.runtime.api.el.Binding;
 import org.mule.runtime.api.el.BindingContext;
@@ -21,87 +25,194 @@ import org.mule.runtime.api.metadata.TypedValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 
 public class DefaultBindingContextBuilder implements BindingContext.Builder {
 
-  private Map<String, Supplier<TypedValue>> bindings;
-  private List<ExpressionModule> modules;
+  private BindingContext parent;
+
+  private TypedValue payloadBinding;
+  private TypedValue attributesBinding;
+  private Supplier<TypedValue> varsBinding;
+
+  private final Map<String, Supplier<TypedValue>> bindings = new HashMap<>();
+  private Collection<ExpressionModule> modules = null;
 
   public DefaultBindingContextBuilder() {
-    this.bindings = new HashMap<>();
-    this.modules = new ArrayList<>();
+    this.parent = NULL_BINDING_CONTEXT;
+    // this.bindings = new HashMap<>();
   }
 
   public DefaultBindingContextBuilder(BindingContext bindingContext) {
-    this.bindings = bindingContext.identifiers().stream().collect(toMap(id -> id, id -> () -> bindingContext.lookup(id).get()));
-    this.modules = new ArrayList<>(bindingContext.modules());
+    this.parent = bindingContext;
+
+    payloadBinding = bindingContext.lookup(PAYLOAD).orElse(null);
+    attributesBinding = bindingContext.lookup(ATTRIBUTES).orElse(null);
+    varsBinding = () -> bindingContext.lookup(VARS).orElse(null);
   }
 
   @Override
   public BindingContext.Builder addBinding(String identifier, TypedValue value) {
-    bindings.put(identifier, () -> value);
+    switch (identifier) {
+      case PAYLOAD:
+        payloadBinding = value;
+        break;
+      case ATTRIBUTES:
+        attributesBinding = value;
+        break;
+      case VARS:
+        varsBinding = () -> value;
+        break;
+      default:
+        bindings.put(identifier, () -> value);
+        break;
+    }
     return this;
   }
 
   @Override
   public BindingContext.Builder addBinding(String identifier, Supplier<TypedValue> lazyValue) {
-    bindings.put(identifier, lazyValue);
+    switch (identifier) {
+      case PAYLOAD:
+        payloadBinding = lazyValue.get();
+        break;
+      case ATTRIBUTES:
+        attributesBinding = lazyValue.get();
+        break;
+      case VARS:
+        varsBinding = lazyValue;
+        break;
+      default:
+        bindings.put(identifier, lazyValue);
+        break;
+    }
     return this;
   }
 
   @Override
   public BindingContext.Builder addAll(BindingContext context) {
-    context.identifiers().forEach(id -> bindings.put(id, () -> context.lookup(id).get()));
-    modules.addAll(context.modules());
+    if (parent == null) {
+      parent = context;
+
+      payloadBinding = context.lookup(PAYLOAD).orElse(null);
+      attributesBinding = context.lookup(ATTRIBUTES).orElse(null);
+      varsBinding = () -> context.lookup(VARS).orElse(null);
+    } else {
+      // context.identifiers().forEach(id -> bindings.put(id, () -> context.lookup(id).get()));
+      context.bindings().forEach(binding -> {
+        addBinding(binding.identifier(), binding.value());
+      });
+      if (!context.modules().isEmpty()) {
+        modules = context.modules();
+      }
+    }
     return this;
   }
 
   @Override
   public BindingContext.Builder addModule(ExpressionModule expressionModule) {
-    this.modules.add(expressionModule);
+    if (modules == null) {
+      modules = new ArrayList<>();
+    }
+    modules.add(expressionModule);
     return this;
   }
 
   @Override
   public BindingContext build() {
-    return new BindingContextImplementation(bindings, modules);
+    return new BindingContextImplementation(parent, unmodifiableMap(bindings),
+                                            payloadBinding, attributesBinding, varsBinding,
+                                            modules != null ? unmodifiableCollection(modules) : emptyList());
   }
 
-  private static class BindingContextImplementation implements BindingContext {
+  public static class BindingContextImplementation implements BindingContext {
 
-    private Map<String, Supplier<TypedValue>> bindings;
-    private List<ExpressionModule> modules;
+    private final BindingContext parent;
 
-    private BindingContextImplementation(Map<String, Supplier<TypedValue>> bindings, List<ExpressionModule> modules) {
-      this.bindings = unmodifiableMap(new HashMap<>(bindings));
-      this.modules = unmodifiableList(new ArrayList<>(modules));
+    private final Optional<TypedValue> payloadBinding;
+    private final Optional<TypedValue> attributesBinding;
+    private final Supplier<TypedValue> varsBinding;
+
+    private final Map<String, Supplier<TypedValue>> bindings;
+    private final Collection<ExpressionModule> modules;
+
+    private BindingContextImplementation(BindingContext parent, Map<String, Supplier<TypedValue>> bindings,
+                                         TypedValue payloadBinding, TypedValue attributesBinding,
+                                         Supplier<TypedValue> varsBinding,
+                                         Collection<ExpressionModule> modules) {
+      this.parent = parent;
+      this.bindings = bindings;
+
+      this.payloadBinding = payloadBinding != null ? of(payloadBinding) : parent.lookup(PAYLOAD);
+      this.attributesBinding = attributesBinding != null ? of(attributesBinding) : parent.lookup(ATTRIBUTES);
+      this.varsBinding = varsBinding;
+
+      this.modules = modules;
     }
 
     @Override
     public Collection<Binding> bindings() {
-      return bindings.entrySet().stream()
-          .map(entry -> new Binding(entry.getKey(), entry.getValue() != null ? entry.getValue().get() : null)).collect(toList());
+      final List<Binding> bindingsList = bindings.entrySet().stream()
+          .map(entry -> new Binding(entry.getKey(), entry.getValue() != null ? entry.getValue().get() : null))
+          .collect(toList());
+
+      bindingsList.addAll(parent.bindings());
+
+      payloadBinding.ifPresent(pb -> bindingsList.add(new Binding(PAYLOAD, payloadBinding.get())));
+      attributesBinding.ifPresent(pb -> bindingsList.add(new Binding(ATTRIBUTES, attributesBinding.get())));
+      if (varsBinding != null && varsBinding.get() != null) {
+        bindingsList.add(new Binding(VARS, varsBinding.get()));
+      }
+
+      return bindingsList;
     }
 
     @Override
     public Collection<String> identifiers() {
-      return bindings.keySet();
+      final Set<String> identifiers = new HashSet<>(bindings.keySet());
+
+      identifiers.addAll(parent.identifiers());
+
+      payloadBinding.ifPresent(pb -> identifiers.add(PAYLOAD));
+      attributesBinding.ifPresent(pb -> identifiers.add(ATTRIBUTES));
+      if (varsBinding != null && varsBinding.get() != null) {
+        identifiers.add(VARS);
+      }
+
+      return identifiers;
     }
 
     @Override
     public Optional<TypedValue> lookup(String identifier) {
-      final Supplier<TypedValue> supplier = bindings.get(identifier);
-      return supplier != null ? ofNullable(supplier.get()) : empty();
+      switch (identifier) {
+        case PAYLOAD:
+          return payloadBinding;
+        case ATTRIBUTES:
+          return attributesBinding;
+        case VARS:
+          if (varsBinding == null) {
+            return parent.lookup(VARS);
+          } else {
+            return of(varsBinding.get());
+          }
+        default:
+          final Supplier<TypedValue> supplier = bindings.get(identifier);
+          return supplier != null ? ofNullable(supplier.get()) : parent.lookup(identifier);
+      }
     }
 
     @Override
     public Collection<ExpressionModule> modules() {
-      return modules;
+      List<ExpressionModule> mods = new ArrayList<>();
+      mods.addAll(parent.modules());
+      mods.addAll(modules);
+      return mods;
     }
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/el/DefaultBindingContextBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/DefaultBindingContextBuilder.java
@@ -46,7 +46,6 @@ public class DefaultBindingContextBuilder implements BindingContext.Builder {
 
   public DefaultBindingContextBuilder() {
     this.parent = NULL_BINDING_CONTEXT;
-    // this.bindings = new HashMap<>();
   }
 
   public DefaultBindingContextBuilder(BindingContext bindingContext) {
@@ -97,14 +96,14 @@ public class DefaultBindingContextBuilder implements BindingContext.Builder {
 
   @Override
   public BindingContext.Builder addAll(BindingContext context) {
-    if (parent == null) {
+    if (parent == NULL_BINDING_CONTEXT) {
+      // If no parent, instead of copyng the values from the inner maps, just set the parent.
       parent = context;
 
       payloadBinding = context.lookup(PAYLOAD).orElse(null);
       attributesBinding = context.lookup(ATTRIBUTES).orElse(null);
       varsBinding = () -> context.lookup(VARS).orElse(null);
     } else {
-      // context.identifiers().forEach(id -> bindings.put(id, () -> context.lookup(id).get()));
       context.bindings().forEach(binding -> {
         addBinding(binding.identifier(), binding.value());
       });

--- a/tests/performance/pom.xml
+++ b/tests/performance/pom.xml
@@ -12,6 +12,8 @@
     <description>Micro-benchmarks to test the performance of core Mule functionality</description>
 
     <properties>
+        <jmh.version>1.21</jmh.version>
+    
         <skipExportTests>false</skipExportTests>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
     </properties>
@@ -117,12 +119,12 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.17.3</version>
+            <version>${jmh.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.17.3</version>
+            <version>${jmh.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -198,27 +200,27 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.mule.jmh</groupId>
-                        <artifactId>jmh-elasticsearch-maven-plugin</artifactId>
-                        <version>${mule.jmh.elasticsearch.maven.plugin.version}</version>
-                            <executions>
-                                <execution>
-                                    <phase>post-integration-test</phase>
-                                    <goals>
-                                        <goal>generate-report</goal>
-                                    </goals>
-                                    <configuration>
-                                        <index>/runtime/jmh/</index>
-                                        <host>${elasticsearch.url}</host>
-                                        <userName>${elasticsearch.user}</userName>
-                                        <userPassword>${elasticsearch.password}</userPassword>
-                                        <version>${project.version}</version>
-                                        <reportPath>${basedir}/target/jmh-result.json</reportPath>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                    </plugin>
+<!--                     <plugin> -->
+<!--                         <groupId>org.mule.jmh</groupId> -->
+<!--                         <artifactId>jmh-elasticsearch-maven-plugin</artifactId> -->
+<!--                         <version>${mule.jmh.elasticsearch.maven.plugin.version}</version> -->
+<!--                             <executions> -->
+<!--                                 <execution> -->
+<!--                                     <phase>post-integration-test</phase> -->
+<!--                                     <goals> -->
+<!--                                         <goal>generate-report</goal> -->
+<!--                                     </goals> -->
+<!--                                     <configuration> -->
+<!--                                         <index>/runtime/jmh/</index> -->
+<!--                                         <host>${elasticsearch.url}</host> -->
+<!--                                         <userName>${elasticsearch.user}</userName> -->
+<!--                                         <userPassword>${elasticsearch.password}</userPassword> -->
+<!--                                         <version>${project.version}</version> -->
+<!--                                         <reportPath>${basedir}/target/jmh-result.json</reportPath> -->
+<!--                                     </configuration> -->
+<!--                                 </execution> -->
+<!--                             </executions> -->
+<!--                     </plugin> -->
                 </plugins>
             </build>
         </profile>

--- a/tests/performance/src/main/java/org/mule/el/BindingContextBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/el/BindingContextBenchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.el;
+
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.mule.runtime.api.el.BindingContextUtils.ATTRIBUTES;
+import static org.mule.runtime.api.el.BindingContextUtils.CORRELATION_ID;
+import static org.mule.runtime.api.el.BindingContextUtils.ERROR;
+import static org.mule.runtime.api.el.BindingContextUtils.NULL_BINDING_CONTEXT;
+import static org.mule.runtime.api.el.BindingContextUtils.VARS;
+import static org.mule.runtime.api.el.BindingContextUtils.addEventBindings;
+import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.api.event.EventContextFactory.create;
+
+import org.mule.AbstractBenchmark;
+import org.mule.runtime.api.el.BindingContext;
+import org.mule.runtime.api.el.BindingContextUtils;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.exception.NullExceptionHandler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.TearDown;
+
+@OutputTimeUnit(NANOSECONDS)
+public class BindingContextBenchmark extends AbstractBenchmark {
+
+  private static final CoreEvent event = CoreEvent.builder(create("", "", CONNECTOR_LOCATION, NullExceptionHandler.getInstance()))
+      .message(of(PAYLOAD)).addVariable("foo", "bar").build();
+
+  private static final BindingContext globalCtx = BindingContext.builder()
+      .addBinding("onParent", new TypedValue<>("hello!", DataType.STRING))
+      .build();
+
+  private static final BindingContext childCtx = BindingContext.builder(globalCtx)
+      .addBinding("onChild", new TypedValue<>("hello!", DataType.STRING))
+      .build();
+
+  private static final BindingContext bctx = event.asBindingContext();
+
+  @TearDown
+  public void teardown() throws MuleException {}
+
+  @Benchmark
+  public Object fromEvent() {
+    return addEventBindings(event, NULL_BINDING_CONTEXT);
+  }
+
+  @Benchmark
+  public Object withParent() {
+    return BindingContext.builder(globalCtx)
+        .addBinding("onChild", new TypedValue<>("hello!", DataType.STRING))
+        .build();
+  }
+
+  @Benchmark
+  public Object payloadBinding() {
+    return bctx.lookup(BindingContextUtils.PAYLOAD);
+  }
+
+  @Benchmark
+  public Object varsBinding() {
+    return bctx.lookup(VARS);
+  }
+
+  @Benchmark
+  public Object threeBindings() {
+    return asList(bctx.lookup(BindingContextUtils.PAYLOAD), bctx.lookup(ATTRIBUTES), bctx.lookup(VARS));
+  }
+
+  @Benchmark
+  public Object fiveBindings() {
+    return asList(bctx.lookup(BindingContextUtils.PAYLOAD), bctx.lookup(ATTRIBUTES), bctx.lookup(VARS), bctx.lookup(ERROR),
+                  bctx.lookup(CORRELATION_ID));
+  }
+
+  @Benchmark
+  public Object parentLookup() {
+    return childCtx.lookup("onParent");
+  }
+}


### PR DESCRIPTION
overhead

Baseline:
```
BindingContextBenchmark.fiveBindings                                     avgt   10    60.302 ±   1.825   ns/op
BindingContextBenchmark.fiveBindings:·gc.alloc.rate                      avgt   10  2169.141 ±  66.248  MB/sec
BindingContextBenchmark.fiveBindings:·gc.alloc.rate.norm                 avgt   10   144.000 ±   0.001    B/op
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Eden_Space             avgt   10  2169.684 ±  71.569  MB/sec
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Eden_Space.norm        avgt   10   144.034 ±   1.122    B/op
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Survivor_Space         avgt   10     0.158 ±   0.041  MB/sec
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Survivor_Space.norm    avgt   10     0.010 ±   0.003    B/op
BindingContextBenchmark.fiveBindings:·gc.count                           avgt   10   997.000            counts
BindingContextBenchmark.fiveBindings:·gc.time                            avgt   10   867.000                ms
BindingContextBenchmark.fromEvent                                      avgt   10   467.912 ±  52.445   ns/op
BindingContextBenchmark.fromEvent:·gc.alloc.rate                       avgt   10  2448.303 ± 248.480  MB/sec
BindingContextBenchmark.fromEvent:·gc.alloc.rate.norm                  avgt   10  1256.001 ±   0.001    B/op
BindingContextBenchmark.fromEvent:·gc.churn.PS_Eden_Space              avgt   10  2447.995 ± 247.201  MB/sec
BindingContextBenchmark.fromEvent:·gc.churn.PS_Eden_Space.norm         avgt   10  1255.863 ±   7.504    B/op
BindingContextBenchmark.fromEvent:·gc.churn.PS_Survivor_Space          avgt   10     0.177 ±   0.049  MB/sec
BindingContextBenchmark.fromEvent:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.091 ±   0.020    B/op
BindingContextBenchmark.fromEvent:·gc.count                            avgt   10  1116.000            counts
BindingContextBenchmark.fromEvent:·gc.time                             avgt   10   904.000                ms
BindingContextBenchmark.parentLookup                                   avgt   10    23.830 ±   0.440   ns/op
BindingContextBenchmark.parentLookup:·gc.alloc.rate                    avgt   10   609.816 ±  10.951  MB/sec
BindingContextBenchmark.parentLookup:·gc.alloc.rate.norm               avgt   10    16.000 ±   0.001    B/op
BindingContextBenchmark.parentLookup:·gc.churn.PS_Eden_Space           avgt   10   610.434 ±  12.042  MB/sec
BindingContextBenchmark.parentLookup:·gc.churn.PS_Eden_Space.norm      avgt   10    16.016 ±   0.083    B/op
BindingContextBenchmark.parentLookup:·gc.churn.PS_Survivor_Space       avgt   10     0.136 ±   0.027  MB/sec
BindingContextBenchmark.parentLookup:·gc.churn.PS_Survivor_Space.norm  avgt   10     0.004 ±   0.001    B/op
BindingContextBenchmark.parentLookup:·gc.count                         avgt   10  1150.000            counts
BindingContextBenchmark.parentLookup:·gc.time                          avgt   10   883.000                ms
BindingContextBenchmark.payloadBinding                                   avgt   10     9.458 ±   0.353   ns/op
BindingContextBenchmark.payloadBinding:·gc.alloc.rate                    avgt   10  1536.240 ±  56.332  MB/sec
BindingContextBenchmark.payloadBinding:·gc.alloc.rate.norm               avgt   10    16.000 ±   0.001    B/op
BindingContextBenchmark.payloadBinding:·gc.churn.PS_Eden_Space           avgt   10  1536.608 ±  54.532  MB/sec
BindingContextBenchmark.payloadBinding:·gc.churn.PS_Eden_Space.norm      avgt   10    16.004 ±   0.109    B/op
BindingContextBenchmark.payloadBinding:·gc.churn.PS_Survivor_Space       avgt   10     0.131 ±   0.018  MB/sec
BindingContextBenchmark.payloadBinding:·gc.churn.PS_Survivor_Space.norm  avgt   10     0.001 ±   0.001    B/op
BindingContextBenchmark.payloadBinding:·gc.count                         avgt   10  1147.000            counts
BindingContextBenchmark.payloadBinding:·gc.time                          avgt   10   909.000                ms
BindingContextBenchmark.threeBindings                                    avgt   10    37.404 ±   1.763   ns/op
BindingContextBenchmark.threeBindings:·gc.alloc.rate                     avgt   10  2526.336 ± 121.390  MB/sec
BindingContextBenchmark.threeBindings:·gc.alloc.rate.norm                avgt   10   104.000 ±   0.001    B/op
BindingContextBenchmark.threeBindings:·gc.churn.PS_Eden_Space            avgt   10  2523.548 ± 118.576  MB/sec
BindingContextBenchmark.threeBindings:·gc.churn.PS_Eden_Space.norm       avgt   10   103.889 ±   0.843    B/op
BindingContextBenchmark.threeBindings:·gc.churn.PS_Survivor_Space        avgt   10     0.181 ±   0.026  MB/sec
BindingContextBenchmark.threeBindings:·gc.churn.PS_Survivor_Space.norm   avgt   10     0.007 ±   0.001    B/op
BindingContextBenchmark.threeBindings:·gc.count                          avgt   10  1167.000            counts
BindingContextBenchmark.threeBindings:·gc.time                           avgt   10   907.000                ms
BindingContextBenchmark.varsBinding                                      avgt   10     9.719 ±   0.323   ns/op
BindingContextBenchmark.varsBinding:·gc.alloc.rate                       avgt   10  1495.065 ±  48.062  MB/sec
BindingContextBenchmark.varsBinding:·gc.alloc.rate.norm                  avgt   10    16.000 ±   0.001    B/op
BindingContextBenchmark.varsBinding:·gc.churn.PS_Eden_Space              avgt   10  1495.857 ±  52.260  MB/sec
BindingContextBenchmark.varsBinding:·gc.churn.PS_Eden_Space.norm         avgt   10    16.008 ±   0.074    B/op
BindingContextBenchmark.varsBinding:·gc.churn.PS_Survivor_Space          avgt   10     0.128 ±   0.031  MB/sec
BindingContextBenchmark.varsBinding:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.001 ±   0.001    B/op
BindingContextBenchmark.varsBinding:·gc.count                            avgt   10  1116.000            counts
BindingContextBenchmark.varsBinding:·gc.time                             avgt   10   885.000                ms
BindingContextBenchmark.withParent                                     avgt   10   275.382 ±   9.090   ns/op
BindingContextBenchmark.withParent:·gc.alloc.rate                      avgt   10  2981.929 ±  94.124  MB/sec
BindingContextBenchmark.withParent:·gc.alloc.rate.norm                 avgt   10   904.001 ±   0.001    B/op
BindingContextBenchmark.withParent:·gc.churn.PS_Eden_Space             avgt   10  2981.156 ± 100.782  MB/sec
BindingContextBenchmark.withParent:·gc.churn.PS_Eden_Space.norm        avgt   10   903.743 ±   3.778    B/op
BindingContextBenchmark.withParent:·gc.churn.PS_Survivor_Space         avgt   10     0.157 ±   0.031  MB/sec
BindingContextBenchmark.withParent:·gc.churn.PS_Survivor_Space.norm    avgt   10     0.048 ±   0.009    B/op
BindingContextBenchmark.withParent:·gc.count                           avgt   10  1196.000            counts
BindingContextBenchmark.withParent:·gc.time                            avgt   10   927.000                ms
```

After (including https://github.com/mulesoft/mule-api/pull/493):
```
BindingContextBenchmark.fiveBindings                                    avgt   10    55.351 ±   3.687   ns/op
BindingContextBenchmark.fiveBindings:·gc.alloc.rate                     avgt   10  1840.294 ± 114.409  MB/sec
BindingContextBenchmark.fiveBindings:·gc.alloc.rate.norm                avgt   10   112.000 ±   0.001    B/op
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Eden_Space            avgt   10  1841.024 ± 108.107  MB/sec
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Eden_Space.norm       avgt   10   112.056 ±   0.916    B/op
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Survivor_Space        avgt   10     0.172 ±   0.035  MB/sec
BindingContextBenchmark.fiveBindings:·gc.churn.PS_Survivor_Space.norm   avgt   10     0.010 ±   0.002    B/op
BindingContextBenchmark.fiveBindings:·gc.count                          avgt   10  1155.000            counts
BindingContextBenchmark.fiveBindings:·gc.time                           avgt   10   918.000                ms
BindingContextBenchmark.fromEvent                                       avgt   10   201.094 ±  26.584   ns/op
BindingContextBenchmark.fromEvent:·gc.alloc.rate                        avgt   10  3051.030 ± 336.195  MB/sec
BindingContextBenchmark.fromEvent:·gc.alloc.rate.norm                   avgt   10   672.001 ±   0.001    B/op
BindingContextBenchmark.fromEvent:·gc.churn.PS_Eden_Space               avgt   10  3049.492 ± 347.785  MB/sec
BindingContextBenchmark.fromEvent:·gc.churn.PS_Eden_Space.norm          avgt   10   671.529 ±   4.619    B/op
BindingContextBenchmark.fromEvent:·gc.churn.PS_Survivor_Space           avgt   10     0.160 ±   0.037  MB/sec
BindingContextBenchmark.fromEvent:·gc.churn.PS_Survivor_Space.norm      avgt   10     0.035 ±   0.007    B/op
BindingContextBenchmark.fromEvent:·gc.count                             avgt   10  1069.000            counts
BindingContextBenchmark.fromEvent:·gc.time                              avgt   10   879.000                ms
BindingContextBenchmark.parentLookup                                    avgt   10    22.085 ±   0.583   ns/op
BindingContextBenchmark.parentLookup:·gc.alloc.rate                     avgt   10   658.001 ±  16.954  MB/sec
BindingContextBenchmark.parentLookup:·gc.alloc.rate.norm                avgt   10    16.000 ±   0.001    B/op
BindingContextBenchmark.parentLookup:·gc.churn.PS_Eden_Space            avgt   10   658.655 ±  15.255  MB/sec
BindingContextBenchmark.parentLookup:·gc.churn.PS_Eden_Space.norm       avgt   10    16.017 ±   0.111    B/op
BindingContextBenchmark.parentLookup:·gc.churn.PS_Survivor_Space        avgt   10     0.134 ±   0.022  MB/sec
BindingContextBenchmark.parentLookup:·gc.churn.PS_Survivor_Space.norm   avgt   10     0.003 ±   0.001    B/op
BindingContextBenchmark.parentLookup:·gc.count                          avgt   10  1130.000            counts
BindingContextBenchmark.parentLookup:·gc.time                           avgt   10   882.000                ms
BindingContextBenchmark.payloadBinding                                  avgt   10     4.482 ±   0.214   ns/op
BindingContextBenchmark.payloadBinding:·gc.alloc.rate                   avgt   10     0.003 ±   0.001  MB/sec
BindingContextBenchmark.payloadBinding:·gc.alloc.rate.norm              avgt   10    ≈ 10⁻⁵              B/op
BindingContextBenchmark.payloadBinding:·gc.count                        avgt   10       ≈ 0            counts
BindingContextBenchmark.threeBindings                                   avgt   10    18.613 ±   0.315   ns/op
BindingContextBenchmark.threeBindings:·gc.alloc.rate                    avgt   10  3512.378 ±  57.318  MB/sec
BindingContextBenchmark.threeBindings:·gc.alloc.rate.norm               avgt   10    72.000 ±   0.001    B/op
BindingContextBenchmark.threeBindings:·gc.churn.PS_Eden_Space           avgt   10  3511.613 ±  64.366  MB/sec
BindingContextBenchmark.threeBindings:·gc.churn.PS_Eden_Space.norm      avgt   10    71.984 ±   0.392    B/op
BindingContextBenchmark.threeBindings:·gc.churn.PS_Survivor_Space       avgt   10     0.188 ±   0.022  MB/sec
BindingContextBenchmark.threeBindings:·gc.churn.PS_Survivor_Space.norm  avgt   10     0.004 ±   0.001    B/op
BindingContextBenchmark.threeBindings:·gc.count                         avgt   10  1216.000            counts
BindingContextBenchmark.threeBindings:·gc.time                          avgt   10   933.000                ms
BindingContextBenchmark.varsBinding                                     avgt   10     6.685 ±   0.023   ns/op
BindingContextBenchmark.varsBinding:·gc.alloc.rate                      avgt   10  2172.609 ±   7.465  MB/sec
BindingContextBenchmark.varsBinding:·gc.alloc.rate.norm                 avgt   10    16.000 ±   0.001    B/op
BindingContextBenchmark.varsBinding:·gc.churn.PS_Eden_Space             avgt   10  2172.114 ±  20.516  MB/sec
BindingContextBenchmark.varsBinding:·gc.churn.PS_Eden_Space.norm        avgt   10    15.996 ±   0.136    B/op
BindingContextBenchmark.varsBinding:·gc.churn.PS_Survivor_Space         avgt   10     0.149 ±   0.024  MB/sec
BindingContextBenchmark.varsBinding:·gc.churn.PS_Survivor_Space.norm    avgt   10     0.001 ±   0.001    B/op
BindingContextBenchmark.varsBinding:·gc.count                           avgt   10  1186.000            counts
BindingContextBenchmark.varsBinding:·gc.time                            avgt   10   916.000                ms
BindingContextBenchmark.withParent                                      avgt   10    78.876 ±   1.494   ns/op
BindingContextBenchmark.withParent:·gc.alloc.rate                       avgt   10  4421.368 ±  81.864  MB/sec
BindingContextBenchmark.withParent:·gc.alloc.rate.norm                  avgt   10   384.000 ±   0.001    B/op
BindingContextBenchmark.withParent:·gc.churn.PS_Eden_Space              avgt   10  4422.621 ±  67.967  MB/sec
BindingContextBenchmark.withParent:·gc.churn.PS_Eden_Space.norm         avgt   10   384.120 ±   2.260    B/op
BindingContextBenchmark.withParent:·gc.churn.PS_Survivor_Space          avgt   10     0.175 ±   0.028  MB/sec
BindingContextBenchmark.withParent:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.015 ±   0.002    B/op
BindingContextBenchmark.withParent:·gc.count                            avgt   10  1205.000            counts
BindingContextBenchmark.withParent:·gc.time                             avgt   10   935.000                ms
```
