### PR TITLE
EE-6312: Fix distribution tests in Windows

### DIFF
--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
@@ -93,7 +93,7 @@ public class MuleDeployment extends MuleInstallation {
   private static final boolean STOP_ON_EXIT = parseBoolean(getProperty("mule.test.stopOnExit", "true"));
   private static final boolean DEBUGGING_ENABLED = parseBoolean(getProperty("mule.test.debug", "false"));
   private static final String REMOTE_REPOSITORIES = getProperty("mule.test.repositories", "");
-  private static final String DEBUG_PORT = getProperty("mule.test.debug.port","5005");
+  private static final String DEBUG_PORT = getProperty("mule.test.debug.port", "5005");
   private static Logger logger = LoggerFactory.getLogger(MuleDeployment.class);
   private static PollingProber prober;
   private String locationSuffix = "";

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
@@ -93,7 +93,7 @@ public class MuleDeployment extends MuleInstallation {
   private static final boolean STOP_ON_EXIT = parseBoolean(getProperty("mule.test.stopOnExit", "true"));
   private static final boolean DEBUGGING_ENABLED = parseBoolean(getProperty("mule.test.debug", "false"));
   private static final String REMOTE_REPOSITORIES = getProperty("mule.test.repositories", "");
-  private static final String DEBUG_PORT = "5005";
+  private static final String DEBUG_PORT = getProperty("mule.test.debug.port","5005");
   private static Logger logger = LoggerFactory.getLogger(MuleDeployment.class);
   private static PollingProber prober;
   private String locationSuffix = "";


### PR DESCRIPTION
Usually, while troubleshooting distro tests, it turns out to be quite
convenient to debug at the same time the runtime and the test classes.

By default, Maven's Failsafe and Surefire plugins uses the port 5005 for
debugging, the same as Mule's testing infrastructure.

So, I think, It'd be quite convenient to have a way to easily configure
the port where a user might want to debug Mule's runtime.