### PR TITLE
MULE-16009: Jenkins Migration Phase 1 3.x: Migrate Mule projects (#7453)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-def UPSTREAM_PROJECTS_LIST = ["Mule-runtime/mule-common/3.7.x"]
+def UPSTREAM_PROJECTS_LIST = ["Mule-runtime/mule-common/3.5.x"]
 
 Map pipelineParams = ["upstreamProjects"   : UPSTREAM_PROJECTS_LIST.join(','),
                       "mavenTool"          : "M3",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,8 @@ def UPSTREAM_PROJECTS_LIST = ["Mule-runtime/mule-common/3.7.x"]
 
 Map pipelineParams = ["upstreamProjects"   : UPSTREAM_PROJECTS_LIST.join(','),
                       "mavenTool"          : "M3",
-                      "jdkTool"            : "JDK7",
                       "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
-                      "mavenAdditionalArgs": "-P distributions,release -DskipGpg  -DxDocLint='-Xdoclint:none' -DskipNoSnapshotsEnforcerPluginRule -Djava.net.preferIPv4Stack -T 2",
+                      "mavenAdditionalArgs": "-P distributions,release,jdk7 -DskipGpg  -DxDocLint='-Xdoclint:none' -DskipNoSnapshotsEnforcerPluginRule -Djava.net.preferIPv4Stack -T 2",
                       "mavenTestGoal"      : "verify -DskipIntegrationTests=false -DskipTests=false -DskipSystemTests=false -Dsurefire.rerunFailingTestsCount=5 -Dmaven.javadoc.skip -DskipVerifications"]
 
 runtimeProjectsBuild(pipelineParams)

--- a/pom.xml
+++ b/pom.xml
@@ -2169,6 +2169,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <additionalparam>${xDocLint}</additionalparam>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Removing JDK 7 constraint to avoid Allure issues
 - Adding the mechanism to pass doclint arguments as a system property to
   avoid Javadoc generation failures on JDK8