### PR TITLE
MULE-16676: Fix deployment-module tests for Java 11

### DIFF
--- a/modules/deployment/pom.xml
+++ b/modules/deployment/pom.xml
@@ -53,6 +53,11 @@
         <dependency>
             <!--for the extensions configuration builder-->
             <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-extensions-api</artifactId>
+        </dependency>
+        <dependency>
+            <!--for the extensions configuration builder-->
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-extensions-support</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Add required classpath to annotation processor when generating extensions metadata