### PR TITLE
less logging when called from a non-mule client which is 3/4 independent

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
@@ -177,7 +177,7 @@ public class HttpRequestToMuleEvent
         {
             if (xCorrelationId != null)
             {
-                LOGGER.warn("'X-Correlation-ID: {}' and 'MULE_CORRELATION_ID: {}' headers found. 'MULE_CORRELATION_ID' will be used.",
+                LOGGER.debug("'X-Correlation-ID: {}' and 'MULE_CORRELATION_ID: {}' headers found. 'MULE_CORRELATION_ID' will be used.",
                             xCorrelationId, muleCorrelationId);
             }
             defaultMuleMessage.setCorrelationId(muleCorrelationId);


### PR DESCRIPTION
We have some clients calling rest endpoints on a mule-application.
As we collect all logs in one logging system the mule-application should not create its own correlationId but takeover the one from our (non-mule) applications (and vice-versa).

To be prepared for mule4 we are sending both correlationIds filled with our previously created one
(as target mule application may switch to Mule4 anytime):

But a WARN logger appears:
`

loggerName |   | org.mule.module.http.internal.listener.HttpMessagePropertiesResolver
-- | -- | --
message |   | 'X-Correlation-ID: MuleHelperProduct-1561980513126' and 'MULE_CORRELATION_ID: MuleHelperProduct-1561980513126' headers found. 'MULE_CORRELATION_ID' will be used.`

I simply set the logger to debug (as I think that is correct) 
but you may feel free to
set it to debug in case xCorrelationId.equals(muleCorrelationId) only and 
stick on the WARN message in the other case.