### PR TITLE
MULE-16817: Pooled connections are not removed from the pool when they should evict.

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/connector/PetStorePooledConnectionEvictionTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/connector/PetStorePooledConnectionEvictionTestCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.test.module.extension.connector;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+
+import org.mule.test.module.extension.AbstractExtensionFunctionalTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class PetStorePooledConnectionEvictionTestCase extends AbstractExtensionFunctionalTestCase {
+
+  private static int AMOUNT_OF_TRIES = 5;
+  private static int TIME_BETWEEN_TRIES_IN_MILLIS = 8000;
+  private static Long IMPOSSIBLE_CONNECTION_AGE = 5000L;
+
+  @Override
+  protected String getConfigFile() {
+    return "petstore-pooled-connection-eviction.xml";
+  }
+
+  @Test
+  public void connectionIsEvicted() throws Exception {
+    List<Long> connectionAgesAtExecution = new ArrayList<>();
+    for (int i = 0; i < AMOUNT_OF_TRIES; i++) {
+      connectionAgesAtExecution.add((Long) flowRunner("get-connection-age").run().getMessage().getPayload().getValue());
+      Thread.sleep(TIME_BETWEEN_TRIES_IN_MILLIS);
+    }
+    for (Long connectionAgeAtExecution : connectionAgesAtExecution) {
+      assertThat(connectionAgeAtExecution, not(greaterThan(IMPOSSIBLE_CONNECTION_AGE)));
+    }
+  }
+
+}

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/connector/PetStorePooledConnectionEvictionTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/connector/PetStorePooledConnectionEvictionTestCase.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 
 public class PetStorePooledConnectionEvictionTestCase extends AbstractExtensionFunctionalTestCase {
 
-  private static int AMOUNT_OF_TRIES = 5;
-  private static int TIME_BETWEEN_TRIES_IN_MILLIS = 8000;
-  private static Long IMPOSSIBLE_CONNECTION_AGE = 5000L;
+  private static int AMOUNT_OF_TRIES = 2;
+  private static int TIME_BETWEEN_TRIES_IN_MILLIS = 4000;
+  private static Long IMPOSSIBLE_CONNECTION_AGE = 3000L;
 
   @Override
   protected String getConfigFile() {

--- a/modules/extensions-spring-support/src/test/resources/models/petstore.json
+++ b/modules/extensions-spring-support/src/test/resources/models/petstore.json
@@ -3820,6 +3820,391 @@
           "output": {
             "type": {
               "format": "java",
+              "type": "Number",
+              "annotations": {
+                "classInformation": {
+                  "classname": "java.lang.Long",
+                  "hasDefaultConstructor": false,
+                  "isInterface": false,
+                  "isInstantiable": false,
+                  "isAbstract": false,
+                  "isFinal": true,
+                  "implementedInterfaces": [
+                    "java.lang.Comparable"
+                  ],
+                  "parent": "java.lang.Number",
+                  "genericTypes": [],
+                  "isMap": false
+                },
+                "int": {}
+              }
+            },
+            "hasDynamicType": false,
+            "description": "",
+            "modelProperties": {}
+          },
+          "outputAttributes": {
+            "type": {
+              "format": "java",
+              "type": "Void"
+            },
+            "hasDynamicType": false,
+            "description": "",
+            "modelProperties": {}
+          },
+          "transactional": false,
+          "requiresConnection": true,
+          "supportsStreaming": false,
+          "notifications": [],
+          "nestedComponents": [],
+          "errors": [
+            "PETSTORE:CONNECTIVITY",
+            "PETSTORE:RETRY_EXHAUSTED"
+          ],
+          "stereotype": {
+            "type": "GET_CONNECTION_AGE",
+            "namespace": "PETSTORE",
+            "parent": {
+              "type": "PROCESSOR",
+              "namespace": "PETSTORE",
+              "parent": {
+                "type": "PROCESSOR",
+                "namespace": "MULE"
+              }
+            }
+          },
+          "parameterGroupModels": [
+            {
+              "parameters": [
+                {
+                  "type": {
+                    "format": "java",
+                    "type": "Object",
+                    "annotations": {
+                      "typeId": "org.mule.runtime.extension.api.runtime.config.ConfigurationProvider"
+                    },
+                    "fields": []
+                  },
+                  "hasDynamicType": false,
+                  "required": true,
+                  "isConfigOverride": false,
+                  "isComponentId": false,
+                  "expressionSupport": "NOT_SUPPORTED",
+                  "role": "BEHAVIOUR",
+                  "dslConfiguration": {
+                    "allowsInlineDefinition": false,
+                    "allowsReferences": true,
+                    "allowTopLevelDefinition": false
+                  },
+                  "layoutModel": {
+                    "password": false,
+                    "text": false,
+                    "query": false,
+                    "order": 4
+                  },
+                  "allowedStereotypeModels": [
+                    {
+                      "type": "CONFIG",
+                      "namespace": "PETSTORE",
+                      "parent": {
+                        "type": "MODULE_CONFIG",
+                        "namespace": "MULE"
+                      }
+                    }
+                  ],
+                  "name": "config-ref",
+                  "description": "The name of the configuration to be used to execute this component",
+                  "modelProperties": {}
+                }
+              ],
+              "exclusiveParametersModels": [],
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 0
+              },
+              "showInDsl": false,
+              "name": "General",
+              "description": "",
+              "modelProperties": {}
+            },
+            {
+              "parameters": [
+                {
+                  "type": {
+                    "format": "java",
+                    "type": "String"
+                  },
+                  "hasDynamicType": false,
+                  "required": false,
+                  "isConfigOverride": false,
+                  "isComponentId": false,
+                  "expressionSupport": "NOT_SUPPORTED",
+                  "role": "BEHAVIOUR",
+                  "dslConfiguration": {
+                    "allowsInlineDefinition": false,
+                    "allowsReferences": false,
+                    "allowTopLevelDefinition": false
+                  },
+                  "layoutModel": {
+                    "password": false,
+                    "text": false,
+                    "query": false,
+                    "order": 1,
+                    "tabName": "Advanced"
+                  },
+                  "allowedStereotypeModels": [],
+                  "name": "target",
+                  "displayModel": {
+                    "displayName": "Target Variable"
+                  },
+                  "description": "The name of a variable on which the operation\u0027s output will be placed",
+                  "modelProperties": {}
+                },
+                {
+                  "type": {
+                    "format": "java",
+                    "type": "String"
+                  },
+                  "hasDynamicType": false,
+                  "required": false,
+                  "isConfigOverride": false,
+                  "isComponentId": false,
+                  "expressionSupport": "REQUIRED",
+                  "defaultValue": "#[payload]",
+                  "role": "BEHAVIOUR",
+                  "dslConfiguration": {
+                    "allowsInlineDefinition": false,
+                    "allowsReferences": false,
+                    "allowTopLevelDefinition": false
+                  },
+                  "layoutModel": {
+                    "password": false,
+                    "text": false,
+                    "query": false,
+                    "order": 2,
+                    "tabName": "Advanced"
+                  },
+                  "allowedStereotypeModels": [],
+                  "name": "targetValue",
+                  "displayModel": {
+                    "displayName": "Target Value"
+                  },
+                  "description": "An expression that will be evaluated against the operation\u0027s output and the outcome of that expression will be stored in the target variable",
+                  "modelProperties": {}
+                }
+              ],
+              "exclusiveParametersModels": [],
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 1
+              },
+              "showInDsl": false,
+              "name": "Output",
+              "description": "",
+              "modelProperties": {}
+            },
+            {
+              "parameters": [
+                {
+                  "type": {
+                    "format": "java",
+                    "type": "Union",
+                    "annotations": {
+                      "typeId": "ReconnectionStrategy"
+                    },
+                    "of": [
+                      {
+                        "type": "Object",
+                        "annotations": {
+                          "typeId": "reconnect"
+                        },
+                        "fields": [
+                          {
+                            "key": {
+                              "name": "frequency"
+                            },
+                            "model": {
+                              "type": "Number",
+                              "annotations": {
+                                "int": {},
+                                "classInformation": {
+                                  "classname": "java.lang.Long",
+                                  "hasDefaultConstructor": false,
+                                  "isInterface": false,
+                                  "isInstantiable": false,
+                                  "isAbstract": false,
+                                  "isFinal": true,
+                                  "implementedInterfaces": [
+                                    "java.lang.Comparable"
+                                  ],
+                                  "parent": "java.lang.Number",
+                                  "genericTypes": [],
+                                  "isMap": false
+                                },
+                                "default": "2000"
+                              }
+                            },
+                            "annotations": {
+                              "description": {
+                                "value": "How often (in ms) to reconnect"
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "name": "blocking"
+                            },
+                            "model": {
+                              "type": "Boolean",
+                              "annotations": {
+                                "default": "true"
+                              }
+                            },
+                            "annotations": {
+                              "description": {
+                                "value": "If false, the reconnection strategy will run in a separate, non-blocking thread"
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "name": "count"
+                            },
+                            "model": {
+                              "type": "Number",
+                              "annotations": {
+                                "int": {},
+                                "default": "2"
+                              }
+                            },
+                            "annotations": {
+                              "description": {
+                                "value": "How many reconnection attempts to make"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Object",
+                        "annotations": {
+                          "typeId": "reconnect-forever"
+                        },
+                        "fields": [
+                          {
+                            "key": {
+                              "name": "frequency"
+                            },
+                            "model": {
+                              "type": "Number",
+                              "annotations": {
+                                "int": {},
+                                "classInformation": {
+                                  "classname": "java.lang.Long",
+                                  "hasDefaultConstructor": false,
+                                  "isInterface": false,
+                                  "isInstantiable": false,
+                                  "isAbstract": false,
+                                  "isFinal": true,
+                                  "implementedInterfaces": [
+                                    "java.lang.Comparable"
+                                  ],
+                                  "parent": "java.lang.Number",
+                                  "genericTypes": [],
+                                  "isMap": false
+                                },
+                                "default": "2000"
+                              }
+                            },
+                            "annotations": {
+                              "description": {
+                                "value": "How often (in ms) to reconnect"
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "name": "blocking"
+                            },
+                            "model": {
+                              "type": "Boolean",
+                              "annotations": {
+                                "default": "true"
+                              }
+                            },
+                            "annotations": {
+                              "description": {
+                                "value": "If false, the reconnection strategy will run in a separate, non-blocking thread"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "hasDynamicType": false,
+                  "required": false,
+                  "isConfigOverride": false,
+                  "isComponentId": false,
+                  "expressionSupport": "NOT_SUPPORTED",
+                  "role": "BEHAVIOUR",
+                  "dslConfiguration": {
+                    "allowsInlineDefinition": true,
+                    "allowsReferences": false,
+                    "allowTopLevelDefinition": false
+                  },
+                  "layoutModel": {
+                    "password": false,
+                    "text": false,
+                    "query": false,
+                    "order": 3,
+                    "tabName": "Advanced"
+                  },
+                  "allowedStereotypeModels": [],
+                  "name": "reconnectionStrategy",
+                  "description": "A retry strategy in case of connectivity errors",
+                  "modelProperties": {
+                    "org.mule.runtime.extension.api.property.QNameModelProperty": {
+                      "value": {
+                        "namespaceURI": "http://www.mulesoft.org/schema/mule/core",
+                        "localPart": "abstract-reconnection-strategy",
+                        "prefix": "mule"
+                      }
+                    },
+                    "org.mule.runtime.extension.api.property.InfrastructureParameterModelProperty": {
+                      "sequence": 3
+                    }
+                  }
+                }
+              ],
+              "exclusiveParametersModels": [],
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 2
+              },
+              "showInDsl": false,
+              "name": "Connection",
+              "description": "",
+              "modelProperties": {}
+            }
+          ],
+          "name": "getConnectionAge",
+          "description": "",
+          "modelProperties": {},
+          "kind": "operation"
+        },
+        {
+          "blocking": true,
+          "executionType": "BLOCKING",
+          "output": {
+            "type": {
+              "format": "java",
               "type": "Array",
               "annotations": {
                 "classInformation": {
@@ -23209,6 +23594,32 @@
           },
           "model": {
             "type": "String"
+          },
+          "annotations": {
+            "visibility": "READ_ONLY"
+          }
+        },
+        {
+          "key": {
+            "name": "timeOfCreation"
+          },
+          "model": {
+            "type": "Number",
+            "annotations": {
+              "classInformation": {
+                "classname": "long",
+                "hasDefaultConstructor": false,
+                "isInterface": false,
+                "isInstantiable": false,
+                "isAbstract": true,
+                "isFinal": true,
+                "implementedInterfaces": [],
+                "parent": "",
+                "genericTypes": [],
+                "isMap": false
+              },
+              "int": {}
+            }
           },
           "annotations": {
             "visibility": "READ_ONLY"

--- a/modules/extensions-spring-support/src/test/resources/petstore-pooled-connection-eviction.xml
+++ b/modules/extensions-spring-support/src/test/resources/petstore-pooled-connection-eviction.xml
@@ -7,7 +7,7 @@
 
     <petstore:config name="pooled-config-with-eviction" cashierName="jim">
         <petstore:pooled-connection username="john" password="doe">
-            <pooling-profile minEvictionMillis="3000" evictionCheckIntervalMillis="1000"/>
+            <pooling-profile maxIdle="1" maxActive="1" minEvictionMillis="2000" evictionCheckIntervalMillis="500"/>
         </petstore:pooled-connection>
         <petstore:pets>
             <petstore:pet value="Lassie" />

--- a/modules/extensions-spring-support/src/test/resources/petstore-pooled-connection-eviction.xml
+++ b/modules/extensions-spring-support/src/test/resources/petstore-pooled-connection-eviction.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:petstore="http://www.mulesoft.org/schema/mule/petstore"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/petstore http://www.mulesoft.org/schema/mule/petstore/current/mule-petstore.xsd">
+
+    <petstore:config name="pooled-config-with-eviction" cashierName="jim">
+        <petstore:pooled-connection username="john" password="doe">
+            <pooling-profile  minEvictionMillis="3000" evictionCheckIntervalMillis="1000"/>
+        </petstore:pooled-connection>
+        <petstore:pets>
+            <petstore:pet value="Lassie" />
+            <petstore:pet value="Sapo Pepe" />
+            <petstore:pet value="My mother's parrot" />
+        </petstore:pets>
+    </petstore:config>
+
+    <flow name="get-connection-age">
+        <petstore:get-connection-age config-ref="pooled-config-with-eviction"/>
+    </flow>
+    
+</mule>

--- a/modules/extensions-spring-support/src/test/resources/petstore-pooled-connection-eviction.xml
+++ b/modules/extensions-spring-support/src/test/resources/petstore-pooled-connection-eviction.xml
@@ -7,7 +7,7 @@
 
     <petstore:config name="pooled-config-with-eviction" cashierName="jim">
         <petstore:pooled-connection username="john" password="doe">
-            <pooling-profile  minEvictionMillis="3000" evictionCheckIntervalMillis="1000"/>
+            <pooling-profile minEvictionMillis="3000" evictionCheckIntervalMillis="1000"/>
         </petstore:pooled-connection>
         <petstore:pets>
             <petstore:pet value="Lassie" />

--- a/modules/extensions-spring-support/src/test/resources/schemas/petstore.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/petstore.xsd
@@ -599,6 +599,31 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:element xmlns="http://www.mulesoft.org/schema/mule/petstore" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="GetConnectionAgeType" substitutionGroup="mule:abstract-operator" name="get-connection-age"></xs:element>
+  <xs:complexType name="GetConnectionAgeType">
+    <xs:complexContent>
+      <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
+        <xs:sequence minOccurs="0" maxOccurs="1">
+          <xs:element minOccurs="0" maxOccurs="1" ref="mule:abstract-reconnection-strategy"></xs:element>
+        </xs:sequence>
+        <xs:attribute type="xs:string" use="required" name="config-ref">
+          <xs:annotation>
+            <xs:documentation>The name of the configuration to be used to execute this component</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="xs:string" use="optional" name="target">
+          <xs:annotation>
+            <xs:documentation>The name of a variable on which the operation's output will be placed</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="mule:expressionString" use="optional" default="#[payload]" name="targetValue">
+          <xs:annotation>
+            <xs:documentation>An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:element xmlns="http://www.mulesoft.org/schema/mule/petstore" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="GetPetsType" substitutionGroup="mule:abstract-operator" name="get-pets"></xs:element>
   <xs:complexType name="GetPetsType">
     <xs:complexContent>

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
@@ -699,19 +699,6 @@ public class CoreComponentBuildingDefinitionProvider implements ComponentBuildin
 
     componentBuildingDefinitions.addAll(getTransformersBuildingDefinitions());
 
-    componentBuildingDefinitions.add(baseDefinition.withIdentifier(POOLING_PROFILE_ELEMENT_IDENTIFIER)
-        .withTypeDefinition(fromType(PoolingProfile.class))
-        .withConstructorParameterDefinition(fromSimpleParameter("maxActive").withDefaultValue(DEFAULT_MAX_POOL_ACTIVE).build())
-        .withConstructorParameterDefinition(fromSimpleParameter("maxIdle").withDefaultValue(DEFAULT_MAX_POOL_IDLE).build())
-        .withConstructorParameterDefinition(fromSimpleParameter("maxWait", value -> Long.valueOf((String) value))
-            .withDefaultValue(valueOf(DEFAULT_MAX_POOL_WAIT)).build())
-        .withConstructorParameterDefinition(fromSimpleParameter("exhaustedAction", POOL_EXHAUSTED_ACTIONS::get)
-            .withDefaultValue(valueOf(DEFAULT_POOL_EXHAUSTED_ACTION)).build())
-        .withConstructorParameterDefinition(fromSimpleParameter("initialisationPolicy", POOL_INITIALISATION_POLICIES::get)
-            .withDefaultValue(valueOf(DEFAULT_POOL_INITIALISATION_POLICY)).build())
-        .withSetterParameterDefinition("disabled", fromSimpleParameter("disabled").build())
-        .build());
-
     componentBuildingDefinitions
         .add(baseDefinition.withIdentifier(RAISE_ERROR).withTypeDefinition(fromType(RaiseErrorProcessor.class))
             .withSetterParameterDefinition("type", fromSimpleParameter("type").build())

--- a/tests/test-extensions/petstore-extension/src/main/java/org/mule/test/petstore/extension/PetStoreClient.java
+++ b/tests/test-extensions/petstore-extension/src/main/java/org/mule/test/petstore/extension/PetStoreClient.java
@@ -25,6 +25,7 @@ public class PetStoreClient {
   private int disconnectCount;
   private Date openingDate;
   private List<Date> closedForHolidays;
+  private Long timeOfCreation;
 
   private List<LocalDateTime> discountDates;
 
@@ -37,6 +38,7 @@ public class PetStoreClient {
     this.openingDate = openingDate;
     this.closedForHolidays = closedForHolidays;
     this.discountDates = discountDates;
+    this.timeOfCreation = System.currentTimeMillis();
   }
 
   public List<String> getPets(String ownerName, PetStoreConnector config) {
@@ -83,5 +85,9 @@ public class PetStoreClient {
 
   public List<LocalDateTime> getDiscountDates() {
     return discountDates;
+  }
+
+  public long getTimeOfCreation() {
+    return timeOfCreation;
   }
 }

--- a/tests/test-extensions/petstore-extension/src/main/java/org/mule/test/petstore/extension/PetStoreOperations.java
+++ b/tests/test-extensions/petstore-extension/src/main/java/org/mule/test/petstore/extension/PetStoreOperations.java
@@ -54,6 +54,10 @@ public class PetStoreOperations {
   public static boolean shouldFailWithConnectionException;
   public static AtomicInteger operationExecutionCounter = new AtomicInteger(0);
 
+  public Long getConnectionAge(@Connection PetStoreClient client,
+                               @Config PetStoreConnector config) {
+    return System.currentTimeMillis() - client.getTimeOfCreation();
+  }
 
   @MediaType(ANY)
   public void scopeWithMuleStereotype(@AllowedStereotypes(ValidatorStereotype.class) Chain validators,


### PR DESCRIPTION
In the CoreComponentBuildingDefinitionProvider class there were 2 definitions for the identifier `pooling-profile`. The one that was being registered last had 2 missing parameters, `minEvictionMillis` and `evictionCheckIntervalMillis`. This made these parameter always have their default values.