### PR TITLE
MULE-17814: Infinite Loop when setting -Dmule.classloading.verbose=true

### DIFF
--- a/modules/launcher/pom.xml
+++ b/modules/launcher/pom.xml
@@ -60,6 +60,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-allure</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-deployment</artifactId>
             <version>${project.version}</version>

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
@@ -12,6 +12,7 @@ import static org.mule.runtime.module.launcher.log4j2.ArtifactAwareContextSelect
 import static org.reflections.ReflectionUtils.getAllMethods;
 import static org.reflections.ReflectionUtils.withName;
 import static org.reflections.ReflectionUtils.withParameters;
+import static java.lang.ClassLoader.getSystemClassLoader;
 
 import org.mule.runtime.api.util.Reference;
 
@@ -60,6 +61,7 @@ abstract class DispatchingLogger extends Logger {
       .weakKeys()
       .weakValues()
       .build(key -> new Reference<>());
+
   private Method updateConfigurationMethod = null;
 
   DispatchingLogger(Logger originalLogger, int ownerClassLoaderHash, LoggerContext loggerContext, ContextSelector contextSelector,
@@ -89,8 +91,8 @@ abstract class DispatchingLogger extends Logger {
           try {
             logger = resolveLogger(resolvedCtxClassLoader);
           } catch (RecursiveLoggerContextInstantiationException rle) {
-            // The required Logger is already under construcion by a previuos resolveLogger call. Falling back to SystemClassLoader.
-            return resolveLogger(ClassLoader.getSystemClassLoader());
+            // The required Logger is already under construction by a previous resolveLogger call. Falling back to SystemClassLoader.
+            return resolveLogger(getSystemClassLoader());
           }
           loggerReference.set(logger);
         }

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
@@ -90,7 +90,7 @@ abstract class DispatchingLogger extends Logger {
           try {
             logger = resolveLogger(resolvedCtxClassLoader);
           } catch (RecursiveLoggerContextInstantiationException rle) {
-            // The required Logger is already under construction by a previous resolveLogger call. Falling back to SystemClassLoader.
+            // The required Logger is already under construction by a previous resolveLogger call. Falling back to container classloader.
             return resolveLogger(this.getClass().getClassLoader());
           }
           loggerReference.set(logger);

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
@@ -12,7 +12,6 @@ import static org.mule.runtime.module.launcher.log4j2.ArtifactAwareContextSelect
 import static org.reflections.ReflectionUtils.getAllMethods;
 import static org.reflections.ReflectionUtils.withName;
 import static org.reflections.ReflectionUtils.withParameters;
-import static java.lang.ClassLoader.getSystemClassLoader;
 
 import org.mule.runtime.api.util.Reference;
 
@@ -92,7 +91,7 @@ abstract class DispatchingLogger extends Logger {
             logger = resolveLogger(resolvedCtxClassLoader);
           } catch (RecursiveLoggerContextInstantiationException rle) {
             // The required Logger is already under construction by a previous resolveLogger call. Falling back to SystemClassLoader.
-            return resolveLogger(getSystemClassLoader());
+            return resolveLogger(this.getClass().getClassLoader());
           }
           loggerReference.set(logger);
         }

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/DispatchingLogger.java
@@ -60,7 +60,6 @@ abstract class DispatchingLogger extends Logger {
       .weakKeys()
       .weakValues()
       .build(key -> new Reference<>());
-
   private Method updateConfigurationMethod = null;
 
   DispatchingLogger(Logger originalLogger, int ownerClassLoaderHash, LoggerContext loggerContext, ContextSelector contextSelector,
@@ -71,7 +70,6 @@ abstract class DispatchingLogger extends Logger {
     this.ownerClassLoaderHash = ownerClassLoaderHash;
   }
 
-
   private Logger getLogger() {
     return getLogger(resolveLoggerContextClassLoader(currentThread().getContextClassLoader()));
   }
@@ -80,7 +78,6 @@ abstract class DispatchingLogger extends Logger {
     if (useThisLoggerContextClassLoader(resolvedCtxClassLoader)) {
       return originalLogger;
     }
-
     // we need to cache reference objects and do this double lookup to avoid cyclic resolutions of the same classloader
     // key which would result in an exception or a deadlock, depending on the cache implementation
     Reference<Logger> loggerReference = loggerCache.get(resolvedCtxClassLoader);
@@ -89,12 +86,16 @@ abstract class DispatchingLogger extends Logger {
       synchronized (loggerReference) {
         logger = loggerReference.get();
         if (logger == null) {
-          logger = resolveLogger(resolvedCtxClassLoader);
+          try {
+            logger = resolveLogger(resolvedCtxClassLoader);
+          } catch (RecursiveLoggerContextInstantiationException rle) {
+            // The required Logger is already under construcion by a previuos resolveLogger call. Falling back to SystemClassLoader.
+            return resolveLogger(ClassLoader.getSystemClassLoader());
+          }
           loggerReference.set(logger);
         }
       }
     }
-
     return logger;
   }
 

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCache.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCache.java
@@ -246,7 +246,7 @@ final class LoggerContextCache implements Disposable {
    * Registers that a {@link MuleLoggerContext} is no longer under construction
    */
   private void endLoggerContextConstruction() {
-    setLoggerContextUnderConstruction(Boolean.FALSE);
+    isLoggerContextUnderConstruction.remove();
   }
 
   /**

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/RecursiveLoggerContextInstantiationException.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/RecursiveLoggerContextInstantiationException.java
@@ -6,8 +6,9 @@
  */
 package org.mule.runtime.module.launcher.log4j2;
 
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+
 import org.mule.runtime.api.exception.MuleRuntimeException;
-import org.mule.runtime.api.i18n.I18nMessageFactory;
 
 /**
  * Indicates that the instantiation of a {@link MuleLoggerContext} is not possible due to the same context being already
@@ -18,6 +19,6 @@ import org.mule.runtime.api.i18n.I18nMessageFactory;
 public class RecursiveLoggerContextInstantiationException extends MuleRuntimeException {
 
   public RecursiveLoggerContextInstantiationException(String message) {
-    super(I18nMessageFactory.createStaticMessage(message));
+    super(createStaticMessage(message));
   }
 }

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/RecursiveLoggerContextInstantiationException.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/RecursiveLoggerContextInstantiationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.launcher.log4j2;
+
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.i18n.I18nMessageFactory;
+
+/**
+ * Indicates that the instantiation of a {@link MuleLoggerContext} is not possible due to the same context being already
+ * under construction (logging during the {@link MuleLoggerContext} construction triggers this recursive instantiation)
+ *
+ * @since 4.3.0
+ */
+public class RecursiveLoggerContextInstantiationException extends MuleRuntimeException {
+
+  public RecursiveLoggerContextInstantiationException(String message) {
+    super(I18nMessageFactory.createStaticMessage(message));
+  }
+}

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
@@ -8,7 +8,10 @@ package org.mule.runtime.module.launcher.log4j2;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 
 import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
@@ -20,8 +20,6 @@ import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
-import io.qameta.allure.Features;
-import io.qameta.allure.Stories;
 import io.qameta.allure.Story;
 import io.qameta.allure.Feature;
 import org.apache.logging.log4j.Level;
@@ -38,8 +36,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
-@Features({@Feature(CORE_COMPONENTS)})
-@Stories({@Story(LOGGER)})
+@Feature(CORE_COMPONENTS)
+@Story(LOGGER)
 public class DispatchingLoggerTestCase extends AbstractMuleTestCase {
 
   private static final String LOGGER_NAME = DispatchingLoggerTestCase.class.getName();

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.launcher.log4j2;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
@@ -13,6 +14,7 @@ import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -99,7 +101,7 @@ public class DispatchingLoggerTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  public void when_RecursiveLoggerContextInstantiationException_expect_fallback_dispatch_using_system_classloader() {
+  public void whenRecursiveLoggerContextInstantiationExceptionExpectFallbackDispatchUsingSystemClassLoader() {
     // Expected Loggers
     Logger currentClassLoaderLogger = mock(Logger.class);
     Logger regionClassLoaderLogger = mock(Logger.class);

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/DispatchingLoggerTestCase.java
@@ -6,18 +6,24 @@
  */
 package org.mule.runtime.module.launcher.log4j2;
 
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.test.allure.AllureConstants.ComponentsFeature.CORE_COMPONENTS;
+import static org.mule.test.allure.AllureConstants.ComponentsFeature.LoggerStory.LOGGER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 
 import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
+import io.qameta.allure.Features;
+import io.qameta.allure.Stories;
+import io.qameta.allure.Story;
+import io.qameta.allure.Feature;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -32,6 +38,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
+@Features({@Feature(CORE_COMPONENTS)})
+@Stories({@Story(LOGGER)})
 public class DispatchingLoggerTestCase extends AbstractMuleTestCase {
 
   private static final String LOGGER_NAME = DispatchingLoggerTestCase.class.getName();

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCacheTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCacheTestCase.java
@@ -6,6 +6,9 @@
  */
 package org.mule.runtime.module.launcher.log4j2;
 
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.test.allure.AllureConstants.ComponentsFeature.CORE_COMPONENTS;
+import static org.mule.test.allure.AllureConstants.ComponentsFeature.LoggerStory.LOGGER;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -13,11 +16,14 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
 
+import io.qameta.allure.Feature;
+import io.qameta.allure.Features;
+import io.qameta.allure.Stories;
+import io.qameta.allure.Story;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +35,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
+@Features({@Feature(CORE_COMPONENTS)})
+@Stories({@Story(LOGGER)})
 public class LoggerContextCacheTestCase {
 
   private ClassLoader currentClassLoader;

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCacheTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCacheTestCase.java
@@ -21,8 +21,6 @@ import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
 
 import io.qameta.allure.Feature;
-import io.qameta.allure.Features;
-import io.qameta.allure.Stories;
 import io.qameta.allure.Story;
 import org.junit.After;
 import org.junit.Before;
@@ -35,8 +33,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
-@Features({@Feature(CORE_COMPONENTS)})
-@Stories({@Story(LOGGER)})
+@Feature(CORE_COMPONENTS)
+@Story(LOGGER)
 public class LoggerContextCacheTestCase {
 
   private ClassLoader currentClassLoader;

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCacheTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/log4j2/LoggerContextCacheTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.launcher.log4j2;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsEqual;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.core.api.util.ClassUtils;
+import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
+import org.mule.tck.size.SmallTest;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+@SmallTest
+@RunWith(MockitoJUnitRunner.class)
+public class LoggerContextCacheTestCase {
+
+  private ClassLoader currentClassLoader;
+  private LoggerContextCache loggerContextCache;
+  @Mock
+  private RegionClassLoader regionClassLoader;
+  @Mock
+  private ArtifactAwareContextSelector contextSelector;
+
+  @Before
+  public void before() {
+    loggerContextCache = new LoggerContextCache(contextSelector, currentClassLoader);
+    currentClassLoader = Thread.currentThread().getContextClassLoader();
+  }
+
+  @After
+  public void after() {
+    loggerContextCache.dispose();
+  }
+
+  @Test
+  public void when_recursive_MuleLoggerContext_instantiation_expect_RecursiveLoggerContextInstantiationException_and_recovery() {
+    LoggerContext expectedLoggerContext = mock(MuleLoggerContext.class);
+    when(contextSelector.buildContext(currentClassLoader))
+        .thenAnswer(invocation -> loggerContextCache.getLoggerContext(currentClassLoader))
+        .thenReturn(expectedLoggerContext);
+    LoggerContext actualLoggerContext;
+    try {
+      actualLoggerContext = loggerContextCache.getLoggerContext(currentClassLoader);
+      fail("Recursive instantiation should throw RecursiveInstantiationException");
+    } catch (MuleRuntimeException e) {
+      assertThat("Exception should be caused by RecursiveContextInstantiation", e.getClass(),
+                 IsEqual.equalTo(RecursiveLoggerContextInstantiationException.class));
+      actualLoggerContext = loggerContextCache.getLoggerContext(currentClassLoader);
+    }
+    assertThat("Invalid LoggerContext", actualLoggerContext, IsEqual.equalTo(expectedLoggerContext));
+  }
+
+  @Test
+  public void when_MuleRuntimeException_during_MuleLoggerContext_instantiation_expect_recovery() {
+    LoggerContext expectedLoggerContext = mock(MuleLoggerContext.class);
+    when(contextSelector.buildContext(currentClassLoader))
+        .thenThrow(MuleRuntimeException.class)
+        .thenAnswer(invocation -> expectedLoggerContext);
+    LoggerContext actualLoggerContext = null;
+    try {
+      loggerContextCache.getLoggerContext(currentClassLoader);
+    } catch (MuleRuntimeException mre) {
+      actualLoggerContext = loggerContextCache.getLoggerContext(currentClassLoader);
+    }
+    assertThat("Invalid loggerContext", actualLoggerContext, IsEqual.equalTo(expectedLoggerContext));
+  }
+
+  @Test
+  public void when_MuleLoggerContext_instantiation_expect_cache_store() {
+    LoggerContext firstExpectedLoggerContext = mock(MuleLoggerContext.class);
+    LoggerContext secondExpectedLoggerContext = mock(MuleLoggerContext.class);
+    when(contextSelector.buildContext(currentClassLoader)).thenReturn(firstExpectedLoggerContext);
+    when(contextSelector.buildContext(regionClassLoader)).thenReturn(secondExpectedLoggerContext);
+    loggerContextCache.getLoggerContext(currentClassLoader);
+    ClassUtils.withContextClassLoader(regionClassLoader, () -> {
+      loggerContextCache.getLoggerContext(regionClassLoader);
+    });
+    assertThat("Additional or missing LoggerContext instances found in cache", loggerContextCache.getAllLoggerContexts(),
+               IsCollectionWithSize.hasSize(2));
+    assertThat("Cache should contain firstExpectedLogger", loggerContextCache.getAllLoggerContexts(),
+               IsCollectionContaining.hasItem(firstExpectedLoggerContext));
+    assertThat("Cache should contain secondExpectedLogger", loggerContextCache.getAllLoggerContexts(),
+               IsCollectionContaining.hasItem(secondExpectedLoggerContext));
+  }
+
+}


### PR DESCRIPTION
In order to prevent JVM version dependent behaviors, LoggerContextCache now throws a Mule exception when a recursive invocation is detected. DispatchingLogger has been modified accordingly and implements a fall back when the exception is thrown.