### PR TITLE
MULE-17116: Correct logger name to own-class logger. (#8013)

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpRequestToMuleEvent.java
@@ -54,9 +54,9 @@ import org.slf4j.LoggerFactory;
 public class HttpRequestToMuleEvent
 {
 
+    private static Logger LOGGER = LoggerFactory.getLogger(HttpRequestToMuleEvent.class);
     private static final String REPEATED_HEADERS_LOG_FORMAT =
       "'X-Correlation-ID: {}' and 'MULE_CORRELATION_ID: {}' headers found. 'MULE_CORRELATION_ID' will be used.";
-    private static Logger LOGGER = LoggerFactory.getLogger(HttpMessagePropertiesResolver.class);
     public static final BackwardsCompatibilityPropertyChecker
       IGNORE_CORRELATION_ID = new BackwardsCompatibilityPropertyChecker(COMPATIBILITY_IGNORE_CORRELATION_ID);
 


### PR DESCRIPTION
(cherry picked from commit 1187af38745dbc092c6530889988f731453faf39)