### PR TITLE
MULE-17804: Remove child contexts uses in policies infrastructure

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/OnExecuteNextErrorConsumerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/OnExecuteNextErrorConsumerTestCase.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.notification.PolicyNotification.AFTER_NEXT;
-import static org.mule.runtime.core.internal.policy.PolicyNextActionMessageProcessor.POLICY_NEXT_EVENT_CTX_IDS;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.component.location.LocationPart;
@@ -22,8 +21,6 @@ import org.mule.runtime.core.internal.context.notification.DefaultFlowCallStack;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.tck.junit4.AbstractMuleTestCase;
-
-import com.google.common.collect.ImmutableSet;
 
 import java.util.function.Function;
 
@@ -59,7 +56,6 @@ public class OnExecuteNextErrorConsumerTestCase extends AbstractMuleTestCase {
     MessagingException messagingException = mock(MessagingException.class);
 
     when(initialEvent.getContext().getId()).thenReturn(EVENT_ID);
-    when(initialEvent.getInternalParameter(POLICY_NEXT_EVENT_CTX_IDS)).thenReturn(ImmutableSet.of(EVENT_ID));
     when(updatedEvent.getFlowCallStack()).thenReturn(flowCallStack);
     when(messagingException.getEvent()).thenReturn(initialEvent);
     when(location.getParts()).thenReturn(newArrayList(mock(LocationPart.class), mock(LocationPart.class)));
@@ -67,7 +63,6 @@ public class OnExecuteNextErrorConsumerTestCase extends AbstractMuleTestCase {
     consumer.accept(messagingException);
 
     verify(notificationHelper).fireNotification(updatedEvent, messagingException, AFTER_NEXT);
-    verify(updatedEvent.getContext()).error(messagingException);
     verify(flowCallStack).push(any());
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/api/policy/PolicyChain.java
+++ b/core/src/main/java/org/mule/runtime/core/api/policy/PolicyChain.java
@@ -146,6 +146,11 @@ public class PolicyChain extends AbstractComponent
         popFlowFlowStackElement().accept(t.getEvent());
         onError.ifPresent(onError -> onError.accept(t));
       }
+
+      @Override
+      public String toString() {
+        return PolicyChain.class.getSimpleName() + ".errorHandler @ " + getLocation().getLocation();
+      }
     };
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeSourcePolicy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeSourcePolicy.java
@@ -26,6 +26,7 @@ import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.api.rx.Exceptions;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.rx.FluxSinkRecorder;
+import org.mule.runtime.core.privileged.event.BaseEventContext;
 
 import java.util.List;
 import java.util.Map;
@@ -196,6 +197,7 @@ public class CompositeSourcePolicy
                                                                                 getParametersTransformer()),
                                          notificationHelper, lastPolicy.getPolicyChain().getLocation())
                                              .accept(error);
+          ((BaseEventContext) ((MessagingException) error).getEvent().getContext()).error(error);
         });
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/OnExecuteNextErrorConsumer.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/OnExecuteNextErrorConsumer.java
@@ -7,17 +7,13 @@
 package org.mule.runtime.core.internal.policy;
 
 import static org.mule.runtime.api.notification.PolicyNotification.AFTER_NEXT;
-import static org.mule.runtime.core.internal.policy.PolicyNextActionMessageProcessor.POLICY_NEXT_EVENT_CTX_IDS;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.core.api.context.notification.FlowStackElement;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.context.notification.DefaultFlowCallStack;
 import org.mule.runtime.core.internal.exception.MessagingException;
-import org.mule.runtime.core.internal.message.InternalEvent;
-import org.mule.runtime.core.privileged.event.BaseEventContext;
 
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -43,17 +39,13 @@ public class OnExecuteNextErrorConsumer implements Consumer<Throwable> {
   public void accept(Throwable error) {
     MessagingException me = (MessagingException) error;
 
-    if (isEventContextHandledByThisNext(me.getEvent())) {
-      CoreEvent newEvent = prepareEvent.apply(me.getEvent());
+    CoreEvent newEvent = prepareEvent.apply(me.getEvent());
 
-      me.setProcessedEvent(newEvent);
+    me.setProcessedEvent(newEvent);
 
-      notificationHelper.fireNotification(newEvent, me, AFTER_NEXT);
+    notificationHelper.fireNotification(newEvent, me, AFTER_NEXT);
 
-      pushAfterNextFlowStackElement().accept(newEvent);
-
-      ((BaseEventContext) newEvent.getContext()).error(error);
-    }
+    pushAfterNextFlowStackElement().accept(newEvent);
   }
 
   private Consumer<CoreEvent> pushAfterNextFlowStackElement() {
@@ -66,8 +58,4 @@ public class OnExecuteNextErrorConsumer implements Consumer<Throwable> {
         + "[after next]";
   }
 
-  private boolean isEventContextHandledByThisNext(CoreEvent event) {
-    final Set<String> eventCtxIds = ((InternalEvent) event).getInternalParameter(POLICY_NEXT_EVENT_CTX_IDS);
-    return eventCtxIds != null && eventCtxIds.contains(event.getContext().getId());
-  }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/OperationPolicyContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/OperationPolicyContext.java
@@ -8,7 +8,6 @@ package org.mule.runtime.core.internal.policy;
 
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.message.InternalEvent;
-import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
 
 /**
@@ -35,19 +34,16 @@ public class OperationPolicyContext {
   }
 
   private CoreEvent originalEvent;
-  private OperationParametersProcessor operationParametersProcessor;
-  private OperationExecutionFunction operationExecutionFunction;
-  private BaseEventContext operationChildContext;
-  private ExecutorCallback operationCallerCallback;
+  private final OperationParametersProcessor operationParametersProcessor;
+  private final OperationExecutionFunction operationExecutionFunction;
+  private final ExecutorCallback operationCallerCallback;
   private InternalEvent nextOperationResponse;
 
   public OperationPolicyContext(OperationParametersProcessor operationParametersProcessor,
                                 OperationExecutionFunction operationExecutionFunction,
-                                BaseEventContext operationChildContext,
                                 ExecutorCallback operationCallerCallback) {
     this.operationParametersProcessor = operationParametersProcessor;
     this.operationExecutionFunction = operationExecutionFunction;
-    this.operationChildContext = operationChildContext;
     this.operationCallerCallback = operationCallerCallback;
   }
 
@@ -65,10 +61,6 @@ public class OperationPolicyContext {
 
   public OperationExecutionFunction getOperationExecutionFunction() {
     return operationExecutionFunction;
-  }
-
-  public BaseEventContext getOperationChildContext() {
-    return operationChildContext;
   }
 
   public ExecutorCallback getOperationCallerCallback() {

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyEventMapper.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyEventMapper.java
@@ -7,25 +7,20 @@
 package org.mule.runtime.core.internal.policy;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static org.mule.runtime.core.internal.policy.OperationPolicyContext.from;
-import static org.mule.runtime.core.internal.policy.PolicyNextActionMessageProcessor.POLICY_NEXT_EVENT_CTX_IDS;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.policy.SourcePolicyParametersTransformer;
-import org.mule.runtime.core.internal.event.EventInternalContextResolver;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 
 /**
@@ -37,8 +32,6 @@ public class PolicyEventMapper {
   private static final Logger LOGGER = getLogger(PolicyEventMapper.class);
 
   private final String policyVarsInternalParameterName;
-  private EventInternalContextResolver<Set<String>> nextEventIdCtxResolver =
-      new EventInternalContextResolver<>(POLICY_NEXT_EVENT_CTX_IDS, () -> emptySet());
 
   public PolicyEventMapper() {
     this(null);
@@ -279,16 +272,11 @@ public class PolicyEventMapper {
   private CoreEvent onPolicyNext(CoreEvent event, boolean propagate) {
     PrivilegedEvent originalEvent = getOriginalEvent(event);
 
-    Set<String> currentNextEventIdCtx = nextEventIdCtxResolver.getCurrentContextFromEvent(event);
-
     return InternalEvent
         .builder(event)
         .message(propagate ? event.getMessage() : originalEvent.getMessage())
         .variables(originalEvent.getVariables())
         .addInternalParameter(policyVarsInternalParameterName(), event.getVariables())
-        .addInternalParameter(POLICY_NEXT_EVENT_CTX_IDS,
-                              ImmutableSet.<String>builder().addAll(currentNextEventIdCtx).add(event.getContext().getId())
-                                  .build())
         .build();
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyNextActionMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyNextActionMessageProcessor.java
@@ -127,6 +127,11 @@ public class PolicyNextActionMessageProcessor extends AbstractComponent implemen
       public void onError(Exception error) {
         onExecuteNextErrorConsumer.accept(error);
       }
+
+      @Override
+      public String toString() {
+        return PolicyNextActionMessageProcessor.class.getSimpleName() + ".errorHandler @ " + getLocation().getLocation();
+      }
     };
   }
 


### PR DESCRIPTION
* Part 1, remove child context from the operation policies wrapper