### PR TITLE
MULE-15924: Miscellaneous performance improvements for proxy scenario

### DIFF
--- a/core/api-changes.json
+++ b/core/api-changes.json
@@ -140,6 +140,70 @@
           "methodName": "enrich",
           "elementKind": "method",
           "justification": "method was deprecated and only used internally"
+        },
+        {
+          "code": "java.class.nonPublicPartOfAPI",
+          "old": "class org.mule.runtime.core.api.util.CaseInsensitiveHashMap.InternalCaseInsensitiveHashMap",
+          "new": "class org.mule.runtime.core.api.util.CaseInsensitiveHashMap.InternalCaseInsensitiveHashMap",
+          "classSimpleName": "InternalCaseInsensitiveHashMap",
+          "exampleUseChainInNewApi": "org.mule.runtime.core.api.util.CaseInsensitiveHashMap.InternalCaseInsensitiveHashMap is used as parameter in method java.util.Map org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V>::wrap(org.mule.runtime.core.api.util.CaseInsensitiveHashMap.InternalCaseInsensitiveHashMap) (method java.util.Map org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V>::wrap(org.mule.runtime.core.api.util.CaseInsensitiveHashMap.InternalCaseInsensitiveHashMap) is part of the API)",
+          "package": "org.mule.runtime.core.api.util",
+          "exampleUseChainInOldApi": "",
+          "elementKind": "class",
+          "justification": "This is not exposed"
+        },
+        {
+          "code": "java.field.serialVersionUIDUnchanged",
+          "old": "field org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V>.serialVersionUID",
+          "new": "field org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V>.serialVersionUID",
+          "serialVersionUID": "-7074633917369299456",
+          "package": "org.mule.runtime.core.api.util",
+          "classSimpleName": "CaseInsensitiveHashMap",
+          "fieldName": "serialVersionUID",
+          "elementKind": "field",
+          "justification": "Just generalizing a type definition"
+        }
+      ]
+    }
+  },
+  "4.1.5": {
+    "revapi": {
+      "ignore": [
+        {
+          "code": "java.method.added",
+          "new": "method <K, V> org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V> org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V>::emptyCaseInsensitiveMap()",
+          "package": "org.mule.runtime.core.api.util",
+          "classSimpleName": "CaseInsensitiveHashMap",
+          "methodName": "emptyCaseInsensitiveMap",
+          "elementKind": "method",
+          "justification": "Added for performance"
+        },
+        {
+          "code": "java.method.added",
+          "new": "method org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V> org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V>::toImmutableCaseInsensitiveMap()",
+          "package": "org.mule.runtime.core.api.util",
+          "classSimpleName": "CaseInsensitiveHashMap",
+          "methodName": "toImmutableCaseInsensitiveMap",
+          "elementKind": "method",
+          "justification": "Added for performance"
+        },
+        {
+          "code": "java.method.added",
+          "new": "method java.util.Map org.mule.runtime.core.api.util.CaseInsensitiveHashMap<K, V>::wrap(org.mule.runtime.core.api.util.CaseInsensitiveHashMap.InternalCaseInsensitiveHashMap)",
+          "package": "org.mule.runtime.core.api.util",
+          "classSimpleName": "CaseInsensitiveHashMap",
+          "methodName": "wrap",
+          "elementKind": "method",
+          "justification": "Added for performance"
+        },
+        {
+          "code": "java.method.added",
+          "new": "method java.lang.String org.mule.runtime.core.api.util.UUID::getClusterUUID(java.lang.String)",
+          "package": "org.mule.runtime.core.api.util",
+          "classSimpleName": "UUID",
+          "methodName": "getClusterUUID",
+          "elementKind": "method",
+          "justification": "Added for performance"
         }
       ]
     }

--- a/core/src/main/java/org/mule/runtime/core/api/policy/DefaultPolicyInstance.java
+++ b/core/src/main/java/org/mule/runtime/core/api/policy/DefaultPolicyInstance.java
@@ -18,6 +18,7 @@ import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingTy
 import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Mono.error;
 import static reactor.core.scheduler.Schedulers.fromExecutor;
+
 import org.mule.api.annotation.NoExtend;
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.exception.MuleException;
@@ -47,12 +48,13 @@ import org.mule.runtime.core.internal.processor.chain.InterceptedReactiveProcess
 import org.mule.runtime.core.internal.processor.strategy.AbstractProcessingStrategy;
 import org.mule.runtime.core.internal.processor.strategy.StreamPerEventSink;
 
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+
 import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
 
 @NoExtend
@@ -244,8 +246,7 @@ public class DefaultPolicyInstance extends AbstractComponent
     @Override
     public ReactiveProcessor onProcessor(ReactiveProcessor processor) {
       if (isExecuteNext(processor)) {
-        return publisher -> Flux.from(publisher)
-            .transform(processor);
+        return super.onProcessor(processor);
       } else if (processor.getProcessingType() == CPU_LITE_ASYNC) {
         return publisher -> Flux.from(publisher)
             .transform(processor)
@@ -259,8 +260,7 @@ public class DefaultPolicyInstance extends AbstractComponent
             .publishOn(fromExecutor(cpuIntensiveScheduler))
             .transform(processor);
       } else {
-        return publisher -> Flux.from(publisher)
-            .transform(processor);
+        return super.onProcessor(processor);
       }
     }
 

--- a/core/src/main/java/org/mule/runtime/core/api/processor/strategy/ProcessingStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/api/processor/strategy/ProcessingStrategy.java
@@ -6,8 +6,6 @@
  */
 package org.mule.runtime.core.api.processor.strategy;
 
-import static reactor.core.publisher.Flux.from;
-
 import org.mule.api.annotation.NoImplement;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.construct.Pipeline;
@@ -39,7 +37,7 @@ public interface ProcessingStrategy {
    * @return enriched pipeline function/
    */
   default ReactiveProcessor onPipeline(ReactiveProcessor pipeline) {
-    return publisher -> from(publisher).transform(pipeline);
+    return pipeline;
   }
 
   /**
@@ -49,7 +47,7 @@ public interface ProcessingStrategy {
    * @return enriched processor function
    */
   default ReactiveProcessor onProcessor(ReactiveProcessor processor) {
-    return publisher -> from(publisher).transform(processor);
+    return processor;
   }
 
   /**

--- a/core/src/main/java/org/mule/runtime/core/api/util/UUID.java
+++ b/core/src/main/java/org/mule/runtime/core/api/util/UUID.java
@@ -34,5 +34,14 @@ public final class UUID {
         .toAppendable(new StringBuilder(38).append(clusterId).append('-')).toString();
   }
 
+  /**
+   * @param clusterIdPrefix cluster id prefix, ending in a `-` separator
+   * @return time-based UUID prefixed with the cluster id so as to ensure uniqueness within cluster.
+   */
+  public static String getClusterUUID(String clusterIdPrefix) {
+    return new com.eaio.uuid.UUID()
+        .toAppendable(new StringBuilder(38).append(clusterIdPrefix)).toString();
+  }
+
 
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/construct/FlowBackPressureException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/construct/FlowBackPressureException.java
@@ -6,7 +6,9 @@
  */
 package org.mule.runtime.core.internal.construct;
 
-import static java.lang.String.format;
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+
+import org.mule.runtime.api.exception.MuleException;
 
 import java.util.concurrent.RejectedExecutionException;
 
@@ -15,27 +17,27 @@ import java.util.concurrent.RejectedExecutionException;
  *
  * @since 4.1
  */
-public class FlowBackPressureException extends Exception {
+public class FlowBackPressureException extends MuleException {
 
   static String BACK_PRESSURE_ERROR_MESSAGE = "Flow '%s' is unable to accept new events at this time";
-  private static final long serialVersionUID = 2992038225993918910L;
+  private static final long serialVersionUID = -4973370165925845336L;
 
   /**
    * Create a new {@link FlowBackPressureException} with no cause. This is typically use when a stream based processing exerts
    * back-pressure without throwing an exception.
-   * 
+   *
    */
   public FlowBackPressureException(String flowName) {
-    super(format(BACK_PRESSURE_ERROR_MESSAGE, flowName));
+    super(createStaticMessage(BACK_PRESSURE_ERROR_MESSAGE, flowName));
   }
 
   /**
    * Create a new {@link FlowBackPressureException} with a cause. This is typically use when a non-stream based processing
-   * strategy is in use and back-pressure is identified by a a {@link RejectedExecutionException}.
+   * strategy is in use and back-pressure is identified by a {@link RejectedExecutionException}.
    *
    */
   public FlowBackPressureException(String flowName, Throwable cause) {
-    super(format(BACK_PRESSURE_ERROR_MESSAGE, flowName), cause);
+    super(createStaticMessage(BACK_PRESSURE_ERROR_MESSAGE, flowName), cause);
   }
 
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
@@ -46,6 +46,7 @@ import static org.mule.runtime.core.internal.logging.LogUtil.log;
 import static org.mule.runtime.core.internal.util.FunctionalUtils.safely;
 import static org.mule.runtime.core.internal.util.JdkVersionUtils.getSupportedJdks;
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.config.custom.CustomizationService;
 import org.mule.runtime.api.deployment.management.ComponentInitialStateManager;
@@ -125,6 +126,8 @@ import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
 import org.mule.runtime.core.privileged.transformer.ExtendedTransformationService;
 
+import org.slf4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -135,7 +138,6 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.transaction.TransactionManager;
 
-import org.slf4j.Logger;
 import reactor.core.publisher.Hooks;
 
 public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMuleContext {
@@ -204,6 +206,7 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
   private SchedulerController schedulerController = new DefaultSchedulerController();
 
   private ClusterConfiguration clusterConfiguration = new NullClusterConfiguration();
+  private String clusterNodeIdPrefix = "";
 
   private SingleResourceTransactionFactoryManager singleResourceTransactionFactoryManager =
       new SingleResourceTransactionFactoryManager();
@@ -847,7 +850,7 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
 
   @Override
   public String getUniqueIdString() {
-    return getClusterUUID(clusterConfiguration.getClusterNodeId());
+    return getClusterUUID(clusterNodeIdPrefix);
   }
 
   @Override
@@ -935,6 +938,7 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
     ClusterConfiguration overriddenClusterConfiguration = getRegistry().get(OBJECT_CLUSTER_CONFIGURATION);
     if (overriddenClusterConfiguration != null) {
       this.clusterConfiguration = overriddenClusterConfiguration;
+      this.clusterNodeIdPrefix = overriddenClusterConfiguration.getClusterNodeId() + "-";
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeSourcePolicy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeSourcePolicy.java
@@ -116,7 +116,7 @@ public class CompositeSourcePolicy extends
           }
           return flowExecutionException;
         })
-        .doOnError(e -> LOGGER.error(e.getMessage(), e));
+        .doOnError(e -> !(e instanceof MessagingException), e -> LOGGER.error(e.getMessage(), e));
   }
 
   /**
@@ -157,7 +157,8 @@ public class CompositeSourcePolicy extends
           return right(new SourcePolicySuccessResult(policiesResultEvent, responseParameters, getParametersProcessor()));
         }).doOnNext(result -> logSourcePolicySuccessfullResult(result.getRight()))
 
-        .doOnError(e -> LOGGER.error(e.getMessage(), e))
+        .doOnError(e -> !(e instanceof FlowExecutionException || e instanceof MessagingException),
+                   e -> LOGGER.error(e.getMessage(), e))
         .onErrorResume(FlowExecutionException.class, e -> {
           Supplier<Map<String, Object>> responseParameters = () -> getParametersTransformer()
               .map(parametersTransformer -> concatMaps(originalFailureResponseParameters, parametersTransformer

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
@@ -29,6 +29,7 @@ import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.event.CoreEvent.Builder;
 import org.mule.runtime.core.api.processor.AbstractMessageProcessorOwner;
@@ -53,6 +54,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.inject.Inject;
+
 import reactor.core.publisher.Mono;
 
 /**
@@ -73,6 +76,9 @@ public class Foreach extends AbstractMessageProcessorOwner implements Initialisa
   static final String DEFAULT_COUNTER_VARIABLE = "counter";
   static final String MAP_NOT_SUPPORTED_MESSAGE =
       "Foreach does not support 'java.util.Map' with no collection expression. To iterate over Map entries use '#[dw::core::Objects::entrySet(payload)]'";
+
+  @Inject
+  protected ExpressionManager expressionManager;
 
   private List<Processor> messageProcessors;
   private String expression = DEFAULT_SPLIT_EXPRESSION;
@@ -238,7 +244,7 @@ public class Foreach extends AbstractMessageProcessorOwner implements Initialisa
   public void initialise() throws InitialisationException {
     Optional<ProcessingStrategy> processingStrategy = getProcessingStrategy(locator, getRootContainerLocation());
     nestedChain = newChain(processingStrategy, messageProcessors);
-    splittingStrategy = new ExpressionSplittingStrategy(muleContext.getExpressionManager(), expression);
+    splittingStrategy = new ExpressionSplittingStrategy(expressionManager, expression);
     super.initialise();
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorManager.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.internal.streaming;
 
+import static com.github.benmanes.caffeine.cache.Caffeine.newBuilder;
 import static java.util.Collections.newSetFromMap;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 
@@ -15,7 +16,6 @@ import org.mule.runtime.api.streaming.Cursor;
 import org.mule.runtime.api.streaming.CursorProvider;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
 import org.mule.runtime.api.streaming.object.CursorIteratorProvider;
-import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.streaming.bytes.ManagedCursorStreamProvider;
 import org.mule.runtime.core.internal.streaming.object.ManagedCursorIteratorProvider;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
@@ -23,11 +23,8 @@ import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import java.util.Collection;
 import java.util.Set;
@@ -46,15 +43,9 @@ public class CursorManager {
   private static Logger LOGGER = LoggerFactory.getLogger(CursorManager.class);
 
   private final LoadingCache<String, EventStreamingState> registry =
-      CacheBuilder.newBuilder()
-          .removalListener((RemovalNotification<String, EventStreamingState> notification) -> notification.getValue().dispose())
-          .build(new CacheLoader<String, EventStreamingState>() {
-
-            @Override
-            public EventStreamingState load(String key) throws Exception {
-              return new EventStreamingState();
-            }
-          });
+      newBuilder()
+          .removalListener((key, value, cause) -> ((EventStreamingState) value).dispose())
+          .build((key) -> new EventStreamingState());
 
   private final MutableStreamingStatistics statistics;
   private final Scheduler disposalScheduler;
@@ -80,7 +71,7 @@ public class CursorManager {
    */
   public CursorProvider manage(CursorProvider provider, BaseEventContext ownerContext) {
     registerEventContext(ownerContext);
-    registry.getUnchecked(ownerContext.getId()).addProvider(provider);
+    registry.get(ownerContext.getId()).addProvider(provider);
 
     final CursorContext context = new CursorContext(provider, ownerContext);
     if (provider instanceof CursorStreamProvider) {
@@ -99,7 +90,7 @@ public class CursorManager {
    * @param providerHandle the handle for the provider that generated it
    */
   public void onOpen(Cursor cursor, CursorContext providerHandle) {
-    registry.getUnchecked(providerHandle.getOwnerContext().getId()).addCursor(providerHandle.getCursorProvider(), cursor);
+    registry.get(providerHandle.getOwnerContext().getId()).addCursor(providerHandle.getCursorProvider(), cursor);
     statistics.incrementOpenCursors();
   }
 
@@ -141,35 +132,31 @@ public class CursorManager {
     private AtomicBoolean disposed = new AtomicBoolean(false);
     private AtomicInteger cursorCount = new AtomicInteger(0);
 
-    private final LoadingCache<CursorProvider, Set<Cursor>> cursors = CacheBuilder.newBuilder()
-        .removalListener((RemovalListener<CursorProvider, Set<Cursor>>) notification -> {
+    private final LoadingCache<CursorProvider, Set<Cursor>> cursors = Caffeine.newBuilder()
+        .removalListener((key, value, cause) -> {
           try {
-            closeProvider(notification.getKey());
-            releaseAll(notification.getValue());
+            closeProvider((CursorProvider) key);
+            releaseAll((Set<Cursor>) value);
           } finally {
-            notification.getKey().releaseResources();
+            ((CursorProvider) key).releaseResources();
           }
         })
-        .build(new CacheLoader<CursorProvider, Set<Cursor>>() {
-
-          @Override
-          public Set<Cursor> load(CursorProvider key) throws Exception {
-            statistics.incrementOpenProviders();
-            return newSetFromMap(new ConcurrentHashMap<>());
-          }
+        .build(key -> {
+          statistics.incrementOpenProviders();
+          return newSetFromMap(new ConcurrentHashMap<>());
         });
 
     private synchronized void addProvider(CursorProvider adapter) {
-      cursors.getUnchecked(adapter);
+      cursors.get(adapter);
     }
 
     private void addCursor(CursorProvider provider, Cursor cursor) {
-      cursors.getUnchecked(provider).add(cursor);
+      cursors.get(provider).add(cursor);
       cursorCount.incrementAndGet();
     }
 
     private boolean removeCursor(CursorProvider provider, Cursor cursor) {
-      Set<Cursor> openCursors = cursors.getUnchecked(provider);
+      Set<Cursor> openCursors = cursors.get(provider);
       if (openCursors.remove(cursor)) {
         statistics.decrementOpenCursors();
         if (cursorCount.decrementAndGet() <= 0 && provider.isClosed()) {

--- a/core/src/main/java/org/mule/runtime/core/internal/util/message/MessageUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/message/MessageUtils.java
@@ -12,7 +12,6 @@ import static org.mule.runtime.core.api.util.StreamingUtils.streamingContent;
 
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
-import org.mule.runtime.api.metadata.DataTypeParamsBuilder;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.streaming.CursorProvider;
@@ -205,9 +204,10 @@ public final class MessageUtils {
     Message.Builder builder = Message.builder().payload(new TypedValue<>(value, dataType, result.getByteLength()));
 
     result.getAttributes().ifPresent(att -> {
-      final DataTypeParamsBuilder dataTypeBuilder = builder(DataType.fromObject(att));
-      result.getAttributesMediaType().ifPresent(amt -> dataTypeBuilder.mediaType(amt));
-      builder.attributes(new TypedValue<>(att, dataTypeBuilder.build(), OptionalLong.empty()));
+      DataType attDataType = result.getAttributesMediaType()
+          .map(amt -> builder().type(att.getClass()).mediaType(amt).build())
+          .orElse(DataType.fromObject(att));
+      builder.attributes(new TypedValue<>(att, attDataType, OptionalLong.empty()));
     });
 
     return builder.build();

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/DefaultExecutionMediator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/DefaultExecutionMediator.java
@@ -17,6 +17,7 @@ import static org.mule.runtime.core.api.util.ExceptionUtils.extractConnectionExc
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.getClassLoader;
 import static reactor.core.publisher.Mono.error;
 import static reactor.core.publisher.Mono.from;
+
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.connection.ConnectionProvider;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
@@ -40,6 +41,10 @@ import org.mule.runtime.module.extension.internal.runtime.config.MutableConfigur
 import org.mule.runtime.module.extension.internal.runtime.exception.ExceptionHandlerManager;
 import org.mule.runtime.module.extension.internal.runtime.exception.ModuleExceptionHandler;
 
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -47,9 +52,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 /**
@@ -230,15 +232,17 @@ public final class DefaultExecutionMediator<T extends ComponentModel> implements
 
   private void intercept(List<Interceptor> interceptors, Consumer<Interceptor> closure,
                          Function<Interceptor, String> exceptionMessageFunction) {
-    interceptors.forEach(interceptor -> {
-      try {
-        closure.accept(interceptor);
-      } catch (Exception e) {
-        if (LOGGER.isDebugEnabled()) {
+    if (!LOGGER.isDebugEnabled()) {
+      interceptors.forEach(closure);
+    } else {
+      interceptors.forEach(interceptor -> {
+        try {
+          closure.accept(interceptor);
+        } catch (Exception e) {
           LOGGER.debug(exceptionMessageFunction.apply(interceptor), e);
         }
-      }
-    });
+      });
+    }
   }
 
   private <T> ExecutionTemplate<T> getExecutionTemplate(ExecutionContextAdapter<ComponentModel> context) {

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/ByteArrayHttpEntity.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/ByteArrayHttpEntity.java
@@ -9,12 +9,14 @@ package org.mule.runtime.http.api.domain.entity;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.of;
 import static org.mule.runtime.api.util.Preconditions.checkNotNull;
+
 import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Represents a byte array HTTP body.
@@ -59,5 +61,11 @@ public final class ByteArrayHttpEntity implements HttpEntity {
   public Optional<Long> getLength() {
     return of((long) content.length);
   }
+
+  @Override
+  public OptionalLong getBytesLength() {
+    return OptionalLong.of(content.length);
+  }
+
 
 }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/EmptyHttpEntity.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/EmptyHttpEntity.java
@@ -8,12 +8,14 @@ package org.mule.runtime.http.api.domain.entity;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.of;
+
 import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Represents an HTTP empty body.
@@ -54,4 +56,8 @@ public final class EmptyHttpEntity implements HttpEntity {
     return of(0L);
   }
 
+  @Override
+  public OptionalLong getBytesLength() {
+    return OptionalLong.of(0L);
+  }
 }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/HttpEntity.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/HttpEntity.java
@@ -6,12 +6,16 @@
  */
 package org.mule.runtime.http.api.domain.entity;
 
+import static java.util.OptionalLong.empty;
+import static java.util.OptionalLong.of;
+
 import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * An entity that can be sent or received via an {@link org.mule.runtime.http.api.domain.message.request.HttpRequest} or
@@ -78,7 +82,22 @@ public interface HttpEntity {
    * messages that carried a 'Content-Length' header will return a length.
    *
    * @return an {@link Optional} with the length (in bytes) or an empty one if unknown
+   *
+   * @deprecated Use {@link #getBytesLength()} instead.
    */
+  @Deprecated
   Optional<Long> getLength();
+
+  /**
+   * Provides the length (in bytes) of the {@link HttpEntity}, if known. For the most part, only received entities from HTTP
+   * messages that carried a 'Content-Length' header will return a length.
+   *
+   * @return an {@link Optional} with the length (in bytes) or an empty one if unknown
+   *
+   * @since 4.2
+   */
+  default OptionalLong getBytesLength() {
+    return getLength().map(l -> of(l)).orElse(empty());
+  }
 
 }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/InputStreamHttpEntity.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/InputStreamHttpEntity.java
@@ -8,16 +8,18 @@ package org.mule.runtime.http.api.domain.entity;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
-import static java.util.Optional.ofNullable;
+import static java.util.OptionalLong.empty;
+import static java.util.OptionalLong.of;
+import static org.mule.runtime.api.util.IOUtils.toByteArray;
 
 import org.mule.api.annotation.NoExtend;
-import org.mule.runtime.api.util.IOUtils;
 import org.mule.runtime.http.api.domain.entity.multipart.HttpPart;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Representation of a stream HTTP body.
@@ -27,15 +29,37 @@ import java.util.Optional;
 @NoExtend
 public class InputStreamHttpEntity implements HttpEntity {
 
-  private Long contentLength;
+  private OptionalLong contentLength;
   private InputStream inputStream;
 
   public InputStreamHttpEntity(InputStream inputStream) {
     requireNonNull(inputStream, "HTTP entity stream cannot be null.");
     this.inputStream = inputStream;
+    this.contentLength = empty();
   }
 
+  /**
+   * @deprecated Use {@link #InputStreamHttpEntity(InputStream, OptionalLong)} or
+   *             {@link #InputStreamHttpEntity(InputStream, long)} instead.
+   */
+  @Deprecated
   public InputStreamHttpEntity(InputStream inputStream, Long contentLength) {
+    this(inputStream);
+    this.contentLength = contentLength == null ? empty() : of(contentLength);
+  }
+
+  /**
+   * @since 4.2
+   */
+  public InputStreamHttpEntity(InputStream inputStream, long contentLength) {
+    this(inputStream);
+    this.contentLength = of(contentLength);
+  }
+
+  /**
+   * @since 4.2
+   */
+  public InputStreamHttpEntity(InputStream inputStream, OptionalLong contentLength) {
     this(inputStream);
     this.contentLength = contentLength;
   }
@@ -57,7 +81,7 @@ public class InputStreamHttpEntity implements HttpEntity {
 
   @Override
   public byte[] getBytes() throws IOException {
-    return IOUtils.toByteArray(this.inputStream);
+    return toByteArray(this.inputStream);
   }
 
   @Override
@@ -67,7 +91,12 @@ public class InputStreamHttpEntity implements HttpEntity {
 
   @Override
   public Optional<Long> getLength() {
-    return ofNullable(contentLength);
+    return contentLength.isPresent() ? Optional.of(contentLength.getAsLong()) : Optional.empty();
+  }
+
+  @Override
+  public OptionalLong getBytesLength() {
+    return contentLength;
   }
 
 }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/multipart/MultipartHttpEntity.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/entity/multipart/MultipartHttpEntity.java
@@ -8,11 +8,13 @@ package org.mule.runtime.http.api.domain.entity.multipart;
 
 import static java.util.Optional.empty;
 import static org.mule.runtime.api.util.Preconditions.checkNotNull;
+
 import org.mule.runtime.http.api.domain.entity.HttpEntity;
 
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Represents a multipart HTTP body.
@@ -56,6 +58,11 @@ public final class MultipartHttpEntity implements HttpEntity {
   @Override
   public Optional<Long> getLength() {
     return empty();
+  }
+
+  @Override
+  public OptionalLong getBytesLength() {
+    return OptionalLong.empty();
   }
 
 }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/message/response/DefaultHttpResponse.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/domain/message/response/DefaultHttpResponse.java
@@ -25,7 +25,7 @@ class DefaultHttpResponse extends BaseHttpMessage implements HttpResponse {
 
   DefaultHttpResponse(ResponseStatus responseStatus, MultiMap<String, String> headers, HttpEntity body) {
     this.responseStatus = responseStatus;
-    this.headers = headers;
+    this.headers = headers != null ? headers.toImmutableMultiMap() : null;
     this.body = body;
   }
 
@@ -49,8 +49,9 @@ class DefaultHttpResponse extends BaseHttpMessage implements HttpResponse {
     return headers.getAll(headerName);
   }
 
+  @Override
   public MultiMap<String, String> getHeaders() {
-    return headers.toImmutableMultiMap();
+    return headers;
   }
 
   @Override

--- a/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/ByteArrayHttpEntityTestCase.java
+++ b/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/ByteArrayHttpEntityTestCase.java
@@ -10,15 +10,15 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mule.runtime.api.util.IOUtils.toByteArray;
 import static org.mule.test.allure.AllureConstants.HttpFeature.HTTP_SERVICE;
 
-import org.mule.runtime.api.util.IOUtils;
+import org.junit.Test;
 
 import java.io.IOException;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
-import org.junit.Test;
 
 @Feature(HTTP_SERVICE)
 @Story("Entities")
@@ -44,8 +44,8 @@ public class ByteArrayHttpEntityTestCase {
 
   @Test
   public void providesNewStream() throws IOException {
-    assertThat(IOUtils.toByteArray(entity.getContent()), equalTo(content));
-    assertThat(IOUtils.toByteArray(entity.getContent()), equalTo(content));
+    assertThat(toByteArray(entity.getContent()), equalTo(content));
+    assertThat(toByteArray(entity.getContent()), equalTo(content));
   }
 
   @Test
@@ -55,7 +55,7 @@ public class ByteArrayHttpEntityTestCase {
 
   @Test
   public void providesSize() {
-    assertThat(entity.getLength().get(), is((long) content.length));
+    assertThat(entity.getBytesLength().getAsLong(), is((long) content.length));
   }
 
 }

--- a/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/EmptyHttpEntityTestCase.java
+++ b/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/EmptyHttpEntityTestCase.java
@@ -11,9 +11,10 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.test.allure.AllureConstants.HttpFeature.HTTP_SERVICE;
 
+import org.junit.Test;
+
 import java.io.IOException;
 
-import org.junit.Test;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -51,7 +52,7 @@ public class EmptyHttpEntityTestCase {
 
   @Test
   public void hasZeroSize() {
-    assertThat(entity.getLength().get(), is(0L));
+    assertThat(entity.getBytesLength().getAsLong(), is(0L));
   }
 
 }

--- a/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/InputStreamHttpEntityTestCase.java
+++ b/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/InputStreamHttpEntityTestCase.java
@@ -14,11 +14,12 @@ import static org.mule.test.allure.AllureConstants.HttpFeature.HTTP_SERVICE;
 
 import org.mule.runtime.api.util.IOUtils;
 
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Test;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -75,9 +76,9 @@ public class InputStreamHttpEntityTestCase {
 
   @Test
   public void hasNoSizeUnlessSpecified() {
-    assertThat(entity.getLength().isPresent(), is(false));
+    assertThat(entity.getBytesLength().isPresent(), is(false));
     HttpEntity specifiedEntity = new InputStreamHttpEntity(new ByteArrayInputStream("TEST".getBytes()), 4L);
-    assertThat(specifiedEntity.getLength().get(), is(4L));
+    assertThat(specifiedEntity.getBytesLength().getAsLong(), is(4L));
   }
 
 }

--- a/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/multipart/MultipartHttpEntityTestCase.java
+++ b/modules/http-api/src/test/java/org/mule/runtime/http/api/domain/entity/multipart/MultipartHttpEntityTestCase.java
@@ -13,13 +13,15 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mule.test.allure.AllureConstants.HttpFeature.HTTP_SERVICE;
+
 import org.mule.runtime.http.api.domain.entity.HttpEntity;
+
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 
@@ -61,7 +63,7 @@ public class MultipartHttpEntityTestCase {
 
   @Test
   public void hasNoSize() {
-    assertThat(entity.getLength().isPresent(), is(false));
+    assertThat(entity.getBytesLength().isPresent(), is(false));
   }
 
 }

--- a/tests/performance/src/main/java/org/mule/UUIDBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/UUIDBenchmark.java
@@ -10,7 +10,6 @@ import static org.mule.runtime.core.api.util.UUID.getClusterUUID;
 import static org.mule.runtime.core.api.util.UUID.getUUID;
 
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.core.api.util.UUID;
 
 import org.openjdk.jmh.annotations.Benchmark;
 
@@ -26,8 +25,17 @@ public class UUIDBenchmark extends AbstractBenchmark {
     return getClusterUUID(getClusterId());
   }
 
+  @Benchmark
+  public String clusterUUIDPrefix() throws MuleException {
+    return getClusterUUID(getClusterIdPrefix());
+  }
+
   private int getClusterId() {
     return 1;
+  }
+
+  private String getClusterIdPrefix() {
+    return "1-";
   }
 
 }


### PR DESCRIPTION
- Avoid creating reactor `Flux` for a no-op
- Prevent copying variables map in event it is hasn’t changed
- Minor improvement in event id generation
- Do not calculate stacktrace when throwing a `FlowBackPressureException `
- Avoid copying the annotations of the flow for every execution
- Do not lo already handled errors in policies
- Use caffeine in `CursorManager`
- Minor improvement in DataType calculation when leaving an operation
- Use `OptionalLong` instead of `Optional<Long>` for http entities length
