### PR TITLE
MULE-16101: Miscellaneous performance improvements

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamProcessingStrategyTestCase.java
@@ -88,6 +88,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                 () -> cpuLight,
                                                 () -> blocking,
                                                 () -> cpuIntensive,
+                                                () -> custom,
                                                 CORES,
                                                 MAX_VALUE);
   }
@@ -246,6 +247,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                                                              () -> cpuLight,
                                                                                              () -> rejectingSchedulerSpy,
                                                                                              () -> cpuIntensive,
+                                                                                             () -> custom,
                                                                                              1,
                                                                                              2))
         .build();
@@ -275,6 +277,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                                                              () -> cpuLight,
                                                                                              () -> blocking,
                                                                                              () -> rejectingSchedulerSpy,
+                                                                                             () -> custom,
                                                                                              1,
                                                                                              2))
         .build();
@@ -302,6 +305,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                                                              () -> cpuLight,
                                                                                              () -> blocking,
                                                                                              () -> cpuIntensive,
+                                                                                             () -> custom,
                                                                                              CORES,
                                                                                              1)),
                        true, CPU_LITE, 1);
@@ -324,6 +328,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                                                              () -> cpuLight,
                                                                                              () -> blocking,
                                                                                              () -> cpuIntensive,
+                                                                                             () -> custom,
                                                                                              CORES,
                                                                                              2)),
                        true, CPU_LITE, 2);
@@ -347,6 +352,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                                                              () -> cpuLight,
                                                                                              () -> blocking,
                                                                                              () -> cpuIntensive,
+                                                                                             () -> custom,
                                                                                              CORES,
                                                                                              1)),
                        true, BLOCKING, 1);
@@ -369,6 +375,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                                                              () -> cpuLight,
                                                                                              () -> blocking,
                                                                                              () -> cpuIntensive,
+                                                                                             () -> custom,
                                                                                              1,
                                                                                              2)),
                        true, BLOCKING, 2);
@@ -418,6 +425,7 @@ public class ProactorStreamProcessingStrategyTestCase extends AbstractProcessing
                                                                                              () -> cpuLight,
                                                                                              () -> blocking,
                                                                                              () -> cpuIntensive,
+                                                                                             () -> custom,
                                                                                              4,
                                                                                              2))
         .processors(blockingProcessor)

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamProcessingStrategyTestCase.java
@@ -45,6 +45,7 @@ public class TransactionAwareProactorStreamProcessingStrategyTestCase extends Pr
                                                                 () -> cpuLight,
                                                                 () -> blocking,
                                                                 () -> cpuIntensive,
+                                                                () -> custom,
                                                                 MAX_VALUE);
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamProcessingStrategyFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamProcessingStrategyFactory.java
@@ -12,10 +12,6 @@ import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingTy
 import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTransactionActive;
 import static org.mule.runtime.core.internal.processor.strategy.BlockingProcessingStrategyFactory.BLOCKING_PROCESSING_STRATEGY_INSTANCE;
 
-import java.util.concurrent.ExecutorService;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.FlowConstruct;
@@ -25,6 +21,10 @@ import org.mule.runtime.core.api.processor.Sink;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
 import org.mule.runtime.core.internal.processor.strategy.ProactorStreamProcessingStrategyFactory.ProactorStreamProcessingStrategy;
 import org.mule.runtime.core.internal.util.rx.ConditionalExecutorServiceDecorator;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Creates default processing strategy with same behavior as {@link ProactorStreamProcessingStrategyFactory} apart from the fact
@@ -52,6 +52,10 @@ public class TransactionAwareProactorStreamProcessingStrategyFactory extends Rea
                                                                     .cpuIntensiveScheduler(muleContext.getSchedulerBaseConfig()
                                                                         .withName(schedulersNamePrefix + "."
                                                                             + CPU_INTENSIVE.name())),
+                                                                () -> muleContext.getSchedulerService()
+                                                                    .customScheduler(muleContext.getSchedulerBaseConfig()
+                                                                        .withName(schedulersNamePrefix + ".retrySupport")
+                                                                        .withMaxConcurrentTasks(CORES)),
                                                                 getMaxConcurrency(),
                                                                 muleContext.getConfiguration().isThreadLoggingEnabled());
   }
@@ -70,11 +74,13 @@ public class TransactionAwareProactorStreamProcessingStrategyFactory extends Rea
                                                      Supplier<Scheduler> cpuLightSchedulerSupplier,
                                                      Supplier<Scheduler> blockingSchedulerSupplier,
                                                      Supplier<Scheduler> cpuIntensiveSchedulerSupplier,
+                                                     Supplier<Scheduler> retrySupportSchedulerSupplier,
                                                      int maxConcurrency, boolean isThreadLoggingEnabled)
 
     {
       super(ringBufferSchedulerSupplier, bufferSize, subscriberCount, waitStrategy, cpuLightSchedulerSupplier,
-            blockingSchedulerSupplier, cpuIntensiveSchedulerSupplier, CORES, maxConcurrency, isThreadLoggingEnabled);
+            blockingSchedulerSupplier, cpuIntensiveSchedulerSupplier, retrySupportSchedulerSupplier, CORES, maxConcurrency,
+            isThreadLoggingEnabled);
     }
 
     TransactionAwareProactorStreamProcessingStrategy(Supplier<Scheduler> ringBufferSchedulerSupplier,
@@ -84,11 +90,12 @@ public class TransactionAwareProactorStreamProcessingStrategyFactory extends Rea
                                                      Supplier<Scheduler> cpuLightSchedulerSupplier,
                                                      Supplier<Scheduler> blockingSchedulerSupplier,
                                                      Supplier<Scheduler> cpuIntensiveSchedulerSupplier,
+                                                     Supplier<Scheduler> retrySupportSchedulerSupplier,
                                                      int maxConcurrency)
 
     {
       this(ringBufferSchedulerSupplier, bufferSize, subscriberCount, waitStrategy, cpuLightSchedulerSupplier,
-           blockingSchedulerSupplier, cpuIntensiveSchedulerSupplier, maxConcurrency, false);
+           blockingSchedulerSupplier, cpuIntensiveSchedulerSupplier, retrySupportSchedulerSupplier, maxConcurrency, false);
     }
 
     @Override


### PR DESCRIPTION
Do not occupy a CPU-LITE thread for handling retry, since that increases the chances of triggering backpressure.