### PR TITLE
MULE-17894: RETRY_EXHAUSTED ErrorType gets replaced by the ErrorType that generated the exhaustion (if present)

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -274,10 +274,12 @@ class UntilSuccessfulRouter {
       if (throwable instanceof MessagingException) {
         exceptionEvent = ((MessagingException) throwable).getEvent();
       }
+      // MessagingException cause is set to null in order to avoid RETRY:EXHAUSTED ErrorType replacement
+      // during ErrorType resolution (see ChainErrorHandlingUtils and MessagingExceptionResolver)
       return new MessagingException(exceptionEvent,
                                     new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG_PREFIX,
                                                                                           cause.getMessage()),
-                                                                      cause, owner),
+                                                                      null, owner),
                                     owner);
     };
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -274,12 +274,12 @@ class UntilSuccessfulRouter {
       if (throwable instanceof MessagingException) {
         exceptionEvent = ((MessagingException) throwable).getEvent();
       }
-      // MessagingException cause is set to null in order to avoid RETRY:EXHAUSTED ErrorType replacement
+      // RetryPolicyExhaustedException cause is not set in order to avoid RETRY:EXHAUSTED ErrorType replacement
       // during ErrorType resolution (see ChainErrorHandlingUtils and MessagingExceptionResolver)
       return new MessagingException(exceptionEvent,
                                     new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG_PREFIX,
                                                                                           cause.getMessage()),
-                                                                      null, owner),
+                                                                      owner),
                                     owner);
     };
   }


### PR DESCRIPTION
Removing the cause from the MessagingException prevents the ErrorType replacement during the MessagingException resolution