### PR TITLE
MULE-15686: Fix Aggregators tests in Windows

### DIFF
--- a/tests/component-plugin/src/main/java/org/mule/functional/api/component/AbstractLogChecker.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/component/AbstractLogChecker.java
@@ -77,7 +77,9 @@ public abstract class AbstractLogChecker implements LogChecker {
   }
 
   protected List<String> splitLines(String wholeMessage) {
-    return asList(wholeMessage.split(lineSeparator()));
+    // The following approach is required until the usage of line separators get fixed at
+    // org.mule.runtime.api.exception.MuleException#getSummaryMessage. More info at: MULE-15932
+    return asList(wholeMessage.replaceAll("\r", "").split("\n"));
   }
 
   protected <T> boolean assertAndSaveError(T checkedValue, Matcher<T> comparison, String failureMessagePrefix,


### PR DESCRIPTION
- Workaround for overcoming issues with mixed line separators on MuleException's SummaryMessage.
 - Related to also to: MULE-15932