### PR TITLE
EE-6312: Fix distribution tests in Windows

### DIFF
--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/maven/MavenTestUtils.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/maven/MavenTestUtils.java
@@ -12,8 +12,16 @@ import static java.lang.String.format;
 import static java.lang.System.getProperty;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
+import static java.util.regex.Matcher.quoteReplacement;
 
 import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
 
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
@@ -23,14 +31,6 @@ import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.InvokerLogger;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.apache.maven.shared.invoker.SystemOutLogger;
-
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Optional;
-
 
 /**
  * Provides Maven related utilities for testing purposes
@@ -82,7 +82,9 @@ public class MavenTestUtils {
    */
   public static File findMavenArtifact(BundleDescriptor descriptor) {
     File artifact = new File(getMavenLocalRepository(), Paths
-        .get(descriptor.getGroupId().replaceAll("\\.", separator), descriptor.getArtifactId(), descriptor.getVersion(),
+        .get(descriptor.getGroupId().replaceAll("\\.", quoteReplacement(separator)),
+             descriptor.getArtifactId(),
+             descriptor.getVersion(),
              descriptor.getArtifactFileName() + "." + descriptor.getType())
         .toString());
 


### PR DESCRIPTION
- We were getting an `IllegalArgumentException` while performing the
`replaceAll` op because the replacement string was taking the value of
`\` which for this operation needs to be quoted