### PR TITLE
MULE-17079: Remove flatMap from

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/processor/TryScope.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/TryScope.java
@@ -22,7 +22,6 @@ import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTr
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.applyWithChildContext;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.buildNewChainWithListOfProcessors;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.getProcessingStrategy;
-import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContext;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContextBlocking;
 import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Flux.from;
@@ -102,9 +101,6 @@ public class TryScope extends AbstractMessageProcessorOwner implements Scope {
       return publisher;
     } else if (isTransactionActive() || transactionConfig.getAction() != ACTION_INDIFFERENT) {
       return Scope.super.apply(publisher);
-    } else if (transactionConfig.getAction() == ACTION_INDIFFERENT) {
-      return from(publisher)
-          .flatMap(event -> processWithChildContext(event, nestedChain, ofNullable(getLocation()), messagingExceptionHandler));
     } else {
       return from(publisher)
           .transform(event -> applyWithChildContext(event, nestedChain, ofNullable(getLocation()), messagingExceptionHandler));

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamProcessingStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamProcessingStrategy.java
@@ -28,6 +28,7 @@ import org.mule.runtime.core.api.construct.BackPressureReason;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.internal.construct.FromFlowRejectedExecutionException;
+import org.mule.runtime.core.internal.processor.chain.InterceptedReactiveProcessor;
 import org.mule.runtime.core.internal.util.rx.RejectionCallbackExecutorServiceDecorator;
 import org.mule.runtime.core.internal.util.rx.RetrySchedulerWrapper;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
@@ -50,6 +51,18 @@ public abstract class ProactorStreamProcessingStrategy extends AbstractReactorSt
   private static final Logger LOGGER = getLogger(ProactorStreamProcessingStrategy.class);
 
   private static final long SCHEDULER_BUSY_RETRY_INTERVAL_NS = MILLISECONDS.toNanos(SCHEDULER_BUSY_RETRY_INTERVAL_MS);
+
+  private static Class<ClassLoader> sdkOperationClass;
+
+  static {
+    try {
+      sdkOperationClass = (Class<ClassLoader>) ProactorStreamProcessingStrategy.class.getClassLoader()
+          .loadClass("org.mule.runtime.module.extension.internal.runtime.operation.OperationMessageProcessor");
+    } catch (ClassNotFoundException e) {
+      LOGGER.debug("OperationMessageProcessor interface not available in current context", e);
+    }
+
+  }
 
   private final Supplier<Scheduler> blockingSchedulerSupplier;
   private final Supplier<Scheduler> cpuIntensiveSchedulerSupplier;
@@ -123,13 +136,20 @@ public abstract class ProactorStreamProcessingStrategy extends AbstractReactorSt
       return publisher -> scheduleProcessor(processor, retryScheduler, from(publisher))
           .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler));
     } else if (maxConcurrency == MAX_VALUE) {
-      // For no limit, pass through the no limit meaning to Reactor's `flatMap`.
-      // Reactor needs the `publishOn` call to be done after a `flatMap` to achieve parallelism. Since at this point we cannot be
-      // sure that there is a `flatMap` call upstream, a `flatMap` call is reuqired here.
-      return publisher -> from(publisher)
-          .flatMap(event -> scheduleProcessor(processor, retryScheduler, Mono.just(event))
-              .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler)),
-                   MAX_VALUE);
+      if (processor.getProcessingType() == CPU_INTENSIVE
+          && (processor instanceof InterceptedReactiveProcessor)
+          && sdkOperationClass != null
+          && sdkOperationClass.isAssignableFrom(((InterceptedReactiveProcessor) processor).getProcessor().getClass())) {
+        // For no limit, the java SDK already does a flatMap internally, so no need to do an additional one here
+        return publisher -> scheduleProcessor(processor, retryScheduler, from(publisher))
+            .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler));
+      } else {
+        // For no limit, pass through the no limit meaning to Reactor's flatMap
+        return publisher -> from(publisher)
+            .flatMap(event -> scheduleProcessor(processor, retryScheduler, Mono.just(event))
+                .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler)),
+                     MAX_VALUE);
+      }
     } else {
       // Otherwise, enforce the concurrency limit from the config,
       return publisher -> from(publisher)
@@ -231,6 +251,4 @@ public abstract class ProactorStreamProcessingStrategy extends AbstractReactorSt
   public BackPressureReason checkBackpressureEmitting(CoreEvent event) {
     return checkCapacity(event);
   }
-
 }
-

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamProcessingStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamProcessingStrategy.java
@@ -28,7 +28,6 @@ import org.mule.runtime.core.api.construct.BackPressureReason;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.internal.construct.FromFlowRejectedExecutionException;
-import org.mule.runtime.core.internal.processor.chain.InterceptedReactiveProcessor;
 import org.mule.runtime.core.internal.util.rx.RejectionCallbackExecutorServiceDecorator;
 import org.mule.runtime.core.internal.util.rx.RetrySchedulerWrapper;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
@@ -51,18 +50,6 @@ public abstract class ProactorStreamProcessingStrategy extends AbstractReactorSt
   private static final Logger LOGGER = getLogger(ProactorStreamProcessingStrategy.class);
 
   private static final long SCHEDULER_BUSY_RETRY_INTERVAL_NS = MILLISECONDS.toNanos(SCHEDULER_BUSY_RETRY_INTERVAL_MS);
-
-  private static Class<ClassLoader> sdkOperationClass;
-
-  static {
-    try {
-      sdkOperationClass = (Class<ClassLoader>) ProactorStreamProcessingStrategy.class.getClassLoader()
-          .loadClass("org.mule.runtime.module.extension.internal.runtime.operation.OperationMessageProcessor");
-    } catch (ClassNotFoundException e) {
-      LOGGER.debug("OperationMessageProcessor interface not available in current context", e);
-    }
-
-  }
 
   private final Supplier<Scheduler> blockingSchedulerSupplier;
   private final Supplier<Scheduler> cpuIntensiveSchedulerSupplier;
@@ -136,19 +123,13 @@ public abstract class ProactorStreamProcessingStrategy extends AbstractReactorSt
       return publisher -> scheduleProcessor(processor, retryScheduler, from(publisher))
           .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler));
     } else if (maxConcurrency == MAX_VALUE) {
-      if ((processor instanceof InterceptedReactiveProcessor)
-          && sdkOperationClass != null
-          && sdkOperationClass.isAssignableFrom(((InterceptedReactiveProcessor) processor).getProcessor().getClass())) {
-        // For no limit, the java SDK already does a flatMap internally, so no need to do an additional one here
-        return publisher -> scheduleProcessor(processor, retryScheduler, from(publisher))
-            .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler));
-      } else {
-        // For no limit, pass through the no limit meaning to Reactor's flatMap
-        return publisher -> from(publisher)
-            .flatMap(event -> scheduleProcessor(processor, retryScheduler, Mono.just(event))
-                .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler)),
-                     MAX_VALUE);
-      }
+      // For no limit, pass through the no limit meaning to Reactor's `flatMap`.
+      // Reactor needs the `publishOn` call to be done after a `flatMap` to achieve parallelism. Since at this point we cannot be
+      // sure that there is a `flatMap` call upstream, a `flatMap` call is reuqired here.
+      return publisher -> from(publisher)
+          .flatMap(event -> scheduleProcessor(processor, retryScheduler, Mono.just(event))
+              .subscriberContext(ctx -> ctx.put(PROCESSOR_SCHEDULER_CONTEXT_KEY, scheduler)),
+                   MAX_VALUE);
     } else {
       // Otherwise, enforce the concurrency limit from the config,
       return publisher -> from(publisher)
@@ -250,4 +231,6 @@ public abstract class ProactorStreamProcessingStrategy extends AbstractReactorSt
   public BackPressureReason checkBackpressureEmitting(CoreEvent event) {
     return checkCapacity(event);
   }
+
 }
+

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -192,8 +192,6 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
     if (isAsync()) {
       return flux
-          // This flatMap allows the operation to run in parallel. The processing strategy relies on this
-          // (ProactorStreamProcessingStrategy#proactor) to do some performance optimizations.
           .flatMap(event -> {
             DeferredMonoSinkExecutorCallback callback = new DeferredMonoSinkExecutorCallback();
             onEvent(event, callback);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -192,6 +192,8 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
     if (isAsync()) {
       return flux
+          // This flatMap allows the operation to run in parallel. The processing strategy relies on this
+          // (ProactorStreamProcessingStrategy#proactor) to do some performance optimizations.
           .flatMap(event -> {
             DeferredMonoSinkExecutorCallback callback = new DeferredMonoSinkExecutorCallback();
             onEvent(event, callback);


### PR DESCRIPTION
ProactorStreamProcessingStrategy#proactor

* Finally understood that the flatMap is required in most cases :S.
Remove previous ugly workaround