### PR TITLE
MULE-14801: SimpleRetryPolicy: Use mule schedulers with Mono.delay instead of reactor ones

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/construct/AbstractPipeline.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/construct/AbstractPipeline.java
@@ -327,6 +327,7 @@ public abstract class AbstractPipeline extends AbstractFlowConstruct implements 
     } catch (MuleException e) {
       // If the pipeline couldn't be started we would need to stop the processingStrategy (if possible) in order to avoid leaks
       doStop();
+      doStopProcessingStrategy();
       throw e;
     }
     canProcessMessage = true;


### PR DESCRIPTION
* ProcessingStrategy was not being stopped, leading to Scheduler leaks