### PR TITLE
MULE-17381: logger.context.reaper thread is lazy initialized and

### DIFF
--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/MuleLog4jContextFactoryTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/MuleLog4jContextFactoryTestCase.java
@@ -51,17 +51,19 @@ public class MuleLog4jContextFactoryTestCase extends AbstractMuleTestCase {
 
   @Test
   public void systemProperties() {
-    new MuleLog4jContextFactory();
+    MuleLog4jContextFactory factory = new MuleLog4jContextFactory();
     assertThat(XmlConfigurationFactory.class.getName(), equalTo(getProperty(LOG_CONFIGURATION_FACTORY_PROPERTY)));
     assertThat(AsyncLoggerExceptionHandler.class.getName(), equalTo(getProperty(ASYNC_LOGGER_EXCEPTION_HANDLER_PROPERTY)));
+    factory.dispose();
   }
 
   @Test
   public void customExceptionHandler() {
     final String customHandler = "custom";
     System.setProperty(ASYNC_LOGGER_EXCEPTION_HANDLER_PROPERTY, customHandler);
-    new MuleLog4jContextFactory();
+    MuleLog4jContextFactory factory = new MuleLog4jContextFactory();
     assertThat(customHandler, equalTo(getProperty(ASYNC_LOGGER_EXCEPTION_HANDLER_PROPERTY)));
+    factory.dispose();
   }
 
   @Test


### PR DESCRIPTION
associated to a wrong thread group - Dispose contexts after test (#8150)