### PR TITLE
MULE-17066: ExecutableComponent api should provide a way to mutate the child event that is going to be created

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/component/ExecutableComponentTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/component/ExecutableComponentTestCase.java
@@ -22,6 +22,7 @@ import org.mule.runtime.api.component.execution.ComponentExecutionException;
 import org.mule.runtime.api.component.execution.ExecutionResult;
 import org.mule.runtime.api.component.execution.InputEvent;
 import org.mule.runtime.api.event.Event;
+import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
@@ -48,7 +49,7 @@ public class ExecutableComponentTestCase extends AbstractMuleContextTestCase {
   }
 
   @Test
-  public void testExecuteWithInputEvent() throws Exception {
+  public void executeWithInputEvent() throws Exception {
     ExecutionResult executionResult = executableComponent.execute(InputEvent.create().message(requestMessage)).get();
     Event response = executionResult.getEvent();
 
@@ -65,7 +66,7 @@ public class ExecutableComponentTestCase extends AbstractMuleContextTestCase {
   }
 
   @Test
-  public void testExecuteWithEvent() throws Exception {
+  public void executeWithEvent() throws Exception {
     Event response = executableComponent.execute(testEvent()).get();
 
     assertThat(componentInEvent.get().getMessage(), equalTo(requestMessage));
@@ -86,7 +87,7 @@ public class ExecutableComponentTestCase extends AbstractMuleContextTestCase {
   }
 
   @Test
-  public void testExecuteWithInputEventError() throws Exception {
+  public void executeWithInputEventError() throws Exception {
     executableComponent.setToThrow(new IllegalStateException("Expected"));
 
     try {
@@ -108,7 +109,7 @@ public class ExecutableComponentTestCase extends AbstractMuleContextTestCase {
   }
 
   @Test
-  public void testExecuteWithEventError() throws Exception {
+  public void executeWithEventError() throws Exception {
     executableComponent.setToThrow(new IllegalStateException("Expected"));
 
     try {
@@ -133,6 +134,12 @@ public class ExecutableComponentTestCase extends AbstractMuleContextTestCase {
       ((BaseEventContext) testEvent().getContext()).success();
       assertThat(parentContext.isTerminated(), is(true));
     }
+  }
+
+  @Test
+  public void executeWithContributor() throws MuleException {
+    executableComponent.execute(testEvent(), eb -> eb.addVariable("its_me", "Mario!"));
+    assertThat(componentInEvent.get().getVariables().get("its_me").getValue(), is("Mario!"));
   }
 
   final class TestExecutableComponent extends AbstractExecutableComponent implements ReactiveProcessor {

--- a/core/api-changes.json
+++ b/core/api-changes.json
@@ -3,6 +3,15 @@
     "revapi": {
       "ignore": [
         {
+          "code": "java.method.finalMethodAddedToNonFinalClass",
+          "new": "method java.util.concurrent.CompletableFuture<org.mule.runtime.api.event.Event> org.mule.runtime.core.privileged.component.AbstractExecutableComponent::execute(org.mule.runtime.api.event.Event, java.util.function.Consumer<org.mule.runtime.core.api.event.CoreEvent.Builder>)",
+          "package": "org.mule.runtime.core.privileged.component",
+          "classSimpleName": "AbstractExecutableComponent",
+          "methodName": "execute",
+          "elementKind": "method",
+          "justification": "No implementors of this API implement a method with this signature."
+        },
+        {
           "code": "java.method.abstractMethodAdded",
           "new": "method org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler::duplicateFor(org.mule.runtime.api.component.location.Location)",
           "package": "org.mule.runtime.core.privileged.exception",


### PR DESCRIPTION
This new method cannot be declared in the `ExecutableComponent`
interface since it is coupled to the `Event.Builder`, which is not in
the `mule-api` but in `mule-core`. So, only privileged api clients may
use this new method.