### PR TITLE
MULE-16101: Miscellaneous performance improvements

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/streaming/DefaultStreamingManager.java
+++ b/core/src/main/java/org/mule/runtime/core/api/streaming/DefaultStreamingManager.java
@@ -52,7 +52,6 @@ public class DefaultStreamingManager implements StreamingManager, Initialisable,
   private boolean initialised = false;
 
   private Scheduler allocationScheduler;
-  private Scheduler disposalScheduler;
 
   @Inject
   private MuleContext muleContext;
@@ -69,9 +68,7 @@ public class DefaultStreamingManager implements StreamingManager, Initialisable,
       statistics = new MutableStreamingStatistics();
       allocationScheduler =
           schedulerService.ioScheduler(muleContext.getSchedulerBaseConfig().withName("StreamingManager-allocate"));
-      disposalScheduler =
-          schedulerService.cpuIntensiveScheduler(muleContext.getSchedulerBaseConfig().withName("StreamingManager-dispose"));
-      cursorManager = new CursorManager(statistics, disposalScheduler);
+      cursorManager = new CursorManager(statistics);
       bufferManager = new PoolingByteBufferManager(allocationScheduler);
       byteStreamingManager = createByteStreamingManager();
       objectStreamingManager = createObjectStreamingManager();
@@ -99,7 +96,6 @@ public class DefaultStreamingManager implements StreamingManager, Initialisable,
     disposeIfNeeded(objectStreamingManager, LOGGER);
     disposeIfNeeded(bufferManager, LOGGER);
     disposeIfNeeded(cursorManager, LOGGER);
-    disposalScheduler.stop();
     allocationScheduler.stop();
 
     initialised = false;

--- a/core/src/main/java/org/mule/runtime/core/api/streaming/bytes/factory/InMemoryCursorStreamProviderFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/api/streaming/bytes/factory/InMemoryCursorStreamProviderFactory.java
@@ -58,9 +58,6 @@ public class InMemoryCursorStreamProviderFactory extends AbstractCursorStreamPro
   }
 
   private Object doResolve(InputStream inputStream) {
-    InMemoryCursorStreamProvider inMemoryCursorStreamProvider =
-        new InMemoryCursorStreamProvider(inputStream, config, getBufferManager());
-    inMemoryCursorStreamProvider.setAnnotations(getAnnotations());
-    return inMemoryCursorStreamProvider;
+    return new InMemoryCursorStreamProvider(inputStream, config, getBufferManager());
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/object/AbstractCursorIteratorProvider.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/object/AbstractCursorIteratorProvider.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.core.internal.streaming.object;
 
 import static org.mule.runtime.api.util.Preconditions.checkState;
-import org.mule.runtime.api.component.AbstractComponent;
+
 import org.mule.runtime.api.streaming.object.CursorIterator;
 import org.mule.runtime.api.streaming.object.CursorIteratorProvider;
 
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @since 4.0
  */
-public abstract class AbstractCursorIteratorProvider extends AbstractComponent implements CursorIteratorProvider {
+public abstract class AbstractCursorIteratorProvider implements CursorIteratorProvider {
 
   protected final Iterator stream;
   private final AtomicBoolean closed = new AtomicBoolean(false);

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/object/factory/AbstractCursorIteratorProviderFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/object/factory/AbstractCursorIteratorProviderFactory.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.core.internal.streaming.object.factory;
 
-import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.event.EventContext;
 import org.mule.runtime.api.streaming.CursorProvider;
 import org.mule.runtime.api.streaming.object.CursorIterator;
@@ -27,8 +26,7 @@ import java.util.Iterator;
  *
  * @since 4.0
  */
-public abstract class AbstractCursorIteratorProviderFactory extends AbstractComponent
-    implements CursorIteratorProviderFactory {
+public abstract class AbstractCursorIteratorProviderFactory implements CursorIteratorProviderFactory {
 
   private final StreamingManager streamingManager;
 

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/object/factory/InMemoryCursorIteratorProviderFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/object/factory/InMemoryCursorIteratorProviderFactory.java
@@ -36,8 +36,6 @@ public class InMemoryCursorIteratorProviderFactory extends AbstractCursorIterato
    */
   @Override
   protected Object resolve(Iterator iterator, EventContext eventContext) {
-    InMemoryCursorIteratorProvider inMemoryCursorIteratorProvider = new InMemoryCursorIteratorProvider(iterator, config);
-    inMemoryCursorIteratorProvider.setAnnotations(getAnnotations());
-    return inMemoryCursorIteratorProvider;
+    return new InMemoryCursorIteratorProvider(iterator, config);
   }
 }


### PR DESCRIPTION
* Remove annotated support from streaming objects
* Use `Caffeine` for caching the cursors. Caffeine uses the ForkJoin pool for doing expiration stuff, so no need to pass a CpuIntensive scheduler for that now.