### PR TITLE
MULE-17381: logger.context.reaper thread is lazy initialized and asso…

### DIFF
--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCache.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCache.java
@@ -79,6 +79,10 @@ final class LoggerContextCache implements Disposable {
         }).build();
 
     executorService = newScheduledThreadPool(1, new LoggerContextReaperThreadFactory(reaperContextClassLoader));
+    int threads = ((ThreadPoolExecutor) executorService).prestartAllCoreThreads();
+    if (threads != 1) {
+      throw new MuleRuntimeException(createStaticMessage("Could not init logger context repeater thread pool"));
+    }    
   }
 
   private void stop(LoggerContext loggerContext) {


### PR DESCRIPTION
…ciated to a wrong thread group