### PR TITLE
MULE-17659: (Custom) Configuration Properties' parameters cannot depend on Deployment Properties

### DIFF
--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDeploymentTestCase.java
@@ -275,7 +275,8 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     Properties deploymentProperties = new Properties();
     deploymentProperties.put(OVERWRITTEN_PROPERTY, OVERWRITTEN_PROPERTY_DEPLOYMENT_VALUE);
     startDeployment();
-    deployAndVerifyPropertyInRegistry(dummyAppDescriptorWithPropsFileBuilder.getArtifactFile().toURI(), deploymentProperties,
+    deployAndVerifyPropertyInRegistry(dummyAppDescriptorWithPropsDependencyFileBuilder.getArtifactFile().toURI(),
+                                      deploymentProperties,
                                       (registry) -> registry.lookupByName(OVERWRITTEN_PROPERTY).get()
                                           .equals(OVERWRITTEN_PROPERTY_DEPLOYMENT_VALUE));
   }

--- a/modules/deployment/src/test/resources/dummy-app-with-props-dependencies-config.xml
+++ b/modules/deployment/src/test/resources/dummy-app-with-props-dependencies-config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <description>Empty Mule Application</description>
+
+   <global-property name="flowName" value="flowNameValue"/>
+
+    <configuration-properties file="${configFile}"/>
+
+</mule>

--- a/modules/deployment/src/test/resources/someProps.yaml
+++ b/modules/deployment/src/test/resources/someProps.yaml
@@ -1,0 +1,1 @@
+property: "hello world"

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/config/DefaultConfigurationPropertiesResolver.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/config/DefaultConfigurationPropertiesResolver.java
@@ -140,6 +140,17 @@ public class DefaultConfigurationPropertiesResolver implements ConfigurationProp
     throw new PropertyNotFoundException(new Pair<>(configurationPropertiesProvider.getDescription(), placeholderKey));
   }
 
+  private Object tryResolveByRoot(String placeholder) {
+    if (!rootResolver.isPresent()) {
+      return resolvePlaceholderKeyValue(placeholder);
+    }
+    try {
+      return rootResolver.get().resolvePlaceholderKeyValue(placeholder);
+    } catch (PropertyNotFoundException e) {
+      return resolvePlaceholderKeyValue(placeholder);
+    }
+  }
+
   private Object replaceAllPlaceholders(String value) {
     String innerPlaceholderKey;
     String testValue = value;
@@ -147,7 +158,7 @@ public class DefaultConfigurationPropertiesResolver implements ConfigurationProp
     while (prefixIndex != -1) {
       int suffixIndex = testValue.indexOf(PLACEHOLDER_SUFFIX, prefixIndex + PLACEHOLDER_PREFIX.length());
       innerPlaceholderKey = testValue.substring(prefixIndex + PLACEHOLDER_PREFIX.length(), suffixIndex);
-      Object objectValueFound = rootResolver.orElse(this).resolvePlaceholderKeyValue(innerPlaceholderKey);
+      Object objectValueFound = tryResolveByRoot(innerPlaceholderKey);
       // only use the value as string if it's a concat of placeholders
       if (value.equals(PLACEHOLDER_PREFIX + innerPlaceholderKey + PLACEHOLDER_SUFFIX)) {
         return objectValueFound;

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/config/DefaultConfigurationPropertiesResolver.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/config/DefaultConfigurationPropertiesResolver.java
@@ -167,7 +167,7 @@ public class DefaultConfigurationPropertiesResolver implements ConfigurationProp
     });
   }
 
-  private void setRootResolver(ConfigurationPropertiesResolver rootResolver) {
+  public void setRootResolver(ConfigurationPropertiesResolver rootResolver) {
     this.rootResolver = of(rootResolver);
     propagateRootResolver(rootResolver);
   }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/model/ApplicationModel.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/model/ApplicationModel.java
@@ -378,14 +378,21 @@ public class ApplicationModel implements ArtifactAst {
 
     DefaultConfigurationPropertiesResolver environmentPropertiesConfigurationPropertiesResolver =
         new DefaultConfigurationPropertiesResolver(empty(), environmentPropertiesConfigurationProvider);
+
+    DefaultConfigurationPropertiesResolver parentLocalResolver;
+    if (deploymentPropertiesConfigurationProperties != null) {
+      parentLocalResolver = new DefaultConfigurationPropertiesResolver(of(environmentPropertiesConfigurationPropertiesResolver),
+                                                                       deploymentPropertiesConfigurationProperties);
+    } else {
+      parentLocalResolver = environmentPropertiesConfigurationPropertiesResolver;
+    }
+
     DefaultConfigurationPropertiesResolver localResolver =
-        new DefaultConfigurationPropertiesResolver(of(new DefaultConfigurationPropertiesResolver(
-                                                                                                 deploymentPropertiesConfigurationProperties != null
-                                                                                                     ? of(new DefaultConfigurationPropertiesResolver(of(environmentPropertiesConfigurationPropertiesResolver),
-                                                                                                                                                     deploymentPropertiesConfigurationProperties))
-                                                                                                     : of(environmentPropertiesConfigurationPropertiesResolver),
+        new DefaultConfigurationPropertiesResolver(of(new DefaultConfigurationPropertiesResolver(of(parentLocalResolver),
                                                                                                  globalPropertiesConfigurationAttributeProvider)),
                                                    environmentPropertiesConfigurationProvider);
+    localResolver.setRootResolver(parentLocalResolver);
+
     List<ConfigurationPropertiesProvider> configConfigurationPropertiesProviders =
         getConfigurationPropertiesProvidersFromComponents(artifactConfig, localResolver);
     FileConfigurationPropertiesProvider externalPropertiesConfigurationProvider =


### PR DESCRIPTION
`ApplicationModel#createConfigurationAttributeResolver`'s code needs [fire. And lots of it.](https://www.youtube.com/watch?v=cDfqwHck2Qg) 