### PR TITLE
MULE-16511: Improve responsePublisher usage in EventContext

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
@@ -26,6 +26,8 @@ import static org.mule.tck.probe.PollingProber.probe;
 import static org.mule.test.allure.AllureConstants.EventContextFeature.EVENT_CONTEXT;
 import static org.mule.test.allure.AllureConstants.EventContextFeature.EventContextStory.RESPONSE_AND_COMPLETION_PUBLISHERS;
 import static reactor.core.publisher.Mono.from;
+import static reactor.core.scheduler.Schedulers.single;
+
 import org.mule.runtime.api.component.TypedComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.event.EventContext;
@@ -43,6 +45,16 @@ import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
 
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.reactivestreams.Publisher;
+
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
@@ -50,6 +62,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -60,15 +73,7 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Story;
-import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 
 /**
  * TODO MULE-14000 Create hamcrest matchers to assert EventContext state
@@ -83,21 +88,21 @@ public class DefaultEventContextTestCase extends AbstractMuleContextTestCase {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
-  private Supplier<DefaultEventContext> context;
-  private Function<CompletableFuture<Void>, BaseEventContext> contextWithCompletion;
-  private Function<ComponentLocation, BaseEventContext> contextWithComponentLocation;
+  private final Supplier<DefaultEventContext> context;
+  private final Function<CompletableFuture<Void>, BaseEventContext> contextWithCompletion;
+  private final Function<ComponentLocation, BaseEventContext> contextWithComponentLocation;
 
   private BaseEventContext parent;
   private BaseEventContext child;
 
-  private AtomicReference<CoreEvent> parentResultValue = new AtomicReference<>();
-  private AtomicReference<Throwable> parentErrorValue = new AtomicReference<>();
-  private AtomicBoolean parentCompletion = new AtomicBoolean();
-  private AtomicBoolean parentTerminated = new AtomicBoolean();
+  private final AtomicReference<CoreEvent> parentResultValue = new AtomicReference<>();
+  private final AtomicReference<Throwable> parentErrorValue = new AtomicReference<>();
+  private final AtomicBoolean parentCompletion = new AtomicBoolean();
+  private final AtomicBoolean parentTerminated = new AtomicBoolean();
 
-  private AtomicReference<CoreEvent> childResultValue = new AtomicReference<>();
-  private AtomicReference<Throwable> childErrorValue = new AtomicReference<>();
-  private AtomicBoolean childCompletion = new AtomicBoolean();
+  private final AtomicReference<CoreEvent> childResultValue = new AtomicReference<>();
+  private final AtomicReference<Throwable> childErrorValue = new AtomicReference<>();
+  private final AtomicBoolean childCompletion = new AtomicBoolean();
 
 
   public DefaultEventContextTestCase(Supplier<DefaultEventContext> context,
@@ -260,6 +265,23 @@ public class DefaultEventContextTestCase extends AbstractMuleContextTestCase {
     }, "A hard reference is being mantained to the child event."));
 
     parent.success(eventParent);
+  }
+
+  @Test
+  public void multipleResponsePublisherSubscriptions() throws MuleException {
+    CoreEvent event = getEventBuilder().message(Message.of(TEST_PAYLOAD)).build();
+
+    AtomicInteger responseCounter = new AtomicInteger();
+
+    // Call getResponsePublisher twice to receive the response in 2 different places
+    Flux.from(parent.getResponsePublisher())
+        .mergeWith(parent.getResponsePublisher())
+        .subscribeOn(single())
+        .subscribe(e -> responseCounter.incrementAndGet());
+
+    parent.success(event);
+
+    probe(() -> responseCounter.get() == 2);
   }
 
   @Test

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -133,13 +133,13 @@ abstract class AbstractEventContext implements BaseEventContext {
   public final void success() {
     if (isResponseDone()) {
       if (debugLogEnabled) {
-        LOGGER.debug("{} empty response was already completed, ignoring.", this.toString());
+        LOGGER.debug("{} empty response was already completed, ignoring.", this);
       }
       return;
     }
 
     if (debugLogEnabled) {
-      LOGGER.debug("{} response completed with no result.", this.toString());
+      LOGGER.debug("{} response completed with no result.", this);
     }
     responseDone(right(null));
   }
@@ -151,13 +151,13 @@ abstract class AbstractEventContext implements BaseEventContext {
   public final void success(CoreEvent event) {
     if (isResponseDone()) {
       if (debugLogEnabled) {
-        LOGGER.debug("{} response was already completed, ignoring.", this.toString());
+        LOGGER.debug("{} response was already completed, ignoring.", this);
       }
       return;
     }
 
     if (debugLogEnabled) {
-      LOGGER.debug("{} response completed with result.", this.toString());
+      LOGGER.debug("{} response completed with result.", this);
     }
     responseDone(right(event));
   }
@@ -169,18 +169,18 @@ abstract class AbstractEventContext implements BaseEventContext {
   public final Publisher<Void> error(Throwable throwable) {
     if (isResponseDone()) {
       if (debugLogEnabled) {
-        LOGGER.debug("{} error response was already completed, ignoring.", this.toString());
+        LOGGER.debug("{} error response was already completed, ignoring.", this);
       }
       return empty();
     }
 
     if (debugLogEnabled) {
-      LOGGER.debug("{} responseDone completed with error.", this.toString());
+      LOGGER.debug("{} responseDone completed with error.", this);
     }
 
     if (throwable instanceof MessagingException) {
       if (debugLogEnabled) {
-        LOGGER.debug("{} handling messaging exception.", this.toString());
+        LOGGER.debug("{} handling messaging exception.", this);
       }
       return just((MessagingException) throwable)
           .flatMapMany(exceptionHandler)
@@ -220,7 +220,7 @@ abstract class AbstractEventContext implements BaseEventContext {
     synchronized (this) {
       if (state == STATE_RESPONSE && allChildrenComplete) {
         if (debugLogEnabled) {
-          LOGGER.debug("{} completed.", this.toString());
+          LOGGER.debug("{} completed.", this);
         }
         this.state = STATE_COMPLETE;
 
@@ -241,7 +241,7 @@ abstract class AbstractEventContext implements BaseEventContext {
   protected synchronized void tryTerminate() {
     if (this.state == STATE_COMPLETE && (externalCompletion == null || externalCompletion.isDone())) {
       if (debugLogEnabled) {
-        LOGGER.debug("{} terminated.", this.toString());
+        LOGGER.debug("{} terminated.", this);
       }
       this.state = STATE_TERMINATED;
 
@@ -277,7 +277,7 @@ abstract class AbstractEventContext implements BaseEventContext {
       consumer.accept(result.getRight(), result.getLeft());
     } catch (Throwable t) {
       LOGGER.error(format("The event consumer %s, of EventContext %s failed with exception:",
-                          consumer.toString(), this.toString()),
+                          consumer, this),
                    t);
     }
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -74,7 +74,7 @@ abstract class AbstractEventContext implements BaseEventContext {
   private volatile byte state = STATE_READY;
   private volatile Either<Throwable, CoreEvent> result;
 
-  private LazyValue<ResponsePublisher> responsePublisher = new LazyValue<>(() -> new ResponsePublisher());
+  private LazyValue<ResponsePublisher> responsePublisher = new LazyValue<>(ResponsePublisher::new);
 
   protected FlowCallStack flowCallStack = new DefaultFlowCallStack();
 
@@ -133,13 +133,13 @@ abstract class AbstractEventContext implements BaseEventContext {
   public final void success() {
     if (isResponseDone()) {
       if (debugLogEnabled) {
-        LOGGER.debug(this + " empty response was already completed, ignoring.");
+        LOGGER.debug("{} empty response was already completed, ignoring.", this.toString());
       }
       return;
     }
 
     if (debugLogEnabled) {
-      LOGGER.debug(this + " response completed with no result.");
+      LOGGER.debug("{} response completed with no result.", this.toString());
     }
     responseDone(right(null));
   }
@@ -151,13 +151,13 @@ abstract class AbstractEventContext implements BaseEventContext {
   public final void success(CoreEvent event) {
     if (isResponseDone()) {
       if (debugLogEnabled) {
-        LOGGER.debug(this + " response was already completed, ignoring.");
+        LOGGER.debug("{} response was already completed, ignoring.", this.toString());
       }
       return;
     }
 
     if (debugLogEnabled) {
-      LOGGER.debug(this + " response completed with result.");
+      LOGGER.debug("{} response completed with result.", this.toString());
     }
     responseDone(right(event));
   }
@@ -169,18 +169,18 @@ abstract class AbstractEventContext implements BaseEventContext {
   public final Publisher<Void> error(Throwable throwable) {
     if (isResponseDone()) {
       if (debugLogEnabled) {
-        LOGGER.debug(this + " error response was already completed, ignoring.");
+        LOGGER.debug("{} error response was already completed, ignoring.", this.toString());
       }
       return empty();
     }
 
     if (debugLogEnabled) {
-      LOGGER.debug(this + " responseDone completed with error.");
+      LOGGER.debug("{} responseDone completed with error.", this.toString());
     }
 
     if (throwable instanceof MessagingException) {
       if (debugLogEnabled) {
-        LOGGER.debug(this + " handling messaging exception.");
+        LOGGER.debug("{} handling messaging exception.", this.toString());
       }
       return just((MessagingException) throwable)
           .flatMapMany(exceptionHandler)
@@ -220,7 +220,7 @@ abstract class AbstractEventContext implements BaseEventContext {
     synchronized (this) {
       if (state == STATE_RESPONSE && allChildrenComplete) {
         if (debugLogEnabled) {
-          LOGGER.debug(this + " completed.");
+          LOGGER.debug("{} completed.", this.toString());
         }
         this.state = STATE_COMPLETE;
 
@@ -241,7 +241,7 @@ abstract class AbstractEventContext implements BaseEventContext {
   protected synchronized void tryTerminate() {
     if (this.state == STATE_COMPLETE && (externalCompletion == null || externalCompletion.isDone())) {
       if (debugLogEnabled) {
-        LOGGER.debug(this + " terminated.");
+        LOGGER.debug("{} terminated.", this.toString());
       }
       this.state = STATE_TERMINATED;
 


### PR DESCRIPTION
Also, avoid using responsePublisher for childContexts, since just using a response callback is enough and avoids the extra Mono creations/subscriptions.