### PR TITLE
MULE-14601: Json Schema Validator treats duplicate keys in an inconsistent way depending on the input type.

### DIFF
--- a/modules/json/src/test/java/org/mule/module/json/JsonDataTestCase.java
+++ b/modules/json/src/test/java/org/mule/module/json/JsonDataTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.module.json;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -111,7 +112,7 @@ public class JsonDataTestCase extends AbstractMuleContextTestCase
         String jsonAsString = "{\"value\":210.0}";
 
         JsonNode json = parser.asJsonNode(jsonAsString);
-        assertEquals(jsonAsString, json.toString());
+        assertThat("JSON has not changed", jsonAsString.equals(json.toString()));
     }
 
     private JsonData readJsonData(String filename) throws Exception

--- a/modules/json/src/test/java/org/mule/module/json/JsonDataTestCase.java
+++ b/modules/json/src/test/java/org/mule/module/json/JsonDataTestCase.java
@@ -6,21 +6,22 @@
  */
 package org.mule.module.json;
 
-import org.mule.tck.junit4.AbstractMuleTestCase;
-import org.mule.util.IOUtils;
-
-import org.codehaus.jackson.node.ArrayNode;
-import org.codehaus.jackson.node.ObjectNode;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.util.IOUtils;
 
-public class JsonDataTestCase extends AbstractMuleTestCase
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.junit.Test;
+
+public class JsonDataTestCase extends AbstractMuleContextTestCase
 {
 
     @Test
@@ -101,6 +102,16 @@ public class JsonDataTestCase extends AbstractMuleTestCase
         Object o = jsonData.get("photos");
         assertNotNull(o);
         assertTrue(o instanceof ObjectNode);
+    }
+
+    @Test
+    public void testReadingANumber() throws Exception
+    {
+        JsonParser parser = new DefaultJsonParser(muleContext);
+        String jsonAsString = "{\"value\":210.0}";
+
+        JsonNode json = parser.asJsonNode(jsonAsString);
+        assertEquals(jsonAsString, json.toString());
     }
 
     private JsonData readJsonData(String filename) throws Exception

--- a/modules/json/src/test/java/org/mule/module/json/JsonDataTestCase.java
+++ b/modules/json/src/test/java/org/mule/module/json/JsonDataTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.module.json;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -112,7 +113,7 @@ public class JsonDataTestCase extends AbstractMuleContextTestCase
         String jsonAsString = "{\"value\":210.0}";
 
         JsonNode json = parser.asJsonNode(jsonAsString);
-        assertThat("JSON has not changed", jsonAsString.equals(json.toString()));
+        assertThat("JSON has not changed", jsonAsString, equalTo(json.toString()));
     }
 
     private JsonData readJsonData(String filename) throws Exception


### PR DESCRIPTION
Adding a test to reproduce the issue reported at SE-10767.
The issue was fixed in a commit associated to MULE-14601.