### PR TITLE
MULE-16221: HTTP:CONNECTIVITY error thrown from WSC hangs execution in

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/client/ExtensionsClientTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/client/ExtensionsClientTestCase.java
@@ -31,15 +31,15 @@ import org.mule.test.heisenberg.extension.model.types.IntegerAttributes;
 import org.mule.test.module.extension.AbstractHeisenbergConfigTestCase;
 import org.mule.test.vegan.extension.VeganPolicy;
 
-import java.util.Collection;
-import java.util.List;
-
-import javax.inject.Inject;
-
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Collection;
+import java.util.List;
+
+import javax.inject.Inject;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
@@ -182,6 +182,16 @@ public abstract class ExtensionsClientTestCase extends AbstractHeisenbergConfigT
     exception.expectMessage("You are not allowed to speak with gus.");
     OperationParameters params = builder().configName(HEISENBERG_CONFIG).build();
     doExecute(HEISENBERG_EXT_NAME, "callGusFring", params);
+  }
+
+  @Test
+  @Description("Executes an operation that fails using the client and checks the throwed exception")
+  public void executeFailureNonBlockingOperation() throws Throwable {
+    exception.expect(MuleException.class);
+    exception.expectCause(instanceOf(ConnectionException.class));
+    exception.expectMessage("You are not allowed to speak with gus.");
+    OperationParameters params = builder().configName(HEISENBERG_CONFIG).build();
+    doExecute(HEISENBERG_EXT_NAME, "callGusFringNonBlocking", params);
   }
 
   @Test

--- a/modules/extensions-spring-support/src/test/resources/models/heisenberg.json
+++ b/modules/extensions-spring-support/src/test/resources/models/heisenberg.json
@@ -16433,6 +16433,47 @@
       "kind": "operation"
     },
     {
+      "blocking": false,
+      "executionType": "CPU_LITE",
+      "output": {
+        "type": {
+          "format": "java",
+          "type": "Void"
+        },
+        "hasDynamicType": false,
+        "description": "",
+        "modelProperties": {}
+      },
+      "outputAttributes": {
+        "type": {
+          "format": "java",
+          "type": "Void"
+        },
+        "hasDynamicType": false,
+        "description": "",
+        "modelProperties": {}
+      },
+      "transactional": false,
+      "requiresConnection": false,
+      "supportsStreaming": false,
+      "notifications": [],
+      "nestedComponents": [],
+      "errors": [],
+      "stereotype": {
+        "type": "HEISENBERG-EMPIRE",
+        "namespace": "HEISENBERG",
+        "parent": {
+          "type": "PROCESSOR",
+          "namespace": "MULE"
+        }
+      },
+      "parameterGroupModels": [],
+      "name": "callGusFringNonBlocking",
+      "description": "",
+      "modelProperties": {},
+      "kind": "operation"
+    },
+    {
       "blocking": true,
       "executionType": "CPU_LITE",
       "output": {

--- a/modules/extensions-spring-support/src/test/resources/schemas/heisenberg.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/heisenberg.xsd
@@ -1809,6 +1809,14 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:element xmlns="http://www.mulesoft.org/schema/mule/heisenberg" type="CallGusFringNonBlockingType" substitutionGroup="heisenberg-empire" name="call-gus-fring-non-blocking"></xs:element>
+  <xs:complexType name="CallGusFringNonBlockingType">
+    <xs:complexContent>
+      <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
+        <xs:sequence minOccurs="0" maxOccurs="1"></xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:element xmlns="http://www.mulesoft.org/schema/mule/heisenberg" type="ColorizeMethType" substitutionGroup="heisenberg-empire" name="colorize-meth"></xs:element>
   <xs:complexType name="ColorizeMethType">
     <xs:complexContent>

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/DefaultExtensionModelFactoryTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/DefaultExtensionModelFactoryTestCase.java
@@ -41,6 +41,7 @@ import static org.mule.test.heisenberg.extension.HeisenbergExtension.HEISENBERG_
 import static org.mule.test.marvel.ironman.IronMan.CONFIG_NAME;
 import static org.mule.test.vegan.extension.VeganExtension.APPLE;
 import static org.mule.test.vegan.extension.VeganExtension.BANANA;
+
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.annotation.EnumAnnotation;
 import org.mule.metadata.api.model.StringType;
@@ -97,14 +98,14 @@ import org.mule.test.marvel.MarvelExtension;
 import org.mule.test.vegan.extension.PaulMcCartneySource;
 import org.mule.test.vegan.extension.VeganExtension;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 @SmallTest
 public class DefaultExtensionModelFactoryTestCase extends AbstractMuleTestCase {
@@ -139,7 +140,7 @@ public class DefaultExtensionModelFactoryTestCase extends AbstractMuleTestCase {
   public void blockingExecutionTypes() {
     final List<String> nonBlockingOperations = Arrays.asList("killMany", "executeAnything", "alwaysFailsWrapper", "getChain",
                                                              "exceptionOnCallbacks", "neverFailsWrapper", "payloadModifier",
-                                                             "blockingNonBlocking");
+                                                             "blockingNonBlocking", "callGusFringNonBlocking");
 
     Reference<Boolean> cpuIntensive = new Reference<>(false);
     Reference<Boolean> blocking = new Reference<>(false);

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/java/JavaDeclarationDelegateTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/java/JavaDeclarationDelegateTestCase.java
@@ -113,6 +113,13 @@ import org.mule.test.petstore.extension.PetStoreConnector;
 import org.mule.test.vegan.extension.PaulMcCartneySource;
 import org.mule.test.vegan.extension.VeganExtension;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.reflect.TypeToken;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Calendar;
@@ -122,12 +129,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-
-import com.google.common.reflect.TypeToken;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
@@ -468,7 +469,7 @@ public class JavaDeclarationDelegateTestCase extends AbstractJavaExtensionDeclar
   }
 
   private void assertTestModuleOperations(ExtensionDeclaration extensionDeclaration) throws Exception {
-    assertThat(extensionDeclaration.getOperations(), hasSize(51));
+    assertThat(extensionDeclaration.getOperations(), hasSize(52));
 
     WithOperationsDeclaration withOperationsDeclaration = extensionDeclaration.getConfigurations().get(0);
     assertThat(withOperationsDeclaration.getOperations().size(), is(19));
@@ -505,6 +506,7 @@ public class JavaDeclarationDelegateTestCase extends AbstractJavaExtensionDeclar
     assertOperation(extensionDeclaration, BY_PASS_WEAPON, "");
     assertOperation(extensionDeclaration, ECHO_AN_OPERATION_WITH_ALIAS, "");
     assertOperation(extensionDeclaration, "executeRemoteKill", "");
+    assertOperation(extensionDeclaration, "callGusFringNonBlocking", "");
 
     OperationDeclaration operation = getOperation(withOperationsDeclaration, SAY_MY_NAME_OPERATION);
     assertThat(operation, is(notNullValue()));

--- a/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/HeisenbergOperations.java
+++ b/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/HeisenbergOperations.java
@@ -7,6 +7,7 @@
 package org.mule.test.heisenberg.extension;
 
 import static java.lang.String.format;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.stream.Collectors.toList;
 import static org.mule.runtime.api.meta.model.operation.ExecutionType.CPU_INTENSIVE;
 import static org.mule.runtime.api.metadata.TypedValue.of;
@@ -87,7 +88,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.inject.Inject;
 
@@ -349,7 +349,7 @@ public class HeisenbergOperations implements Disposable {
 
   @MediaType(TEXT_PLAIN)
   public void callGusFringNonBlocking(CompletionCallback<Void, Void> callback) {
-    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final ExecutorService executor = newSingleThreadExecutor();
 
     executor.execute(() -> {
       callback.error(new HeisenbergException(CALL_GUS_MESSAGE));

--- a/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/HeisenbergOperations.java
+++ b/tests/test-extensions/heisenberg-extension/src/main/java/org/mule/test/heisenberg/extension/HeisenbergOperations.java
@@ -44,7 +44,6 @@ import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
 import org.mule.runtime.extension.api.annotation.param.display.Example;
 import org.mule.runtime.extension.api.annotation.param.display.Summary;
-import org.mule.runtime.extension.api.annotation.param.stereotype.AllowedStereotypes;
 import org.mule.runtime.extension.api.annotation.param.stereotype.Stereotype;
 import org.mule.runtime.extension.api.client.DefaultOperationParametersBuilder;
 import org.mule.runtime.extension.api.client.ExtensionsClient;
@@ -54,10 +53,8 @@ import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.runtime.parameter.Literal;
 import org.mule.runtime.extension.api.runtime.parameter.ParameterResolver;
 import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
-import org.mule.runtime.extension.api.runtime.route.Chain;
 import org.mule.runtime.extension.api.runtime.streaming.PagingProvider;
 import org.mule.runtime.extension.api.runtime.streaming.StreamingHelper;
-import org.mule.runtime.extension.api.stereotype.ValidatorStereotype;
 import org.mule.test.heisenberg.extension.exception.CureCancerExceptionEnricher;
 import org.mule.test.heisenberg.extension.exception.HealthException;
 import org.mule.test.heisenberg.extension.exception.HeisenbergException;
@@ -78,6 +75,8 @@ import org.mule.test.heisenberg.extension.model.types.IntegerAttributes;
 import org.mule.test.heisenberg.extension.stereotypes.EmpireStereotype;
 import org.mule.test.heisenberg.extension.stereotypes.KillingStereotype;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -87,10 +86,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import javax.inject.Inject;
-
-import com.google.common.collect.ImmutableMap;
 
 
 @Stereotype(EmpireStereotype.class)
@@ -346,6 +345,15 @@ public class HeisenbergOperations implements Disposable {
   @MediaType(TEXT_PLAIN)
   public String callGusFring() throws HeisenbergException {
     throw new HeisenbergException(CALL_GUS_MESSAGE);
+  }
+
+  @MediaType(TEXT_PLAIN)
+  public void callGusFringNonBlocking(CompletionCallback<Void, Void> callback) {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    executor.execute(() -> {
+      callback.error(new HeisenbergException(CALL_GUS_MESSAGE));
+    });
   }
 
   @OnException(CureCancerExceptionEnricher.class)


### PR DESCRIPTION
CompositeProcessorChainRouter

Remove the child context introduced by `ExtensionsClient#executeAsync`
in order to make it consistent with `ExtensionsClient#execute`.

This change fixes the symptom described in the issue.