### PR TITLE
MULE-15987: Incomplete Multipart request should return 400 instead of 500.

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
@@ -104,9 +104,9 @@ public class HttpRequestToMuleEvent
             }
             catch (MuleRuntimeException e)
             {
-                //If this point is reached, it can only be because a multipart
-                //content type request was received and failure occurred while
-                //attempting to parse its contents.
+                //Because request.getEntity() will attempt to lazily parse
+                //multipart request payloads, if this point is reached it can
+                //only be because an error occurred at the parsing stage.
                 throw new HttpRequestParsingException("Unable to parse multipart payload", e);
             }
             if (entity != null && !(entity instanceof EmptyHttpEntity))

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
@@ -18,10 +18,12 @@ import static org.mule.module.http.internal.HttpParser.decodeUrlEncodedBody;
 import static org.mule.module.http.internal.domain.HttpProtocol.HTTP_0_9;
 import static org.mule.module.http.internal.domain.HttpProtocol.HTTP_1_0;
 import static org.mule.module.http.internal.multipart.HttpPartDataSource.createDataHandlerFrom;
+
 import org.mule.DefaultMuleEvent;
 import org.mule.DefaultMuleMessage;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
+import org.mule.api.MuleRuntimeException;
 import org.mule.api.construct.FlowConstruct;
 import org.mule.endpoint.URIBuilder;
 import org.mule.module.http.api.HttpHeaders;
@@ -95,7 +97,15 @@ public class HttpRequestToMuleEvent
         Object payload = NullPayload.getInstance();
         if (parseRequest)
         {
-            final HttpEntity entity = request.getEntity();
+            final HttpEntity entity;
+            try
+            {
+                entity = request.getEntity();
+            }
+            catch (MuleRuntimeException e)
+            {
+                throw new HttpRequestParsingException("Unable to parse request multitype content!",e);
+            }
             if (entity != null && !(entity instanceof EmptyHttpEntity))
             {
                 if (entity instanceof MultipartHttpEntity)

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
@@ -104,8 +104,9 @@ public class HttpRequestToMuleEvent
             }
             catch (MuleRuntimeException e)
             {
-                //Catch generic MuleRuntimeException, but this will only be raised if internal parsing for multipart
-                //content failed at getEntity(). Throw specific HttpRequestParsingException:
+                //If this point is reached, it can only be because a multipart
+                //content type request was received and failure occurred while
+                //attempting to parse its contents.
                 throw new HttpRequestParsingException("Unable to parse multipart payload", e);
             }
             if (entity != null && !(entity instanceof EmptyHttpEntity))

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
@@ -104,7 +104,9 @@ public class HttpRequestToMuleEvent
             }
             catch (MuleRuntimeException e)
             {
-                throw new HttpRequestParsingException("Unable to parse request multitype content!",e);
+                //Catch generic MuleRuntimeException, but this will only be raised if internal parsing for multipart
+                //content failed at getEntity(). Throw specific HttpRequestParsingException:
+                throw new HttpRequestParsingException("Unable to parse multipart payload", e);
             }
             if (entity != null && !(entity instanceof EmptyHttpEntity))
             {

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerIncompleteMultipartRequestTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerIncompleteMultipartRequestTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.http.functional.listener;
+
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mule.module.http.api.HttpConstants.HttpStatus;
+import static org.mule.module.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
+import static org.mule.module.http.api.HttpConstants.HttpStatus.OK;
+
+import org.mule.util.IOUtils;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.fluent.Request;
+
+public class HttpListenerIncompleteMultipartRequestTestCase extends FunctionalTestCase
+{
+    private static final String END_LINE = System.lineSeparator();
+    private static final String CONTENT_TYPE_HEADER = "Content-Type";
+    private static final String CONTENT_TYPE_MULTIPART = "multipart/form-data";
+    private static final String PART_HEADER = "Content-Disposition: form-data; name=\"field2\"";
+    private static final String BOUNDARY_DEF = "boundary=\"BOUNDARY\"";
+    private static final String BOUNDARY_START = "--BOUNDARY";
+    private static final String BOUNDARY_END = "--BOUNDARY--";
+    private static final String TEST_EMAIL = "api/email";
+
+    @Rule
+    public DynamicPort httpPort = new DynamicPort("httpPort");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-listener-incomplete-multipart-config.xml";
+    }
+
+    @Test
+    public void returnsOKOnMultipartFormDataWithBoundaryStartAndEnd() throws Exception
+    {
+        String payload = "value1";
+        String body = BOUNDARY_START + END_LINE + PART_HEADER + END_LINE + END_LINE + payload + END_LINE + BOUNDARY_END;
+        sendPostByteArrayRequestAndValidateStatusCode(body, OK, "", payload);
+    }
+
+    @Test
+    public void returnsBadRequestOnMultipartFormDataWithNoBoundariesAndNoValue() throws Exception
+    {
+        String body = "emptyContent=";
+        sendPostByteArrayRequestAndValidateStatusCode(body, BAD_REQUEST, BAD_REQUEST.getReasonPhrase(),"HTTP request parsing failed with error: \"Unable to parse request multitype content!\"");
+    }
+
+    protected String getUrl(String path)
+    {
+        return format("http://localhost:%s/%s", httpPort.getValue(),path);
+    }
+
+    protected void sendPostByteArrayRequestAndValidateStatusCode(String body, HttpStatus status, String msg, String payload) throws IOException
+    {
+        Request request = Request.Post(getUrl(TEST_EMAIL));
+        request.addHeader(CONTENT_TYPE_HEADER, CONTENT_TYPE_MULTIPART + ";" + BOUNDARY_DEF);
+        request.bodyByteArray(body.getBytes());
+
+        HttpResponse response = request.execute().returnResponse();
+        StatusLine statusLine = response.getStatusLine();
+
+        assertThat(statusLine.getStatusCode(), is(status.getStatusCode()));
+        assertThat(statusLine.getReasonPhrase(), containsString(msg));
+        assertThat(IOUtils.toString(response.getEntity().getContent()), containsString(payload));
+    }
+
+}

--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerIncompleteMultipartRequestTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerIncompleteMultipartRequestTestCase.java
@@ -58,7 +58,7 @@ public class HttpListenerIncompleteMultipartRequestTestCase extends FunctionalTe
     public void returnsBadRequestOnMultipartFormDataWithNoBoundariesAndNoValue() throws Exception
     {
         String body = "emptyContent=";
-        sendPostByteArrayRequestAndValidateStatusCode(body, BAD_REQUEST, BAD_REQUEST.getReasonPhrase(),"HTTP request parsing failed with error: \"Unable to parse request multitype content!\"");
+        sendPostByteArrayRequestAndValidateStatusCode(body, BAD_REQUEST, BAD_REQUEST.getReasonPhrase(),"HTTP request parsing failed with error: \"Unable to parse multipart payload\"");
     }
 
     protected String getUrl(String path)

--- a/modules/http/src/test/resources/http-listener-incomplete-multipart-config.xml
+++ b/modules/http/src/test/resources/http-listener-incomplete-multipart-config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+<http:listener-config name="httpConf" host="localhost" port="${httpPort}"/>
+
+<flow name="listenerAll" >
+    <http:listener config-ref="httpConf" path="/api/email" allowedMethods="POST"/>
+    <set-payload value="#[message.inboundAttachments.field2]" mimeType="text/plain" encoding="UTF-8"/>
+</flow>
+</mule>


### PR DESCRIPTION
MULE-15987: When a request with Content-Type: multipart/form-data and a parameter with no value is sent, the HTTP Listener returns a 500 error instead of a 400 error (should return invalid request as the request is not complete).