### PR TITLE
MULE-15989: Remove overhead in `target` processing on operations

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
@@ -24,6 +24,7 @@ import static org.mule.runtime.extension.api.values.ValueResolvingException.UNKN
 import static org.mule.runtime.module.extension.api.util.MuleExtensionUtils.getInitialiserEvent;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.getClassLoader;
 import static org.mule.runtime.module.extension.internal.value.ValueProviderUtils.getValueProviderModels;
+
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
@@ -50,6 +51,7 @@ import org.mule.runtime.api.util.LazyValue;
 import org.mule.runtime.api.value.Value;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.context.MuleContextAware;
+import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.core.api.streaming.CursorProviderFactory;
@@ -81,6 +83,9 @@ import org.mule.runtime.module.extension.internal.runtime.source.ExtensionMessag
 import org.mule.runtime.module.extension.internal.util.ReflectionCache;
 import org.mule.runtime.module.extension.internal.value.ValueProviderMediator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -88,9 +93,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import javax.inject.Inject;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class that groups all the common behaviour between different extension's components, like {@link OperationMessageProcessor} and
@@ -121,6 +123,9 @@ public abstract class ExtensionComponent<T extends ComponentModel> extends Abstr
   protected CursorProviderFactory cursorProviderFactory;
 
   protected MuleContext muleContext;
+
+  @Inject
+  protected ExpressionManager expressionManager;
 
   @Inject
   protected ConnectionManagerAdapter connectionManager;

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -37,6 +37,7 @@ import static reactor.core.publisher.Flux.error;
 import static reactor.core.publisher.Flux.from;
 import static reactor.core.publisher.Mono.fromCallable;
 import static reactor.core.publisher.Mono.subscriberContext;
+
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.DefaultMuleException;
@@ -87,6 +88,9 @@ import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolver
 import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolvingContext;
 import org.mule.runtime.module.extension.internal.util.ReflectionCache;
 
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
@@ -95,8 +99,6 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
@@ -389,7 +391,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
 
   protected TargetReturnDelegate getTargetReturnDelegate() {
-    return new TargetReturnDelegate(target, targetValue, componentModel, cursorProviderFactory, muleContext);
+    return new TargetReturnDelegate(target, targetValue, componentModel, expressionManager, cursorProviderFactory, muleContext);
   }
 
   protected ValueReturnDelegate getValueReturnDelegate() {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetReturnDelegate.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetReturnDelegate.java
@@ -12,6 +12,7 @@ import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.streaming.CursorProviderFactory;
 import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextAdapter;
@@ -28,6 +29,8 @@ import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContext
  */
 final class TargetReturnDelegate extends AbstractReturnDelegate {
 
+  private final ExpressionManager expressionManager;
+
   private final String target;
   private final String targetValue;
 
@@ -39,18 +42,19 @@ final class TargetReturnDelegate extends AbstractReturnDelegate {
   TargetReturnDelegate(String target,
                        String targetValue,
                        ComponentModel componentModel,
+                       ExpressionManager expressionManager,
                        CursorProviderFactory cursorProviderFactory,
                        MuleContext muleContext) {
     super(componentModel, cursorProviderFactory, muleContext);
+    this.expressionManager = expressionManager;
     this.target = target;
     this.targetValue = targetValue;
   }
 
   @Override
   public CoreEvent asReturnValue(Object value, ExecutionContextAdapter operationContext) {
-    TypedValue result =
-        operationContext.getMuleContext().getExpressionManager()
-            .evaluate(targetValue, getTargetBindingContext(toMessage(value, operationContext)));
+    TypedValue result = expressionManager
+        .evaluate(targetValue, getTargetBindingContext(toMessage(value, operationContext)));
     return CoreEvent.builder(operationContext.getEvent())
         .securityContext(operationContext.getSecurityContext())
         .addVariable(this.target, result.getValue(), result.getDataType())

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/resulthandler/CollectionReturnHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/resulthandler/CollectionReturnHandler.java
@@ -13,6 +13,7 @@ import org.mule.metadata.api.model.MetadataType;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.CollectionDataType;
 import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.util.Preconditions;
 
 import java.util.Collection;
@@ -39,7 +40,7 @@ public final class CollectionReturnHandler implements ReturnHandler<Collection> 
    */
   @Override
   public Message.Builder toMessageBuilder(Collection value) {
-    return Message.builder().collectionValue(value, dataType.getItemDataType().getType());
+    return Message.builder().payload(new TypedValue<>(value, getDataType()));
   }
 
   /**

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/resulthandler/MapReturnHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/resulthandler/MapReturnHandler.java
@@ -14,6 +14,7 @@ import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.meta.model.HasOutputModel;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.MapDataType;
+import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.util.Preconditions;
 
 import java.util.Map;
@@ -28,28 +29,26 @@ import java.util.Map;
  */
 public final class MapReturnHandler implements ReturnHandler<Map> {
 
-  private final Class<?> mapKeyType;
-  private final Class<?> mapValueType;
   private final MapDataType mapDataType;
 
   public MapReturnHandler(HasOutputModel hasOutputModel) {
     MetadataType type = hasOutputModel.getOutput().getType();
     Preconditions.checkArgument(isMap(type), "The given output type is not a Map");
     mapDataType = (MapDataType) toDataType(type);
-    mapKeyType = mapDataType.getKeyDataType().getType();
-    mapValueType = mapDataType.getValueDataType().getType();
   }
 
   /**
    * {@inheritDoc}
    */
+  @Override
   public Message.Builder toMessageBuilder(Map value) {
-    return Message.builder().mapValue(value, mapKeyType, mapValueType);
+    return Message.builder().payload(new TypedValue<>(value, getDataType()));
   }
 
   /**
    * {@inheritDoc}
    */
+  @Override
   public DataType getDataType() {
     return mapDataType;
   }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetOutputMessageReturnDelegateTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetOutputMessageReturnDelegateTestCase.java
@@ -17,10 +17,12 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_JSON;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.getDefaultCursorStreamProviderFactory;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.metadata.MediaType;
+import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.streaming.StreamingManager;
 import org.mule.runtime.extension.api.runtime.operation.Result;
@@ -29,19 +31,21 @@ import org.mule.runtime.module.extension.internal.loader.java.property.MediaType
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
-import java.nio.charset.Charset;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.nio.charset.Charset;
+
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
 public class TargetOutputMessageReturnDelegateTestCase extends AbstractMuleContextTestCase {
 
   private static final String TARGET = "myFlowVar";
+
+  private ExpressionManager expressionManager;
 
   @Mock
   protected ExecutionContextAdapter operationContext;
@@ -62,6 +66,7 @@ public class TargetOutputMessageReturnDelegateTestCase extends AbstractMuleConte
 
   @Before
   public void before() throws MuleException {
+    expressionManager = muleContext.getExpressionManager();
     event = eventBuilder(muleContext).message(Message.builder().value("").attributesValue(attributes).build()).build();
     when(operationContext.getEvent()).thenReturn(event);
     when(operationContext.getMuleContext()).thenReturn(muleContext);
@@ -69,7 +74,8 @@ public class TargetOutputMessageReturnDelegateTestCase extends AbstractMuleConte
   }
 
   private TargetReturnDelegate createDelegate(String expression) {
-    return new TargetReturnDelegate(TARGET, expression, componentModel, getDefaultCursorStreamProviderFactory(), muleContext);
+    return new TargetReturnDelegate(TARGET, expression, componentModel, expressionManager,
+                                    getDefaultCursorStreamProviderFactory(), muleContext);
   }
 
   @Test

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetReturnDelegateTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetReturnDelegateTestCase.java
@@ -9,7 +9,7 @@ package org.mule.runtime.module.extension.internal.runtime.operation;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.getDefaultCursorStreamProviderFactory;
+
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.tck.size.SmallTest;
@@ -26,7 +26,9 @@ public class TargetReturnDelegateTestCase extends ValueReturnDelegateTestCase {
 
   @Override
   protected ReturnDelegate createReturnDelegate() {
-    return new TargetReturnDelegate(TARGET, "#[message]", componentModel, getCursorProviderFactory(), muleContext);
+    return new TargetReturnDelegate(TARGET, "#[message]", componentModel, muleContext.getExpressionManager(),
+                                    getCursorProviderFactory(),
+                                    muleContext);
   }
 
   @After


### PR DESCRIPTION
This accounts for around 3-4% of all the cpu usage in the CPU-LITE threads for the high-concurrency proxy scenario