### PR TITLE
MULE-16936: sinks must be used by only one thread when running a transaction

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/rx/RoundRobinFluxSinkSupplierTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/rx/RoundRobinFluxSinkSupplierTestCase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.util.rx;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import reactor.core.publisher.FluxSink;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class RoundRobinFluxSinkSupplierTestCase {
+
+  private static final int SINKS_COUNT = 10;
+
+  @Test
+  public void loopAroundSinks() {
+    Supplier factoryMock = mock(Supplier.class);
+    when(factoryMock.get()).thenAnswer(invocationOnMock -> mock(FluxSink.class));
+
+    FluxSinkSupplier<FluxSink> roundRobin = new RoundRobinFluxSinkSupplier(SINKS_COUNT, factoryMock);
+    List<FluxSink> sinks = new ArrayList<>();
+
+    for (int i = 0; i < SINKS_COUNT; i++) {
+      sinks.add(roundRobin.get());
+    }
+    verify(factoryMock, times(SINKS_COUNT)).get();
+
+    // We got all different sinks
+    assertThat(new HashSet<>(sinks), hasSize(SINKS_COUNT));
+
+    // Go for another round and check sinks repeat
+    for (int i = 0; i < SINKS_COUNT; i++) {
+      assertThat(roundRobin.get(), is(sinks.get(i)));
+    }
+
+  }
+
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplierTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplierTestCase.java
@@ -13,6 +13,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static java.util.Collections.synchronizedSet;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -65,7 +66,7 @@ public class TransactionAwareFluxSinkSupplierTestCase {
   @Test
   public void newSinkPerThread() throws Exception {
     List<Thread> threads = new ArrayList<>();
-    Set<FluxSink> sinks = new HashSet<>();
+    Set<FluxSink> sinks = synchronizedSet(new HashSet<>());
     for (int i = 0; i < THREAD_TEST; i++) {
       Thread thread = new Thread(() -> {
         Transaction tx = mock(Transaction.class);
@@ -75,9 +76,7 @@ public class TransactionAwareFluxSinkSupplierTestCase {
             FluxSink sink = txSupplier.get();
             // Assert that supplied for same thread supplies same sink
             assertThat(txSupplier.get(), is(sink));
-            synchronized (sinks) {
-              sinks.add(sink);
-            }
+            sinks.add(sink);
           } finally {
             TransactionCoordination.getInstance().unbindTransaction(tx);
           }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplierTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplierTestCase.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.util.rx;
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.runtime.api.tx.TransactionException;
+import org.mule.runtime.core.api.transaction.Transaction;
+import org.mule.runtime.core.api.transaction.TransactionCoordination;
+import reactor.core.publisher.FluxSink;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TransactionAwareFluxSinkSupplierTestCase {
+
+  private static final int THREAD_TEST = 10;
+
+  private FluxSinkSupplier mockSupplier = mock(FluxSinkSupplier.class);
+  private FluxSink mockSink = mock(FluxSink.class);
+  private FluxSinkSupplier<FluxSink> txSupplier;
+
+  @Before
+  public void setUp() {
+    when(mockSupplier.get()).thenReturn(mockSink);
+    txSupplier = new TransactionAwareFluxSinkSupplier(() -> mock(FluxSink.class), mockSupplier);
+  }
+
+  @Test
+  public void delegatesWhenNotInTx() {
+    assertThat(txSupplier.get(), is(mockSink));
+    // Assert that it doesn't change between calls
+    assertThat(txSupplier.get(), is(mockSink));
+  }
+
+  @Test
+  public void returnsNewSinkWhenInTx() throws TransactionException {
+    Transaction tx = mock(Transaction.class);
+    try {
+      TransactionCoordination.getInstance().bindTransaction(tx);
+      FluxSink supplied = txSupplier.get();
+      // Assert is another sink
+      assertThat(supplied, is(not(mockSink)));
+      // Assert that supplied for same thread supplies same sink
+      assertThat(txSupplier.get(), is(supplied));
+    } finally {
+      TransactionCoordination.getInstance().unbindTransaction(tx);
+    }
+  }
+
+  @Test
+  public void newSinkPerThread() throws Exception {
+    List<Thread> threads = new ArrayList<>();
+    Set<FluxSink> sinks = new HashSet<>();
+    for (int i = 0; i < THREAD_TEST; i++) {
+      Thread thread = new Thread(() -> {
+        Transaction tx = mock(Transaction.class);
+        try {
+          try {
+            TransactionCoordination.getInstance().bindTransaction(tx);
+            FluxSink sink = txSupplier.get();
+            // Assert that supplied for same thread supplies same sink
+            assertThat(txSupplier.get(), is(sink));
+            synchronized (sinks) {
+              sinks.add(sink);
+            }
+          } finally {
+            TransactionCoordination.getInstance().unbindTransaction(tx);
+          }
+        } catch (TransactionException e) {
+
+        }
+      });
+      threads.add(thread);
+    }
+
+    for (Thread t : threads) {
+      t.start();
+    }
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    // Every thread created has a different sink
+    assertThat(sinks, hasSize(THREAD_TEST));
+  }
+
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/util/rx/FluxSinkSupplier.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/rx/FluxSinkSupplier.java
@@ -11,5 +11,12 @@ import reactor.core.publisher.FluxSink;
 
 import java.util.function.Supplier;
 
+/**
+ * Supplier of {@link FluxSink}.
+ *
+ * @param <T> the value type
+ *
+ * @since 4.3
+ */
 public interface FluxSinkSupplier<T> extends Supplier<FluxSink<T>>, Disposable {
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/util/rx/FluxSinkSupplier.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/rx/FluxSinkSupplier.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.util.rx;
+
+import org.mule.runtime.api.lifecycle.Disposable;
+import reactor.core.publisher.FluxSink;
+
+import java.util.function.Supplier;
+
+public interface FluxSinkSupplier<T> extends Supplier<FluxSink<T>>, Disposable {
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/util/rx/RoundRobinFluxSinkSupplier.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/rx/RoundRobinFluxSinkSupplier.java
@@ -21,7 +21,7 @@ import reactor.core.publisher.FluxSink;
  *
  * @since 4.2
  */
-public class RoundRobinFluxSinkSupplier<T> implements FluxSinkSupplier {
+public class RoundRobinFluxSinkSupplier<T> implements FluxSinkSupplier<T> {
 
   private final List<FluxSink<T>> fluxSinks;
   private final AtomicInteger index = new AtomicInteger(0);

--- a/core/src/main/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplier.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.util.rx;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import reactor.core.publisher.FluxSink;
+
+import java.util.function.Supplier;
+
+import static java.lang.Thread.currentThread;
+import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTransactionActive;
+
+/**
+ * Provides a unique {@link FluxSink} for each Thread in transactional context. In case of non-transactional context,
+ * it delegates the request.
+ *
+ * @param <T> the value type
+ *
+ * @since 4.3
+ */
+public class TransactionAwareFluxSinkSupplier<T> implements FluxSinkSupplier {
+
+  private final Supplier<FluxSink<T>> newSinkFactory;
+  private final FluxSinkSupplier<T> delegate;
+  private final Cache<Thread, FluxSink<T>> sinks = Caffeine.newBuilder().weakKeys().build();
+
+  public TransactionAwareFluxSinkSupplier(Supplier<FluxSink<T>> sinkFactory, FluxSinkSupplier<T> delegate) {
+    this.newSinkFactory = sinkFactory;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public FluxSink<T> get() {
+    // In case of tx we need to ensure that in use of the delegate supplier there are no 2 threads trying to use the
+    // same sink. This could cause a race condition in which the second thread simply queues the event in the busy sink.
+    // So, this thread will not unbind the tx (causing an error next time it tries to bind one), and the first one will
+    // then process the queued event without having the tx bound (so it will process as if it wasn't a tx in the
+    // beginning).
+    if (isTransactionActive()) {
+      return sinks.get(currentThread(), t -> newSinkFactory.get());
+    } else {
+      return delegate.get();
+    }
+  }
+
+  @Override
+  public void dispose() {
+    delegate.dispose();
+    sinks.asMap().forEach((t, sink) -> sink.complete());
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplier.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/rx/TransactionAwareFluxSinkSupplier.java
@@ -23,7 +23,7 @@ import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTr
  *
  * @since 4.3
  */
-public class TransactionAwareFluxSinkSupplier<T> implements FluxSinkSupplier {
+public class TransactionAwareFluxSinkSupplier<T> implements FluxSinkSupplier<T> {
 
   private final Supplier<FluxSink<T>> newSinkFactory;
   private final FluxSinkSupplier<T> delegate;
@@ -52,5 +52,6 @@ public class TransactionAwareFluxSinkSupplier<T> implements FluxSinkSupplier {
   public void dispose() {
     delegate.dispose();
     sinks.asMap().forEach((t, sink) -> sink.complete());
+    sinks.invalidateAll();
   }
 }


### PR DESCRIPTION
The test case is the Perf test running correctly :) 