### PR TITLE
Fix Object Store corrupted file move

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/util/store/PersistentObjectStorePartition.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/store/PersistentObjectStorePartition.java
@@ -23,6 +23,7 @@ import org.mule.runtime.api.store.ObjectStoreException;
 import org.mule.runtime.api.store.ObjectStoreNotAvailableException;
 import org.mule.runtime.api.store.TemplateObjectStore;
 import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.util.FileUtils;
 import org.mule.runtime.core.privileged.store.DeserializationPostInitialisable;
 import org.mule.runtime.api.store.ExpirableObjectStore;
 import org.mule.runtime.core.api.util.UUID;
@@ -252,7 +253,8 @@ public class PersistentObjectStorePartition<T extends Serializable> extends Temp
     Path relativePath = workingDirectory.relativize(absoluteFilePath);
     File corruptedFile = new File(muleContext.getConfiguration().getWorkingDirectory()
         + File.separator + CORRUPTED_FOLDER + File.separator + relativePath.toString());
-    Files.move(file.toPath(), corruptedFile.getParentFile().toPath());
+    FileUtils.openDirectory(corruptedFile.getParentFile().getAbsolutePath());
+    Files.move(file.toPath(), corruptedFile.toPath());
   }
 
   private void loadStoredKeysAndFileNames() throws ObjectStoreException {


### PR DESCRIPTION
Hi There.
Sorry, there is no JIRA ticket. But at the moment it seems impossible to create new JIRA accounts, as the link to create an account always redirects to Anypoint, and my Anypoint login does not work for JIRA.

If someone can create a JIRA ticket for this, I'd be happy to recreate the branch/commit/PR.

The summary of this issue is that the code to move corrupted files from the object store folder was not behaving correctly. It was not creating the required folder tree first before moving.

The existing test was passing but was not correct. The corrupted file was being moved in the test but was being renamed to have the object store name, rather than being nested under a folder having the object store name. The test has been fixed to expect the correct nesting.

Expected (and new result):
`<working_dir>/corrupted-files/junit4867812718450648275/temp1676195331268480483.obj`, where `junit4867812718450648275` is the object store name and `temp1676195331268480483.obj` is the corrupted file.

Previous result (incorrect, but was passing):
`<working_dir>/corrupted-files/junit4867812718450648275`, where `junit4867812718450648275` is the corrupted file.
