### PR TITLE
MULE-15493: OAuth2 Request config always fetches token at startup

### DIFF
--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/OAuthTokenMuleException.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/OAuthTokenMuleException.java
@@ -13,12 +13,12 @@ import org.mule.api.DefaultMuleException;
  * 
  * @since 3.10
  */
-public class OAuthTokenMuleExeption extends DefaultMuleException
+public class OAuthTokenMuleException extends DefaultMuleException
 {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 4742375792184017374L;
 
-    public OAuthTokenMuleExeption(Throwable cause)
+    public OAuthTokenMuleException(Throwable cause)
     {
         super(cause);
     }

--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/OAuthTokenMuleExeption.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/OAuthTokenMuleExeption.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.oauth2.internal;
+
+import org.mule.api.DefaultMuleException;
+
+/**
+ * Standard exception wrapper for token response processing problems. 
+ * 
+ * @since 3.10
+ */
+public class OAuthTokenMuleExeption extends DefaultMuleException
+{
+
+    private static final long serialVersionUID = 1L;
+
+    public OAuthTokenMuleExeption(Throwable cause)
+    {
+        super(cause);
+    }
+
+}

--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsGrantType.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsGrantType.java
@@ -22,7 +22,7 @@ import org.mule.module.http.api.HttpHeaders;
 import org.mule.module.http.internal.domain.request.HttpRequestBuilder;
 import org.mule.module.oauth2.api.RequestAuthenticationException;
 import org.mule.module.oauth2.internal.AbstractGrantType;
-import org.mule.module.oauth2.internal.OAuthTokenMuleExeption;
+import org.mule.module.oauth2.internal.OAuthTokenMuleException;
 import org.mule.module.oauth2.internal.authorizationcode.state.ResourceOwnerOAuthContext;
 import org.mule.module.oauth2.internal.tokenmanager.TokenManagerConfig;
 
@@ -49,7 +49,7 @@ public class ClientCredentialsGrantType extends AbstractGrantType implements Ini
             tokenRequestHandler.refreshAccessToken();
             accessTokenRefreshedOnStart = true;
         }
-        catch(OAuthTokenMuleExeption e)
+        catch(OAuthTokenMuleException e)
         {
             throw e;
         }

--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsGrantType.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsGrantType.java
@@ -22,6 +22,7 @@ import org.mule.module.http.api.HttpHeaders;
 import org.mule.module.http.internal.domain.request.HttpRequestBuilder;
 import org.mule.module.oauth2.api.RequestAuthenticationException;
 import org.mule.module.oauth2.internal.AbstractGrantType;
+import org.mule.module.oauth2.internal.OAuthTokenMuleExeption;
 import org.mule.module.oauth2.internal.authorizationcode.state.ResourceOwnerOAuthContext;
 import org.mule.module.oauth2.internal.tokenmanager.TokenManagerConfig;
 
@@ -47,6 +48,10 @@ public class ClientCredentialsGrantType extends AbstractGrantType implements Ini
         try {
             tokenRequestHandler.refreshAccessToken();
             accessTokenRefreshedOnStart = true;
+        }
+        catch(OAuthTokenMuleExeption e)
+        {
+            throw e;
         }
         catch (MessagingException | DefaultMuleException e)
         {

--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsTokenRequestHandler.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsTokenRequestHandler.java
@@ -21,6 +21,7 @@ import org.mule.module.oauth2.internal.AbstractTokenRequestHandler;
 import org.mule.module.oauth2.internal.ApplicationCredentials;
 import org.mule.module.oauth2.internal.MuleEventLogger;
 import org.mule.module.oauth2.internal.OAuthConstants;
+import org.mule.module.oauth2.internal.OAuthTokenMuleExeption;
 import org.mule.module.oauth2.internal.TokenNotFoundException;
 import org.mule.module.oauth2.internal.TokenResponseProcessor;
 import org.mule.module.oauth2.internal.authorizationcode.TokenResponseConfiguration;
@@ -155,13 +156,13 @@ public class ClientCredentialsTokenRequestHandler extends AbstractTokenRequestHa
             logger.error(String.format("Could not extract access token or refresh token from token URL. Access token is %s, Refresh token is %s",
                                        e.getTokenResponseProcessor().getAccessToken(), e.getTokenResponseProcessor().getRefreshToken()));
             muleEventLogger.logContent(e.getTokenUrlResponse());
-            throw new DefaultMuleException(e);
+            throw new OAuthTokenMuleExeption(e);
         }
         catch (TokenUrlResponseException e)
         {
             logger.error((String.format("HTTP response from token URL %s returned a failure status code", getTokenUrl())));
             muleEventLogger.logContent(e.getTokenUrlResponse());
-            throw new DefaultMuleException(e);
+            throw new OAuthTokenMuleExeption(e);
         }
     }
 

--- a/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsTokenRequestHandler.java
+++ b/modules/oauth/src/main/java/org/mule/module/oauth2/internal/clientcredentials/ClientCredentialsTokenRequestHandler.java
@@ -21,7 +21,7 @@ import org.mule.module.oauth2.internal.AbstractTokenRequestHandler;
 import org.mule.module.oauth2.internal.ApplicationCredentials;
 import org.mule.module.oauth2.internal.MuleEventLogger;
 import org.mule.module.oauth2.internal.OAuthConstants;
-import org.mule.module.oauth2.internal.OAuthTokenMuleExeption;
+import org.mule.module.oauth2.internal.OAuthTokenMuleException;
 import org.mule.module.oauth2.internal.TokenNotFoundException;
 import org.mule.module.oauth2.internal.TokenResponseProcessor;
 import org.mule.module.oauth2.internal.authorizationcode.TokenResponseConfiguration;
@@ -156,13 +156,13 @@ public class ClientCredentialsTokenRequestHandler extends AbstractTokenRequestHa
             logger.error(String.format("Could not extract access token or refresh token from token URL. Access token is %s, Refresh token is %s",
                                        e.getTokenResponseProcessor().getAccessToken(), e.getTokenResponseProcessor().getRefreshToken()));
             muleEventLogger.logContent(e.getTokenUrlResponse());
-            throw new OAuthTokenMuleExeption(e);
+            throw new OAuthTokenMuleException(e);
         }
         catch (TokenUrlResponseException e)
         {
             logger.error((String.format("HTTP response from token URL %s returned a failure status code", getTokenUrl())));
             muleEventLogger.logContent(e.getTokenUrlResponse());
-            throw new OAuthTokenMuleExeption(e);
+            throw new OAuthTokenMuleException(e);
         }
     }
 

--- a/modules/oauth/src/test/java/org/mule/module/oauth2/internal/clientcredentials/functional/ClientCredentialsFailureTestCase.java
+++ b/modules/oauth/src/test/java/org/mule/module/oauth2/internal/clientcredentials/functional/ClientCredentialsFailureTestCase.java
@@ -85,16 +85,8 @@ public class ClientCredentialsFailureTestCase extends AbstractMuleTestCase
             public void run() throws Exception
             {
                 ApplicationContextBuilder applicationContextBuilder = new ApplicationContextBuilder().setApplicationResources(new String[] {"client-credentials/client-credentials-minimal-config.xml"});
-                MuleContext muleContext = applicationContextBuilder.build();
-
-                try
-                {
-                    ((Flow)(muleContext.getRegistry().lookupFlowConstruct("testFlow"))).process(MuleTestUtils.getTestEvent("", muleContext));
-                    fail();
-                }
-                catch (Exception e) {
-                    assertThat(e.getCause().getCause(), instanceOf(TokenNotFoundException.class));
-                }
+                expectedException.expectCause(isA(TokenNotFoundException.class));
+                applicationContextBuilder.build();
             }
         });
     }


### PR DESCRIPTION
Addendum: Only continue deployment for connectivity/networking errors, not for errors generated by the token server