### PR TITLE
MULE-17234: Limit static resource loader to it's base path (#8066)

### DIFF
--- a/transports/http/src/main/java/org/mule/transport/http/components/StaticResourceMessageProcessor.java
+++ b/transports/http/src/main/java/org/mule/transport/http/components/StaticResourceMessageProcessor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.transport.http.components;
 
+import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
+import static org.mule.transport.http.i18n.HttpMessages.fileNotFound;
 import org.mule.DefaultMuleEvent;
 import org.mule.DefaultMuleMessage;
 import org.mule.api.MuleEvent;
@@ -14,6 +16,7 @@ import org.mule.api.config.ConfigurationException;
 import org.mule.api.lifecycle.Initialisable;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.api.processor.MessageProcessor;
+import org.mule.config.i18n.Message;
 import org.mule.transport.NullPayload;
 import org.mule.transport.http.HttpConnector;
 import org.mule.transport.http.HttpConstants;
@@ -26,8 +29,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import javax.activation.MimetypesFileTypeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A MessageProcessor that can be used by HTTP endpoints to serve static files from a directory on the
@@ -39,6 +48,8 @@ public class StaticResourceMessageProcessor implements MessageProcessor, Initial
 {
     public static final String DEFAULT_MIME_TYPE = "application/octet-stream";
     public static final String ROOT_PATH = "/";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StaticResourceMessageProcessor.class);
 
     private String resourceBase;
     private String defaultFile = "index.html";
@@ -70,6 +81,13 @@ public class StaticResourceMessageProcessor implements MessageProcessor, Initial
         }
 
         File file = new File(resourceBase + path);
+        URI uri = file.toURI().normalize();
+
+        if (!uri.getPath().startsWith(resourceBase))
+        {
+            LOGGER.debug("Requested resource is not within base path limits.");
+            throw new ResourceNotFoundException(getErrorMessage(path), event);
+        }
         MuleEvent resultEvent = event;
 
         if (file.isDirectory() && path.endsWith("/"))
@@ -110,7 +128,7 @@ public class StaticResourceMessageProcessor implements MessageProcessor, Initial
         }
         catch (IOException e)
         {
-            throw new ResourceNotFoundException(HttpMessages.fileNotFound(resourceBase + path),event);
+            throw new ResourceNotFoundException(getErrorMessage(path), event);
         }
         finally
         {
@@ -118,6 +136,11 @@ public class StaticResourceMessageProcessor implements MessageProcessor, Initial
         }
 
         return resultEvent;
+    }
+
+    private Message getErrorMessage(String s)
+    {
+        return fileNotFound(escapeHtml(s));
     }
 
     public String getResourceBase()

--- a/transports/http/src/test/java/org/mule/transport/http/functional/StaticResourcesMPFunctionalTestCase.java
+++ b/transports/http/src/test/java/org/mule/transport/http/functional/StaticResourcesMPFunctionalTestCase.java
@@ -6,8 +6,8 @@
  */
 package org.mule.transport.http.functional;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-
 import org.mule.tck.junit4.FunctionalTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.transport.http.HttpConstants;
@@ -173,6 +173,15 @@ public class StaticResourcesMPFunctionalTestCase extends FunctionalTestCase
         request(url, false);
         assertEquals(HttpConstants.SC_OK, responseCode);
         assertEquals(payload, "Test index.html");
+    }
+
+    @Test
+    public void onlyServeFilesWithinBasePath() throws Exception
+    {
+        String url = format("http://localhost:%d/static/../http-static-resource-test.xml", port1.getNumber());
+        request(url, true);
+        assertEquals(HttpConstants.SC_NOT_FOUND, responseCode);
+        assertEquals(payload, "The file: /../http-static-resource-test.xml  was not found.. Message payload is of type: String");
     }
 
 }

--- a/transports/http/src/test/resources/http-static-resource-test.xml
+++ b/transports/http/src/test/resources/http-static-resource-test.xml
@@ -17,19 +17,19 @@
     <flow name="main-http">
         <http:inbound-endpoint address="http://localhost:${port1}/static"/>
 
-        <http:static-resource-handler resourceBase="${test.root}/dummy-docroot" defaultFile="index.html"/>
+        <http:static-resource-handler resourceBase="${test.root}dummy-docroot" defaultFile="index.html"/>
     </flow>
 
     <flow name="main-https">
         <https:inbound-endpoint address="https://localhost:${port2}/static" connector-ref="httpsConnector"/>
 
-        <https:static-resource-handler resourceBase="${test.root}/dummy-docroot"/>
+        <https:static-resource-handler resourceBase="${test.root}dummy-docroot"/>
     </flow>
 
     <flow name="main-http-root">
         <http:inbound-endpoint address="http://localhost:${port3}"/>
 
-        <http:static-resource-handler resourceBase="${test.root}/dummy-docroot" defaultFile="index.html"/>
+        <http:static-resource-handler resourceBase="${test.root}dummy-docroot" defaultFile="index.html"/>
     </flow>
 
     <!-- these services test that we can have flows bound on the same http


### PR DESCRIPTION
(cherry picked from commit 2f92f34b1d96b9c7b6b0d1ad30866c3b2233507d)
(cherry picked from commit 0480767260c2aab94b28d3986741c648c68eac79)