### PR TITLE
MULE-17381: logger.context.reaper thread is lazy initialized and asso…

### DIFF
--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelectorTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelectorTestCase.java
@@ -43,8 +43,14 @@ import org.mule.tck.probe.PollingProber;
 import org.mule.tck.probe.Probe;
 import org.mule.tck.size.SmallTest;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,11 +59,6 @@ import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
@@ -92,6 +93,11 @@ public class ArtifactAwareContextSelectorTestCase extends AbstractMuleTestCase {
     when(regionClassLoader.getArtifactId()).thenReturn(getClass().getName());
     when(regionClassLoader.findLocalResource("log4j2.xml")).thenReturn(CONFIG_LOCATION.toURI().toURL());
     when(regionClassLoader.getArtifactDescriptor()).thenReturn(artifactDescriptor);
+  }
+
+  @After
+  public void after() throws Exception {
+    dispose();
   }
 
   @Test
@@ -154,8 +160,12 @@ public class ArtifactAwareContextSelectorTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  public void usesLoggerContextReaperThread() {
+  public void usesLoggerContextReaperThread() throws Exception {
+    // make sure that selector is disposed therefore the reaper thread is stopped
+    dispose();
     assertReaperThreadNotRunning();
+    // call again the before process to intialize the selector and reaper thread
+    before();
 
     MuleLoggerContext context = getContext();
     selector.removeContext(context);


### PR DESCRIPTION
…ciated to a wrong thread group - Dispose contexts after test