### PR TITLE
Exclude jakarta mail from apikit/raml parser which was introduced in …

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -388,7 +388,7 @@
 /mule-standalone-${productVersion}/lib/opt/parser-interface-impl-v2-3.9.3-+
 /mule-standalone-${productVersion}/lib/opt/quartz-2.2.1.jar
 /mule-standalone-${productVersion}/lib/opt/raml-parser-0.9-+
-/mule-standalone-${productVersion}/lib/opt/raml-parser-2-1.0.33.jar
+/mule-standalone-${productVersion}/lib/opt/raml-parser-2-1.0.34.jar
 /mule-standalone-${productVersion}/lib/opt/reflections-0.9.9.jar
 /mule-standalone-${productVersion}/lib/opt/relaxngDatatype-20020414.jar
 /mule-standalone-${productVersion}/lib/opt/rhino-1.7R4.jar
@@ -442,7 +442,7 @@
 /mule-standalone-${productVersion}/lib/opt/xmlbeans-2.6.3.jar
 /mule-standalone-${productVersion}/lib/opt/xmltooling-1.4.1.jar
 /mule-standalone-${productVersion}/lib/opt/xqj-api-1.0.jar
-/mule-standalone-${productVersion}/lib/opt/yagi-1.0.33.jar
+/mule-standalone-${productVersion}/lib/opt/yagi-1.0.34.jar
 /mule-standalone-${productVersion}/lib/opt/validation-api-1.1.0.Final.jar
 /mule-standalone-${productVersion}/lib/shared
 /mule-standalone-${productVersion}/lib/shared/README.txt

--- a/distributions/standalone/pom.xml
+++ b/distributions/standalone/pom.xml
@@ -216,6 +216,10 @@
                     <groupId>javax.mail</groupId>
                     <artifactId>mailapi</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>jakarta.mail</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
…1.0.34 as it may introduce incompatibilities with Email connector.