### PR TITLE
MULE-16467: Fix mule-compatibility-plugin tests in Windows

### DIFF
--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
@@ -363,12 +363,7 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase {
   public static void disposeContext() throws MuleException {
     try {
       if (muleContext != null && !(muleContext.isDisposed() || muleContext.isDisposing())) {
-        try {
-          muleContext.dispose();
-        } catch (IllegalStateException e) {
-          // Ignore
-          LOGGER.warn(e + " : " + e.getMessage());
-        }
+        dispose();
 
         verifyAndStopSchedulers();
 
@@ -386,6 +381,15 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase {
       muleContext = null;
       clearLoggingConfig();
     }
+  }
+
+  public static void dispose() {
+      try {
+        muleContext.dispose();
+      } catch (IllegalStateException e) {
+        // Ignore
+        LOGGER.warn(e + " : " + e.getMessage());
+      }
   }
 
   private static List<SchedulerView> schedulersOnInit;


### PR DESCRIPTION
It was necessary to separate the code because at the time of deleting files and directories it was blocked by open connections