### PR TITLE
MULE-16009: Jenkins Migration Phase 1 3.x: Migrate Mule projects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,11 @@
 def UPSTREAM_PROJECTS_LIST = ["Mule-runtime/mule-common/3.5.x"]
 
-Map pipelineParams = ["upstreamProjects"   : UPSTREAM_PROJECTS_LIST.join(','),
-                      "mavenTool"          : "M3",
-                      "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
-                      "mavenAdditionalArgs": "-P distributions,release,jdk7 -DskipGpg  -DxDocLint='-Xdoclint:none' -DskipNoSnapshotsEnforcerPluginRule -Djava.net.preferIPv4Stack -T 2",
-                      "mavenTestGoal"      : "verify -DskipIntegrationTests=false -DskipTests=false -DskipSystemTests=false -Dsurefire.rerunFailingTestsCount=5 -Dmaven.javadoc.skip -DskipVerifications"]
+Map pipelineParams = ["upstreamProjects"           : UPSTREAM_PROJECTS_LIST.join(','),
+                      "jdkTool"                    : "JDK7",
+                      "enableAllureTestReportStage": false,
+                      "mavenTool"                  : "M3",
+                      "mavenSettingsXmlId"         : "mule-runtime-maven-settings-MuleSettings",
+                      "mavenAdditionalArgs"        : "-P distributions,release,jdk7 -DskipGpg  -DxDocLint='-Xdoclint:none' -DskipNoSnapshotsEnforcerPluginRule -Djava.net.preferIPv4Stack -T 2",
+                      "mavenTestGoal"              : "verify -DskipIntegrationTests=false -DskipTests=false -DskipSystemTests=false -Dsurefire.rerunFailingTestsCount=5 -Dmaven.javadoc.skip -DskipVerifications"]
 
 runtimeProjectsBuild(pipelineParams)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,12 @@ def UPSTREAM_PROJECTS_LIST = ["Mule-runtime/mule-common/3.5.x"]
 
 Map pipelineParams = ["upstreamProjects"           : UPSTREAM_PROJECTS_LIST.join(','),
                       "jdkTool"                    : "JDK7",
-                      "enableAllureTestReportStage": false,
                       "mavenTool"                  : "M3",
+                      "enableAllureTestReportStage": false,
+                      "enableSonarQubeStage"       : false,
+                      "enableNexusIqStage"         : false,
                       "mavenSettingsXmlId"         : "mule-runtime-maven-settings-MuleSettings",
-                      "mavenAdditionalArgs"        : "-P distributions,release,jdk7 -DskipGpg  -DxDocLint='-Xdoclint:none' -DskipNoSnapshotsEnforcerPluginRule -Djava.net.preferIPv4Stack -T 2",
+                      "mavenAdditionalArgs"        : "-P distributions -DskipGpg -Djava.net.preferIPv4Stack",
                       "mavenTestGoal"              : "verify -DskipIntegrationTests=false -DskipTests=false -DskipSystemTests=false -Dsurefire.rerunFailingTestsCount=5 -Dmaven.javadoc.skip -DskipVerifications"]
 
 runtimeProjectsBuild(pipelineParams)


### PR DESCRIPTION
- Removing unnecessary maven args
  - Disabling NexusIq and SonarQube that doesn't work well  on JDK7
  - Downgrading to JDK 7 and disabling Allure stage that doesn't work with
    JDK7