### PR TITLE
MULE-16636: CursorProvider is retained too long when cursors are open…

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorProviderJanitor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorProviderJanitor.java
@@ -88,14 +88,15 @@ public class CursorProviderJanitor {
    */
   public void releaseCursor(Cursor cursor) {
     try {
-      cursor.release();
-      if (cursors.remove(cursor) && provider.isClosed() && cursors.isEmpty()) {
-        releaseResources();
+      if (cursors.remove(cursor)) {
+        statistics.decrementOpenCursors();
+        cursor.release();
+        if (provider.isClosed() && cursors.isEmpty()) {
+          releaseResources();
+        }
       }
     } catch (Exception e) {
       LOGGER.warn("Exception was found trying to release cursor resources. Execution will continue", e);
-    } finally {
-      statistics.decrementOpenCursors();
     }
   }
 }


### PR DESCRIPTION
…ed but not consumed