### PR TITLE
MULE-17110: NTLM authentication with dynamic credentials is successful despite credentials changes

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/request/grizzly/GrizzlyHttpClient.java
@@ -503,7 +503,7 @@ public class GrizzlyHttpClient implements HttpClient
                                                                               .setPrincipal(authentication.getUsername())
                                                                               .setPassword(authentication.getPassword())
                                                                               .setUsePreemptiveAuth(authentication.isPreemptive())
-                                                                              .setCredentialsMayVary(authentication.credentialsMayVary());
+                                                                              .setForceConnectionClose(authentication.credentialsMayVary());
 
 
                     if (authentication.getType() == HttpAuthenticationType.BASIC)

--- a/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestsWithNtlmAuthenticationConnectionPersistenceTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/requester/HttpRequestsWithNtlmAuthenticationConnectionPersistenceTestCase.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.module.http.functional.requester;
 
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;


### PR DESCRIPTION
Missing header and method called not renamed after refactor.