### PR TITLE
MULE-16500: Janitor must be dereferenced so that taken byte arrays are freed

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/CursorProviderJanitorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/CursorProviderJanitorTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mule.test.allure.AllureConstants.StreamingFeature.STREAMING;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.mule.runtime.api.streaming.Cursor;
+import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import io.qameta.allure.Feature;
+
+@Feature(STREAMING)
+public class CursorProviderJanitorTestCase extends AbstractMuleTestCase {
+
+  @Test
+  public void resourcesReleasedOnJanitorRelease() {
+    CursorProvider provider = mock(CursorProvider.class);
+    MutableStreamingStatistics statistics = mock(MutableStreamingStatistics.class);
+    Set<Cursor> cursors = new HashSet<Cursor>();
+    Cursor cursor = mock(Cursor.class);
+    cursors.add(cursor);
+    CursorProviderJanitor janitor = new CursorProviderJanitor(provider, cursors, statistics);
+    janitor.releaseResources();
+    assertThat(janitor.provider, is(nullValue()));
+    assertThat(cursors, is(empty()));
+    verify(cursor).release();
+    verify(provider).releaseResources();
+  }
+
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorProviderJanitor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorProviderJanitor.java
@@ -26,7 +26,7 @@ public class CursorProviderJanitor {
 
   private static final Logger LOGGER = getLogger(CursorProviderJanitor.class);
 
-  private final CursorProvider provider;
+  CursorProvider provider;
   private final Set<Cursor> cursors;
   private final MutableStreamingStatistics statistics;
   private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -76,6 +76,8 @@ public class CursorProviderJanitor {
       cursors.forEach(this::releaseCursor);
     } finally {
       provider.releaseResources();
+      cursors.clear();
+      provider = null;
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/StreamingGhostBuster.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/StreamingGhostBuster.java
@@ -136,7 +136,7 @@ public class StreamingGhostBuster implements Lifecycle {
    */
   private class StreamingWeakReference extends WeakReference<ManagedCursorProvider> {
 
-    private CursorProviderJanitor janitor;
+    private final CursorProviderJanitor janitor;
     private boolean clear = false;
 
     public StreamingWeakReference(ManagedCursorProvider referent, ReferenceQueue<ManagedCursorProvider> referenceQueue) {
@@ -148,7 +148,6 @@ public class StreamingGhostBuster implements Lifecycle {
       if (!clear) {
         clear = true;
         janitor.releaseResources();
-        janitor = null;
       }
     }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/StreamingGhostBuster.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/StreamingGhostBuster.java
@@ -136,7 +136,7 @@ public class StreamingGhostBuster implements Lifecycle {
    */
   private class StreamingWeakReference extends WeakReference<ManagedCursorProvider> {
 
-    private final CursorProviderJanitor janitor;
+    private CursorProviderJanitor janitor;
     private boolean clear = false;
 
     public StreamingWeakReference(ManagedCursorProvider referent, ReferenceQueue<ManagedCursorProvider> referenceQueue) {
@@ -148,6 +148,7 @@ public class StreamingGhostBuster implements Lifecycle {
       if (!clear) {
         clear = true;
         janitor.releaseResources();
+        janitor = null;
       }
     }
 


### PR DESCRIPTION
when ghostbuster applied.