### PR TITLE
Revert "Revert "MULE-16438: Validators are not executed when compiling a connector with parent 1.2.0 (#7742)" (#7770)"

### DIFF
--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/resources/BaseExtensionResourcesGeneratorAnnotationProcessor.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/resources/BaseExtensionResourcesGeneratorAnnotationProcessor.java
@@ -12,10 +12,12 @@ import static java.util.stream.Collectors.toList;
 import static javax.tools.Diagnostic.Kind.ERROR;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 import static org.mule.runtime.api.dsl.DslResolvingContext.getDefault;
+import static org.mule.runtime.api.util.MuleSystemProperties.FORCE_EXTENSION_VALIDATION_PROPERTY_NAME;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 import static org.mule.runtime.core.api.util.ExceptionUtils.extractOfType;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.TYPE_PROPERTY_NAME;
 import static org.mule.runtime.module.extension.api.loader.AbstractJavaExtensionModelLoader.VERSION;
+
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.core.api.extension.MuleExtensionModelProvider;
@@ -48,7 +50,6 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
-
 
 /**
  * Annotation processor that picks up all the extensions annotated with {@link Extension} and use a
@@ -83,6 +84,9 @@ public abstract class BaseExtensionResourcesGeneratorAnnotationProcessor extends
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     log("Starting Resources generator for Extensions");
+
+    System.setProperty(FORCE_EXTENSION_VALIDATION_PROPERTY_NAME, "true");
+
     ResourcesGenerator generator = new AnnotationProcessorResourceGenerator(fetchResourceFactories(), processingEnv);
 
     try {


### PR DESCRIPTION
This reverts commit 0c82dd0e04540aa5a29f2db410e382e771399547.