### PR TITLE
MULE-15904: Allow to discover mule services from a particular folder …

### DIFF
--- a/modules/service/src/main/java/org/mule/runtime/module/service/internal/discoverer/FileSystemServiceProviderDiscoverer.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/internal/discoverer/FileSystemServiceProviderDiscoverer.java
@@ -119,10 +119,11 @@ public class FileSystemServiceProviderDiscoverer implements ServiceProviderDisco
   private List<ServiceDescriptor> getServiceDescriptors(ServiceDescriptorFactory serviceDescriptorFactory)
       throws ServiceResolutionError {
     List<ServiceDescriptor> foundServices = new LinkedList<>();
-    for (String serviceFile : this.targetServicesFolder.get().list(new SuffixFileFilter(".jar"))) {
+    File servicesFolter = this.targetServicesFolder.get();
+    for (String serviceFile : servicesFolter.list(new SuffixFileFilter(".jar"))) {
       final File tempFolder = new File(getServicesTempFolder(), getBaseName(serviceFile));
       try {
-        unzip(new File(getServicesFolder(), serviceFile), tempFolder);
+        unzip(new File(servicesFolter, serviceFile), tempFolder);
       } catch (IOException e) {
         throw new ServiceResolutionError("Error processing service JAR file", e);
       }


### PR DESCRIPTION
…location - Remove usage of services folder from static helper class

When cherry-pick was made I didn't realize that the code on 4.1.x was a bit different and the static method was still used to get the folder assuming that it is running always in Standalone.