### PR TITLE
MULE-15788 More details when DefaultExpressionManager.validateExpression fails

### DIFF
--- a/core/src/main/java/org/mule/expression/DefaultExpressionManager.java
+++ b/core/src/main/java/org/mule/expression/DefaultExpressionManager.java
@@ -597,7 +597,7 @@ public class DefaultExpressionManager implements ExpressionManager, MuleContextA
         }
         catch (InvalidExpressionException e)
         {
-            logger.warn("Expression '" + expression + "' is invalid: " + e.getMessage());
+            logger.warn(e.getMessage());
             if (logger.isDebugEnabled())
             {
             	logger.debug("Expression '" + expression + "' is invalid.", e);

--- a/core/src/main/java/org/mule/expression/DefaultExpressionManager.java
+++ b/core/src/main/java/org/mule/expression/DefaultExpressionManager.java
@@ -597,7 +597,11 @@ public class DefaultExpressionManager implements ExpressionManager, MuleContextA
         }
         catch (InvalidExpressionException e)
         {
-            logger.warn(e.getMessage());
+            logger.warn("Expression '" + expression + "' is invalid: " + e.getMessage());
+            if (logger.isDebugEnabled())
+            {
+            	logger.debug("Expression '" + expression + "' is invalid.", e);
+            }
             return false;
         }
     }


### PR DESCRIPTION
MULE-15788 More details when DefaultExpressionManager.validateExpression fails

added expression string in case InvalidExpressionException is thrown
and allow logging complete stacktrace on debug level.

https://support.mulesoft.com/s/case/50034000015fyNqAAI/orgmuleexpressiondefaultexpressionmanagerisvalidexpressionstring-hides-details