### PR TITLE
SE-10276: Close file streams left open

### DIFF
--- a/core/src/main/java/org/mule/util/store/QueuePersistenceObjectStore.java
+++ b/core/src/main/java/org/mule/util/store/QueuePersistenceObjectStore.java
@@ -269,9 +269,8 @@ public class QueuePersistenceObjectStore<T extends Serializable> extends Abstrac
 
     protected void serialize(T value, File outputFile) throws ObjectStoreException
     {
-        try
+        try (FileOutputStream out = new FileOutputStream(outputFile))
         {
-            FileOutputStream out = new FileOutputStream(outputFile);
             out.write(muleContext.getObjectSerializer().serialize(value));
             out.flush();
         }


### PR DESCRIPTION
File stream left open caused an exception on Windows when trying to delete the file
This fix was verified and there was no exception