### PR TITLE
MULE-17463: Improve Performance of creating FlowBackPressureException

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/config/i18n/CoreMessages.java
+++ b/core/src/main/java/org/mule/runtime/core/api/config/i18n/CoreMessages.java
@@ -14,6 +14,7 @@ import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.config.MuleManifest;
 import org.mule.runtime.core.api.config.bootstrap.ArtifactType;
+import org.mule.runtime.core.api.construct.BackPressureReason;
 import org.mule.runtime.core.api.context.notification.ListenerSubscriptionPair;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
@@ -966,6 +967,10 @@ public class CoreMessages extends I18nMessageFactory {
 
   public static I18nMessage nullWatermark() {
     return factory.createMessage(BUNDLE_PATH, 350);
+  }
+
+  public static I18nMessage backpressure(String flowName, BackPressureReason reason) {
+    return factory.createMessage(BUNDLE_PATH, 351, flowName, reason.toString());
   }
 
   private CoreMessages() {}

--- a/core/src/main/java/org/mule/runtime/core/internal/construct/BackPressureStrategySelector.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/construct/BackPressureStrategySelector.java
@@ -67,7 +67,7 @@ class BackPressureStrategySelector {
       throws FlowBackPressureException {
     final BackPressureReason reason = abstractPipeline.getProcessingStrategy().checkBackpressureEmitting(event);
     if (reason != null) {
-      createAndThrowIfNeeded(abstractPipeline.getName(), reason);
+      throw abstractPipeline.getBackPressureExceptions().get(reason);
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/construct/FlowBackPressureException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/construct/FlowBackPressureException.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.core.internal.construct;
 
-import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.core.api.config.i18n.CoreMessages.backpressure;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.construct.BackPressureReason;
@@ -28,7 +28,7 @@ public abstract class FlowBackPressureException extends MuleException {
    * back-pressure without throwing an exception.
    */
   public FlowBackPressureException(String flowName, BackPressureReason reason) {
-    super(createStaticMessage(BACK_PRESSURE_ERROR_MESSAGE, flowName, reason.toString()));
+    super(backpressure(flowName, reason));
   }
 
   /**
@@ -36,29 +36,7 @@ public abstract class FlowBackPressureException extends MuleException {
    * strategy is in use and back-pressure is identified by a {@link RejectedExecutionException}.
    */
   public FlowBackPressureException(String flowName, BackPressureReason reason, Throwable cause) {
-    super(createStaticMessage(BACK_PRESSURE_ERROR_MESSAGE, flowName, reason.toString()), cause);
-  }
-
-  public static FlowBackPressureException createFlowBackPressureException(String flowName, BackPressureReason reason) {
-    switch (reason) {
-      case MAX_CONCURRENCY_EXCEEDED:
-        return new FlowBackPressureMaxConcurrencyExceededException(flowName, reason);
-      case REQUIRED_SCHEDULER_BUSY:
-        return new FlowBackPressureRequiredSchedulerBusyException(flowName, reason);
-      case REQUIRED_SCHEDULER_BUSY_WITH_FULL_BUFFER:
-        return new FlowBackPressureRequiredSchedulerBusyWithFullBufferException(flowName, reason);
-      case EVENTS_ACCUMULATED:
-        return new FlowBackPressureEventsAccumulatedException(flowName, reason);
-      default:
-        return null;
-    }
-  }
-
-  public static void createAndThrowIfNeeded(String flowName, BackPressureReason reason) throws FlowBackPressureException {
-    final FlowBackPressureException toThrow = createFlowBackPressureException(flowName, reason);
-    if (toThrow != null) {
-      throw toThrow;
-    }
+    super(backpressure(flowName, reason), cause);
   }
 
   public static FlowBackPressureException createFlowBackPressureException(String flowName, BackPressureReason reason,

--- a/core/src/main/resources/META-INF/org/mule/runtime/core/i18n/core-messages.properties
+++ b/core/src/main/resources/META-INF/org/mule/runtime/core/i18n/core-messages.properties
@@ -293,3 +293,4 @@
 348=The endpoint {0} does not return responses and therefore can't be used for polling.
 349=Value retrieved from event for variable {0} is not serializable and hence can't be saved to the object store
 350=Watermark value will not be updated since poll processor returned no results
+351=Flow '{0}' is unable to accept new events at this time. Reason: {1}


### PR DESCRIPTION
It turns out that building the message of the exception (`String.format`) is expensive. Since the message contains the name of the flow, the exceptions are prebuilt for each flow.