### PR TITLE
MULE-15777: Relative log config file path should be resolved consistently regardless of the OS

### DIFF
--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationDescriptorFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationDescriptorFactory.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.deployment.impl.internal.application;
 
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleHomeFolder;
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
 import static org.mule.runtime.deployment.model.api.application.ApplicationDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
 
@@ -22,6 +23,7 @@ import org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDes
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +48,9 @@ public class ApplicationDescriptorFactory
                                     File artifactLocation) {
     super.doDescriptorConfig(artifactModel, descriptor, artifactLocation);
     if (artifactModel.getLogConfigFile() != null) {
-      descriptor.setLogConfigFile(new File(artifactModel.getLogConfigFile()));
+      Path logConfigFilePath = new File(artifactModel.getLogConfigFile()).toPath();
+      Path muleHomeFolderPath = getMuleHomeFolder().toPath();
+      descriptor.setLogConfigFile(muleHomeFolderPath.resolve(logConfigFilePath).toFile());
     }
   }
 

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/domain/DomainDescriptorFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/domain/DomainDescriptorFactory.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.deployment.impl.internal.domain;
 
+import static org.mule.runtime.container.api.MuleFoldersUtil.getMuleHomeFolder;
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.DOMAIN;
 import static org.mule.runtime.deployment.model.api.domain.DomainDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
 
@@ -20,6 +21,7 @@ import org.mule.runtime.module.deployment.impl.internal.artifact.AbstractDeploya
 import org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorLoader;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -54,7 +56,9 @@ public class DomainDescriptorFactory extends AbstractDeployableDescriptorFactory
   protected void doDescriptorConfig(MuleDomainModel artifactModel, DomainDescriptor descriptor, File artifactLocation) {
     super.doDescriptorConfig(artifactModel, descriptor, artifactLocation);
     if (artifactModel.getLogConfigFile() != null) {
-      descriptor.setLogConfigFile(new File(artifactModel.getLogConfigFile()));
+      Path logConfigFilePath = new File(artifactModel.getLogConfigFile()).toPath();
+      Path muleHomeFolderPath = getMuleHomeFolder().toPath();
+      descriptor.setLogConfigFile(muleHomeFolderPath.resolve(logConfigFilePath).toFile());
     }
   }
 


### PR DESCRIPTION
- Relative paths are now being resolved based on mule.home folder in a
consistent way for both, Unix and Windows