### PR TITLE
MULE-17894: Reverting the changes due to backward compatibility issue

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -274,12 +274,10 @@ class UntilSuccessfulRouter {
       if (throwable instanceof MessagingException) {
         exceptionEvent = ((MessagingException) throwable).getEvent();
       }
-      // RetryPolicyExhaustedException cause is not set in order to avoid RETRY:EXHAUSTED ErrorType replacement
-      // during ErrorType resolution (see ChainErrorHandlingUtils and MessagingExceptionResolver)
       return new MessagingException(exceptionEvent,
                                     new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG_PREFIX,
                                                                                           cause.getMessage()),
-                                                                      owner),
+                                                                      cause, owner),
                                     owner);
     };
   }


### PR DESCRIPTION
Mule allows to make assertions about exception causes and even access its fields. thus setting the RetryPolicyException cause to null cannot be used as a fix for MULE-17894 