### PR TITLE
MULE-16371: Implement error handling/propagation with side reactor chains

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/api/DefaultMuleEventTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/DefaultMuleEventTestCase.java
@@ -8,12 +8,15 @@
 package org.mule.runtime.core.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_XML;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
@@ -30,13 +33,14 @@ import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
+import java.nio.charset.Charset;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.nio.charset.Charset;
 
 @SmallTest
 public class DefaultMuleEventTestCase extends AbstractMuleContextTestCase {
@@ -48,7 +52,7 @@ public class DefaultMuleEventTestCase extends AbstractMuleContextTestCase {
   public static final String PROPERTY_NAME = "test";
   public static final String PROPERTY_VALUE = "foo";
 
-  private Message muleMessage = of("test-data");
+  private final Message muleMessage = of("test-data");
   private Flow flow;
   private EventContext messageContext;
   private PrivilegedEvent muleEvent;
@@ -58,6 +62,11 @@ public class DefaultMuleEventTestCase extends AbstractMuleContextTestCase {
     flow = getTestFlow(muleContext);
     messageContext = create(flow, TEST_CONNECTOR_LOCATION);
     muleEvent = InternalEvent.builder(messageContext).message(muleMessage).build();
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/api/MessagingExceptionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/MessagingExceptionTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.api;
 
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -25,8 +26,10 @@ import static org.mule.runtime.api.exception.MuleException.INFO_LOCATION_KEY;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.notification.EnrichedNotificationInfo.createInfo;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.exception.MessagingException.PAYLOAD_INFO_KEY;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -50,6 +53,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketException;
+import java.util.Map;
 import java.util.Optional;
 
 import org.hamcrest.core.Is;
@@ -99,6 +103,11 @@ public class MessagingExceptionTestCase extends AbstractMuleContextTestCase {
     when(mockContext.getConfiguration()).thenReturn(mockConfiguration);
 
     testEvent = eventBuilder(muleContext).message(of(TEST_PAYLOAD)).build();
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/api/event/MuleEventTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/event/MuleEventTestCase.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.internal.context.DefaultMuleContext.currentMuleContext;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
@@ -41,17 +43,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.qameta.allure.Description;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import io.qameta.allure.Description;
 
 
 public class MuleEventTestCase extends AbstractMuleContextTestCase {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @After
   public void teardown() {

--- a/core-tests/src/test/java/org/mule/runtime/core/api/transformer/TransformerChainingTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/transformer/TransformerChainingTestCase.java
@@ -7,11 +7,14 @@
 package org.mule.runtime.core.api.transformer;
 
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
 import org.mule.runtime.api.exception.MuleException;
@@ -21,10 +24,11 @@ import org.mule.runtime.core.privileged.transformer.ExtendedTransformationServic
 import org.mule.runtime.core.privileged.transformer.TransformerChain;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import java.nio.charset.Charset;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.nio.charset.Charset;
 
 public class TransformerChainingTestCase extends AbstractMuleContextTestCase {
 
@@ -33,6 +37,11 @@ public class TransformerChainingTestCase extends AbstractMuleContextTestCase {
   @Before
   public void setUp() throws Exception {
     transformationService = new ExtendedTransformationService(muleContext);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/construct/DefaultFlowTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/construct/DefaultFlowTestCase.java
@@ -9,6 +9,7 @@ package org.mule.runtime.core.internal.construct;
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
@@ -33,9 +34,10 @@ import static org.mule.runtime.core.api.construct.Flow.INITIAL_STATE_STOPPED;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE;
 import static org.mule.runtime.core.api.processor.strategy.AsyncProcessingStrategyFactory.DEFAULT_MAX_CONCURRENCY;
 import static org.mule.runtime.core.api.rx.Exceptions.propagateWrappingFatal;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static reactor.core.publisher.Mono.just;
 
-import io.qameta.allure.Issue;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.lifecycle.Disposable;
@@ -60,6 +62,7 @@ import org.mule.tck.core.lifecycle.LifecycleTrackerProcessor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
@@ -73,6 +76,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.InOrder;
 import org.reactivestreams.Publisher;
+
+import io.qameta.allure.Issue;
 import reactor.core.publisher.Flux;
 
 @RunWith(Parameterized.class)
@@ -128,6 +133,12 @@ public class DefaultFlowTestCase extends AbstractFlowConstructTestCase {
         .processors(processors)
         .initialState(INITIAL_STATE_STOPPED)
         .build();
+  }
+
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Override

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/DefaultExpressionManagerMelDefaultTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/DefaultExpressionManagerMelDefaultTestCase.java
@@ -25,16 +25,17 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.DataType.BYTE_ARRAY;
 import static org.mule.runtime.api.metadata.DataType.OBJECT;
 import static org.mule.runtime.api.metadata.DataType.STRING;
+import static org.mule.runtime.api.util.MuleSystemProperties.MULE_MEL_AS_DEFAULT;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
-import static org.mule.runtime.core.api.config.MuleProperties.MULE_MEL_AS_DEFAULT;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.test.allure.AllureConstants.ExpressionLanguageFeature.EXPRESSION_LANGUAGE;
 import static org.mule.test.allure.AllureConstants.ExpressionLanguageFeature.ExpressionLanguageStory.SUPPORT_MVEL_DW;
 
 import org.mule.runtime.api.el.BindingContext;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.el.ExtendedExpressionManager;
@@ -42,16 +43,16 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.junit4.rule.SystemProperty;
 
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.ByteArrayInputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
@@ -77,6 +78,7 @@ public class DefaultExpressionManagerMelDefaultTestCase extends AbstractMuleCont
     Map<String, Object> objects = new HashMap<>();
     objects.putAll(super.getStartUpRegistryObjects());
     objects.put(COMPATIBILITY_PLUGIN_INSTALLED, new Object());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/DefaultExpressionManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/DefaultExpressionManagerTestCase.java
@@ -38,7 +38,9 @@ import static org.mule.runtime.api.metadata.MediaType.XML;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_EXPRESSION_LANGUAGE;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalToIgnoringLineBreaks;
 import static org.mule.tck.util.MuleContextUtils.mockMuleContext;
 import static org.mule.test.allure.AllureConstants.ExpressionLanguageFeature.EXPRESSION_LANGUAGE;
@@ -68,6 +70,12 @@ import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguage;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.weave.v2.el.WeaveDefaultExpressionLanguageFactoryService;
 
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -75,12 +83,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.ByteArrayInputStream;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
@@ -106,6 +108,7 @@ public class DefaultExpressionManagerTestCase extends AbstractMuleContextTestCas
     Map<String, Object> objects = new HashMap<>();
     objects.putAll(super.getStartUpRegistryObjects());
     objects.put(COMPATIBILITY_PLUGIN_INSTALLED, new Object());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/ExpressionLanguageExtensionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/ExpressionLanguageExtensionTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.core.internal.el;
 
-import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -27,15 +26,16 @@ import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguageContext;
 import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
 
-import org.junit.Test;
-
 import java.text.DateFormat;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Test;
 
 public class ExpressionLanguageExtensionTestCase extends AbstractELTestCase {
 
-  private String a = "hi";
+  private final String a = "hi";
   private String b = "hi";
 
   public ExpressionLanguageExtensionTestCase(String mvelOptimizer) {
@@ -44,7 +44,9 @@ public class ExpressionLanguageExtensionTestCase extends AbstractELTestCase {
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
-    return singletonMap("key1", new TestExtension());
+    final Map<String, Object> objects = new HashMap<>(super.getStartUpRegistryObjects());
+    objects.put("key1", new TestExtension());
+    return objects;
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/context/AbstractELTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/context/AbstractELTestCase.java
@@ -6,13 +6,17 @@
  */
 package org.mule.runtime.core.internal.el.context;
 
+import static java.util.Collections.singletonMap;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCause;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mule.mvel2.optimizers.OptimizerFactory.DYNAMIC;
 import static org.mule.mvel2.optimizers.OptimizerFactory.SAFE_REFLECTIVE;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
+
 import org.mule.mvel2.ImmutableElementException;
 import org.mule.mvel2.PropertyAccessException;
 import org.mule.mvel2.optimizers.OptimizerFactory;
@@ -21,14 +25,15 @@ import org.mule.runtime.api.el.BindingContext;
 import org.mule.runtime.api.event.EventContext;
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.core.api.construct.Flow;
-import org.mule.runtime.core.internal.el.ExtendedExpressionLanguageAdaptor;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
+import org.mule.runtime.core.internal.el.ExtendedExpressionLanguageAdaptor;
 import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguage;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -44,6 +49,11 @@ public abstract class AbstractELTestCase extends AbstractMuleContextTestCase {
 
   public AbstractELTestCase(String mvelOptimizer) {
     OptimizerFactory.setDefaultOptimizer(mvelOptimizer);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Before

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/dataweave/AbstractWeaveExpressionLanguageTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/dataweave/AbstractWeaveExpressionLanguageTestCase.java
@@ -6,14 +6,19 @@
  */
 package org.mule.runtime.core.internal.el.dataweave;
 
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.of;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.el.DefaultExpressionLanguageFactoryService;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.weave.v2.el.WeaveDefaultExpressionLanguageFactoryService;
+
+import java.util.Map;
 
 import org.junit.Before;
 
@@ -29,6 +34,11 @@ public abstract class AbstractWeaveExpressionLanguageTestCase extends AbstractMu
     weaveExpressionExecutor = new WeaveDefaultExpressionLanguageFactoryService(null);
     when(registry.lookupByType(DefaultExpressionLanguageFactoryService.class)).thenReturn(of(weaveExpressionExecutor));
     expressionLanguage = new DataWeaveExpressionLanguageAdaptor(muleContext, registry, weaveExpressionExecutor);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
 }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/MVELExpressionLanguageTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/MVELExpressionLanguageTestCase.java
@@ -30,8 +30,11 @@ import static org.mule.runtime.api.metadata.DataType.STRING;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguageTestCase.Variant.EXPRESSION_STRAIGHT_UP;
 import static org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguageTestCase.Variant.EXPRESSION_WITH_DELIMITER;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
+
 import org.mule.mvel2.CompileException;
 import org.mule.mvel2.ParserContext;
 import org.mule.mvel2.PropertyAccessException;
@@ -40,7 +43,6 @@ import org.mule.mvel2.optimizers.OptimizerFactory;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.el.BindingContext;
-import org.mule.runtime.api.el.ExpressionLanguageSession;
 import org.mule.runtime.api.el.ValidationResult;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
@@ -128,6 +130,11 @@ public class MVELExpressionLanguageTestCase extends AbstractMuleContextTestCase 
     final DefaultComponentLocation location = fromSingleComponent("myFlow");
     when(((Component) flowConstruct).getAnnotation(LOCATION_KEY)).thenReturn(location);
     when(((Component) flowConstruct).getLocation()).thenReturn(location);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/MVELMapHandlingTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/MVELMapHandlingTestCase.java
@@ -11,17 +11,19 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
 import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Test;
 
 public class MVELMapHandlingTestCase extends AbstractMuleContextTestCase {
 
@@ -34,6 +36,7 @@ public class MVELMapHandlingTestCase extends AbstractMuleContextTestCase {
     Map<String, Object> objects = new HashMap<>();
     objects.putAll(super.getStartUpRegistryObjects());
     objects.put(COMPATIBILITY_PLUGIN_INSTALLED, new Object());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 
@@ -93,12 +96,12 @@ public class MVELMapHandlingTestCase extends AbstractMuleContextTestCase {
 
   @Test
   public void map() throws Exception {
-    Map<String, String> payload = new HashMap<String, String>();
+    Map<String, String> payload = new HashMap<>();
     CoreEvent event = eventBuilder(muleContext).message(of(payload)).build();
     Map result = (Map) el.evaluate("#[{\"a\" : {\"b\" : \"c\"}, \"d\" : [\"e\"]}]", event).getValue();
     Map result2 = (Map) el.evaluate("#[{\"d\" : [\"e\"], \"a\" : {\"b\" : \"c\"}}]", event).getValue();
-    assertThat((String) ((ArrayList<String>) result.get("d")).get(0), equalTo("e"));
-    assertThat((String) ((ArrayList<String>) result2.get("d")).get(0), equalTo("e"));
+    assertThat(((ArrayList<String>) result.get("d")).get(0), equalTo("e"));
+    assertThat(((ArrayList<String>) result2.get("d")).get(0), equalTo("e"));
   }
 
   private void runExpressionAndExpect(String expression, Object expectedValue, CoreEvent event) throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/AbstractVarAssignmentDataTypePropagatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/AbstractVarAssignmentDataTypePropagatorTestCase.java
@@ -8,10 +8,13 @@
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.mvel2.MVEL.compileExpression;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.runtime.api.metadata.MediaType.UNKNOWN;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.mvel2.MVEL;
@@ -47,6 +50,11 @@ public abstract class AbstractVarAssignmentDataTypePropagatorTestCase extends Ab
 
   protected AbstractVarAssignmentDataTypePropagatorTestCase(EnricherDataTypePropagator dataTypePropagator) {
     this.dataTypePropagator = dataTypePropagator;
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   protected void doAssignmentDataTypePropagationTest(String expression) throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/AbstractVarExpressionDataTypeResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/AbstractVarExpressionDataTypeResolverTestCase.java
@@ -7,9 +7,12 @@
 
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.mvel2.MVEL.compileExpression;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.mvel2.MVEL;
@@ -28,11 +31,12 @@ import org.mule.runtime.core.internal.el.mvel.VariableVariableResolverFactory;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Test;
 
 public abstract class AbstractVarExpressionDataTypeResolverTestCase extends AbstractMuleContextTestCase {
 
@@ -47,6 +51,11 @@ public abstract class AbstractVarExpressionDataTypeResolverTestCase extends Abst
                                                           String variableName) {
     this.expressionDataTypeResolver = expressionDataTypeResolver;
     this.variableName = variableName;
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/MvelEnricherDataTypePropagatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/MvelEnricherDataTypePropagatorTestCase.java
@@ -7,11 +7,14 @@
 
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
+import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.mvel2.MVEL.compileExpression;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.mvel2.ParserContext;
 import org.mule.mvel2.compiler.CompiledExpression;
@@ -21,10 +24,11 @@ import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguage;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
 
 public class MvelEnricherDataTypePropagatorTestCase extends AbstractMuleContextTestCase {
 
@@ -33,6 +37,11 @@ public class MvelEnricherDataTypePropagatorTestCase extends AbstractMuleContextT
   private final TypedValue typedValue = new TypedValue<>(TEST_MESSAGE, DataType.STRING);
   private final EnricherDataTypePropagator propagator1 = mock(EnricherDataTypePropagator.class);
   private final EnricherDataTypePropagator propagator2 = mock(EnricherDataTypePropagator.class);
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void invokesDataTypeAllPropagators() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/MvelExpressionDataTypeResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/MvelExpressionDataTypeResolverTestCase.java
@@ -8,9 +8,12 @@
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
 import static java.util.Collections.EMPTY_LIST;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.mvel2.MVEL.compileExpression;
 import static org.mule.runtime.api.metadata.MediaType.ANY;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.mvel2.ParserContext;
@@ -18,6 +21,8 @@ import org.mule.mvel2.compiler.CompiledExpression;
 import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguage;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -27,6 +32,11 @@ public class MvelExpressionDataTypeResolverTestCase extends AbstractMuleContextT
   public static final String MEL_EXPRESSION = "someExpression";
 
   private MvelDataTypeResolver dataTypeResolver;
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void returnsDefaultDataTypeForNonNullValue() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PayloadEnricherDataTypePropagatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PayloadEnricherDataTypePropagatorTestCase.java
@@ -8,11 +8,14 @@
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
 import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.mvel2.MVEL.compileExpression;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.runtime.core.internal.el.mvel.MessageVariableResolverFactory.MESSAGE_PAYLOAD;
 import static org.mule.runtime.core.internal.el.mvel.MessageVariableResolverFactory.PAYLOAD;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.mvel2.ParserContext;
@@ -24,15 +27,21 @@ import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguage;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.nio.charset.Charset;
+import java.util.Map;
+
+import org.junit.Test;
 
 public class PayloadEnricherDataTypePropagatorTestCase extends AbstractMuleContextTestCase {
 
   public static final Charset CUSTOM_ENCODING = UTF_16;
 
   private final PayloadEnricherDataTypePropagator dataTypePropagator = new PayloadEnricherDataTypePropagator();
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void propagatesPayloadDataType() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PayloadExpressionDataTypeResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PayloadExpressionDataTypeResolverTestCase.java
@@ -8,11 +8,14 @@
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
 import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.mvel2.MVEL.compileExpression;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
 import static org.mule.runtime.core.internal.el.mvel.MessageVariableResolverFactory.MESSAGE_PAYLOAD;
 import static org.mule.runtime.core.internal.el.mvel.MessageVariableResolverFactory.PAYLOAD;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.mvel2.ParserContext;
@@ -23,15 +26,21 @@ import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.nio.charset.Charset;
+import java.util.Map;
+
+import org.junit.Test;
 
 public class PayloadExpressionDataTypeResolverTestCase extends AbstractMuleContextTestCase {
 
   public static final Charset CUSTOM_ENCODING = UTF_16;
 
   private final PayloadExpressionDataTypeResolver dataTypeResolver = new PayloadExpressionDataTypeResolver();
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void returnsPayloadDataType() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PropertyEnricherDataTypePropagatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PropertyEnricherDataTypePropagatorTestCase.java
@@ -7,10 +7,13 @@
 
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.mvel2.MVEL.compileExpression;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.mvel2.ParserContext;
@@ -21,16 +24,22 @@ import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguage;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.Test;
 
 public class PropertyEnricherDataTypePropagatorTestCase extends AbstractMuleContextTestCase {
 
   private static final Charset CUSTOM_ENCODING = StandardCharsets.UTF_16;
 
   private final EnricherDataTypePropagator dataTypePropagator = new PropertyEnricherDataTypePropagator();
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void propagatesDataTypeForInlinedInvocationProperty() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PropertyExpressionDataTypeResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/mvel/datatype/PropertyExpressionDataTypeResolverTestCase.java
@@ -8,10 +8,13 @@
 package org.mule.runtime.core.internal.el.mvel.datatype;
 
 import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.mvel2.MVEL.compileExpression;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.mvel2.ParserContext;
@@ -21,15 +24,21 @@ import org.mule.runtime.core.internal.el.mvel.MVELExpressionLanguage;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.nio.charset.Charset;
+import java.util.Map;
+
+import org.junit.Test;
 
 public class PropertyExpressionDataTypeResolverTestCase extends AbstractMuleContextTestCase {
 
   public static final String EXPRESSION_VALUE = "bar";
   public static final Charset CUSTOM_ENCODING = UTF_16;
   private final ExpressionDataTypeResolver expressionDataTypeResolver = new PropertyExpressionDataTypeResolver();
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void returnsInlineFlowVarDataType() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.core.internal.event;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.hamcrest.CoreMatchers.is;
@@ -19,7 +20,9 @@ import static org.mule.runtime.api.component.ComponentIdentifier.buildFromString
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.SOURCE;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
 import static org.mule.runtime.core.internal.event.DefaultEventContext.child;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.internal.dsl.DslConstants.CORE_PREFIX;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 import static org.mule.tck.probe.PollingProber.DEFAULT_POLLING_INTERVAL;
 import static org.mule.tck.probe.PollingProber.probe;
@@ -49,6 +52,7 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -116,6 +120,11 @@ public class DefaultEventContextTestCase extends AbstractMuleContextTestCase {
   public void setup() {
     this.parent = context.get();
     setupParentListeners(parent);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   private BaseEventContext addChild(BaseEventContext parent) {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
@@ -7,9 +7,12 @@
 package org.mule.runtime.core.internal.exception;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 
 import org.mule.runtime.api.event.EventContext;
@@ -20,6 +23,7 @@ import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.junit4.rule.VerboseExceptions;
 
 import java.util.Collection;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -59,6 +63,11 @@ public abstract class AbstractErrorHandlerTestCase extends AbstractMuleContextTe
 
     context = create(flow, TEST_CONNECTOR_LOCATION);
     muleEvent = InternalEvent.builder(context).message(of("")).build();
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/exception/ErrorHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/exception/ErrorHandlerTestCase.java
@@ -17,7 +17,6 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -25,10 +24,12 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.ANY;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.EXPRESSION;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.internal.exception.DefaultErrorTypeRepository.CRITICAL_ERROR_TYPE;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ErrorHandlingStory.ERROR_HANDLER;
+
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
 import org.mule.runtime.api.exception.MuleException;
@@ -47,8 +48,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import io.qameta.allure.Feature;
-import io.qameta.allure.Story;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,6 +55,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
 
 @SmallTest
 @Feature(ERROR_HANDLING)
@@ -71,24 +73,15 @@ public class ErrorHandlerTestCase extends AbstractMuleTestCase {
 
   @Mock
   private MessagingExceptionHandlerAcceptor mockTestExceptionStrategy2;
-  private DefaultMessagingExceptionHandlerAcceptor defaultMessagingExceptionHandler =
+  private final DefaultMessagingExceptionHandlerAcceptor defaultMessagingExceptionHandler =
       spy(new DefaultMessagingExceptionHandlerAcceptor());
 
-  private CoreEvent event;
-
-  private MuleContextWithRegistry mockMuleContext = mockContextWithServices();
+  private final MuleContextWithRegistry mockMuleContext = mockContextWithServices();
   @Mock
   private ErrorType mockErrorType;
-  private MessagingException mockException;
 
   @Before
   public void before() throws MuleException {
-    Error mockError = mock(Error.class);
-    when(mockError.getErrorType()).thenReturn(mockErrorType);
-
-    event = getEventBuilder().message(Message.of("")).error(mockError).build();
-
-    mockException = new MessagingException(event, new Exception());
     when(mockTestExceptionStrategy2.accept(any(CoreEvent.class))).thenReturn(true);
   }
 
@@ -99,8 +92,14 @@ public class ErrorHandlerTestCase extends AbstractMuleTestCase {
     when(mockMuleContext.getDefaultErrorHandler(empty())).thenReturn(defaultMessagingExceptionHandler);
     errorHandler.setMuleContext(mockMuleContext);
     errorHandler.setRootContainerName("root");
-    errorHandler.initialise();
+    initialiseIfNeeded(errorHandler, mockMuleContext);
     when(mockTestExceptionStrategy1.accept(any(CoreEvent.class))).thenReturn(false);
+
+    Error mockError = mock(Error.class);
+    when(mockError.getErrorType()).thenReturn(mockErrorType);
+    CoreEvent event = getEventBuilder().message(Message.of("")).error(mockError).build();
+    MessagingException mockException = new MessagingException(event, new Exception());
+
     errorHandler.handleException(mockException, event);
     verify(mockTestExceptionStrategy1, times(0)).apply(any(MessagingException.class));
     verify(defaultMessagingExceptionHandler, times(0)).apply(any(MessagingException.class));
@@ -118,7 +117,7 @@ public class ErrorHandlerTestCase extends AbstractMuleTestCase {
     errorHandler.setRootContainerName("root");
     expectedException
         .expectMessage(containsString("Only last <on-error> inside <error-handler> can accept any errors."));
-    errorHandler.initialise();
+    initialiseIfNeeded(errorHandler, mockMuleContext);
   }
 
   @Test
@@ -129,7 +128,13 @@ public class ErrorHandlerTestCase extends AbstractMuleTestCase {
     errorHandler.setExceptionListeners(new ArrayList<>(asList(mockTestExceptionStrategy1)));
     errorHandler.setMuleContext(mockMuleContext);
     errorHandler.setRootContainerName("root");
-    errorHandler.initialise();
+    initialiseIfNeeded(errorHandler, mockMuleContext);
+
+    Error mockError = mock(Error.class);
+    when(mockError.getErrorType()).thenReturn(mockErrorType);
+    CoreEvent event = getEventBuilder().message(Message.of("")).error(mockError).build();
+    MessagingException mockException = new MessagingException(event, new Exception());
+
     errorHandler.handleException(mockException, event);
     verify(mockTestExceptionStrategy1, times(0)).apply(any(MessagingException.class));
     verify(defaultMessagingExceptionHandler, times(0)).apply(any(MessagingException.class));
@@ -199,13 +204,13 @@ public class ErrorHandlerTestCase extends AbstractMuleTestCase {
     when(mockMuleContext.getConfiguration().getDefaultErrorHandlerName()).thenReturn("myDefault");
     when(mockMuleContext.getDefaultErrorHandler(of("root"))).thenReturn(errorHandler);
     mockErrorRepository();
-    errorHandler.initialise();
+
+    initialiseIfNeeded(errorHandler, mockMuleContext);
     return errorHandler;
   }
 
   private void mockErrorRepository() {
-    ErrorTypeRepository errorTypeRepository = mock(ErrorTypeRepository.class, RETURNS_DEEP_STUBS);
-    when(mockMuleContext.getErrorTypeRepository()).thenReturn(errorTypeRepository);
+    ErrorTypeRepository errorTypeRepository = mockMuleContext.getErrorTypeRepository();
     ErrorType anyErrorType = mock(ErrorType.class);
     when(errorTypeRepository.lookupErrorType(ANY)).thenReturn(of(anyErrorType));
     when(errorTypeRepository.lookupErrorType(EXPRESSION)).thenReturn(of(mock(ErrorType.class)));

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorTestCase.java
@@ -7,7 +7,6 @@
 package org.mule.runtime.core.internal.processor;
 
 import static java.lang.Thread.currentThread;
-import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -18,7 +17,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.core.api.construct.Flow.builder;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
@@ -41,7 +39,6 @@ import org.mule.tck.junit4.AbstractReactiveProcessorTestCase;
 import org.mule.tck.testmodels.mule.TestTransaction;
 
 import java.beans.ExceptionListener;
-import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,7 +50,7 @@ public class AsyncDelegateMessageProcessorTestCase extends AbstractReactiveProce
   protected TestListener target = new TestListener();
   private Exception exceptionThrown;
   protected Latch latch = new Latch();
-  private Latch asyncEntryLatch = new Latch();
+  private final Latch asyncEntryLatch = new Latch();
   private Flow flow;
 
   @Rule
@@ -62,11 +59,6 @@ public class AsyncDelegateMessageProcessorTestCase extends AbstractReactiveProce
   public AsyncDelegateMessageProcessorTestCase(Mode mode) {
     super(mode);
     setStartContext(true);
-  }
-
-  @Override
-  protected Map<String, Object> getStartUpRegistryObjects() {
-    return singletonMap(REGISTRY_KEY, componentLocator);
   }
 
   @Override

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/InvokerMessageProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/InvokerMessageProcessorTestCase.java
@@ -13,6 +13,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -24,12 +26,12 @@ import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.testmodels.fruit.Apple;
 
-import org.junit.Test;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.Test;
 
 public class InvokerMessageProcessorTestCase extends AbstractMuleContextTestCase {
 
@@ -40,6 +42,7 @@ public class InvokerMessageProcessorTestCase extends AbstractMuleContextTestCase
     Map<String, Object> objects = new HashMap<>();
     objects.putAll(super.getStartUpRegistryObjects());
     objects.put(COMPATIBILITY_PLUGIN_INSTALLED, new Object());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/interceptor/ReactiveInterceptorAdapterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/interceptor/ReactiveInterceptorAdapterTestCase.java
@@ -41,6 +41,8 @@ import static org.mule.runtime.core.api.construct.Flow.builder;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.UNKNOWN;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE_ASYNC;
 import static org.mule.runtime.core.internal.component.ComponentAnnotations.ANNOTATION_PARAMETERS;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.EventMatcher.hasErrorType;
 import static org.mule.tck.junit4.matcher.EventMatcher.hasErrorTypeThat;
 import static org.mule.tck.junit4.matcher.MessagingExceptionMatcher.withEventThat;
@@ -159,6 +161,11 @@ public class ReactiveInterceptorAdapterTestCase extends AbstractMuleContextTestC
   @Before
   public void before() throws MuleException {
     flow = builder("flow", muleContext).processors(processor).build();
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
@@ -22,6 +22,7 @@ import static org.mule.runtime.core.api.management.stats.RouterStatistics.TYPE_O
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/FirstSuccessfulTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/FirstSuccessfulTestCase.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.core.internal.routing;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.instanceOf;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
@@ -15,10 +15,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.createErrorMock;
 
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
@@ -32,10 +32,13 @@ import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.runtime.core.privileged.event.DefaultMuleSession;
 import org.mule.runtime.core.privileged.event.MuleSession;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
-import org.mule.runtime.core.privileged.routing.CouldNotRouteOutboundMessageException;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import java.util.Map;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class FirstSuccessfulTestCase extends AbstractMuleContextTestCase {
 
@@ -46,6 +49,11 @@ public class FirstSuccessfulTestCase extends AbstractMuleContextTestCase {
 
   public FirstSuccessfulTestCase() {
     setStartContext(true);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
@@ -6,8 +6,8 @@
  */
 package org.mule.runtime.core.internal.routing;
 
+import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -23,11 +23,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.api.metadata.DataType.MULE_MESSAGE_LIST;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
-import static org.mule.test.allure.AllureConstants.RoutersFeature.ParallelForEachStory.PARALLEL_FOR_EACH;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
+import static org.mule.test.allure.AllureConstants.RoutersFeature.ParallelForEachStory.PARALLEL_FOR_EACH;
 import static reactor.core.publisher.Flux.from;
+
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.event.Event;
 import org.mule.runtime.api.exception.MuleException;
@@ -52,13 +55,14 @@ import java.util.Map;
 
 import javax.management.DescriptorKey;
 
-import io.qameta.allure.Description;
-import io.qameta.allure.Feature;
-import io.qameta.allure.Story;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
 
 @Feature(ROUTERS)
 @Story(PARALLEL_FOR_EACH)
@@ -67,13 +71,14 @@ public class ParallelForEachTestCase extends AbstractMuleContextTestCase {
   @Rule
   public ExpectedException expectedException = none();
 
-  private ParallelForEach router = new ParallelForEach();
-  private ForkJoinStrategyFactory mockForkJoinStrategyFactory = mock(ForkJoinStrategyFactory.class);
+  private final ParallelForEach router = new ParallelForEach();
+  private final ForkJoinStrategyFactory mockForkJoinStrategyFactory = mock(ForkJoinStrategyFactory.class);
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
     when(componentLocator.find(Location.builder().globalName(APPLE_FLOW).build())).thenReturn(of(mock(Flow.class)));
-    return singletonMap(REGISTRY_KEY, componentLocator);
+    return of(REGISTRY_KEY, componentLocator,
+              OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/RoundRobinTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/RoundRobinTestCase.java
@@ -6,14 +6,13 @@
  */
 package org.mule.runtime.core.internal.routing;
 
+import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.api.message.Message.of;
@@ -22,12 +21,13 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.component.ComponentIdentifier;
-import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
@@ -74,11 +74,11 @@ public class RoundRobinTestCase extends AbstractMuleContextTestCase {
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
-    ConfigurationComponentLocator configurationComponentLocator = mock(ConfigurationComponentLocator.class);
-    when(configurationComponentLocator.find(any(Location.class))).thenReturn(empty());
-    when(configurationComponentLocator.find(any(ComponentIdentifier.class))).thenReturn(emptyList());
+    when(componentLocator.find(any(Location.class))).thenReturn(empty());
+    when(componentLocator.find(any(ComponentIdentifier.class))).thenReturn(emptyList());
 
-    return singletonMap(REGISTRY_KEY, configurationComponentLocator);
+    return of(REGISTRY_KEY, componentLocator,
+              OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ScatterGatherRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ScatterGatherRouterTestCase.java
@@ -26,9 +26,11 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.api.metadata.DataType.MULE_MESSAGE_MAP;
 import static org.mule.runtime.core.api.config.MuleDeploymentProperties.MULE_LAZY_INIT_DEPLOYMENT_PROPERTY;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair.of;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ScatterGatherStory.SCATTER_GATHER;
 import static reactor.core.publisher.Flux.from;
@@ -56,13 +58,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import io.qameta.allure.Description;
-import io.qameta.allure.Feature;
-import io.qameta.allure.Story;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
 
 @Feature(ROUTERS)
 @Story(SCATTER_GATHER)
@@ -71,9 +74,9 @@ public class ScatterGatherRouterTestCase extends AbstractMuleContextTestCase {
   @Rule
   public ExpectedException expectedException = none();
 
-  private ScatterGatherRouter router = new ScatterGatherRouter();
-  private ForkJoinStrategyFactory mockForkJoinStrategyFactory = mock(ForkJoinStrategyFactory.class);
-  private ConfigurationProperties configurationProperties = mock(ConfigurationProperties.class);
+  private final ScatterGatherRouter router = new ScatterGatherRouter();
+  private final ForkJoinStrategyFactory mockForkJoinStrategyFactory = mock(ForkJoinStrategyFactory.class);
+  private final ConfigurationProperties configurationProperties = mock(ConfigurationProperties.class);
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
@@ -83,6 +86,7 @@ public class ScatterGatherRouterTestCase extends AbstractMuleContextTestCase {
     Map<String, Object> registryObjects = new HashMap<>();
     registryObjects.put(REGISTRY_KEY, componentLocator);
     registryObjects.put("_configurationProperties", configurationProperties);
+    registryObjects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return registryObjects;
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
@@ -6,9 +6,9 @@
  */
 package org.mule.runtime.core.internal.routing;
 
+import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
@@ -25,9 +25,12 @@ import static org.mockito.Mockito.verify;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.transaction.TransactionCoordination.getInstance;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.createAndRegisterFlow;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.event.CoreEvent;
@@ -98,7 +101,7 @@ public class UntilSuccessfulTestCase extends AbstractMuleContextTestCase {
   private Flow flow;
   private UntilSuccessful untilSuccessful;
   private ConfigurableMessageProcessor targetMessageProcessor;
-  private boolean tx;
+  private final boolean tx;
 
   public UntilSuccessfulTestCase(boolean tx) {
     this.tx = tx;
@@ -106,7 +109,8 @@ public class UntilSuccessfulTestCase extends AbstractMuleContextTestCase {
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
-    return singletonMap(REGISTRY_KEY, componentLocator);
+    return of(REGISTRY_KEY, componentLocator,
+              OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Override

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyTestCase.java
@@ -10,6 +10,7 @@ package org.mule.runtime.core.internal.routing.forkjoin;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -31,8 +32,10 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.TIMEOUT;
 import static org.mule.runtime.core.api.rx.Exceptions.rxExceptionToMuleException;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair.of;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.test.allure.AllureConstants.ForkJoinStrategiesFeature.FORK_JOIN_STRATEGIES;
 import static reactor.core.publisher.Flux.fromIterable;
 import static reactor.core.publisher.Mono.from;
@@ -61,18 +64,19 @@ import org.mule.runtime.core.privileged.routing.RoutingResult;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.testmodels.fruit.Apple;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
@@ -97,6 +101,11 @@ public abstract class AbstractForkJoinStrategyTestCase extends AbstractMuleConte
     timeoutErrorType = muleContext.getErrorTypeRepository().getErrorType(TIMEOUT).get();
     setupConcurrentProcessingStrategy();
     strategy = createStrategy(processingStrategy, Integer.MAX_VALUE, true, MAX_VALUE);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/source/polling/DefaultSchedulerMessageSourceTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/source/polling/DefaultSchedulerMessageSourceTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.internal.source.polling;
 
+import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.of;
 import static org.mockito.ArgumentMatchers.any;
@@ -19,9 +20,12 @@ import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.createFlowWithSource;
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.scheduler.Scheduler;
@@ -70,7 +74,8 @@ public class DefaultSchedulerMessageSourceTestCase extends AbstractMuleContextTe
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
-    return singletonMap(REGISTRY_KEY, componentLocator);
+    return of(REGISTRY_KEY, componentLocator,
+              OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/ExpressionTransformerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/ExpressionTransformerTestCase.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.internal.message.InternalMessage;
@@ -19,12 +21,12 @@ import org.mule.runtime.core.internal.transformer.expression.ExpressionArgument;
 import org.mule.runtime.core.internal.transformer.expression.ExpressionTransformer;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class ExpressionTransformerTestCase extends AbstractMuleContextTestCase {
 
@@ -33,6 +35,7 @@ public class ExpressionTransformerTestCase extends AbstractMuleContextTestCase {
     Map<String, Object> objects = new HashMap<>();
     objects.putAll(super.getStartUpRegistryObjects());
     objects.put(COMPATIBILITY_PLUGIN_INSTALLED, new Object());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/RegistryTransformerLifecycleTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/RegistryTransformerLifecycleTestCase.java
@@ -6,8 +6,11 @@
  */
 package org.mule.runtime.core.internal.transformer.simple;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.mule.runtime.core.api.construct.Flow.builder;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -17,17 +20,23 @@ import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
 
 /**
  * Highlights the issue: MULE-4599 where dispose cannot be called on a transformer since it is a prototype in Spring, so spring
  * does not manage the object.
  */
 public class RegistryTransformerLifecycleTestCase extends AbstractMuleContextTestCase {
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void testLifecycleInTransientRegistry() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/SetPayloadMessageProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/transformer/simple/SetPayloadMessageProcessorTestCase.java
@@ -8,6 +8,7 @@
 package org.mule.runtime.core.internal.transformer.simple;
 
 import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -16,6 +17,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -32,6 +35,7 @@ import org.mule.runtime.core.internal.processor.simple.SetPayloadMessageProcesso
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +61,11 @@ public class SetPayloadMessageProcessorTestCase extends AbstractMuleContextTestC
     when(muleContext.getConfiguration()).thenReturn(mock(MuleConfiguration.class));
     when(expressionManager.parse(anyString(), any(CoreEvent.class), any(ComponentLocation.class)))
         .thenAnswer(invocation -> (String) invocation.getArguments()[0]);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/DWAttributeEvaluatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/DWAttributeEvaluatorTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.internal.util;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,6 +21,9 @@ import static org.mule.runtime.api.metadata.DataType.STRING;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_JAVA;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_JSON;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
@@ -52,13 +56,18 @@ public class DWAttributeEvaluatorTestCase extends AbstractMuleContextTestCase {
   private static final String DW_CAR_LIST = "#[[{color : 'RED', price: 1000}]]";
   private static final DataType CAR_DATA_TYPE = DataType.fromType(Car.class);
   private static final DataType CAR_LIST_DATA_TYPE = DataType.builder().collectionType(List.class).itemType(Car.class).build();
-  private CoreEvent mockMuleEvent = mock(CoreEvent.class);
+  private final CoreEvent mockMuleEvent = mock(CoreEvent.class);
   private DefaultExpressionManager expressionManager;
 
   @Before
   public void setUp() throws MuleException {
     expressionManager = new DefaultExpressionManager();
     initialiseIfNeeded(expressionManager, muleContext);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/journal/queue/LocalTxQueueTransactionJournalTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/journal/queue/LocalTxQueueTransactionJournalTestCase.java
@@ -7,24 +7,27 @@
 package org.mule.runtime.core.internal.util.journal.queue;
 
 import static java.lang.Math.abs;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.util.journal.TransactionJournal.TX1_LOG_FILE_NAME;
 import static org.mule.runtime.core.internal.util.journal.TransactionJournal.TX2_LOG_FILE_NAME;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.util.queue.DefaultQueueStore;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import com.google.common.collect.Multimap;
-
 import java.io.File;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Random;
 
 import org.junit.Before;
@@ -32,7 +35,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Answers;
+
+import com.google.common.collect.Multimap;
 
 public class LocalTxQueueTransactionJournalTestCase extends AbstractMuleContextTestCase {
 
@@ -47,12 +51,17 @@ public class LocalTxQueueTransactionJournalTestCase extends AbstractMuleContextT
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  private DefaultQueueStore mockQueueInfo = mock(DefaultQueueStore.class, Answers.RETURNS_DEEP_STUBS.get());
+  private final DefaultQueueStore mockQueueInfo = mock(DefaultQueueStore.class, RETURNS_DEEP_STUBS);
 
 
   @Before
   public void setUpMocks() {
     when(mockQueueInfo.getName()).thenReturn(QUEUE_NAME);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/journal/queue/XaTxQueueTransactionJournalTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/journal/queue/XaTxQueueTransactionJournalTestCase.java
@@ -6,19 +6,22 @@
  */
 package org.mule.runtime.core.internal.util.journal.queue;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.util.queue.DefaultQueueStore;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import com.google.common.collect.Multimap;
-
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 
 import javax.transaction.xa.Xid;
 
@@ -26,7 +29,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Answers;
+
+import com.google.common.collect.Multimap;
 
 public class XaTxQueueTransactionJournalTestCase extends AbstractMuleContextTestCase {
 
@@ -36,12 +40,17 @@ public class XaTxQueueTransactionJournalTestCase extends AbstractMuleContextTest
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  private DefaultQueueStore mockQueueInfo = mock(DefaultQueueStore.class, Answers.RETURNS_DEEP_STUBS.get());
-
+  private final DefaultQueueStore mockQueueInfo = mock(DefaultQueueStore.class, RETURNS_DEEP_STUBS);
 
   @Before
   public void setUpMocks() {
     when(mockQueueInfo.getName()).thenReturn(QUEUE_NAME);
+  }
+
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/LocalTxQueueTransactionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/LocalTxQueueTransactionTestCase.java
@@ -8,6 +8,7 @@ package org.mule.runtime.core.internal.util.queue;
 
 import static java.lang.System.currentTimeMillis;
 import static java.lang.Thread.sleep;
+import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -24,6 +25,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
 import org.mule.runtime.core.api.MuleContext;
@@ -38,6 +41,7 @@ import org.mule.runtime.core.internal.util.journal.queue.LocalTxQueueTransaction
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.concurrent.locks.Lock;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -52,6 +56,7 @@ public class LocalTxQueueTransactionTestCase extends AbstractMuleContextTestCase
   private static final int TIMEOUT = 10;
 
   private static final long QUEUE_DELAY_MILLIS = 2000;
+  private static final long QUEUE_DELAY_TOLERANCE_MILLIS = 20;
   private DelayedQueueStore delayedQueue;
 
   @Rule
@@ -75,6 +80,11 @@ public class LocalTxQueueTransactionTestCase extends AbstractMuleContextTestCase
     persistentTransactionContext = new PersistentQueueTransactionContext(txLog, createRecoverOnlyQueueProvider(inQueue));
     queueTransactionRecoverer = new LocalTxQueueTransactionRecoverer(txLog, createRecoverOnlyQueueProvider(inQueue));
     localTxTransactionContext = createLocalTxContext(txLog, createQueueProvider(delayedQueue));
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   private LocalTxQueueTransactionContext createLocalTxContext(LocalTxQueueTransactionJournal txLog, QueueProvider provider)
@@ -226,7 +236,7 @@ public class LocalTxQueueTransactionTestCase extends AbstractMuleContextTestCase
     assertThat(polledValue, nullValue());
     // And it waited at least for the given timeout
     assertThat((double) (timeAfterPoll - timeBeforePoll),
-               anyOf(greaterThanOrEqualTo((double) timeout), closeTo((double) timeout, 20)));
+               anyOf(greaterThanOrEqualTo((double) timeout), closeTo(timeout, QUEUE_DELAY_TOLERANCE_MILLIS)));
   }
 
   @Test
@@ -253,8 +263,7 @@ public class LocalTxQueueTransactionTestCase extends AbstractMuleContextTestCase
     localTxTransactionContext.poll(delayedQueue, QUEUE_DELAY_MILLIS);
     long elapsedMillis = currentTimeMillis() - timeMillisBeforePoll;
 
-    final long toleranceMillis = 5;
-    assertThat(elapsedMillis, lessThanOrEqualTo(QUEUE_DELAY_MILLIS + toleranceMillis));
+    assertThat(elapsedMillis, lessThanOrEqualTo(QUEUE_DELAY_MILLIS + QUEUE_DELAY_TOLERANCE_MILLIS));
   }
 
   @Test
@@ -267,8 +276,7 @@ public class LocalTxQueueTransactionTestCase extends AbstractMuleContextTestCase
     localTxTransactionContext.doCommit();
     long elapsedMillis = currentTimeMillis() - timeMillisBeforeOffer;
 
-    final long toleranceMillis = 5;
-    assertThat(elapsedMillis, lessThanOrEqualTo(waitTime + toleranceMillis));
+    assertThat(elapsedMillis, lessThanOrEqualTo(waitTime + QUEUE_DELAY_TOLERANCE_MILLIS));
   }
 
   private static class DelayedQueueStore extends DefaultQueueStore {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/QueueManagerLifecycleOrderTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/QueueManagerLifecycleOrderTestCase.java
@@ -17,6 +17,7 @@ import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_SECURITY_MA
 import static org.mule.runtime.core.api.processor.strategy.AsyncProcessingStrategyFactory.DEFAULT_MAX_CONCURRENCY;
 import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.interception.InterceptorManager.INTERCEPTOR_MANAGER_REGISTRY_KEY;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.deployment.management.ComponentInitialStateManager;
@@ -68,7 +69,7 @@ public class QueueManagerLifecycleOrderTestCase extends AbstractMuleTestCase {
     objects.put(OBJECT_QUEUE_MANAGER, rtqm);
     objects.put(OBJECT_SECURITY_MANAGER, new DefaultMuleSecurityManager());
     objects.put(INTERCEPTOR_MANAGER_REGISTRY_KEY, mock(InterceptorManager.class));
-    objects.put("errorTypeRepository", createDefaultErrorTypeRepository());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     muleContext = new DefaultMuleContextFactory().createMuleContext(testServicesConfigurationBuilder,
                                                                     new SimpleConfigurationBuilder(objects));
     testServicesConfigurationBuilder.configure(muleContext);

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/QueueManagerLifecycleOrderTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/QueueManagerLifecycleOrderTestCase.java
@@ -15,7 +15,9 @@ import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_NOTIFICATIO
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_QUEUE_MANAGER;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_SECURITY_MANAGER;
 import static org.mule.runtime.core.api.processor.strategy.AsyncProcessingStrategyFactory.DEFAULT_MAX_CONCURRENCY;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.interception.InterceptorManager.INTERCEPTOR_MANAGER_REGISTRY_KEY;
+
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.deployment.management.ComponentInitialStateManager;
 import org.mule.runtime.api.exception.MuleException;
@@ -52,8 +54,8 @@ import org.junit.Test;
 @SmallTest
 public class QueueManagerLifecycleOrderTestCase extends AbstractMuleTestCase {
 
-  private List<Object> startStopOrder = new ArrayList<>();
-  private RecordingTQM rtqm = new RecordingTQM();
+  private final List<Object> startStopOrder = new ArrayList<>();
+  private final RecordingTQM rtqm = new RecordingTQM();
 
   @Rule
   public TestServicesConfigurationBuilder testServicesConfigurationBuilder = new TestServicesConfigurationBuilder();
@@ -66,6 +68,7 @@ public class QueueManagerLifecycleOrderTestCase extends AbstractMuleTestCase {
     objects.put(OBJECT_QUEUE_MANAGER, rtqm);
     objects.put(OBJECT_SECURITY_MANAGER, new DefaultMuleSecurityManager());
     objects.put(INTERCEPTOR_MANAGER_REGISTRY_KEY, mock(InterceptorManager.class));
+    objects.put("errorTypeRepository", createDefaultErrorTypeRepository());
     muleContext = new DefaultMuleContextFactory().createMuleContext(testServicesConfigurationBuilder,
                                                                     new SimpleConfigurationBuilder(objects));
     testServicesConfigurationBuilder.configure(muleContext);

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/component/ExecutableComponentTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/component/ExecutableComponentTestCase.java
@@ -7,6 +7,7 @@
 
 package org.mule.runtime.core.privileged.component;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -16,6 +17,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static reactor.core.publisher.Mono.error;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.publisher.Mono.fromFuture;
@@ -32,6 +35,7 @@ import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -50,6 +54,11 @@ public class ExecutableComponentTestCase extends AbstractMuleContextTestCase {
   protected void doSetUp() throws Exception {
     muleContext.getInjector().inject(executableComponent);
     requestMessage = testEvent().getMessage();
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/CompositeProcessorChainRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/CompositeProcessorChainRouterTestCase.java
@@ -23,9 +23,11 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.internal.event.DefaultEventContext.child;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.interception.InterceptorManager.INTERCEPTOR_MANAGER_REGISTRY_KEY;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.createAndRegisterFlow;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ProcessorChainRouterStory.PROCESSOR_CHAIN_ROUTER;
@@ -45,10 +47,6 @@ import org.mule.runtime.core.privileged.processor.chain.DefaultMessageProcessorC
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +54,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
@@ -81,6 +83,7 @@ public class CompositeProcessorChainRouterTestCase extends AbstractMuleContextTe
     final Map<String, Object> objects = new HashMap<>();
     objects.put(REGISTRY_KEY, componentLocator);
     objects.put(INTERCEPTOR_MANAGER_REGISTRY_KEY, mock(InterceptorManager.class));
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 
@@ -228,7 +231,7 @@ public class CompositeProcessorChainRouterTestCase extends AbstractMuleContextTe
 
   private static class ProcessingStrategyChainRouter extends CompositeProcessorChainRouter {
 
-    private ProcessingStrategy processingStrategy;
+    private final ProcessingStrategy processingStrategy;
 
     ProcessingStrategyChainRouter(ProcessingStrategy processingStrategy) {
       this.processingStrategy = processingStrategy;

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.privileged.processor;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -23,6 +24,7 @@ import static org.mule.functional.junit4.matchers.ThrowableRootCauseMatcher.hasR
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.applyWithChildContext;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChildContext;
@@ -31,10 +33,12 @@ import static org.mule.runtime.core.privileged.processor.MessageProcessors.proce
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContext;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContextBlocking;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContextDontComplete;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.getNotificationDispatcher;
 import static reactor.core.publisher.Mono.empty;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.publisher.Mono.just;
+
 import org.mule.runtime.api.event.EventContext;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -52,17 +56,19 @@ import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
-import io.qameta.allure.Issue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.reactivestreams.Publisher;
+
+import io.qameta.allure.Issue;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
@@ -97,6 +103,11 @@ public class MessageProcessorsTestCase extends AbstractMuleContextTestCase {
     output = builder(eventContext).message(of(TEST_MESSAGE)).build();
     response = builder(eventContext).message(of(TEST_MESSAGE)).build();
     responsePublisher = eventContext.getResponsePublisher();
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
@@ -93,8 +93,7 @@ public class MessageProcessorsTestCase extends AbstractMuleContextTestCase {
     flow = mock(Flow.class, RETURNS_DEEP_STUBS);
     exceptionHandler = new OnErrorPropagateHandler();
     exceptionHandler.setMuleContext(muleContext);
-    exceptionHandler
-        .setNotificationFirer(getNotificationDispatcher(muleContext));
+    exceptionHandler.setNotificationFirer(getNotificationDispatcher(muleContext));
     exceptionHandler.initialise();
     exceptionHandler.start();
     when(flow.getExceptionListener()).thenReturn(exceptionHandler);

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainTestCase.java
@@ -7,6 +7,7 @@
 
 package org.mule.runtime.core.privileged.processor.chain;
 
+import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -43,9 +44,11 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNee
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_INTENSIVE;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.createAndRegisterFlow;
 import static org.mule.tck.junit4.AbstractReactiveProcessorTestCase.Mode.BLOCKING;
 import static org.mule.tck.junit4.AbstractReactiveProcessorTestCase.Mode.NON_BLOCKING;
@@ -181,7 +184,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
-    return singletonMap(REGISTRY_KEY, componentLocator);
+    return of(REGISTRY_KEY, componentLocator,
+              OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/core/api-changes.json
+++ b/core/api-changes.json
@@ -4,6 +4,28 @@
       "ignore": [
         {
           "code": "java.annotation.added",
+          "old": "class org.mule.runtime.core.privileged.exception.AbstractExceptionListener",
+          "new": "class org.mule.runtime.core.privileged.exception.AbstractExceptionListener",
+          "annotationType": "org.mule.api.annotation.NoExtend",
+          "annotation": "@org.mule.api.annotation.NoExtend",
+          "package": "org.mule.runtime.core.privileged.exception",
+          "classSimpleName": "AbstractExceptionListener",
+          "elementKind": "class",
+          "justification": "Add missing annotation"
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "class org.mule.runtime.core.api.exception.LoggingExceptionHandler",
+          "new": "class org.mule.runtime.core.api.exception.LoggingExceptionHandler",
+          "annotationType": "org.mule.api.annotation.NoExtend",
+          "annotation": "@org.mule.api.annotation.NoExtend",
+          "package": "org.mule.runtime.core.api.exception",
+          "classSimpleName": "LoggingExceptionHandler",
+          "elementKind": "class",
+          "justification": "Add missing annotation"
+        },
+        {
+          "code": "java.annotation.added",
           "old": "class org.mule.runtime.core.privileged.processor.chain.DefaultMessageProcessorChainBuilder.DefaultMessageProcessorChain",
           "new": "class org.mule.runtime.core.privileged.processor.chain.DefaultMessageProcessorChainBuilder.DefaultMessageProcessorChain",
           "annotationType": "org.mule.api.annotation.NoExtend",

--- a/core/src/main/java/org/mule/runtime/core/api/exception/BaseExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/BaseExceptionHandler.java
@@ -6,11 +6,14 @@
  */
 package org.mule.runtime.core.api.exception;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.core.api.event.CoreEvent;
 
 import java.util.function.Consumer;
 
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
 
 import reactor.core.publisher.Mono;
 
@@ -20,6 +23,8 @@ import reactor.core.publisher.Mono;
  * @since 4.2
  */
 public abstract class BaseExceptionHandler implements FlowExceptionHandler {
+
+  private static final Logger LOGGER = getLogger(BaseExceptionHandler.class);
 
   @Override
   public CoreEvent handleException(Exception exception, CoreEvent event) {
@@ -37,6 +42,10 @@ public abstract class BaseExceptionHandler implements FlowExceptionHandler {
 
   @Override
   public void routeError(Exception error, Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Routing error in '" + this.toString() + "'...");
+    }
+
     onError(error);
     FlowExceptionHandler.super.routeError(error, continueCallback, propagateCallback);
   }

--- a/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
@@ -9,6 +9,7 @@ package org.mule.runtime.core.api.exception;
 import static org.mule.runtime.core.api.rx.Exceptions.propagateWrappingFatal;
 import static reactor.core.publisher.Flux.error;
 import static reactor.core.publisher.Mono.just;
+
 import org.mule.api.annotation.NoImplement;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.exception.MessagingException;
@@ -62,10 +63,12 @@ public interface FlowExceptionHandler extends Function<Exception, Publisher<Core
 
   /**
    * Routes the error towards the destination error handler, calling the corresponding callback in case of failure or success.
-   * 
+   *
    * @param error the {@link Exception} to route
    * @param continueCallback the callback called in case the error is successfully handled
    * @param propagateCallback the callback is called in case the error-handling fails
+   *
+   * @since 4.3
    */
   default void routeError(Exception error, Consumer<CoreEvent> continueCallback,
                           Consumer<Throwable> propagateCallback) {

--- a/core/src/main/java/org/mule/runtime/core/api/exception/LoggingExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/LoggingExceptionHandler.java
@@ -8,6 +8,8 @@ package org.mule.runtime.core.api.exception;
 
 import static org.mule.runtime.api.exception.ExceptionHelper.getRootMuleException;
 import static org.slf4j.LoggerFactory.getLogger;
+
+import org.mule.api.annotation.NoExtend;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
@@ -19,6 +21,7 @@ import org.slf4j.Logger;
  *
  * @since 4.0
  */
+@NoExtend
 public class LoggingExceptionHandler extends BaseExceptionHandler {
 
   private static final LoggingExceptionHandler INSTANCE = new LoggingExceptionHandler();
@@ -40,4 +43,8 @@ public class LoggingExceptionHandler extends BaseExceptionHandler {
     }
   }
 
+  @Override
+  public String toString() {
+    return LoggingExceptionHandler.class.getSimpleName();
+  }
 }

--- a/core/src/main/java/org/mule/runtime/core/api/exception/NullExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/NullExceptionHandler.java
@@ -31,4 +31,8 @@ public final class NullExceptionHandler extends BaseExceptionHandler {
     // Do nothing
   }
 
+  @Override
+  public String toString() {
+    return NullExceptionHandler.class.getSimpleName();
+  }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -401,7 +401,8 @@ abstract class AbstractEventContext implements BaseEventContext {
     return (this == highlight ? "=> " : "") + basicToString()
         + lineSeparator()
         + childContexts.stream()
-            .map(ctx -> leftPad("", (1 + level) * TO_STRING_TAB_SIZE) + ((AbstractEventContext) ctx).detailedToString(1 + level, highlight))
+            .map(ctx -> leftPad("", (1 + level) * TO_STRING_TAB_SIZE)
+                + ((AbstractEventContext) ctx).detailedToString(1 + level, highlight))
             .collect(joining(lineSeparator()));
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -7,10 +7,14 @@
 package org.mule.runtime.core.internal.event;
 
 import static java.lang.String.format;
+import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static org.apache.commons.lang3.StringUtils.leftPad;
 import static org.mule.runtime.api.functional.Either.left;
 import static org.mule.runtime.api.functional.Either.right;
 import static reactor.core.publisher.Mono.empty;
+
 import org.mule.runtime.api.functional.Either;
 import org.mule.runtime.api.util.LazyValue;
 import org.mule.runtime.core.api.context.notification.FlowCallStack;
@@ -33,6 +37,7 @@ import java.util.function.Consumer;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 
@@ -48,6 +53,7 @@ abstract class AbstractEventContext implements BaseEventContext {
   private static final byte STATE_COMPLETE = 2;
   private static final byte STATE_TERMINATED = 3;
 
+  private static final int TO_STRING_TAB_SIZE = 4;
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractEventContext.class);
   private static final FlowExceptionHandler NULL_EXCEPTION_HANDLER = NullExceptionHandler.getInstance();
 
@@ -72,10 +78,6 @@ abstract class AbstractEventContext implements BaseEventContext {
 
   public AbstractEventContext() {
     this(NULL_EXCEPTION_HANDLER, 0, Optional.empty());
-  }
-
-  public AbstractEventContext(FlowExceptionHandler exceptionHandler) {
-    this(exceptionHandler, 0, Optional.empty());
   }
 
   /**
@@ -392,4 +394,19 @@ abstract class AbstractEventContext implements BaseEventContext {
   public Lock getChildContextsWriteLock() {
     return childContextsReadWriteLock.writeLock();
   }
+
+  protected abstract String basicToString();
+
+  protected final String detailedToString(int level, BaseEventContext highlight) {
+    return (this == highlight ? "=> " : "") + basicToString()
+        + lineSeparator()
+        + childContexts.stream()
+            .map(ctx -> leftPad("", (1 + level) * TO_STRING_TAB_SIZE) + ((AbstractEventContext) ctx).detailedToString(1 + level, highlight))
+            .collect(joining(lineSeparator()));
+  }
+
+  protected byte getState() {
+    return state;
+  }
+
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventContext.java
@@ -7,12 +7,14 @@
 package org.mule.runtime.core.internal.event;
 
 import static java.lang.System.identityHashCode;
+import static java.lang.System.lineSeparator;
 import static java.time.Instant.now;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static org.mule.runtime.core.api.util.StringUtils.EMPTY;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.streaming.CursorProvider;
@@ -38,12 +40,16 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import org.slf4j.Logger;
+
 /**
  * Default immutable implementation of {@link BaseEventContext}.
  *
  * @since 4.0
  */
 public final class DefaultEventContext extends AbstractEventContext implements Serializable {
+
+  private static final Logger LOGGER = getLogger(DefaultEventContext.class);
 
   private static final long serialVersionUID = -3664490832964509653L;
 
@@ -252,8 +258,17 @@ public final class DefaultEventContext extends AbstractEventContext implements S
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + " { id: " + id + "; correlationId: " + correlationId + "; flowName: "
-        + getOriginatingLocation().getRootContainerName() + "; serverId: " + serverId + " }";
+    if (LOGGER.isTraceEnabled()) {
+      return lineSeparator() + detailedToString(0, this) + lineSeparator();
+    } else {
+      return basicToString();
+    }
+  }
+
+  @Override
+  protected String basicToString() {
+    return getClass().getSimpleName() + " { state: " + getState() + "; id: " + id + "; flowName: "
+        + getOriginatingLocation().getRootContainerName() + " }";
   }
 
   private static class ChildEventContext extends AbstractEventContext implements Serializable {
@@ -327,9 +342,17 @@ public final class DefaultEventContext extends AbstractEventContext implements S
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + " { id: " + getId() + "; correlationId: " + parent.getCorrelationId()
-          + "; flowName: " + parent.getOriginatingLocation().getRootContainerName() + "; componentLocation: "
-          + (componentLocation != null ? componentLocation.getLocation() : EMPTY) + ";";
+      if (LOGGER.isTraceEnabled()) {
+        return lineSeparator() + ((AbstractEventContext) root).detailedToString(0, this) + lineSeparator();
+      } else {
+        return basicToString();
+      }
+    }
+
+    @Override
+    public String basicToString() {
+      return getClass().getSimpleName() + " { state: " + getState() + "; id: " + getId() + "; componentLocation: "
+          + (componentLocation != null ? componentLocation.getLocation() : EMPTY) + " }";
     }
 
     @Override

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/AbstractSystemExceptionStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/AbstractSystemExceptionStrategy.java
@@ -12,7 +12,7 @@ import static org.mule.runtime.core.privileged.event.PrivilegedEvent.setCurrentE
 
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.scheduler.Scheduler;
-import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.api.scheduler.SchedulerService;
 import org.mule.runtime.core.api.connector.ConnectException;
 import org.mule.runtime.core.api.exception.RollbackSourceCallback;
 import org.mule.runtime.core.api.exception.SystemExceptionHandler;
@@ -20,11 +20,16 @@ import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.runtime.core.privileged.exception.AbstractExceptionListener;
 
+import javax.inject.Inject;
+
 /**
  * Fire a notification, log exception, clean up transaction if any, and trigger reconnection strategy if this is a
  * <code>ConnectException</code>.
  */
 public abstract class AbstractSystemExceptionStrategy extends AbstractExceptionListener implements SystemExceptionHandler {
+
+  @Inject
+  private SchedulerService schedulerService;
 
   protected Scheduler retryScheduler;
 
@@ -62,10 +67,9 @@ public abstract class AbstractSystemExceptionStrategy extends AbstractExceptionL
   }
 
   @Override
-  protected void doInitialise(MuleContext context) throws InitialisationException {
-    retryScheduler =
-        muleContext.getSchedulerService().ioScheduler(muleContext.getSchedulerBaseConfig().withShutdownTimeout(0, MILLISECONDS));
-    super.doInitialise(context);
+  protected void doInitialise() throws InitialisationException {
+    retryScheduler = schedulerService.ioScheduler(muleContext.getSchedulerBaseConfig().withShutdownTimeout(0, MILLISECONDS));
+    super.doInitialise();
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorContinueHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorContinueHandler.java
@@ -12,11 +12,9 @@ import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.Location;
-import org.mule.runtime.api.exception.ErrorTypeRepository;
 import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.message.ErrorType;
-import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.exception.ErrorTypeMatcher;
 import org.mule.runtime.core.api.exception.SingleErrorTypeMatcher;
@@ -39,11 +37,10 @@ public class OnErrorContinueHandler extends TemplateOnErrorHandler {
   }
 
   @Override
-  protected void doInitialise(MuleContext muleContext) throws InitialisationException {
-    super.doInitialise(muleContext);
+  protected void doInitialise() throws InitialisationException {
+    super.doInitialise();
 
-    ErrorTypeRepository errorTypeRepository = muleContext.getErrorTypeRepository();
-    sourceErrorMatcher = new SingleErrorTypeMatcher(errorTypeRepository.getSourceResponseErrorType());
+    sourceErrorMatcher = new SingleErrorTypeMatcher(getErrorTypeRepository().getSourceResponseErrorType());
 
     if (errorType != null) {
       String[] errors = errorType.split(",");
@@ -51,7 +48,7 @@ public class OnErrorContinueHandler extends TemplateOnErrorHandler {
         String sanitizedError = error.trim();
         ComponentIdentifier errorTypeIdentifier = buildFromStringRepresentation(sanitizedError);
 
-        Optional<ErrorType> errorType = errorTypeRepository.lookupErrorType(errorTypeIdentifier);
+        Optional<ErrorType> errorType = getErrorTypeRepository().lookupErrorType(errorTypeIdentifier);
         if (errorType.isPresent()) {
           if (sourceErrorMatcher.match(errorType.get())) {
             throw new InitialisationException(getInitialisationError(sanitizedError), this);
@@ -60,7 +57,7 @@ public class OnErrorContinueHandler extends TemplateOnErrorHandler {
       }
     } else if (!when.isPresent()) {
       // No error type and no expression, force ANY matcher
-      errorTypeMatcher = new SingleErrorTypeMatcher(errorTypeRepository.getAnyErrorType());
+      errorTypeMatcher = new SingleErrorTypeMatcher(getErrorTypeRepository().getAnyErrorType());
     }
 
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/FirstSuccessful.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/FirstSuccessful.java
@@ -6,6 +6,9 @@
  */
 package org.mule.runtime.core.internal.routing;
 
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
+
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -15,14 +18,12 @@ import org.mule.runtime.core.api.context.MuleContextAware;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.privileged.processor.Router;
-import org.reactivestreams.Publisher;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
-import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
+import org.reactivestreams.Publisher;
 
 /**
  * FirstSuccessful routes an event to the first target route that can accept it without throwing or returning an exception. If no
@@ -38,6 +39,7 @@ public class FirstSuccessful extends AbstractComponent implements Router, Lifecy
   @Override
   public void initialise() throws InitialisationException {
     for (ProcessorRoute route : routes) {
+      route.setMessagingExceptionHandler(null);
       initialiseIfNeeded(route, muleContext);
     }
   }

--- a/core/src/main/java/org/mule/runtime/core/privileged/exception/AbstractExceptionListener.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/exception/AbstractExceptionListener.java
@@ -8,7 +8,6 @@ package org.mule.runtime.core.privileged.exception;
 
 import static java.lang.Boolean.TRUE;
 import static java.text.MessageFormat.format;
-import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.mule.runtime.api.exception.ExceptionHelper.getRootMuleException;
 import static org.mule.runtime.api.exception.ExceptionHelper.sanitize;
@@ -19,6 +18,7 @@ import static org.mule.runtime.api.notification.SecurityNotification.SECURITY_AU
 import static org.mule.runtime.core.api.exception.Errors.CORE_NAMESPACE_NAME;
 import static org.mule.runtime.core.api.exception.Errors.Identifiers.UNKNOWN_ERROR_IDENTIFIER;
 
+import org.mule.api.annotation.NoExtend;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.TypedException;
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
  * <code>AbstractSystemExceptionStrategy</code> (if you are creating a System Exception Strategy) rather than directly from this
  * class.
  */
+@NoExtend
 public abstract class AbstractExceptionListener extends AbstractMessageProcessorOwner {
 
   protected static final String NOT_SET = "<not set>";
@@ -94,17 +95,25 @@ public abstract class AbstractExceptionListener extends AbstractMessageProcessor
   @Override
   public final synchronized void initialise() throws InitialisationException {
     if (!initialised.get()) {
-      doInitialise(muleContext);
+      doInitialise();
       super.initialise();
       initialised.set(true);
     }
   }
 
-  protected void doInitialise(MuleContext context) throws InitialisationException {
-    requireNonNull(muleContext);
+  protected void doInitialise() throws InitialisationException {
     if (logger.isDebugEnabled()) {
       logger.debug("Initialising exception listener: " + toString());
     }
+    doInitialise(muleContext);
+  }
+
+  /**
+   * @deprecated Implement {@link #doInitialise()} instead.
+   */
+  @Deprecated
+  protected void doInitialise(MuleContext muleContext) throws InitialisationException {
+    // nothing to do
   }
 
   protected void fireNotification(Exception ex, CoreEvent event) {
@@ -235,5 +244,10 @@ public abstract class AbstractExceptionListener extends AbstractMessageProcessor
 
   public void setStatistics(FlowConstructStatistics statistics) {
     this.statistics = statistics;
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + (getLocation() != null ? " @ " + getLocation().getLocation() : "");
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/MessageProcessors.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/MessageProcessors.java
@@ -100,6 +100,15 @@ public class MessageProcessors {
     return defaultMessageProcessorChainBuilder.chain(processors).build();
   }
 
+  public static MessageProcessorChain buildNewChainWithListOfProcessors(Optional<ProcessingStrategy> processingStrategy,
+                                                                        List<Processor> processors,
+                                                                        FlowExceptionHandler messagingExceptionHandler) {
+    DefaultMessageProcessorChainBuilder defaultMessageProcessorChainBuilder = new DefaultMessageProcessorChainBuilder();
+    processingStrategy.ifPresent(defaultMessageProcessorChainBuilder::setProcessingStrategy);
+    defaultMessageProcessorChainBuilder.setMessagingExceptionHandler(messagingExceptionHandler);
+    return defaultMessageProcessorChainBuilder.chain(processors).build();
+  }
+
   /**
    * Creates a new {@link MessageProcessorChain} from a {@link List} of {@link Processor}'s. Note that this performs chains
    * construction but will not inject {@link MuleContext} or perform any lifecycle.

--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChain.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChain.java
@@ -9,6 +9,8 @@ package org.mule.runtime.core.privileged.processor.chain;
 import static java.lang.String.format;
 import static java.lang.Thread.currentThread;
 import static org.apache.commons.lang3.StringUtils.replace;
+import static org.mule.runtime.api.functional.Either.left;
+import static org.mule.runtime.api.functional.Either.right;
 import static org.mule.runtime.api.notification.MessageProcessorNotification.MESSAGE_PROCESSOR_POST_INVOKE;
 import static org.mule.runtime.api.notification.MessageProcessorNotification.MESSAGE_PROCESSOR_PRE_INVOKE;
 import static org.mule.runtime.api.notification.MessageProcessorNotification.createFrom;
@@ -17,6 +19,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.setMuleContextIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
+import static org.mule.runtime.core.api.rx.Exceptions.propagateWrappingFatal;
 import static org.mule.runtime.core.api.rx.Exceptions.unwrap;
 import static org.mule.runtime.core.api.util.StreamingUtils.updateEventForStreaming;
 import static org.mule.runtime.core.api.util.StringUtils.isBlank;
@@ -29,6 +32,7 @@ import static org.mule.runtime.core.privileged.processor.chain.ChainErrorHandlin
 import static org.mule.runtime.core.privileged.processor.chain.ChainErrorHandlingUtils.resolveMessagingException;
 import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.Exceptions.propagate;
+import static reactor.core.publisher.Flux.create;
 import static reactor.core.publisher.Flux.from;
 import static reactor.core.publisher.Operators.lift;
 
@@ -36,6 +40,7 @@ import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.functional.Either;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.lifecycle.LifecycleException;
 import org.mule.runtime.api.lifecycle.Startable;
@@ -45,6 +50,7 @@ import org.mule.runtime.core.api.context.notification.MuleContextListener;
 import org.mule.runtime.core.api.context.notification.ServerNotificationManager;
 import org.mule.runtime.core.api.context.thread.notification.ThreadNotificationService;
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.exception.FlowExceptionHandler;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
@@ -56,6 +62,9 @@ import org.mule.runtime.core.internal.interception.InterceptorManager;
 import org.mule.runtime.core.internal.processor.chain.InterceptedReactiveProcessor;
 import org.mule.runtime.core.internal.processor.interceptor.ReactiveAroundInterceptorAdapter;
 import org.mule.runtime.core.internal.processor.interceptor.ReactiveInterceptorAdapter;
+import org.mule.runtime.core.internal.rx.FluxSinkRecorder;
+import org.mule.runtime.core.internal.rx.FluxSinkRecorderToReactorSinkAdapter;
+import org.mule.runtime.core.internal.rx.SinkRecorderToReactorSinkAdapter;
 import org.mule.runtime.core.internal.util.MessagingExceptionResolver;
 import org.mule.runtime.core.privileged.component.AbstractExecutableComponent;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
@@ -117,6 +126,7 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
 
   private final String name;
   private final List<Processor> processors;
+  private final FlowExceptionHandler messagingExceptionHandler;
   private final ProcessingStrategy processingStrategy;
   private final List<ReactiveInterceptorAdapter> additionalInterceptors = new LinkedList<>();
 
@@ -134,10 +144,11 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
 
   AbstractMessageProcessorChain(String name,
                                 Optional<ProcessingStrategy> processingStrategyOptional,
-                                List<Processor> processors) {
+                                List<Processor> processors, FlowExceptionHandler messagingExceptionHandler) {
     this.name = name;
     this.processingStrategy = processingStrategyOptional.orElse(null);
     this.processors = processors;
+    this.messagingExceptionHandler = messagingExceptionHandler;
   }
 
   @Override
@@ -147,6 +158,31 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
 
   @Override
   public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
+    if (messagingExceptionHandler != null) {
+      final FluxSinkRecorder<Either<MessagingException, CoreEvent>> errorSwitchSinkSinkRef = new FluxSinkRecorder<>();
+      SinkRecorderToReactorSinkAdapter<Either<MessagingException, CoreEvent>> errorSwitchSinkAdapter =
+          new FluxSinkRecorderToReactorSinkAdapter<>(errorSwitchSinkSinkRef);
+
+      final Flux<CoreEvent> baseStream = from(doApply(publisher, (context, throwable) -> messagingExceptionHandler
+          .routeError(throwable,
+                      handled -> errorSwitchSinkAdapter.next(right(handled)),
+                      rethrown -> errorSwitchSinkAdapter.next(left((MessagingException) rethrown, CoreEvent.class)))));
+      return baseStream
+          // This Either here is used to propagate errors. If the error is sent directly through the merged with Flux,
+          // it will be cancelled, ignoring the onErrorcontinue of the parent Flux.
+          .map(event -> right(MessagingException.class, event))
+          .doOnComplete(() -> errorSwitchSinkSinkRef.complete())
+          .mergeWith(create(errorSwitchSinkSinkRef))
+          .map(result -> result.reduce(me -> {
+            throw propagateWrappingFatal(me);
+          }, response -> response));
+    } else {
+      return doApply(publisher, (context, throwable) -> context.error(throwable));
+    }
+  }
+
+  public Publisher<CoreEvent> doApply(Publisher<CoreEvent> publisher,
+                                      BiConsumer<BaseEventContext, ? super Exception> errorBubbler) {
     List<BiFunction<Processor, ReactiveProcessor, ReactiveProcessor>> interceptors = resolveInterceptors();
     Flux<CoreEvent> stream = from(publisher);
     for (Processor processor : getProcessorsToExecute()) {
@@ -158,9 +194,10 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
                                                     getLocalOperatorErrorHook(processor, muleContext)))
           // #2 Register continue error strategy to handle errors without stopping the stream.
           .onErrorContinue(exception -> !(exception instanceof LifecycleException),
-                           getContinueStrategyErrorHandler(processor));
+                           getContinueStrategyErrorHandler(processor, errorBubbler));
     }
-    return stream.subscriberContext(ctx -> {
+
+    stream = stream.subscriberContext(ctx -> {
       ClassLoader tccl = currentThread().getContextClassLoader();
       if (tccl == null || tccl.getParent() == null
           || appClClass == null || !appClClass.isAssignableFrom(tccl.getClass())) {
@@ -171,13 +208,16 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
             .put(TCCL_REACTOR_CTX_KEY, tccl.getParent());
       }
     });
+
+    return stream;
   }
 
   /*
    * Used to process failed events which are dropped from the reactor stream due to error. Errors are processed by invoking the
    * current EventContext error callback.
    */
-  private BiConsumer<Throwable, Object> getContinueStrategyErrorHandler(Processor processor) {
+  private BiConsumer<Throwable, Object> getContinueStrategyErrorHandler(Processor processor,
+                                                                        BiConsumer<BaseEventContext, ? super Exception> errorBubbler) {
     final MessagingExceptionResolver exceptionResolver =
         (processor instanceof Component) ? new MessagingExceptionResolver((Component) processor) : null;
     final Function<MessagingException, MessagingException> messagingExceptionMapper =
@@ -194,7 +234,8 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
       if (object != null && !(object instanceof CoreEvent) && throwable instanceof MessagingException) {
         notifyError(processor,
                     (BaseEventContext) ((MessagingException) throwable).getEvent().getContext(),
-                    messagingExceptionMapper.apply((MessagingException) throwable));
+                    messagingExceptionMapper.apply((MessagingException) throwable),
+                    errorBubbler);
       } else {
         CoreEvent event = (CoreEvent) object;
         if (throwable instanceof MessagingException) {
@@ -203,19 +244,22 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
                       (BaseEventContext) (event != null
                           ? event.getContext()
                           : ((MessagingException) throwable).getEvent().getContext()),
-                      messagingExceptionMapper.apply((MessagingException) throwable));
+                      messagingExceptionMapper.apply((MessagingException) throwable),
+                      errorBubbler);
         } else {
           notifyError(processor,
                       ((BaseEventContext) event.getContext()),
-                      resolveException(processor, event, throwable, muleContext, exceptionResolver));
+                      resolveException(processor, event, throwable, muleContext, exceptionResolver),
+                      errorBubbler);
         }
       }
     };
   }
 
-  private void notifyError(Processor processor, BaseEventContext context, final MessagingException resolvedException) {
+  private void notifyError(Processor processor, BaseEventContext context, final MessagingException resolvedException,
+                           BiConsumer<BaseEventContext, ? super Exception> errorBubbler) {
     errorNotification(processor)
-        .andThen(context::error)
+        .andThen(t -> errorBubbler.accept(context, t))
         .accept(resolvedException);
   }
 

--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChainBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChainBuilder.java
@@ -7,9 +7,10 @@
 package org.mule.runtime.core.privileged.processor.chain;
 
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.privileged.processor.MessageProcessorBuilder;
+import org.mule.runtime.core.api.exception.FlowExceptionHandler;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
+import org.mule.runtime.core.privileged.processor.MessageProcessorBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,7 @@ public abstract class AbstractMessageProcessorChainBuilder implements MessagePro
   protected List processors = new ArrayList();
   protected String name;
   protected ProcessingStrategy processingStrategy;
+  protected FlowExceptionHandler messagingExceptionHandler;
   protected MuleContext muleContext;
 
   // Argument is of type Object because it could be a MessageProcessor or a MessageProcessorBuilder
@@ -48,5 +50,9 @@ public abstract class AbstractMessageProcessorChainBuilder implements MessagePro
   @Override
   public void setProcessingStrategy(ProcessingStrategy processingStrategy) {
     this.processingStrategy = processingStrategy;
+  }
+
+  public void setMessagingExceptionHandler(FlowExceptionHandler messagingExceptionHandler) {
+    this.messagingExceptionHandler = messagingExceptionHandler;
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainBuilder.java
@@ -22,6 +22,7 @@ import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.exception.FlowExceptionHandler;
 import org.mule.runtime.core.api.processor.InterceptingMessageProcessor;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
@@ -37,7 +38,6 @@ import java.util.function.Supplier;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * <p>
@@ -116,7 +116,8 @@ public class DefaultMessageProcessorChainBuilder extends AbstractMessageProcesso
     } else {
       return new DefaultMessageProcessorChain(name != null ? "(chain) of " + name : "(chain)",
                                               processingStrategyOptional,
-                                              new ArrayList<>(tempList));
+                                              new ArrayList<>(tempList),
+                                              messagingExceptionHandler);
     }
   }
 
@@ -124,7 +125,7 @@ public class DefaultMessageProcessorChainBuilder extends AbstractMessageProcesso
                                                           List<Processor> processorsForLifecycle) {
     return new InterceptingMessageProcessorChain(name != null ? "(intercepting chain) of " + name : "(intercepting chain)",
                                                  ofNullable(processingStrategy), head,
-                                                 processors, processorsForLifecycle);
+                                                 processors, processorsForLifecycle, messagingExceptionHandler);
   }
 
   @Override
@@ -164,20 +165,23 @@ public class DefaultMessageProcessorChainBuilder extends AbstractMessageProcesso
   protected static class DefaultMessageProcessorChain extends AbstractMessageProcessorChain {
 
     protected DefaultMessageProcessorChain(String name, Optional<ProcessingStrategy> processingStrategyOptional,
-                                           List<Processor> processors) {
-      super(name, processingStrategyOptional, processors);
+                                           List<Processor> processors,
+                                           FlowExceptionHandler messagingExceptionHandler) {
+      super(name, processingStrategyOptional, processors, messagingExceptionHandler);
     }
 
     /**
      * This constructor left for backwards compatibility
      *
-     * @deprecated Use {@link #DefaultMessageProcessorChainBuilder(String, Optional, List)} instead.
+     * @deprecated Use {@link #DefaultMessageProcessorChainBuilder(String, Optional, List, FlowExceptionHandler)} instead.
      */
     @Deprecated
     protected DefaultMessageProcessorChain(String name, Optional<ProcessingStrategy> processingStrategyOptional, Processor head,
                                            List<Processor> processors,
                                            List<Processor> processorsForLifecycle) {
-      super(name, processingStrategyOptional, processors);
+      super(name, processingStrategyOptional, processors,
+            // just let the error be propagated to the outer chain...
+            (exception, event) -> null);
     }
   }
 
@@ -189,8 +193,9 @@ public class DefaultMessageProcessorChainBuilder extends AbstractMessageProcesso
     protected InterceptingMessageProcessorChain(String name, Optional<ProcessingStrategy> processingStrategyOptional,
                                                 Processor head,
                                                 List<Processor> processors,
-                                                List<Processor> processorsForLifecycle) {
-      super(name, processingStrategyOptional, processors);
+                                                List<Processor> processorsForLifecycle,
+                                                FlowExceptionHandler messagingExceptionHandler) {
+      super(name, processingStrategyOptional, processors, messagingExceptionHandler);
       this.head = head;
       this.processorsForLifecycle = processorsForLifecycle;
     }
@@ -219,43 +224,71 @@ public class DefaultMessageProcessorChainBuilder extends AbstractMessageProcesso
   public static MessageProcessorChain newLazyProcessorChainBuilder(AbstractMessageProcessorChainBuilder chainBuilder,
                                                                    MuleContext muleContext,
                                                                    Supplier<ProcessingStrategy> processingStrategySupplier) {
-    return new AbstractMessageProcessorChain(chainBuilder.name, empty(), chainBuilder.processors) {
+    return new LazyProcessorChainBuilder(chainBuilder.name, empty(), chainBuilder.processors, chainBuilder,
+                                         processingStrategySupplier);
+  }
 
-      private MessageProcessorChain delegate;
+  public interface MessagingExceptionHandlerAware {
 
-      @Override
-      public void initialise() throws InitialisationException {
-        chainBuilder.setProcessingStrategy(processingStrategySupplier.get());
-        delegate = chainBuilder.build();
-        delegate.setAnnotations(getAnnotations());
-        initialiseIfNeeded(delegate, muleContext);
-      }
+    void setMessagingExceptionHandler(FlowExceptionHandler messagingExceptionHandler);
+  }
 
-      @Override
-      public void start() throws MuleException {
-        startIfNeeded(delegate);
-      }
+  private static final class LazyProcessorChainBuilder extends AbstractMessageProcessorChain
+      implements MessagingExceptionHandlerAware {
 
-      @Override
-      public void dispose() {
-        disposeIfNeeded(delegate, LOGGER);
-      }
+    private final AbstractMessageProcessorChainBuilder chainBuilder;
+    private final Supplier<ProcessingStrategy> processingStrategySupplier;
+    private FlowExceptionHandler messagingExceptionHandler;
+    private MessageProcessorChain delegate;
 
-      @Override
-      public void stop() throws MuleException {
-        stopIfNeeded(delegate);
-      }
+    private LazyProcessorChainBuilder(String name, Optional<ProcessingStrategy> processingStrategyOptional,
+                                      List<Processor> processors,
+                                      AbstractMessageProcessorChainBuilder chainBuilder,
+                                      Supplier<ProcessingStrategy> processingStrategySupplier) {
+      super(name, processingStrategyOptional, processors, null);
+      this.chainBuilder = chainBuilder;
+      this.processingStrategySupplier = processingStrategySupplier;
+    }
 
-      @Override
-      public CoreEvent process(CoreEvent event) throws MuleException {
-        return delegate.process(event);
-      }
+    @Override
+    public void initialise() throws InitialisationException {
+      chainBuilder.setProcessingStrategy(processingStrategySupplier.get());
+      chainBuilder.setMessagingExceptionHandler(messagingExceptionHandler);
+      delegate = chainBuilder.build();
+      delegate.setAnnotations(getAnnotations());
+      initialiseIfNeeded(delegate, muleContext);
+    }
 
-      @Override
-      public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
-        return delegate.apply(publisher);
-      }
-    };
+    @Override
+    public void start() throws MuleException {
+      startIfNeeded(delegate);
+    }
+
+    @Override
+    public void dispose() {
+      disposeIfNeeded(delegate, LOGGER);
+    }
+
+    @Override
+    public void stop() throws MuleException {
+      stopIfNeeded(delegate);
+    }
+
+    @Override
+    public CoreEvent process(CoreEvent event) throws MuleException {
+      return delegate.process(event);
+    }
+
+    @Override
+    public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
+      return delegate.apply(publisher);
+    }
+
+    @Override
+    public void setMessagingExceptionHandler(FlowExceptionHandler messagingExceptionHandler) {
+      this.messagingExceptionHandler = messagingExceptionHandler;
+
+    }
   }
 
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.runtime;
 
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.of;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
@@ -19,6 +20,8 @@ import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.rx.Exceptions.unwrap;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.publisher.Mono.just;
 
@@ -39,6 +42,8 @@ import org.mule.runtime.module.extension.internal.runtime.resolver.ResolverSet;
 import org.mule.runtime.module.extension.internal.runtime.resolver.ResolverSetResult;
 import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolvingContext;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import java.util.Map;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -96,6 +101,11 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
     processor.setCacheIdGeneratorFactory(mock(MetadataCacheIdGeneratorFactory.class));
 
     initialiseIfNeeded(processor, muleContext);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/AbstractOperationMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/AbstractOperationMessageProcessorTestCase.java
@@ -9,6 +9,7 @@ package org.mule.runtime.module.extension.internal.runtime.operation;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -30,7 +31,9 @@ import static org.mule.runtime.api.meta.model.parameter.ParameterRole.CONTENT;
 import static org.mule.runtime.api.util.ExtensionModelTestUtils.visitableMock;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CONNECTION_MANAGER;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STREAMING_MANAGER;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.internal.metadata.cache.MetadataCacheManager.METADATA_CACHE_MANAGER_KEY;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.stubComponentExecutor;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.getDefaultCursorStreamProviderFactory;
@@ -108,6 +111,7 @@ import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.test.metadata.extension.resolver.TestNoConfigMetadataResolver;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -376,6 +380,11 @@ public abstract class AbstractOperationMessageProcessorTestCase extends Abstract
     when(connectionManagerAdapter.getConnection(anyString())).thenReturn(null);
     when(connectionManagerAdapter.getReconnectionConfigFor(any())).thenReturn(ReconnectionConfig.getDefault());
     messageProcessor = setUpOperationMessageProcessor();
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   protected CoreEvent configureEvent() throws Exception {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
@@ -93,8 +93,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -102,6 +100,9 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ProcessorChainExecutorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ProcessorChainExecutorTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.module.extension.internal.runtime.operation;
 
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -15,6 +16,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static reactor.core.publisher.Mono.error;
 
 import org.mule.runtime.api.event.Event;
@@ -29,15 +32,16 @@ import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.module.extension.api.runtime.privileged.EventedResult;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import reactor.core.publisher.Mono;
 
@@ -64,6 +68,11 @@ public class ProcessorChainExecutorTestCase extends AbstractMuleContextTestCase 
             .variables(coreEvent.getVariables())
             .build()));
     when(chain.getMessageProcessors()).thenReturn(singletonList(processor));
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetOutputMessageReturnDelegateTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/TargetOutputMessageReturnDelegateTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.operation;
 
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -15,8 +16,11 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_JSON;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.getDefaultCursorStreamProviderFactory;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.meta.model.ComponentModel;
@@ -31,6 +35,7 @@ import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,6 +75,11 @@ public class TargetOutputMessageReturnDelegateTestCase extends AbstractMuleConte
     when(operationContext.getEvent()).thenReturn(event);
     when(operationContext.getMuleContext()).thenReturn(muleContext);
     when(componentModel.getModelProperty(MediaTypeModelProperty.class)).thenReturn(empty());
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   private TargetReturnDelegate createDelegate(String expression) {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ValueReturnDelegateContractTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ValueReturnDelegateContractTestCase.java
@@ -8,6 +8,7 @@ package org.mule.runtime.module.extension.internal.runtime.operation;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -25,7 +26,9 @@ import static org.mule.metadata.api.model.MetadataFormat.JAVA;
 import static org.mule.runtime.api.metadata.MediaType.ANY;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_JSON;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.CONNECTION_PARAM;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.probe.PollingProber.probe;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
@@ -47,12 +50,12 @@ import org.mule.runtime.core.api.streaming.bytes.InMemoryCursorStreamConfig;
 import org.mule.runtime.core.api.streaming.bytes.factory.InMemoryCursorStreamProviderFactory;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.core.internal.streaming.bytes.ManagedCursorStreamProvider;
+import org.mule.runtime.core.internal.streaming.bytes.SimpleByteBufferManager;
 import org.mule.runtime.core.internal.util.message.ResultsToMessageList;
 import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextAdapter;
 import org.mule.runtime.module.extension.internal.loader.java.property.MediaTypeModelProperty;
-import org.mule.runtime.core.internal.streaming.bytes.SimpleByteBufferManager;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -61,6 +64,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.After;
@@ -117,6 +121,11 @@ public abstract class ValueReturnDelegateContractTestCase extends AbstractMuleCo
     when(operationContext.getMuleContext()).thenReturn(muleContext);
     when(operationContext.getComponentModel()).thenReturn(componentModel);
     when(operationContext.getVariable(contains(CONNECTION_PARAM))).thenReturn(connectionHandler);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/NestedProcessorValueResolverTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/NestedProcessorValueResolverTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.resolver;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
@@ -15,6 +16,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.el.ExpressionManager;
@@ -23,6 +26,8 @@ import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.route.Chain;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.reactivestreams.Publisher;
+
 import reactor.core.publisher.Mono;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,6 +52,11 @@ public class NestedProcessorValueResolverTestCase extends AbstractMuleContextTes
     final CoreEvent testEvent = testEvent();
     when(messageProcessor.process(any(CoreEvent.class))).thenReturn(testEvent);
     when(messageProcessor.apply(any(Publisher.class))).thenReturn(Mono.just(testEvent));
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeExpressionValueResolverMelDefaultTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeExpressionValueResolverMelDefaultTestCase.java
@@ -21,9 +21,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.getType;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.toDataType;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.java.api.JavaTypeLoader;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -60,6 +63,7 @@ public class TypeSafeExpressionValueResolverMelDefaultTestCase extends AbstractM
     final Map<String, Object> objects = new HashMap<>();
     objects.putAll(super.getStartUpRegistryObjects());
     objects.put(COMPATIBILITY_PLUGIN_INSTALLED, new Object());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeExpressionValueResolverMelTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeExpressionValueResolverMelTestCase.java
@@ -21,9 +21,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.config.MuleProperties.COMPATIBILITY_PLUGIN_INSTALLED;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.getType;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.toDataType;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.java.api.JavaTypeLoader;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -56,6 +59,7 @@ public class TypeSafeExpressionValueResolverMelTestCase extends AbstractMuleCont
     final Map<String, Object> objects = new HashMap<>();
     objects.putAll(super.getStartUpRegistryObjects());
     objects.put(COMPATIBILITY_PLUGIN_INSTALLED, new Object());
+    objects.put(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     return objects;
   }
 

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeExpressionValueResolverTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeExpressionValueResolverTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.module.extension.internal.runtime.resolver;
 
 import static java.lang.Thread.currentThread;
+import static java.util.Collections.singletonMap;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -22,9 +23,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.getType;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.toDataType;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.java.api.JavaTypeLoader;
 import org.mule.runtime.api.el.BindingContext;
@@ -33,6 +37,8 @@ import org.mule.runtime.core.api.el.ExpressionManagerSession;
 import org.mule.runtime.core.api.el.ExtendedExpressionManager;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +54,11 @@ public class TypeSafeExpressionValueResolverTestCase extends AbstractMuleContext
   public ExpectedException expected = none();
 
   private ExtendedExpressionManager expressionManager;
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Override
   protected void doSetUp() throws Exception {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeValueResolverWrapperTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/TypeSafeValueResolverWrapperTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.resolver;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,6 +18,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.transformation.TransformationService;
@@ -25,15 +29,17 @@ import org.mule.runtime.core.api.el.ExtendedExpressionManager;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 @SmallTest
 public class TypeSafeValueResolverWrapperTestCase extends AbstractMuleContextTestCase {
 
-  private TransformationService transformationService = mock(TransformationService.class);
-  private ValueResolver<String> staticValueResolver = mock(ValueResolver.class);
-  private ValueResolver<String> dynamicValueResolver = mock(ValueResolver.class);
-  private ExpressionManager expressionManager = mock(ExpressionManager.class);
+  private final TransformationService transformationService = mock(TransformationService.class);
+  private final ValueResolver<String> staticValueResolver = mock(ValueResolver.class);
+  private final ValueResolver<String> dynamicValueResolver = mock(ValueResolver.class);
+  private final ExpressionManager expressionManager = mock(ExpressionManager.class);
   private TypeSafeValueResolverWrapper<Integer> dynamicResolver;
   private TypeSafeValueResolverWrapper<Integer> staticResolver;
 
@@ -58,6 +64,11 @@ public class TypeSafeValueResolverWrapperTestCase extends AbstractMuleContextTes
     initialiseIfNeeded(staticResolver, muleContext);
 
     when(transformationService.transform(eq("123"), any(DataType.class), any(DataType.class))).thenReturn(123);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Test

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/source/AbstractExtensionMessageSourceTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/source/AbstractExtensionMessageSourceTestCase.java
@@ -8,6 +8,7 @@ package org.mule.runtime.module.extension.internal.runtime.source;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
@@ -26,6 +27,7 @@ import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STREAMING_M
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Unhandleable.FLOW_BACK_PRESSURE;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.source.MessageSource.BackPressureStrategy.FAIL;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.MuleTestUtils.spyInjector;
 import static org.mule.tck.util.MuleContextUtils.getNotificationDispatcher;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.TYPE_LOADER;
@@ -68,6 +70,7 @@ import org.mule.runtime.core.internal.execution.MessageProcessingManager;
 import org.mule.runtime.core.internal.metadata.cache.MetadataCacheId;
 import org.mule.runtime.core.internal.metadata.cache.MetadataCacheIdGenerator;
 import org.mule.runtime.core.internal.metadata.cache.MetadataCacheIdGeneratorFactory;
+import org.mule.runtime.core.internal.streaming.bytes.SimpleByteBufferManager;
 import org.mule.runtime.core.internal.streaming.bytes.factory.NullCursorStreamProviderFactory;
 import org.mule.runtime.core.internal.util.MessagingExceptionResolver;
 import org.mule.runtime.extension.api.metadata.MetadataResolverFactory;
@@ -85,12 +88,10 @@ import org.mule.runtime.module.extension.internal.loader.java.property.MediaType
 import org.mule.runtime.module.extension.internal.loader.java.property.MetadataResolverFactoryModelProperty;
 import org.mule.runtime.module.extension.internal.loader.java.property.SourceCallbackModelProperty;
 import org.mule.runtime.module.extension.internal.runtime.resolver.ResolverSet;
-import org.mule.runtime.core.internal.streaming.bytes.SimpleByteBufferManager;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.test.metadata.extension.resolver.TestNoConfigMetadataResolver;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.After;
@@ -199,9 +200,7 @@ public abstract class AbstractExtensionMessageSourceTestCase extends AbstractMul
     ErrorTypeRepository errorTypeRepository = mock(ErrorTypeRepository.class);
     when(errorTypeRepository.getErrorType(FLOW_BACK_PRESSURE)).thenReturn(of(mock(ErrorType.class)));
 
-    Map<String, Object> registryObjects = new HashMap<>();
-    registryObjects.put("errorTypeRepository", errorTypeRepository);
-    return registryObjects;
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, errorTypeRepository);
   }
 
   @Before

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/streaming/DefaultStreamingHelperTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/streaming/DefaultStreamingHelperTestCase.java
@@ -6,12 +6,16 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.streaming;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
+
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.TypedValue;
@@ -31,6 +35,7 @@ import org.mule.tck.size.SmallTest;
 import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -42,7 +47,7 @@ public class DefaultStreamingHelperTestCase extends AbstractMuleContextTestCase 
   private CursorProviderFactory cursorProviderFactory;
   private CoreEvent event;
 
-  private List<String> valueList = Arrays.asList("Apple", "Banana", "Kiwi");
+  private final List<String> valueList = Arrays.asList("Apple", "Banana", "Kiwi");
 
   @Override
   protected void doSetUp() throws Exception {
@@ -52,6 +57,11 @@ public class DefaultStreamingHelperTestCase extends AbstractMuleContextTestCase 
         new InMemoryCursorIteratorProviderFactory(InMemoryCursorIteratorConfig.getDefault(), streamingManager);
     event = testEvent();
     streamingHelper = new DefaultStreamingHelper(cursorProviderFactory, streamingManager, event);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Override

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/component/OnErrorCheckLogHandler.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/component/OnErrorCheckLogHandler.java
@@ -9,10 +9,10 @@ package org.mule.functional.api.component;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.fail;
 import static org.mule.tck.processor.FlowAssert.addAssertion;
+
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
-import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.util.StringUtils;
 import org.mule.runtime.core.privileged.exception.MessagingExceptionHandlerAcceptor;
@@ -23,12 +23,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.reactivestreams.Publisher;
+
 import reactor.core.publisher.Flux;
 
 public class OnErrorCheckLogHandler extends TemplateOnErrorHandler
     implements MessagingExceptionHandlerAcceptor, FlowAssertion {
 
-  private List<LogChecker> checkers = new ArrayList<>();
+  private final List<LogChecker> checkers = new ArrayList<>();
   private StringBuilder errors;
   private boolean propagate = false;
   private boolean succeedIfNoLog = false;
@@ -41,10 +42,10 @@ public class OnErrorCheckLogHandler extends TemplateOnErrorHandler
   private boolean handledException = false;
 
   @Override
-  protected void doInitialise(MuleContext muleContext) throws InitialisationException {
+  protected void doInitialise() throws InitialisationException {
     // Add a dummy processor to force the routing logic into the execution chain
     setMessageProcessors(singletonList(event -> event));
-    super.doInitialise(muleContext);
+    super.doInitialise();
   }
 
   @Override

--- a/tests/performance/src/main/java/org/mule/EventBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/EventBenchmark.java
@@ -11,8 +11,10 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.runtime.core.internal.event.EventQuickCopy.quickCopy;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.privileged.registry.LegacyRegistryUtils.lookupObject;
 import static org.mule.runtime.core.privileged.registry.LegacyRegistryUtils.registerObject;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
@@ -47,6 +49,7 @@ public class EventBenchmark extends AbstractBenchmark {
   public void setup() throws Exception {
     muleContext = createMuleContextWithServices();
     muleContext.start();
+    registerObject(muleContext, OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
     flow = createFlow(muleContext);
     registerObject(muleContext, FLOW_NAME, flow, FlowConstruct.class);
     Message.Builder messageBuilder = Message.builder().value(PAYLOAD);

--- a/tests/unit/src/main/java/org/mule/functional/transformer/simple/AbstractAddVariablePropertyProcessorTestCase.java
+++ b/tests/unit/src/main/java/org/mule/functional/transformer/simple/AbstractAddVariablePropertyProcessorTestCase.java
@@ -8,6 +8,7 @@ package org.mule.functional.transformer.simple;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,6 +25,8 @@ import static org.mule.runtime.api.metadata.DataType.STRING;
 import static org.mule.runtime.api.metadata.MediaType.ANY;
 import static org.mule.runtime.api.metadata.MediaType.APPLICATION_XML;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.matcher.DataTypeMatcher.like;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
@@ -47,6 +50,7 @@ import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 
 import javax.activation.MimeTypeParseException;
 
@@ -81,7 +85,7 @@ public abstract class AbstractAddVariablePropertyProcessorTestCase extends Abstr
   private CoreEvent event;
   private Message message;
   private TypedValue typedValue;
-  private AbstractAddVariablePropertyProcessor addVariableProcessor;
+  private final AbstractAddVariablePropertyProcessor addVariableProcessor;
   private ExpressionManagerSession mockSession;
   private CheckedRunnable afterAssertions;
 
@@ -109,6 +113,11 @@ public abstract class AbstractAddVariablePropertyProcessorTestCase extends Abstr
     event = createTestEvent(message);
 
     afterAssertions = () -> verify(streamingManager, never()).manage(any(CursorProvider.class), any(EventContext.class));
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @After

--- a/tests/unit/src/main/java/org/mule/functional/transformer/simple/AbstractRemoveVariablePropertyProcessorTestCase.java
+++ b/tests/unit/src/main/java/org/mule/functional/transformer/simple/AbstractRemoveVariablePropertyProcessorTestCase.java
@@ -8,6 +8,7 @@ package org.mule.functional.transformer.simple;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,8 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.DataType.OBJECT;
 import static org.mule.runtime.api.metadata.DataType.STRING;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
 import org.mule.runtime.api.exception.MuleException;
@@ -32,13 +35,14 @@ import org.mule.runtime.core.privileged.processor.simple.AbstractRemoveVariableP
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import java.nio.charset.Charset;
-import java.util.HashSet;
-import java.util.Set;
 
 @SmallTest
 public abstract class AbstractRemoveVariablePropertyProcessorTestCase extends AbstractMuleContextTestCase {
@@ -53,10 +57,10 @@ public abstract class AbstractRemoveVariablePropertyProcessorTestCase extends Ab
 
   private Message message;
   private CoreEvent event;
-  private MuleContext mockMuleContext = mock(MuleContext.class);
-  private ExtendedExpressionManager mockExpressionManager = mock(ExtendedExpressionManager.class);
+  private final MuleContext mockMuleContext = mock(MuleContext.class);
+  private final ExtendedExpressionManager mockExpressionManager = mock(ExtendedExpressionManager.class);
   private TypedValue typedValue;
-  private AbstractRemoveVariablePropertyProcessor removeVariableProcessor;
+  private final AbstractRemoveVariablePropertyProcessor removeVariableProcessor;
   private ExpressionManagerSession mockSession;
 
   public AbstractRemoveVariablePropertyProcessorTestCase(AbstractRemoveVariablePropertyProcessor abstractAddVariableProcessor) {
@@ -75,6 +79,11 @@ public abstract class AbstractRemoveVariablePropertyProcessorTestCase extends Ab
     when(mockExpressionManager.openSession(any(), any(), any())).thenReturn(mockSession);
     when(mockSession.evaluate(eq(EXPRESSION), eq(STRING))).thenReturn(typedValue);
     removeVariableProcessor.setMuleContext(mockMuleContext);
+  }
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   protected CoreEvent createTestEvent(final Message message) throws MuleException {

--- a/tests/unit/src/main/java/org/mule/tck/MuleTestUtils.java
+++ b/tests/unit/src/main/java/org/mule/tck/MuleTestUtils.java
@@ -21,6 +21,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNee
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
+
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.exception.MuleException;
@@ -53,6 +54,8 @@ import org.mockito.Mockito;
  * Utilities for creating test and Mock Mule objects
  */
 public final class MuleTestUtils {
+
+  public static final String OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY = "errorTypeRegistry";
 
   public static final String APPLE_SERVICE = "appleService";
   public static final String APPLE_FLOW = "appleFlow";

--- a/tests/unit/src/main/java/org/mule/tck/core/internal/serialization/AbstractSerializerProtocolContractTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/core/internal/serialization/AbstractSerializerProtocolContractTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.tck.core.internal.serialization;
 
+import static java.util.Collections.singletonMap;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -14,6 +15,8 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
 import org.mule.runtime.api.serialization.SerializationProtocol;
@@ -22,18 +25,24 @@ import org.mule.runtime.core.internal.el.datetime.DateTime;
 import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Test;
 
 public abstract class AbstractSerializerProtocolContractTestCase extends AbstractMuleContextTestCase {
 
   private static final String STRING_MESSAGE = "Hello World";
 
   protected SerializationProtocol serializationProtocol;
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test(expected = IllegalArgumentException.class)
   public final void nullBytes() throws Exception {

--- a/tests/unit/src/main/java/org/mule/tck/core/util/queue/AbstractTransactionQueueManagerTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/core/util/queue/AbstractTransactionQueueManagerTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.tck.core.util.queue;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -13,16 +14,19 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 
 import org.mule.runtime.api.util.concurrent.Latch;
-import org.mule.runtime.core.internal.util.queue.AbstractQueueManager;
 import org.mule.runtime.core.api.util.queue.DefaultQueueConfiguration;
 import org.mule.runtime.core.api.util.queue.Queue;
 import org.mule.runtime.core.api.util.queue.QueueManager;
 import org.mule.runtime.core.api.util.queue.QueueSession;
+import org.mule.runtime.core.internal.util.queue.AbstractQueueManager;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -43,6 +47,12 @@ public abstract class AbstractTransactionQueueManagerTestCase extends AbstractMu
   protected abstract AbstractQueueManager createQueueManager() throws Exception;
 
   protected abstract boolean isPersistent();
+
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void testPutTake() throws Exception {

--- a/tests/unit/src/main/java/org/mule/tck/core/util/queue/QueueStoreTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/core/util/queue/QueueStoreTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.tck.core.util.queue;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
@@ -13,6 +14,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.util.queue.QueueConfiguration.MAXIMUM_CAPACITY;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
 import org.mule.runtime.api.store.ObjectStoreException;
@@ -21,14 +24,15 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.util.queue.QueueStore;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Map;
+
 import org.hamcrest.core.Is;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
-
-import java.io.Serializable;
-import java.util.ArrayList;
 
 public abstract class QueueStoreTestCase extends AbstractMuleContextTestCase {
 
@@ -41,6 +45,11 @@ public abstract class QueueStoreTestCase extends AbstractMuleContextTestCase {
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
+  }
 
   @Test
   public void offerAndPollSingleValue() throws InterruptedException, ObjectStoreException {

--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractReactiveProcessorTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractReactiveProcessorTestCase.java
@@ -6,22 +6,21 @@
  */
 package org.mule.tck.junit4;
 
+import static com.google.common.collect.ImmutableMap.of;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.setMuleContextIfNeeded;
+import static org.mule.runtime.core.internal.exception.ErrorTypeRepositoryFactory.createDefaultErrorTypeRepository;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
+import static org.mule.tck.MuleTestUtils.OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY;
 import static org.mule.tck.junit4.AbstractReactiveProcessorTestCase.Mode.BLOCKING;
 import static org.mule.tck.junit4.AbstractReactiveProcessorTestCase.Mode.NON_BLOCKING;
 
 import org.mule.runtime.api.component.ComponentIdentifier;
-import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.core.api.construct.Flow;
@@ -30,19 +29,19 @@ import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.message.InternalEvent;
 
+import java.util.Collection;
+import java.util.Map;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.reactivestreams.Publisher;
-
-import java.util.Collection;
-import java.util.Map;
 
 import reactor.core.publisher.Mono;
 
 /**
  * Abstract base test case extending {@link AbstractMuleContextTestCase} to be used when a {@link Processor} or {@link Flow} that
- * implements both {@link Processor#process(CoreEvent)} and {@link Processor#apply(Publisher)} needs paramatized tests so that both
- * approaches are tested with the same test method. Test cases that extend this abstract class should use (@link
+ * implements both {@link Processor#process(CoreEvent)} and {@link Processor#apply(Publisher)} needs parameterized tests so that
+ * both approaches are tested with the same test method. Test cases that extend this abstract class should use (@link
  * {@link #process(Processor, CoreEvent)} to invoke {@link Processor}'s as part of the test, rather than invoking them directly.
  */
 @RunWith(Parameterized.class)
@@ -51,9 +50,6 @@ public abstract class AbstractReactiveProcessorTestCase extends AbstractMuleCont
   protected Scheduler scheduler;
 
   protected Mode mode;
-
-  protected ConfigurationComponentLocator configurationComponentLocator =
-      mock(ConfigurationComponentLocator.class, RETURNS_DEEP_STUBS.get());
 
   public AbstractReactiveProcessorTestCase(Mode mode) {
     this.mode = mode;
@@ -66,10 +62,11 @@ public abstract class AbstractReactiveProcessorTestCase extends AbstractMuleCont
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
-    when(configurationComponentLocator.find(any(Location.class))).thenReturn(empty());
-    when(configurationComponentLocator.find(any(ComponentIdentifier.class))).thenReturn(emptyList());
+    when(componentLocator.find(any(Location.class))).thenReturn(empty());
+    when(componentLocator.find(any(ComponentIdentifier.class))).thenReturn(emptyList());
 
-    return singletonMap(REGISTRY_KEY, configurationComponentLocator);
+    return of(REGISTRY_KEY, componentLocator,
+              OBJECT_ERROR_TYPE_REPO_REGISTRY_KEY, createDefaultErrorTypeRepository());
   }
 
   @Override


### PR DESCRIPTION
* Support in AbstractMessageProcessorChain
* Avoid child contexts in sub-flow, error handlers
* Improve logging for troubleshooting of error handling