### PR TITLE
MULE-16995: Shared runtime deps in app mess up classloading

### DIFF
--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractDependencyFileBuilder.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/builder/AbstractDependencyFileBuilder.java
@@ -13,6 +13,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.SystemUtils.JAVA_IO_TMPDIR;
 import static org.mule.runtime.module.artifact.api.classloader.MuleMavenPlugin.MULE_MAVEN_PLUGIN_ARTIFACT_ID;
 import static org.mule.runtime.module.artifact.api.classloader.MuleMavenPlugin.MULE_MAVEN_PLUGIN_GROUP_ID;
+
 import org.mule.runtime.api.exception.MuleRuntimeException;
 
 import java.io.File;
@@ -48,7 +49,7 @@ public abstract class AbstractDependencyFileBuilder<T extends AbstractDependency
   private final List<AbstractDependencyFileBuilder> sharedLibraries = new ArrayList<>();
   private String groupId = "org.mule.test";
   private String version = "1.0.0";
-  private String type = "jar";
+  private final String type = "jar";
   private String classifier;
   private File artifactPomFile;
   private File artifactPomPropertiesFile;
@@ -328,4 +329,9 @@ public abstract class AbstractDependencyFileBuilder<T extends AbstractDependency
     }
     return new ArrayList<>(allCompileDependencies);
   }
+
+  protected boolean isShared(AbstractDependencyFileBuilder dependencyFileBuilder) {
+    return this.sharedLibraries.contains(dependencyFileBuilder);
+  }
+
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/ArtifactClassLoaderModelBuilder.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/ArtifactClassLoaderModelBuilder.java
@@ -24,6 +24,8 @@ import static org.mule.tools.api.classloader.Constants.PLUGIN_DEPENDENCY_FIELD;
 import static org.mule.tools.api.classloader.Constants.PLUGIN_FIELD;
 import static org.mule.tools.api.classloader.Constants.SHARED_LIBRARIES_FIELD;
 import static org.mule.tools.api.classloader.Constants.SHARED_LIBRARY_FIELD;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.i18n.I18nMessageFactory;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
@@ -48,6 +50,7 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.Logger;
 
 /**
  * ClassLoaderModelBuilder that adds the concept of Shared Library for the configured dependencies.
@@ -55,6 +58,8 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  * @since 4.2.0
  */
 public abstract class ArtifactClassLoaderModelBuilder extends ClassLoaderModel.ClassLoaderModelBuilder {
+
+  private static final Logger LOGGER = getLogger(ArtifactClassLoaderModelBuilder.class);
 
   private static final String GROUP_ID = "groupId";
   private static final String ARTIFACT_ID = "artifactId";
@@ -78,7 +83,7 @@ public abstract class ArtifactClassLoaderModelBuilder extends ClassLoaderModel.C
 
   /**
    * Sets a flag to export the configured shared libraries when building the ClassLoaderModel
-   * 
+   *
    * @return this builder
    * @since 4.2.0
    */
@@ -89,7 +94,7 @@ public abstract class ArtifactClassLoaderModelBuilder extends ClassLoaderModel.C
 
   /**
    * Sets a flag to include additional dependencies for each plugin if the deployable artifact defines them.
-   * 
+   *
    * @since 4.2.0
    */
   public ClassLoaderModel.ClassLoaderModelBuilder additionalPluginLibraries() {
@@ -217,10 +222,25 @@ public abstract class ArtifactClassLoaderModelBuilder extends ClassLoaderModel.C
           for (Xpp3Dom sharedLibrary : sharedLibraries) {
             String groupId = getAttribute(sharedLibrary, GROUP_ID);
             String artifactId = getAttribute(sharedLibrary, ARTIFACT_ID);
-            findAndExportSharedLibrary(groupId, artifactId);
+
+            if (!validateMuleRuntimeSharedLibrary(groupId, artifactId)) {
+              findAndExportSharedLibrary(groupId, artifactId);
+            }
           }
         }
       }
+    }
+  }
+
+  protected final boolean validateMuleRuntimeSharedLibrary(String groupId, String artifactId) {
+    if ("org.mule.runtime".equals(groupId)
+        || "com.mulesoft.mule.runtime.modules".equals(groupId)) {
+      LOGGER
+          .warn("Shared library '{}:{}' is a Mule Runtime dependency. It will not be shared by the app in order to avoid classloading issues. Please consider removing it, or at least not putting it as a sharedLibrary.",
+                groupId, artifactId);
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/HeavyweightClassLoaderModelBuilder.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/HeavyweightClassLoaderModelBuilder.java
@@ -9,13 +9,12 @@ package org.mule.runtime.module.deployment.impl.internal.maven;
 import static com.vdurmont.semver4j.Semver.SemverType.LOOSE;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
+
 import org.mule.runtime.module.artifact.api.descriptor.BundleDependency;
 import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.BundleScope;
 import org.mule.tools.api.classloader.model.AppClassLoaderModel;
 import org.mule.tools.api.classloader.model.Artifact;
-
-import com.vdurmont.semver4j.Semver;
 
 import java.io.File;
 import java.net.URI;
@@ -27,6 +26,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Plugin;
 
+import com.vdurmont.semver4j.Semver;
+
 /**
  * Builder for a {@link org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel} with information from a
  * {@link org.mule.tools.api.classloader.model.ClassLoaderModel} included when packaging the artifact in a heavyweight manner.
@@ -37,7 +38,7 @@ public class HeavyweightClassLoaderModelBuilder extends ArtifactClassLoaderModel
 
   private static final Semver CLASS_LOADER_MODEL_VERSION_110 = new Semver("1.1.0", LOOSE);
 
-  private org.mule.tools.api.classloader.model.ClassLoaderModel packagerClassLoaderModel;
+  private final org.mule.tools.api.classloader.model.ClassLoaderModel packagerClassLoaderModel;
 
   public HeavyweightClassLoaderModelBuilder(File applicationFolder, BundleDescriptor artifactBundleDescriptor,
                                             org.mule.tools.api.classloader.model.ClassLoaderModel packagerClassLoaderModel) {
@@ -121,9 +122,9 @@ public class HeavyweightClassLoaderModelBuilder extends ArtifactClassLoaderModel
   private void exportSharedLibrariesResourcesAndPackages() {
     packagerClassLoaderModel.getDependencies().stream()
         .filter(Artifact::isShared)
-        .forEach(
-                 sharedDep -> findAndExportSharedLibrary(
-                                                         sharedDep.getArtifactCoordinates().getGroupId(),
+        .filter(sharedDep -> !validateMuleRuntimeSharedLibrary(sharedDep.getArtifactCoordinates().getGroupId(),
+                                                               sharedDep.getArtifactCoordinates().getArtifactId()))
+        .forEach(sharedDep -> findAndExportSharedLibrary(sharedDep.getArtifactCoordinates().getGroupId(),
                                                          sharedDep.getArtifactCoordinates().getArtifactId()));
   }
 }

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/ApplicationFileBuilder.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/builder/ApplicationFileBuilder.java
@@ -43,7 +43,7 @@ import java.util.Properties;
  */
 public class ApplicationFileBuilder extends DeployableFileBuilder<ApplicationFileBuilder> {
 
-  private Properties properties = new Properties();
+  private final Properties properties = new Properties();
   private String minMuleVersion = "4.0.0";
 
   /**

--- a/modules/deployment/pom.xml
+++ b/modules/deployment/pom.xml
@@ -214,6 +214,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <testComponentPlugin>${org.mule.tests.plugin:mule-tests-component-plugin:jar:mule-plugin}</testComponentPlugin>
+                        <extensionsApiLib>${org.mule.runtime:mule-extensions-api:jar}</extensionsApiLib>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
@@ -144,15 +144,6 @@ import org.mule.tck.util.CompilerUtils.JarCompiler;
 import org.mule.tck.util.CompilerUtils.SingleClassCompiler;
 import org.mule.test.runner.classloader.TestModuleDiscoverer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.mockito.verification.VerificationMode;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -169,6 +160,15 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.verification.VerificationMode;
 
 @RunWith(Parameterized.class)
 /**

--- a/modules/deployment/src/test/resources/org/foo/privileged/PrivilegedExtension.java
+++ b/modules/deployment/src/test/resources/org/foo/privileged/PrivilegedExtension.java
@@ -11,12 +11,14 @@ import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.runtime.extension.api.annotation.Extension;
 import org.mule.runtime.extension.api.annotation.Operations;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.annotation.privileged.DeclarationEnrichers;
 
 /**
  * Extension for testing purposes
  */
 @Extension(name = "Privileged")
 @Operations({PrivilegedOperation.class})
+@DeclarationEnrichers({})
 public class PrivilegedExtension {
 
   @Parameter


### PR DESCRIPTION
* Also, parameterize `ApplicationDeploymentTestCase` to cover both versions of the classloaderModel