### PR TITLE
MULE-16764: Don't override item sequence info in parent event

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
@@ -201,7 +201,8 @@ public class Foreach extends AbstractMessageProcessorOwner implements Initialisa
           }
         }))
         .takeLast(1)
-        .map(s -> CoreEvent.builder(currentEvent.get()).message(request.getMessage()).build())
+            .map(s -> CoreEvent.builder(currentEvent.get()).message(request.getMessage())
+                    .itemSequenceInfo(request.getItemSequenceInfo()).build())
         .onErrorStop();
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
@@ -201,8 +201,8 @@ public class Foreach extends AbstractMessageProcessorOwner implements Initialisa
           }
         }))
         .takeLast(1)
-            .map(s -> CoreEvent.builder(currentEvent.get()).message(request.getMessage())
-                    .itemSequenceInfo(request.getItemSequenceInfo()).build())
+        .map(s -> CoreEvent.builder(currentEvent.get()).message(request.getMessage())
+            .itemSequenceInfo(request.getItemSequenceInfo()).build())
         .onErrorStop();
   }
 


### PR DESCRIPTION
Fix a regression introduced in #MULE-16764 