### PR TITLE
MULE-17409: MetadataCacheIdGenerator for configuration elements is no…

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/metadata/DslElementBasedMetadataCacheIdGenerator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/metadata/DslElementBasedMetadataCacheIdGenerator.java
@@ -177,6 +177,10 @@ public class DslElementBasedMetadataCacheIdGenerator implements MetadataCacheIdG
       }
     } else {
       resolveDslTagId(component).ifPresent(keyParts::add);
+      if (component.getModel() instanceof ConfigurationModel) {
+        resolveGlobalElement(component)
+            .ifPresent(keyParts::add);
+      }
     }
 
     keyParts.add(typeInformation.getComponentTypeMetadataCacheId());


### PR DESCRIPTION
…t taking into account parameters and only using DslTagId hash