### PR TITLE
MULE-15539: OAuth: Provide option `encodeClientCredentialsInBody` in authCode

### DIFF
--- a/modules/oauth-api/api-changes.json
+++ b/modules/oauth-api/api-changes.json
@@ -1,4 +1,19 @@
 {
+  "4.1.4": {
+  	"revapi": {
+  	  "ignore" : [
+        {
+          "code": "java.method.defaultMethodAddedToInterface",
+          "new": "method org.mule.runtime.oauth.api.builder.OAuthAuthorizationCodeDancerBuilder org.mule.runtime.oauth.api.builder.OAuthAuthorizationCodeDancerBuilder::encodeClientCredentialsInBody(boolean)",
+          "package": "org.mule.runtime.oauth.api.builder",
+          "classSimpleName": "OAuthAuthorizationCodeDancerBuilder",
+          "methodName": "encodeClientCredentialsInBody",
+          "elementKind": "method",
+          "justification": "Needed to fix an issue in the OAuth module."
+        }
+  	  ]
+  	}
+  },
   "4.1.1": {
     "revapi": {
       "ignore": [

--- a/modules/oauth-api/api-changes.json
+++ b/modules/oauth-api/api-changes.json
@@ -9,7 +9,7 @@
           "classSimpleName": "OAuthAuthorizationCodeDancerBuilder",
           "methodName": "encodeClientCredentialsInBody",
           "elementKind": "method",
-          "justification": "Needed to fix an issue in the OAuth module."
+          "justification": "Needed to fix an issue in the OAuth module. (MULE-15539)"
         }
   	  ]
   	}

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/builder/OAuthAuthorizationCodeDancerBuilder.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/builder/OAuthAuthorizationCodeDancerBuilder.java
@@ -26,6 +26,16 @@ import java.util.function.Supplier;
 public interface OAuthAuthorizationCodeDancerBuilder extends OAuthDancerBuilder<AuthorizationCodeOAuthDancer> {
 
   /**
+   * @param encodeClientCredentialsInBody If @{code true}, the client id and client secret will be sent in the request body.
+   *        Otherwise, they will be sent as basic authentication.
+   *
+   * @return this builder
+   */
+  default OAuthAuthorizationCodeDancerBuilder encodeClientCredentialsInBody(boolean encodeClientCredentialsInBody) {
+    return this;
+  }
+
+  /**
    * The produced {@link AuthorizationCodeOAuthDancer} will create an {@link HttpServer} to listen on the provided
    * {@code localCallbackUrl}.
    *


### PR DESCRIPTION
credentials in header