### PR TITLE
MULE-16727: Remove maven parallel execution (-T 2) to avoid error 'No…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ def UPSTREAM_PROJECTS_LIST = ["Mule-runtime/mule-common/3.x"]
 Map pipelineParams = ["upstreamProjects"   : UPSTREAM_PROJECTS_LIST.join(','),
                       "mavenTool"          : "M3",
                       "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
-                      "mavenAdditionalArgs": "-P distributions,release -DskipGpg  -DxDocLint='-Xdoclint:none' -DskipNoSnapshotsEnforcerPluginRule -Djava.net.preferIPv4Stack -T 2",
+                      "mavenAdditionalArgs": "-P distributions,release -DskipGpg  -DxDocLint='-Xdoclint:none' -DskipNoSnapshotsEnforcerPluginRule -Djava.net.preferIPv4Stack",
                       "mavenTestGoal"      : "verify -DskipIntegrationTests=false -DskipTests=false -DskipSystemTests=false -Dsurefire.rerunFailingTestsCount=5 -Dmaven.javadoc.skip -DskipVerifications"]
 
 runtimeProjectsBuild(pipelineParams)


### PR DESCRIPTION
… providers found matching selection: 1.6'