### PR TITLE
MULE-17868: Make proactor processing strategy default again

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/StreamEmitterProcessingStrategyFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/StreamEmitterProcessingStrategyFactory.java
@@ -157,9 +157,7 @@ public class StreamEmitterProcessingStrategyFactory extends AbstractStreamProces
         try {
           super.stopSchedulersIfNeeded();
         } finally {
-          if (flowDispatchSchedulerLazy.isComputed()) {
-            flowDispatchSchedulerLazy.get().stop();
-          }
+          flowDispatchSchedulerLazy.ifComputed(Scheduler::stop);
         }
       }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/StreamEmitterProcessingStrategyFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/StreamEmitterProcessingStrategyFactory.java
@@ -25,6 +25,7 @@ import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.api.scheduler.SchedulerConfig;
+import org.mule.runtime.api.util.LazyValue;
 import org.mule.runtime.api.util.concurrent.Latch;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.BackPressureReason;
@@ -117,7 +118,7 @@ public class StreamEmitterProcessingStrategyFactory extends AbstractStreamProces
     private boolean sinkCreated = false;
     private final AtomicInteger disposedEmittersCount = new AtomicInteger(0);
 
-    private Scheduler flowDispatchScheduler;
+    private LazyValue<Scheduler> flowDispatchSchedulerLazy;
 
 
     public StreamEmitterProcessingStrategy(int bufferSize,
@@ -136,7 +137,7 @@ public class StreamEmitterProcessingStrategyFactory extends AbstractStreamProces
     @Override
     public void start() throws MuleException {
       super.start();
-      flowDispatchScheduler = flowDispatchSchedulerSupplier.get();
+      flowDispatchSchedulerLazy = new LazyValue<>(flowDispatchSchedulerSupplier);
     }
 
     @Override
@@ -156,8 +157,8 @@ public class StreamEmitterProcessingStrategyFactory extends AbstractStreamProces
         try {
           super.stopSchedulersIfNeeded();
         } finally {
-          if (flowDispatchScheduler != null) {
-            flowDispatchScheduler.stop();
+          if (flowDispatchSchedulerLazy.isComputed()) {
+            flowDispatchSchedulerLazy.get().stop();
           }
         }
       }
@@ -279,7 +280,7 @@ public class StreamEmitterProcessingStrategyFactory extends AbstractStreamProces
     }
 
     protected Scheduler getFlowDispatcherScheduler() {
-      return flowDispatchScheduler;
+      return flowDispatchSchedulerLazy.get();
     }
 
     @Override


### PR DESCRIPTION
* Fix unit tests, make proactor not create a scheduler it doesn't need