### PR TITLE
MULE-17435: Add logic to copy the plugin jar and log MD5 when 'Could …

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/api/ExtensionPluginMetadataGenerator.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/ExtensionPluginMetadataGenerator.java
@@ -26,6 +26,7 @@ import org.mule.runtime.extension.api.annotation.Extension;
 import org.mule.runtime.extension.api.loader.ExtensionModelLoader;
 import org.mule.runtime.module.extension.internal.manager.DefaultExtensionManager;
 import org.mule.test.runner.infrastructure.ExtensionsTestInfrastructureDiscoverer;
+import org.mule.test.runner.utils.TroubleshootingUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -159,8 +160,10 @@ class ExtensionPluginMetadataGenerator {
         try {
           return Class.forName(extensionClassName);
         } catch (ClassNotFoundException e) {
+          TroubleshootingUtils.copyPluginToAuxJenkinsFolderForTroubleshooting(firstURL);
           throw new IllegalArgumentException("Cannot load Extension class '" + extensionClassName + " obtained from: '" + firstURL
-              + "' using classpath: " + new ClassPathUrlProvider().getURLs(), e);
+              + "' with MD5 '" + TroubleshootingUtils.getMD5FromFile(firstURL) + "' using classpath: "
+              + new ClassPathUrlProvider().getURLs(), e);
         }
       }
       logger.debug("No class found annotated with {}", Extension.class.getName());

--- a/tests/runner/src/main/java/org/mule/test/runner/api/PluginResourcesResolver.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/PluginResourcesResolver.java
@@ -16,10 +16,11 @@ import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorC
 import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.PRIVILEGED_EXPORTED_PACKAGES;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_ARTIFACT_PATH_INSIDE_JAR;
 import static org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor.MULE_AUTO_GENERATED_ARTIFACT_PATH_INSIDE_JAR;
-import static org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor.META_INF;
 import static org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor.MULE_ARTIFACT_JSON_DESCRIPTOR;
+
 import org.mule.runtime.api.deployment.meta.MulePluginModel;
 import org.mule.runtime.api.deployment.persistence.MulePluginModelJsonSerializer;
+import org.mule.test.runner.utils.TroubleshootingUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,7 +71,9 @@ public class PluginResourcesResolver {
       try (InputStream stream = pluginJsonUrl.openStream()) {
         mulePluginModel = new MulePluginModelJsonSerializer().deserialize(IOUtils.toString(stream));
       } catch (IOException e) {
-        throw new IllegalArgumentException(format("Could not read extension describer on plugin '%s'", pluginJsonUrl),
+        TroubleshootingUtils.copyPluginToAuxJenkinsFolderForTroubleshooting(pluginJsonUrl);
+        throw new IllegalArgumentException(format("Could not read extension describer on plugin '%s' from JAR with MD5 '%s'",
+                                                  pluginJsonUrl, TroubleshootingUtils.getMD5FromFile(pluginJsonUrl)),
                                            e);
       }
 

--- a/tests/runner/src/main/java/org/mule/test/runner/utils/TroubleshootingUtils.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/utils/TroubleshootingUtils.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.test.runner.utils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.xml.bind.DatatypeConverter;
+
+public class TroubleshootingUtils {
+
+  private TroubleshootingUtils() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static final String PLUGINS_COPIED_FOR_TROUBLESHOOTING_FOLDER = "pluginsCopiedForTroubleshooting";
+
+  public static Path getJenkinsWorkspacePath(Path pluginJsonUrl) {
+    // The workspace name change from job to job with the form <folder>_<job name>_<branch>. Ex 'Mule-runtime_mule-ee_mule-4.x'
+    // So we use the ".m2" folder which is in the root of the workspace in all jobs and also works running locally.
+    return getPathOfFileContaining(pluginJsonUrl, ".m2").getParent();
+  }
+
+  public static Path getJenkinsWorkspacePath(URL pluginJsonUrl) {
+    return getJenkinsWorkspacePath(Paths.get(getPathStringFromJarURL(pluginJsonUrl))).getParent();
+  }
+
+  public static Path getJarPathFromPluginJson(Path pluginJsonUrl) {
+    return getPathOfFileContaining(pluginJsonUrl, "mule-plugin.jar");
+  }
+
+  public static Path getJarPathFromPluginJson(URL pluginJsonUrl) {
+    return getJarPathFromPluginJson(Paths.get(getPathStringFromJarURL(pluginJsonUrl)));
+  }
+
+  public static Path getPathOfFileContaining(URL pluginJsonUrl, String substring) {
+    Path pluginJsonPath = Paths.get(getPathStringFromJarURL(pluginJsonUrl));
+
+    return getPathOfFileContaining(pluginJsonPath, substring);
+  }
+
+  public static String getPathStringFromJarURL(URL pluginJsonUrl) {
+    String pluginJsonString = "";
+
+    if (pluginJsonUrl.toString().contains("jar:")) {
+      JarURLConnection connection = null;
+      try {
+        connection = (JarURLConnection) pluginJsonUrl.openConnection();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+      pluginJsonString = connection.getJarFileURL().getFile();
+    } else {
+      pluginJsonString = pluginJsonUrl.getPath();
+    }
+
+    return pluginJsonString;
+  }
+
+  public static Path getPathOfFileContaining(Path pluginJsonUrl, String substring) {
+    Path auxPath = pluginJsonUrl;
+    while (auxPath != null && !auxPath.getFileName().toString().contains(substring)) {
+      auxPath = auxPath.getParent();
+    }
+
+    if (auxPath == null) {
+      throw new RuntimeException(String.format("Could not find the substring '%s' in path '%s'", substring,
+                                               pluginJsonUrl.toAbsolutePath()));
+    }
+
+    return auxPath;
+  }
+
+  public static String getMD5FromFile(Path filePath) {
+    String md5Checksum = "";
+
+    try {
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      md.update(Files.readAllBytes(filePath));
+      byte[] digest = md.digest();
+      md5Checksum = DatatypeConverter
+          .printHexBinary(digest).toLowerCase();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("There was a problem getting MD5 Algorithm from the class MessageDigest", e);
+    }
+
+    return md5Checksum;
+  }
+
+  public static String getMD5FromFile(URL filePath) {
+    return getMD5FromFile(getJarPathFromPluginJson(filePath));
+  }
+
+  public static void copyPluginToAuxJenkinsFolderForTroubleshooting(Path pluginJsonUrl) throws IOException {
+    Path extensionJarPath = getJarPathFromPluginJson(pluginJsonUrl);
+    Path jenkinsTroubleshootingFolderPath =
+        Paths.get(getJenkinsWorkspacePath(pluginJsonUrl).toString(), PLUGINS_COPIED_FOR_TROUBLESHOOTING_FOLDER);
+    Path extensionJarTargetPath =
+        Paths.get(jenkinsTroubleshootingFolderPath.toString(), extensionJarPath.getFileName().toString());
+
+    if (!jenkinsTroubleshootingFolderPath.toFile().exists()) {
+      Files.createDirectories(jenkinsTroubleshootingFolderPath);
+    }
+
+    Files.copy(extensionJarPath, extensionJarTargetPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+  }
+
+  public static void copyPluginToAuxJenkinsFolderForTroubleshooting(URL pluginJsonUrl) throws IOException {
+    copyPluginToAuxJenkinsFolderForTroubleshooting(Paths.get(getPathStringFromJarURL(pluginJsonUrl)));
+  }
+}


### PR DESCRIPTION
…not read extension describer on plugin' error is thrown