### PR TITLE
MULE-9653: Force the install of test-dependant-plugin and test-empty-…

### DIFF
--- a/tests/test-plugins/pom.xml
+++ b/tests/test-plugins/pom.xml
@@ -22,4 +22,23 @@
         <module>dependant-plugin</module>
     </modules>
 
+    <build>
+        <!-- As these tests plugins are used in the deployment-model-impl module tests we need to be sure they are available in the local repository in the test phase  -->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-before-test-phase</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
…plugin plugins modules to be sure they are available in the local repo before the execution of the module deployment-model-impl where they are used.