### PR TITLE
 MULE-16260: Gatekeeper policy causes memory leak on policy engine

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/DefaultPolicyStateHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/DefaultPolicyStateHandlerTestCase.java
@@ -7,7 +7,6 @@
 package org.mule.runtime.core.internal.policy;
 
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -19,10 +18,10 @@ import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
-import java.util.function.BiConsumer;
-
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.function.BiConsumer;
 
 public class DefaultPolicyStateHandlerTestCase extends AbstractMuleTestCase {
 
@@ -32,10 +31,10 @@ public class DefaultPolicyStateHandlerTestCase extends AbstractMuleTestCase {
   private static final String TEST_POLICY_ID = "test-policy-id";
   private static final String TEST_POLICY_ID2 = "test-policy-id2";
 
-  private InternalEvent eventTestExecutionId = mock(InternalEvent.class, RETURNS_DEEP_STUBS);
-  private InternalEvent eventTestExecutionId2 = mock(InternalEvent.class, RETURNS_DEEP_STUBS);
+  private final InternalEvent eventTestExecutionId = mock(InternalEvent.class, RETURNS_DEEP_STUBS);
+  private final InternalEvent eventTestExecutionId2 = mock(InternalEvent.class, RETURNS_DEEP_STUBS);
 
-  private DefaultPolicyStateHandler defaultPolicyStateHandler = new DefaultPolicyStateHandler();
+  private final DefaultPolicyStateHandler defaultPolicyStateHandler = new DefaultPolicyStateHandler();
 
   @Test
   public void destroyStateWithNoData() {
@@ -67,7 +66,6 @@ public class DefaultPolicyStateHandlerTestCase extends AbstractMuleTestCase {
     PolicyStateId policyStateExecutionId = new PolicyStateId(TEST_EXECUTION_ID, TEST_POLICY_ID);
     defaultPolicyStateHandler.destroyState(policyStateExecutionId.getExecutionIdentifier());
     assertThat(defaultPolicyStateHandler.getLatestState(policyStateExecutionId).isPresent(), is(false));
-    assertThat(defaultPolicyStateHandler.retrieveNextOperation(policyStateExecutionId.getExecutionIdentifier()), nullValue());
   }
 
   @Test
@@ -84,8 +82,6 @@ public class DefaultPolicyStateHandlerTestCase extends AbstractMuleTestCase {
     assertThat(defaultPolicyStateHandler.getLatestState(policyStateExecutionId).isPresent(), is(false));
     assertThat(defaultPolicyStateHandler.policyStateIdsByExecutionIdentifier
         .containsKey(policyStateExecutionId.getExecutionIdentifier()), is(false));
-    assertThat(defaultPolicyStateHandler.nextOperationMap.containsKey(policyStateExecutionId.getExecutionIdentifier()),
-               is(false));
     assertThat(defaultPolicyStateHandler.stateMap.containsKey(policyStateExecutionId), is(false));
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyProcessorLeakTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyProcessorLeakTestCase.java
@@ -33,7 +33,6 @@ public class PolicyProcessorLeakTestCase extends AbstractMuleTestCase {
   private static final int GC_POLLING_TIMEOUT = 10000;
 
   private final DefaultPolicyStateHandler policyStateHandler = new DefaultPolicyStateHandler();
-  private final PolicyNextChaining policyNextChaining = new PolicyNextChaining();
   private Policy policy;
 
   @Before
@@ -54,7 +53,7 @@ public class PolicyProcessorLeakTestCase extends AbstractMuleTestCase {
     Processor nextProcessor = new TestProcessor();
     final PhantomReference<Processor> processorRef = new PhantomReference<>(nextProcessor, new ReferenceQueue<>());
     SourcePolicyProcessor policyProcessor =
-        new SourcePolicyProcessor(policy, policyStateHandler, policyNextChaining, nextProcessor);
+        new SourcePolicyProcessor(policy, policyStateHandler, nextProcessor);
 
     final CoreEvent event = testEvent();
     try {
@@ -74,7 +73,7 @@ public class PolicyProcessorLeakTestCase extends AbstractMuleTestCase {
     Processor nextProcessor = new TestProcessor();
     final PhantomReference<Processor> processorRef = new PhantomReference<>(nextProcessor, new ReferenceQueue<>());
     OperationPolicyProcessor policyProcessor =
-        new OperationPolicyProcessor(policy, policyStateHandler, policyNextChaining, nextProcessor);
+        new OperationPolicyProcessor(policy, policyStateHandler, nextProcessor);
 
     final CoreEvent event = testEvent();
     try {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyProcessorLeakTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyProcessorLeakTestCase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.policy;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.tck.probe.PollingProber.DEFAULT_POLLING_INTERVAL;
+import static reactor.core.publisher.Mono.just;
+
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.policy.Policy;
+import org.mule.runtime.core.api.policy.PolicyChain;
+import org.mule.runtime.core.api.processor.Processor;
+import org.mule.runtime.core.privileged.event.BaseEventContext;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.probe.JUnitLambdaProbe;
+import org.mule.tck.probe.PollingProber;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+
+public class PolicyProcessorLeakTestCase extends AbstractMuleTestCase {
+
+  private static final int GC_POLLING_TIMEOUT = 10000;
+
+  private final DefaultPolicyStateHandler policyStateHandler = new DefaultPolicyStateHandler();
+  private final PolicyNextChaining policyNextChaining = new PolicyNextChaining();
+  private Policy policy;
+
+  @Before
+  public void before() throws MuleException {
+    final PolicyChain policyChain = new PolicyChain() {
+
+      @Override
+      public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
+        // Skip the 'next' call
+        return publisher;
+      }
+    };
+    policy = new Policy(policyChain, "policyId");
+  }
+
+  @Test
+  public void sourceNextOperationRefCleared() throws MuleException {
+    Processor nextProcessor = new TestProcessor();
+    final PhantomReference<Processor> processorRef = new PhantomReference<>(nextProcessor, new ReferenceQueue<>());
+    SourcePolicyProcessor policyProcessor =
+        new SourcePolicyProcessor(policy, policyStateHandler, policyNextChaining, nextProcessor);
+
+    final CoreEvent event = testEvent();
+    try {
+      just(event).transform(policyProcessor).block();
+      nextProcessor = null;
+      policyProcessor = null;
+      policy = null;
+    } finally {
+      ((BaseEventContext) event.getContext()).success();
+    }
+
+    probeNextRefGcd(processorRef);
+  }
+
+  @Test
+  public void operationNextOperationRefCleared() throws MuleException {
+    Processor nextProcessor = new TestProcessor();
+    final PhantomReference<Processor> processorRef = new PhantomReference<>(nextProcessor, new ReferenceQueue<>());
+    OperationPolicyProcessor policyProcessor =
+        new OperationPolicyProcessor(policy, policyStateHandler, policyNextChaining, nextProcessor);
+
+    final CoreEvent event = testEvent();
+    try {
+      just(event).transform(policyProcessor).block();
+      nextProcessor = null;
+      policyProcessor = null;
+      policy = null;
+    } finally {
+      ((BaseEventContext) event.getContext()).success();
+    }
+
+    probeNextRefGcd(processorRef);
+  }
+
+  private void probeNextRefGcd(final PhantomReference<Processor> processorRef) {
+    new PollingProber(GC_POLLING_TIMEOUT, DEFAULT_POLLING_INTERVAL).check(new JUnitLambdaProbe(() -> {
+      System.gc();
+      assertThat(processorRef.isEnqueued(), is(true));
+      return true;
+    }, "A hard reference is being mantained to the next processor."));
+  }
+
+  private static final class TestProcessor implements Processor {
+
+    @Override
+    public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
+      return publisher;
+    }
+
+    @Override
+    public CoreEvent process(CoreEvent event) throws MuleException {
+      return event;
+    }
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/api/policy/PolicyStateHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/policy/PolicyStateHandler.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  *
  * Keeps track of the operation associated with a certain context of execution. Such context of execution is defined by the unique
  * identifier of the generated {@link CoreEvent}.
- * 
+ *
  * Implementations will be executed concurrently but always using different identifiers. There will be no concurrent invocation
  * for the same identifier.
  *
@@ -28,16 +28,18 @@ public interface PolicyStateHandler {
 
   /**
    * Associated the {@code identifier} with the policy next operation to execute
-   * 
+   *
    * @param executionIdentifier the identifier of the context
    * @param nextOperation the next operation of the policy
    */
+  @Deprecated
   void updateNextOperation(String executionIdentifier, Processor nextOperation);
 
   /**
    * @param executionIdentifier the identifier of the context
    * @return the next operation for the context.
    */
+  @Deprecated
   Processor retrieveNextOperation(String executionIdentifier);
 
   /**
@@ -56,7 +58,7 @@ public interface PolicyStateHandler {
 
   /**
    * Updates the event of the policy for the context with the given identifier.
-   * 
+   *
    * @param identifier the identifier of the context
    * @param lastStateEvent the last state of the event
    */

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyStateHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyStateHandler.java
@@ -26,14 +26,17 @@ public class DefaultPolicyStateHandler implements PolicyStateHandler {
   protected Map<PolicyStateId, CoreEvent> stateMap = new HashMap<>();
   protected Map<String, Processor> nextOperationMap = new HashMap<>();
 
+  @Override
   public synchronized void updateNextOperation(String identifier, Processor nextOperation) {
-    nextOperationMap.put(identifier, nextOperation);
+    throw new UnsupportedOperationException("Use a subscriberContext instead.");
   }
 
+  @Override
   public synchronized Processor retrieveNextOperation(String identifier) {
-    return nextOperationMap.get(identifier);
+    throw new UnsupportedOperationException("Use a subscriberContext instead.");
   }
 
+  @Override
   public Optional<CoreEvent> getLatestState(PolicyStateId identifier) {
     final CoreEvent state;
     synchronized (this) {
@@ -42,6 +45,7 @@ public class DefaultPolicyStateHandler implements PolicyStateHandler {
     return ofNullable(state);
   }
 
+  @Override
   public void updateState(PolicyStateId identifier, CoreEvent lastStateEvent) {
     ((BaseEventContext) lastStateEvent.getContext()).getRootContext()
         .onTerminated((response, throwable) -> destroyState(identifier.getExecutionIdentifier()));
@@ -51,6 +55,7 @@ public class DefaultPolicyStateHandler implements PolicyStateHandler {
     }
   }
 
+  @Override
   public synchronized void destroyState(String identifier) {
     List<PolicyStateId> policyStateIds = policyStateIdsByExecutionIdentifier.removeAll(identifier);
     if (policyStateIds != null) {

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyNextActionMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyNextActionMessageProcessor.java
@@ -7,22 +7,20 @@
 package org.mule.runtime.core.internal.policy;
 
 import static java.util.Optional.ofNullable;
-import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.notification.PolicyNotification.AFTER_NEXT;
 import static org.mule.runtime.api.notification.PolicyNotification.BEFORE_NEXT;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContext;
 import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Mono.empty;
-import static reactor.core.publisher.Mono.error;
 import static reactor.core.publisher.Mono.from;
+import static reactor.core.publisher.Mono.subscriberContext;
 
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.event.EventContext;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.message.Message;
@@ -38,13 +36,13 @@ import org.mule.runtime.core.internal.util.MessagingExceptionResolver;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.inject.Inject;
-
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
 
 /**
  * Next-operation message processor implementation.
@@ -58,6 +56,8 @@ public class PolicyNextActionMessageProcessor extends AbstractComponent implemen
 
   private static final Logger LOGGER = getLogger(PolicyNextActionMessageProcessor.class);
 
+  public static final String POLICY_NEXT_OPERATION = "policy.nextOperation";
+
   @Inject
   private PolicyStateHandler policyStateHandler;
 
@@ -66,7 +66,7 @@ public class PolicyNextActionMessageProcessor extends AbstractComponent implemen
 
   private PolicyNotificationHelper notificationHelper;
 
-  private PolicyEventConverter policyEventConverter = new PolicyEventConverter();
+  private final PolicyEventConverter policyEventConverter = new PolicyEventConverter();
 
   private PolicyStateIdFactory stateIdFactory;
 
@@ -95,35 +95,33 @@ public class PolicyNextActionMessageProcessor extends AbstractComponent implemen
         .doOnNext(coreEvent -> logExecuteNextEvent("Before execute-next", coreEvent.getContext(),
                                                    coreEvent.getMessage(), muleContext.getConfiguration().getId()))
         .flatMap(event -> {
-          PolicyStateId policyStateId = stateIdFactory.create(event);
-          Processor nextOperation = policyStateHandler.retrieveNextOperation(policyStateId.getExecutionIdentifier());
+          return subscriberContext().flatMap(ctx -> {
+            final Processor nextOperation = ctx.get(POLICY_NEXT_OPERATION);
 
-          if (nextOperation == null) {
-            return error(new MuleRuntimeException(createStaticMessage("There's no next operation configured for event context id "
-                + policyStateId.getExecutionIdentifier())));
-          }
+            PolicyStateId policyStateId = stateIdFactory.create(event);
 
-          popBeforeNextFlowFlowStackElement().accept(event);
-          notificationHelper.notification(BEFORE_NEXT).accept(event);
+            popBeforeNextFlowFlowStackElement().accept(event);
+            notificationHelper.notification(BEFORE_NEXT).accept(event);
 
-          return from(processWithChildContext(event, nextOperation, ofNullable(getLocation())))
-              .doOnSuccessOrError(notificationHelper.successOrErrorNotification(AFTER_NEXT)
-                  .andThen((ev, t) -> pushAfterNextFlowStackElement().accept(event)))
-              .onErrorResume(MessagingException.class, t -> {
+            return from(processWithChildContext(event, nextOperation, ofNullable(getLocation())))
+                .doOnSuccessOrError(notificationHelper.successOrErrorNotification(AFTER_NEXT)
+                    .andThen((ev, t) -> pushAfterNextFlowStackElement().accept(event)))
+                .onErrorResume(MessagingException.class, t -> {
 
-                policyStateHandler.getLatestState(policyStateId)
-                    .ifPresent(latestStateEvent -> t.setProcessedEvent(policyEventConverter
-                        .createEvent((PrivilegedEvent) t.getEvent(), (PrivilegedEvent) latestStateEvent)));
+                  policyStateHandler.getLatestState(policyStateId)
+                      .ifPresent(latestStateEvent -> t.setProcessedEvent(policyEventConverter
+                          .createEvent((PrivilegedEvent) t.getEvent(), (PrivilegedEvent) latestStateEvent)));
 
-                // Given we've used child context to ensure AFTER_NEXT notifications are fired at exactly the right time we need
-                // to propagate the error to parent context manually.
-                ((BaseEventContext) event.getContext())
-                    .error(resolveMessagingException(t.getFailingComponent(), muleContext).apply(t));
-                return empty();
-              })
-              .doOnNext(coreEvent -> logExecuteNextEvent("After execute-next",
-                                                         coreEvent.getContext(), coreEvent.getMessage(),
-                                                         this.muleContext.getConfiguration().getId()));
+                  // Given we've used child context to ensure AFTER_NEXT notifications are fired at exactly the right time we need
+                  // to propagate the error to parent context manually.
+                  ((BaseEventContext) event.getContext())
+                      .error(resolveMessagingException(t.getFailingComponent(), muleContext).apply(t));
+                  return empty();
+                })
+                .doOnNext(coreEvent -> logExecuteNextEvent("After execute-next",
+                                                           coreEvent.getContext(), coreEvent.getMessage(),
+                                                           this.muleContext.getConfiguration().getId()));
+          });
         });
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/SourcePolicyProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/SourcePolicyProcessor.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.core.internal.policy;
 
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.internal.policy.PolicyNextActionMessageProcessor.POLICY_NEXT_OPERATION;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.publisher.Mono.just;
@@ -93,7 +94,9 @@ public class SourcePolicyProcessor implements Processor {
               .transform(policy.getPolicyChain())
               .cast(PrivilegedEvent.class)
               .map(event -> policyEventConverter.createEvent(event, sourceEvent));
-        });
+        })
+        .cast(CoreEvent.class)
+        .subscriberContext(ctx -> ctx.put(POLICY_NEXT_OPERATION, nextProcessor));
   }
 
   private Processor buildSourceExecutionWithPolicyFunction(PolicyStateId policyStateId, PrivilegedEvent sourceEvent) {

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/SourcePolicyProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/SourcePolicyProcessor.java
@@ -86,17 +86,16 @@ public class SourcePolicyProcessor implements Processor {
         .cast(PrivilegedEvent.class)
         .flatMap(sourceEvent -> {
           PolicyStateId policyStateId = stateIdFactory.create(sourceEvent);
-          policyStateHandler.updateNextOperation(policyStateId.getExecutionIdentifier(),
-                                                 buildSourceExecutionWithPolicyFunction(policyStateId, sourceEvent));
+          final Processor nextOperation = buildSourceExecutionWithPolicyFunction(policyStateId, sourceEvent);
           return just(sourceEvent)
               .map(event -> policyEventConverter.createEvent(sourceEvent, noVariablesEvent(sourceEvent)))
               .cast(CoreEvent.class)
               .transform(policy.getPolicyChain())
               .cast(PrivilegedEvent.class)
-              .map(event -> policyEventConverter.createEvent(event, sourceEvent));
+              .map(event -> policyEventConverter.createEvent(event, sourceEvent))
+              .subscriberContext(ctx -> ctx.put(POLICY_NEXT_OPERATION, nextOperation));
         })
-        .cast(CoreEvent.class)
-        .subscriberContext(ctx -> ctx.put(POLICY_NEXT_OPERATION, nextProcessor));
+        .cast(CoreEvent.class);
   }
 
   private Processor buildSourceExecutionWithPolicyFunction(PolicyStateId policyStateId, PrivilegedEvent sourceEvent) {

--- a/tests/performance/src/main/java/org/mule/runtime/core/policy/DefaultPolicyStateHandlerBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/runtime/core/policy/DefaultPolicyStateHandlerBenchmark.java
@@ -19,17 +19,17 @@ import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.internal.policy.DefaultPolicyStateHandler;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 
-import java.util.Optional;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Threads;
 
+import java.util.Optional;
+
 public class DefaultPolicyStateHandlerBenchmark extends AbstractBenchmark {
 
-  private PolicyStateHandler handler = new DefaultPolicyStateHandler();
+  private final PolicyStateHandler handler = new DefaultPolicyStateHandler();
 
-  private Processor dummyProcessor = event -> event;
+  private final static Processor DUMMY_PROCESSOR = event -> event;
 
   @Benchmark
   @Threads(32)
@@ -39,15 +39,13 @@ public class DefaultPolicyStateHandlerBenchmark extends AbstractBenchmark {
 
     PolicyStateId policyStateId = new PolicyStateId(event.getContext().getCorrelationId(), "myPolicy");
 
-    handler.updateNextOperation(event.getContext().getCorrelationId(), dummyProcessor);
     handler.updateState(policyStateId, event);
 
     // execute-next
-    final Processor nextOperation = handler.retrieveNextOperation(event.getContext().getCorrelationId());
     final Optional<CoreEvent> latestState = handler.getLatestState(policyStateId);
 
     ((BaseEventContext) event.getContext()).success();
-    return Pair.of(nextOperation, latestState);
+    return Pair.of(DUMMY_PROCESSOR, latestState);
   }
 
   @Benchmark
@@ -60,17 +58,15 @@ public class DefaultPolicyStateHandlerBenchmark extends AbstractBenchmark {
 
     Optional<CoreEvent> latestState = handler.getLatestState(policyStateId);
     handler.updateState(policyStateId, latestState.orElse(event));
-    handler.updateNextOperation(event.getContext().getCorrelationId(), dummyProcessor);
 
     // execute-next
-    final Processor nextOperation = handler.retrieveNextOperation(event.getContext().getCorrelationId());
     latestState = handler.getLatestState(policyStateId);
 
     handler.updateState(policyStateId, event);
     handler.updateState(policyStateId, event);
 
     ((BaseEventContext) event.getContext()).success();
-    return Pair.of(nextOperation, latestState);
+    return Pair.of(DUMMY_PROCESSOR, latestState);
   }
 
 }


### PR DESCRIPTION
* Use subscription context instead of a map for the `next`