### PR TITLE
Mule 17880

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/store/PartitionedInMemoryObjectStoreTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/store/PartitionedInMemoryObjectStoreTestCase.java
@@ -45,6 +45,11 @@ public class PartitionedInMemoryObjectStoreTestCase extends AbstractMuleTestCase
       }
     };
   }
+  
+  @Test
+  public void expireByTtlWithNegativeMaxEntriesAndEmptyStore() throws ObjectStoreException {
+    store.expire(1, -1, TEST_PARTITION);
+  }
 
   @Test
   public void expireByTtlMultipleKeysInsertedInTheSameNanoSecond() throws ObjectStoreException {

--- a/core/src/main/java/org/mule/runtime/core/internal/store/PartitionedInMemoryObjectStore.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/store/PartitionedInMemoryObjectStore.java
@@ -176,7 +176,7 @@ public class PartitionedInMemoryObjectStore<T extends Serializable> extends Abst
   }
 
   private void trimToMaxSize(ConcurrentLinkedQueue<ExpiryEntry> store, int maxEntries, ConcurrentMap<String, T> partition) {
-    if (maxEntries == UNBOUNDED) {
+    if (maxEntries < UNBOUNDED) {
       return;
     }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/store/PartitionedInMemoryObjectStore.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/store/PartitionedInMemoryObjectStore.java
@@ -176,7 +176,7 @@ public class PartitionedInMemoryObjectStore<T extends Serializable> extends Abst
   }
 
   private void trimToMaxSize(ConcurrentLinkedQueue<ExpiryEntry> store, int maxEntries, ConcurrentMap<String, T> partition) {
-    if (maxEntries < UNBOUNDED) {
+    if (maxEntries <= UNBOUNDED) {
       return;
     }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/util/store/MuleObjectStoreManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/store/MuleObjectStoreManager.java
@@ -280,6 +280,9 @@ public class MuleObjectStoreManager implements ObjectStoreManager, Initialisable
       this.store = store;
       this.entryTTL = entryTTL;
       this.maxEntries = maxEntries;
+      if (this.entryTTL < UNBOUNDED) {
+        LOGGER.warn("Partition {} configured with negative max entries, defaulting to UNBOUNDED", partitionName);
+      }
     }
 
     @Override
@@ -288,7 +291,7 @@ public class MuleObjectStoreManager implements ObjectStoreManager, Initialisable
         try {
           store.expire(entryTTL, maxEntries, partitionName);
         } catch (Exception e) {
-          LOGGER.warn("Running expirty on partition " + partitionName + " of " + store + " threw " + e + ":" + e.getMessage());
+          LOGGER.warn("Running expiry on partition " + partitionName + " of " + store + " threw " + e + ":" + e.getMessage());
         }
       }
     }


### PR DESCRIPTION
negative maxEntries shouldn't throw an exception during expiration