### PR TITLE
WIP: MULE-17894: RETRY_EXHAUSTED ErrorType gets replaced by the ErrorType that caused the exhaustion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,6 @@ Map pipelineParams = [ "upstreamProjects" : UPSTREAM_PROJECTS_LIST.join(','),
                       // "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
                        "mavenAdditionalArgs" : "-Djava.net.preferIPv4Stack=true",
                        "mavenCompileGoal" : "clean install -U -DskipTests -DskipITs -Dinvoker.skip=true -Darchetype.test.skip -Dmaven.javadoc.skip",
-]
+                       "projectType" : "Runtime" ]
 
-runtimeProjectsBuild(pipelineParams)
+runtimeBuild(pipelineParams)

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/AbstractPolicyProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/AbstractPolicyProcessorTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.core.internal.policy;
 
-import static com.google.common.collect.ImmutableMap.of;
 import static java.util.UUID.randomUUID;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,10 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
-import static org.mule.runtime.core.internal.event.EventQuickCopy.quickCopy;
-import static org.mule.runtime.core.internal.policy.OperationPolicyContext.OPERATION_POLICY_CONTEXT;
 import static org.mule.runtime.core.internal.policy.PolicyNextActionMessageProcessor.POLICY_NEXT_OPERATION;
-import static org.mule.runtime.core.internal.policy.SourcePolicyContext.SOURCE_POLICY_CONTEXT;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
 import static reactor.core.publisher.Mono.from;
@@ -33,6 +29,7 @@ import org.mule.runtime.core.api.policy.Policy;
 import org.mule.runtime.core.api.policy.PolicyChain;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
+import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.DefaultMuleSession;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent.Builder;
@@ -44,6 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.reactivestreams.Publisher;
+
 import reactor.core.publisher.Mono;
 
 public abstract class AbstractPolicyProcessorTestCase extends AbstractMuleTestCase {
@@ -72,8 +70,8 @@ public abstract class AbstractPolicyProcessorTestCase extends AbstractMuleTestCa
     operationPolicyContext = mock(OperationPolicyContext.class, RETURNS_DEEP_STUBS);
     sourcePolicyContext = new SourcePolicyContext(mock(PolicyPointcutParameters.class));
     initialEvent = createTestEvent();
-    initialEvent = quickCopy(initialEvent, of(OPERATION_POLICY_CONTEXT, operationPolicyContext,
-                                              SOURCE_POLICY_CONTEXT, sourcePolicyContext));
+    ((InternalEvent) initialEvent).setSourcePolicyContext(sourcePolicyContext);
+    ((InternalEvent) initialEvent).setOperationPolicyContext(operationPolicyContext);
 
     when(flowProcessor.apply(any())).thenAnswer(invocation -> invocation.getArgument(0));
     policyProcessor = getProcessor();

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/CompositeSourcePolicyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/CompositeSourcePolicyTestCase.java
@@ -28,9 +28,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.api.rx.Exceptions.propagateWrappingFatal;
-import static org.mule.runtime.core.internal.event.EventQuickCopy.quickCopy;
 import static org.mule.runtime.core.internal.execution.SourcePolicyTestUtils.block;
-import static org.mule.runtime.core.internal.policy.SourcePolicyContext.SOURCE_POLICY_CONTEXT;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
 import static reactor.core.publisher.Mono.error;
 
@@ -44,6 +42,7 @@ import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.execution.SourcePolicyTestUtils;
+import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 
@@ -90,10 +89,10 @@ public class CompositeSourcePolicyTestCase extends AbstractCompositePolicyTestCa
   public void setUp() throws Exception {
     initialEvent = createTestEvent();
     SourcePolicyContext policyContext = new SourcePolicyContext(mock(PolicyPointcutParameters.class));
-    initialEvent = quickCopy(initialEvent, of(SOURCE_POLICY_CONTEXT, policyContext));
+    ((InternalEvent) initialEvent).setSourcePolicyContext(policyContext);
 
     modifiedEvent = createTestEvent();
-    modifiedEvent = quickCopy(modifiedEvent, of(SOURCE_POLICY_CONTEXT, policyContext));
+    ((InternalEvent) initialEvent).setSourcePolicyContext(policyContext);
 
     when(nextProcessResultEvent.getMessage()).thenReturn(mock(Message.class));
     when(flowExecutionProcessor.apply(any())).thenAnswer(invocation -> {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/DefaultPolicyManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/DefaultPolicyManagerTestCase.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
-import static org.mule.runtime.core.internal.policy.SourcePolicyContext.SOURCE_POLICY_CONTEXT;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
 
 import org.mule.runtime.api.component.Component;
@@ -28,6 +27,7 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.policy.Policy;
 import org.mule.runtime.core.api.policy.PolicyChain;
 import org.mule.runtime.core.api.policy.PolicyProvider;
+import org.mule.runtime.core.internal.message.EventInternalContext;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
@@ -115,12 +115,12 @@ public class DefaultPolicyManagerTestCase extends AbstractMuleContextTestCase {
 
     SourcePolicyContext ctx = mock(SourcePolicyContext.class);
     when(ctx.getPointcutParameters()).thenReturn(policyParams1);
-    when(event1.getInternalParameter(SOURCE_POLICY_CONTEXT)).thenReturn(ctx);
+    when(event1.getSourcePolicyContext()).thenReturn((EventInternalContext) ctx);
 
     final InternalEvent event2 = mock(InternalEvent.class);
     ctx = mock(SourcePolicyContext.class);
     when(ctx.getPointcutParameters()).thenReturn(policyParams2);
-    when(event2.getInternalParameter(SOURCE_POLICY_CONTEXT)).thenReturn(ctx);
+    when(event2.getSourcePolicyContext()).thenReturn((EventInternalContext) ctx);
 
     final SourcePolicy policy1 = policyManager.createSourcePolicyInstance(flow1Component, event1, ePub -> ePub,
                                                                           mock(MessageSourceResponseParametersProcessor.class));
@@ -147,7 +147,7 @@ public class DefaultPolicyManagerTestCase extends AbstractMuleContextTestCase {
 
     final InternalEvent event = mock(InternalEvent.class);
     SourcePolicyContext ctx = mock(SourcePolicyContext.class);
-    when(event.getInternalParameter(SOURCE_POLICY_CONTEXT)).thenReturn(ctx);
+    when(event.getSourcePolicyContext()).thenReturn((EventInternalContext) ctx);
     when(ctx.getPointcutParameters()).thenReturn(policyParams);
 
     final SourcePolicy policy1 = policyManager.createSourcePolicyInstance(flow1Component, event, ePub -> ePub,
@@ -213,12 +213,12 @@ public class DefaultPolicyManagerTestCase extends AbstractMuleContextTestCase {
 
     final InternalEvent event1 = mock(InternalEvent.class);
     SourcePolicyContext ctx = mock(SourcePolicyContext.class);
-    when(event1.getInternalParameter(SOURCE_POLICY_CONTEXT)).thenReturn(ctx);
+    when(event1.getSourcePolicyContext()).thenReturn((EventInternalContext) ctx);
     when(ctx.getPointcutParameters()).thenReturn(sourcePolicyParams1);
 
     final InternalEvent event2 = mock(InternalEvent.class);
     ctx = mock(SourcePolicyContext.class);
-    when(event2.getInternalParameter(SOURCE_POLICY_CONTEXT)).thenReturn(ctx);
+    when(event2.getSourcePolicyContext()).thenReturn((EventInternalContext) ctx);
     when(ctx.getPointcutParameters()).thenReturn(sourcePolicyParams2);
 
     final OperationPolicy operationPolicy1 = policyManager.createOperationPolicy(operation1Component, event1,

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/NoSourcePolicyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/NoSourcePolicyTestCase.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.internal.execution.SourcePolicyTestUtils.block;
-import static org.mule.runtime.core.internal.policy.SourcePolicyContext.SOURCE_POLICY_CONTEXT;
 import static reactor.core.publisher.Mono.error;
 
 import org.mule.runtime.api.functional.Either;
@@ -25,6 +24,7 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.api.util.CaseInsensitiveHashMap;
 import org.mule.runtime.core.internal.exception.MessagingException;
+import org.mule.runtime.core.internal.message.EventInternalContext;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 import org.mule.tck.junit4.AbstractMuleTestCase;
@@ -63,7 +63,7 @@ public class NoSourcePolicyTestCase extends AbstractMuleTestCase {
     noSourcePolicy = new NoSourcePolicy(flowProcessor);
 
     when(initialEvent.getVariables()).thenReturn(new CaseInsensitiveHashMap<>());
-    when(initialEvent.getInternalParameter(SOURCE_POLICY_CONTEXT)).thenReturn(sourcePolicyContext);
+    when(initialEvent.getSourcePolicyContext()).thenReturn((EventInternalContext) sourcePolicyContext);
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyPointcutParametersManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyPointcutParametersManagerTestCase.java
@@ -18,12 +18,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.core.internal.policy.SourcePolicyContext.SOURCE_POLICY_CONTEXT;
 import static org.mule.tck.junit4.matcher.IsEmptyOptional.empty;
 
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.core.internal.message.EventInternalContext;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.policy.api.OperationPolicyPointcutParametersFactory;
@@ -71,7 +71,7 @@ public class PolicyPointcutParametersManagerTestCase extends AbstractMuleTestCas
     SourcePolicyContext ctx = mock(SourcePolicyContext.class);
     when(ctx.getPointcutParameters()).thenReturn(parameters);
 
-    when(event.getInternalParameter(SOURCE_POLICY_CONTEXT)).thenReturn(ctx);
+    when(event.getSourcePolicyContext()).thenReturn((EventInternalContext) ctx);
   }
 
   @Test
@@ -162,7 +162,7 @@ public class PolicyPointcutParametersManagerTestCase extends AbstractMuleTestCas
   public void createOperationParametersWhenEmptyFactoryAndEmptySourceParameters() {
     Map<String, Object> operationParameters = new HashMap<>();
 
-    when(event.getInternalParameter(any())).thenReturn(null);
+    when(event.getSourcePolicyContext()).thenReturn(null);
     PolicyPointcutParameters parameters =
         parametersManager.createOperationPointcutParameters(component, event, operationParameters);
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyProcessorLeakTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/PolicyProcessorLeakTestCase.java
@@ -6,14 +6,10 @@
  */
 package org.mule.runtime.core.internal.policy;
 
-import static com.google.common.collect.ImmutableMap.of;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mule.runtime.core.internal.event.EventQuickCopy.quickCopy;
-import static org.mule.runtime.core.internal.policy.OperationPolicyContext.OPERATION_POLICY_CONTEXT;
-import static org.mule.runtime.core.internal.policy.SourcePolicyContext.SOURCE_POLICY_CONTEXT;
 import static org.mule.tck.probe.PollingProber.DEFAULT_POLLING_INTERVAL;
 import static reactor.core.publisher.Mono.just;
 
@@ -22,6 +18,7 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.policy.Policy;
 import org.mule.runtime.core.api.policy.PolicyChain;
 import org.mule.runtime.core.api.processor.Processor;
+import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 import org.mule.tck.junit4.AbstractMuleTestCase;
@@ -57,8 +54,9 @@ public class PolicyProcessorLeakTestCase extends AbstractMuleTestCase {
   @Override
   protected CoreEvent testEvent() throws MuleException {
     CoreEvent event = super.testEvent();
-    return quickCopy(event, of(OPERATION_POLICY_CONTEXT, mock(OperationPolicyContext.class, RETURNS_DEEP_STUBS),
-                               SOURCE_POLICY_CONTEXT, new SourcePolicyContext(mock(PolicyPointcutParameters.class))));
+    ((InternalEvent) event).setSourcePolicyContext(new SourcePolicyContext(mock(PolicyPointcutParameters.class)));
+    ((InternalEvent) event).setOperationPolicyContext(mock(OperationPolicyContext.class, RETURNS_DEEP_STUBS));
+    return event;
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/XaQueueTransactionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/queue/XaQueueTransactionTestCase.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.util.queue;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.stubbing.Answer;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
+import org.mule.runtime.core.api.context.MuleContextBuilder;
+import org.mule.runtime.core.api.transaction.xa.ResourceManagerException;
+import org.mule.runtime.core.api.util.queue.DefaultQueueConfiguration;
+import org.mule.runtime.core.api.util.queue.QueueConfiguration;
+import org.mule.runtime.core.internal.util.journal.queue.MuleXid;
+import org.mule.runtime.core.internal.util.journal.queue.XaTxQueueTransactionJournal;
+import org.mule.runtime.core.internal.util.xa.XaTransactionRecoverer;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import java.io.Serializable;
+import java.util.concurrent.locks.Lock;
+
+import static java.lang.System.currentTimeMillis;
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class XaQueueTransactionTestCase extends AbstractMuleContextTestCase {
+
+  public static final String QUEUE_NAME = "inQueue";
+  private static final int TIMEOUT = 10;
+  private static final Xid TEST_XID = new MuleXid(9, new byte[] {1, 2, 3, 4}, new byte[] {5, 6, 7, 8});
+
+  private static final long QUEUE_DELAY_MILLIS = 2000;
+  private static final long QUEUE_DELAY_TOLERANCE_MILLIS = 20;
+  private DelayedQueueStore delayedQueue;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private XaTxQueueTransactionJournal txLog;
+  private DefaultQueueStore inQueue;
+  private PersistentXaTransactionContext persistentTransactionContext;
+  private XaTransactionRecoverer xaTransactionRecoverer;
+  private XaQueueTransactionContext localTxTransactionContext;
+
+  @Override
+  protected void doSetUp() throws Exception {
+    ((DefaultMuleConfiguration) muleContext.getConfiguration()).setWorkingDirectory(temporaryFolder.getRoot().getAbsolutePath());
+    txLog = new XaTxQueueTransactionJournal(temporaryFolder.getRoot().getAbsolutePath(), muleContext);
+
+    QueueConfiguration queueConfiguration = new DefaultQueueConfiguration(0, true);
+    inQueue = new DefaultQueueStore(QUEUE_NAME, muleContext, queueConfiguration);
+    delayedQueue = new DelayedQueueStore(QUEUE_NAME, muleContext, queueConfiguration, QUEUE_DELAY_MILLIS);
+
+    persistentTransactionContext = new PersistentXaTransactionContext(txLog, createRecoverOnlyQueueProvider(inQueue), TEST_XID);
+    xaTransactionRecoverer = new XaTransactionRecoverer(txLog, createRecoverOnlyQueueProvider(inQueue));
+    localTxTransactionContext = createLocalTxContext(txLog, createQueueProvider(delayedQueue));
+  }
+
+  private XaQueueTransactionContext createLocalTxContext(XaTxQueueTransactionJournal txLog, QueueProvider provider)
+      throws InterruptedException {
+    Lock lock = mock(Lock.class);
+    when(lock.tryLock(anyLong(), eq(MILLISECONDS))).thenAnswer((Answer<Boolean>) invocationOnMock -> {
+      sleep(invocationOnMock.getArgument(0, Long.class) / 2);
+      return true;
+    });
+    return new PersistentXaTransactionContext(txLog, provider, TEST_XID);
+  }
+
+  @Override
+  protected void configureMuleContext(MuleContextBuilder contextBuilder) {
+    DefaultMuleConfiguration muleConfiguration = new DefaultMuleConfiguration();
+    muleConfiguration.setWorkingDirectory(temporaryFolder.getRoot().getAbsolutePath());
+    contextBuilder.setMuleConfiguration(muleConfiguration);
+  }
+
+  private QueueProvider createRecoverOnlyQueueProvider(final DefaultQueueStore queue) {
+    return new QueueProvider() {
+
+      @Override
+      public QueueStore getQueue(String queueName) {
+        throw new NotImplementedException("This is test code");
+      }
+
+      @Override
+      public RecoverableQueueStore getRecoveryQueue(String queueName) {
+        return queue;
+      }
+    };
+  }
+
+  private QueueProvider createQueueProvider(final DefaultQueueStore queue) {
+    return new QueueProvider() {
+
+      @Override
+      public QueueStore getQueue(String queueName) {
+        return queue;
+      }
+
+      @Override
+      public RecoverableQueueStore getRecoveryQueue(String queueName) {
+        return queue;
+      }
+    };
+  }
+
+  @Test
+  public void offerAndFailThenRecover() throws Exception {
+    final DefaultQueueStore outQueue = new DefaultQueueStore(QUEUE_NAME, muleContext, new DefaultQueueConfiguration(0, true));
+    persistentTransactionContext = new PersistentXaTransactionContext(txLog, createRecoverOnlyQueueProvider(outQueue), TEST_XID);
+    persistentTransactionContext.offer(outQueue, testEvent(), TIMEOUT);
+    assertThat(outQueue.poll(TIMEOUT), nullValue());
+    txLog.close();
+    txLog = new XaTxQueueTransactionJournal(temporaryFolder.getRoot().getAbsolutePath(), muleContext);
+    xaTransactionRecoverer = new XaTransactionRecoverer(txLog, createRecoverOnlyQueueProvider(inQueue));
+    xaTransactionRecoverer.recover(XAResource.TMSTARTRSCAN);
+    Serializable muleEvent = outQueue.poll(TIMEOUT);
+    assertThat(muleEvent, nullValue());
+  }
+
+  @Test
+  public void pollDoesNotReturnNullBeforeTimeoutUsingTransactionContext() throws InterruptedException {
+    // When input queue is empty
+    assertThat(inQueue.getSize(), is(0));
+
+    long timeout = 300;
+
+    // If we poll an element from the queue with a given timeout
+    long timeBeforePoll = currentTimeMillis();
+    Serializable polledValue = persistentTransactionContext.poll(inQueue, timeout);
+    long timeAfterPoll = currentTimeMillis();
+
+    // Then the value is null
+    assertThat(polledValue, nullValue());
+    // And it waited at least for the given timeout
+    assertThat((double) (timeAfterPoll - timeBeforePoll),
+               anyOf(greaterThanOrEqualTo((double) timeout), closeTo(timeout, QUEUE_DELAY_TOLERANCE_MILLIS)));
+  }
+
+  @Test
+  public void pollDoesNotReturnNullBeforeTimeoutUsingDirectlyTheQueue() throws InterruptedException {
+    // When input queue is empty
+    assertThat(inQueue.getSize(), is(0));
+
+    final long timeout = 300;
+
+    // If we poll an element from the queue with a given timeout
+    long timeBeforePoll = currentTimeMillis();
+    Serializable polledValue = inQueue.poll(timeout);
+    long timeAfterPoll = currentTimeMillis();
+
+    // Then the value is null
+    assertThat(polledValue, nullValue());
+    // And it waited at least for the given timeout
+    assertThat(timeAfterPoll - timeBeforePoll, greaterThanOrEqualTo(timeout));
+  }
+
+  @Test
+  public void pollDoesNotDelayMuchMoreThanGivenTimeout() throws InterruptedException {
+    long timeMillisBeforePoll = currentTimeMillis();
+    localTxTransactionContext.poll(delayedQueue, QUEUE_DELAY_MILLIS);
+    long elapsedMillis = currentTimeMillis() - timeMillisBeforePoll;
+
+    assertThat(elapsedMillis, lessThanOrEqualTo(QUEUE_DELAY_MILLIS + QUEUE_DELAY_TOLERANCE_MILLIS));
+  }
+
+  @Test
+  public void offerDoesNotDelayMuchMoreThanGivenTimeout() throws InterruptedException, ResourceManagerException {
+    long waitTime = QUEUE_DELAY_MILLIS / 2;
+    int item = 1;
+
+    long timeMillisBeforeOffer = currentTimeMillis();
+    localTxTransactionContext.offer(delayedQueue, item, waitTime);
+    localTxTransactionContext.doCommit();
+    long elapsedMillis = currentTimeMillis() - timeMillisBeforeOffer;
+
+    assertThat(elapsedMillis, lessThanOrEqualTo(waitTime + QUEUE_DELAY_TOLERANCE_MILLIS));
+  }
+
+  private static class DelayedQueueStore extends DefaultQueueStore {
+
+    private final long delayMillis;
+
+    DelayedQueueStore(String name, MuleContext muleContext, QueueConfiguration config, long delayMillis) {
+      super(name, muleContext, config);
+      this.delayMillis = delayMillis;
+    }
+
+    @Override
+    public Serializable poll(long timeout) throws InterruptedException {
+      if (timeout == 0) {
+        return super.poll(timeout);
+      }
+
+      if (timeout <= delayMillis) {
+        sleep(timeout);
+        return null;
+      }
+
+      sleep(delayMillis);
+      return super.poll(timeout - delayMillis);
+    }
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/api/processor/strategy/ProcessingStrategy.java
+++ b/core/src/main/java/org/mule/runtime/core/api/processor/strategy/ProcessingStrategy.java
@@ -38,14 +38,23 @@ public interface ProcessingStrategy {
   Sink createSink(FlowConstruct flowConstruct, ReactiveProcessor pipeline);
 
   /**
-   * For sinks created internally by the components in a flow, have them accounted for in the processing strategy for a graceful
-   * shutdown.
+   * For sinks created internally by the components in a flow, have them accounted for in the processing strategy.
    *
-   * @param flux the flux whose sink will be registered
+   * @param publisher the publisher whose sink will be registered
    * @param sinkRepresentation a representation of the chain for it to appear in log entries.
    */
-  default void registerInternalSink(Publisher<CoreEvent> flux, String sinkRepresentation) {
-    Flux.from(flux).subscribe();
+  default void registerInternalSink(Publisher<CoreEvent> publisher, String sinkRepresentation) {
+    Flux.from(publisher).subscribe();
+  }
+
+  /**
+   * For publishers created outside of the main publisher of a flow, have them accounted for in the processing strategy.
+   *
+   * @param publisher the publishers whose lifecycle will be tied to the main publisher of the flow.
+   * @return the provided publishers with the additional callbacks observed.
+   */
+  default Publisher<CoreEvent> configureInternalPublisher(Publisher<CoreEvent> publisher) {
+    return publisher;
   }
 
   /**

--- a/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
@@ -20,7 +20,7 @@ import java.util.List;
  * This exception is thrown when a Retry policy has made all the retry attempts it wants to make and is still failing.
  */
 public final class RetryPolicyExhaustedException extends FatalException
-    implements ComposedErrorException, ErrorMessageAwareException {
+    implements ComposedErrorException {
 
   /** Serial version */
   private static final long serialVersionUID = 3300563235465630595L;
@@ -42,11 +42,6 @@ public final class RetryPolicyExhaustedException extends FatalException
 
   public RetryPolicyExhaustedException(Throwable cause, Object component) {
     super(cause, component);
-  }
-
-  @Override
-  public Message getErrorMessage() {
-    return Message.of(getMessage());
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
@@ -20,7 +20,7 @@ import java.util.List;
  * This exception is thrown when a Retry policy has made all the retry attempts it wants to make and is still failing.
  */
 public final class RetryPolicyExhaustedException extends FatalException
-    implements ComposedErrorException, ErrorMessageAwareException {
+    implements ComposedErrorException {
 
   /** Serial version */
   private static final long serialVersionUID = 3300563235465630595L;
@@ -31,15 +31,13 @@ public final class RetryPolicyExhaustedException extends FatalException
     super(message, component);
   }
 
-  public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component) {
-    super(message, cause, component);
+  public RetryPolicyExhaustedException(I18nMessage message, Object component, List<Error> errors) {
+    super(message, component);
+    this.errors.addAll(errors);
   }
 
-  // TODO: Validates that this change is possible (involves regenerating the serialVersionUID or adding an exception in api-changes)
-  // (perhaps we can create a new MuleException extending this one)
-  public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component, List<Error> errors) {
+  public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component) {
     super(message, cause, component);
-    this.errors.addAll(errors);
   }
 
   public RetryPolicyExhaustedException(Throwable cause, Object component) {
@@ -49,10 +47,5 @@ public final class RetryPolicyExhaustedException extends FatalException
   @Override
   public List<Error> getErrors() {
     return errors;
-  }
-
-  @Override
-  public Message getErrorMessage() {
-    return Message.of(getMessage());
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
@@ -20,7 +20,7 @@ import java.util.List;
  * This exception is thrown when a Retry policy has made all the retry attempts it wants to make and is still failing.
  */
 public final class RetryPolicyExhaustedException extends FatalException
-    implements ComposedErrorException {
+    implements ComposedErrorException, ErrorMessageAwareException {
 
   /** Serial version */
   private static final long serialVersionUID = 3300563235465630595L;
@@ -31,13 +31,15 @@ public final class RetryPolicyExhaustedException extends FatalException
     super(message, component);
   }
 
-  public RetryPolicyExhaustedException(I18nMessage message, Object component, List<Error> errors) {
-    super(message, component);
-    this.errors.addAll(errors);
-  }
-
   public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component) {
     super(message, cause, component);
+  }
+
+  // TODO: Validates that this change is possible (involves regenerating the serialVersionUID or adding an exception in api-changes)
+  // (perhaps we can create a new MuleException extending this one)
+  public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component, List<Error> errors) {
+    super(message, cause, component);
+    this.errors.addAll(errors);
   }
 
   public RetryPolicyExhaustedException(Throwable cause, Object component) {
@@ -47,5 +49,10 @@ public final class RetryPolicyExhaustedException extends FatalException
   @Override
   public List<Error> getErrors() {
     return errors;
+  }
+
+  @Override
+  public Message getErrorMessage() {
+    return Message.of(getMessage());
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
@@ -6,34 +6,19 @@
  */
 package org.mule.runtime.core.api.retry.policy;
 
-import org.mule.runtime.api.exception.ComposedErrorException;
-import org.mule.runtime.api.exception.ErrorMessageAwareException;
-import org.mule.runtime.api.message.Error;
-import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.lifecycle.FatalException;
 import org.mule.runtime.api.i18n.I18nMessage;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This exception is thrown when a Retry policy has made all the retry attempts it wants to make and is still failing.
  */
-public final class RetryPolicyExhaustedException extends FatalException
-    implements ComposedErrorException {
+public final class RetryPolicyExhaustedException extends FatalException {
 
   /** Serial version */
   private static final long serialVersionUID = 3300563235465630595L;
 
-  private final List<Error> errors = new ArrayList<>();
-
   public RetryPolicyExhaustedException(I18nMessage message, Object component) {
     super(message, component);
-  }
-
-  public RetryPolicyExhaustedException(I18nMessage message, Object component, List<Error> errors) {
-    super(message, component);
-    this.errors.addAll(errors);
   }
 
   public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component) {
@@ -42,10 +27,5 @@ public final class RetryPolicyExhaustedException extends FatalException
 
   public RetryPolicyExhaustedException(Throwable cause, Object component) {
     super(cause, component);
-  }
-
-  @Override
-  public List<Error> getErrors() {
-    return errors;
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
@@ -6,19 +6,34 @@
  */
 package org.mule.runtime.core.api.retry.policy;
 
+import org.mule.runtime.api.exception.ComposedErrorException;
+import org.mule.runtime.api.exception.ErrorMessageAwareException;
+import org.mule.runtime.api.message.Error;
+import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.lifecycle.FatalException;
 import org.mule.runtime.api.i18n.I18nMessage;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This exception is thrown when a Retry policy has made all the retry attempts it wants to make and is still failing.
  */
-public final class RetryPolicyExhaustedException extends FatalException {
+public final class RetryPolicyExhaustedException extends FatalException
+    implements ComposedErrorException, ErrorMessageAwareException {
 
   /** Serial version */
   private static final long serialVersionUID = 3300563235465630595L;
 
+  private final List<Error> errors = new ArrayList<>();
+
   public RetryPolicyExhaustedException(I18nMessage message, Object component) {
     super(message, component);
+  }
+
+  public RetryPolicyExhaustedException(I18nMessage message, Object component, List<Error> errors) {
+    super(message, component);
+    this.errors.addAll(errors);
   }
 
   public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component) {
@@ -27,5 +42,15 @@ public final class RetryPolicyExhaustedException extends FatalException {
 
   public RetryPolicyExhaustedException(Throwable cause, Object component) {
     super(cause, component);
+  }
+
+  @Override
+  public Message getErrorMessage() {
+    return Message.of(getMessage());
+  }
+
+  @Override
+  public List<Error> getErrors() {
+    return errors;
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/event/BaseEventDecorator.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/BaseEventDecorator.java
@@ -171,6 +171,26 @@ abstract class BaseEventDecorator implements InternalEvent, DeserializationPostI
     event.setSdkInternalContext(context);
   }
 
+  @Override
+  public <T extends EventInternalContext> EventInternalContext<T> getSourcePolicyContext() {
+    return event.getSourcePolicyContext();
+  }
+
+  @Override
+  public <T extends EventInternalContext> void setSourcePolicyContext(EventInternalContext<T> context) {
+    event.setSourcePolicyContext(context);
+  }
+
+  @Override
+  public <T extends EventInternalContext> EventInternalContext<T> getOperationPolicyContext() {
+    return event.getOperationPolicyContext();
+  }
+
+  @Override
+  public <T extends EventInternalContext> void setOperationPolicyContext(EventInternalContext<T> context) {
+    event.setOperationPolicyContext(context);
+  }
+
   /**
    * Invoked after deserialization. This is called when the marker interface {@link DeserializationPostInitialisable} is used.
    * This will get invoked after the object has been deserialized passing in the current MuleContext.

--- a/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventBuilder.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventBuilder.java
@@ -76,6 +76,8 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
   private MuleSession session;
   private SecurityContext securityContext;
   private EventInternalContext sdkInternalContext;
+  private EventInternalContext sourcePolicyContext;
+  private EventInternalContext operationPolicyContext;
   private InternalEvent originalEvent;
   private boolean modified;
   private boolean internalParametersInitialized = false;
@@ -103,6 +105,8 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
     this.originalVars = (CaseInsensitiveHashMap<String, TypedValue<?>>) event.getVariables();
     this.internalParameters = (Map<String, Object>) event.getInternalParameters();
     sdkInternalContext = copyOf(event.getSdkInternalContext());
+    sourcePolicyContext = copyOf(event.getSourcePolicyContext());
+    operationPolicyContext = copyOf(event.getOperationPolicyContext());
   }
 
   public DefaultEventBuilder(BaseEventContext messageContext, InternalEvent event) {
@@ -307,6 +311,8 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
                                              securityContext,
                                              itemSequenceInfo,
                                              sdkInternalContext,
+                                             sourcePolicyContext,
+                                             operationPolicyContext,
                                              error,
                                              legacyCorrelationId,
                                              notificationsEnabled);
@@ -372,6 +378,8 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
 
     private transient Map<String, ?> internalParameters;
     private transient EventInternalContext sdkInternalContext;
+    private transient EventInternalContext sourcePolicyContext;
+    private transient EventInternalContext operationPolicyContext;
     private transient LazyValue<BindingContext> bindingContextBuilder =
         new LazyValue<>(() -> addEventBindings(this, NULL_BINDING_CONTEXT));
 
@@ -385,6 +393,9 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
       this.legacyCorrelationId = null;
       this.error = null;
       this.itemSequenceInfo = null;
+      this.sdkInternalContext = null;
+      this.sourcePolicyContext = null;
+      this.operationPolicyContext = null;
       this.internalParameters = new SmallMap<>();
     }
 
@@ -397,6 +408,8 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
                                         SecurityContext securityContext,
                                         Optional<ItemSequenceInfo> itemSequenceInfo,
                                         EventInternalContext sdkInternalContext,
+                                        EventInternalContext sourcePolicyContext,
+                                        EventInternalContext operationPolicyContext,
                                         Error error,
                                         String legacyCorrelationId,
                                         boolean notificationsEnabled) {
@@ -409,6 +422,8 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
 
       this.itemSequenceInfo = itemSequenceInfo.orElse(null);
       this.sdkInternalContext = sdkInternalContext;
+      this.sourcePolicyContext = sourcePolicyContext;
+      this.operationPolicyContext = operationPolicyContext;
       this.error = error;
       this.legacyCorrelationId = legacyCorrelationId;
 
@@ -593,6 +608,26 @@ public class DefaultEventBuilder implements InternalEvent.Builder {
     @Override
     public void setSdkInternalContext(EventInternalContext sdkInternalContext) {
       this.sdkInternalContext = sdkInternalContext;
+    }
+
+    @Override
+    public EventInternalContext getSourcePolicyContext() {
+      return sourcePolicyContext;
+    }
+
+    @Override
+    public void setSourcePolicyContext(EventInternalContext sourcePolicyContext) {
+      this.sourcePolicyContext = sourcePolicyContext;
+    }
+
+    @Override
+    public EventInternalContext getOperationPolicyContext() {
+      return operationPolicyContext;
+    }
+
+    @Override
+    public void setOperationPolicyContext(EventInternalContext operationPolicyContext) {
+      this.operationPolicyContext = operationPolicyContext;
     }
 
     @Override

--- a/core/src/main/java/org/mule/runtime/core/internal/execution/FlowProcessMediator.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/execution/FlowProcessMediator.java
@@ -165,6 +165,8 @@ public class FlowProcessMediator implements Initialisable {
       final CompletableFuture<Void> responseCompletion = new CompletableFuture<>();
       final FlowProcessor flowExecutionProcessor = new FlowProcessor(template, flowConstruct);
       final CoreEvent event = createEvent(template, messageSource, responseCompletion, flowConstruct);
+      policyManager.addSourcePointcutParametersIntoEvent(messageSource, event.getMessage().getAttributes(),
+                                                         (InternalEvent) event);
 
       try {
         final SourcePolicy policy =
@@ -469,7 +471,6 @@ public class FlowProcessMediator implements Initialisable {
                                  ((BaseEventContext) eventCtx).getRootContext());
       }
 
-      policyManager.addSourcePointcutParametersIntoEvent(source, eventMessage.getAttributes(), eventBuilder);
       return eventMessage;
     }).build();
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/message/InternalEvent.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/message/InternalEvent.java
@@ -60,6 +60,34 @@ public interface InternalEvent extends PrivilegedEvent {
   <T extends EventInternalContext> void setSdkInternalContext(EventInternalContext<T> context);
 
   /**
+   * @return a {@link EventInternalContext} with state from the policy infrastructure relative to sources
+   * @since 4.3.0
+   */
+  <T extends EventInternalContext> EventInternalContext<T> getSourcePolicyContext();
+
+  /**
+   * Sets context related to the policy infrastructure relative to sources
+   *
+   * @param context an {@link EventInternalContext}
+   * @since 4.3.0
+   */
+  <T extends EventInternalContext> void setSourcePolicyContext(EventInternalContext<T> context);
+
+  /**
+   * @return a {@link EventInternalContext} with state from the policy infrastructure relative to operations
+   * @since 4.3.0
+   */
+  <T extends EventInternalContext> EventInternalContext<T> getOperationPolicyContext();
+
+  /**
+   * Sets context related to the policy infrastructure relative to operations
+   *
+   * @param context an {@link EventInternalContext}
+   * @since 4.3.0
+   */
+  <T extends EventInternalContext> void setOperationPolicyContext(EventInternalContext<T> context);
+
+  /**
    * Create new {@link Builder} based on an existing {@link CoreEvent} instance. The existing {@link EventContext} is conserved.
    *
    * @param event existing event to use as a template to create builder instance

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeOperationPolicy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeOperationPolicy.java
@@ -12,10 +12,7 @@ import static org.mule.runtime.api.functional.Either.left;
 import static org.mule.runtime.api.functional.Either.right;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.util.collection.SmallMap.copy;
-import static org.mule.runtime.api.util.collection.SmallMap.of;
 import static org.mule.runtime.core.api.util.concurrent.FunctionalReadWriteLock.readWriteLock;
-import static org.mule.runtime.core.internal.event.EventQuickCopy.quickCopy;
-import static org.mule.runtime.core.internal.policy.OperationPolicyContext.OPERATION_POLICY_CONTEXT;
 import static org.mule.runtime.core.internal.policy.OperationPolicyContext.from;
 import static org.mule.runtime.core.internal.util.rx.RxUtils.propagateCompletion;
 import static reactor.core.Exceptions.propagate;
@@ -239,13 +236,12 @@ public class CompositeOperationPolicy
                                                             operationExecutionFunction,
                                                             callback);
     if (getParametersTransformer().isPresent()) {
-      return InternalEvent.builder(operationEvent)
+      operationEvent = InternalEvent.builder(operationEvent)
           .message(getParametersTransformer().get().fromParametersToMessage(parametersProcessor.getOperationParameters()))
-          .addInternalParameter(OPERATION_POLICY_CONTEXT, ctx)
           .build();
-    } else {
-      return quickCopy(operationEvent, of(OPERATION_POLICY_CONTEXT, ctx));
     }
+    ((InternalEvent) operationEvent).setOperationPolicyContext(ctx);
+    return operationEvent;
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeOperationPolicy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/CompositeOperationPolicy.java
@@ -17,7 +17,7 @@ import static org.mule.runtime.core.api.util.concurrent.FunctionalReadWriteLock.
 import static org.mule.runtime.core.internal.event.EventQuickCopy.quickCopy;
 import static org.mule.runtime.core.internal.policy.OperationPolicyContext.OPERATION_POLICY_CONTEXT;
 import static org.mule.runtime.core.internal.policy.OperationPolicyContext.from;
-import static org.mule.runtime.core.internal.util.rx.RxUtils.subscribeFluxOnPublisherSubscription;
+import static org.mule.runtime.core.internal.util.rx.RxUtils.propagateCompletion;
 import static reactor.core.Exceptions.propagate;
 import static reactor.core.publisher.Flux.create;
 import static reactor.core.publisher.Flux.from;
@@ -26,6 +26,7 @@ import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.functional.Either;
 import org.mule.runtime.api.lifecycle.Disposable;
+import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.policy.OperationPolicyParametersTransformer;
 import org.mule.runtime.core.api.policy.Policy;
@@ -70,6 +71,8 @@ public class CompositeOperationPolicy
 
   private final LoadingCache<String, FluxSinkSupplier<CoreEvent>> policySinks;
 
+  private final long shutdownTimeout;
+  private final Scheduler completionCallbackScheduler;
   private final AtomicBoolean disposed;
   private final FunctionalReadWriteLock readWriteLock;
 
@@ -82,14 +85,18 @@ public class CompositeOperationPolicy
    * won't be able to change the response parameters of the source and the original response parameters generated from the source
    * will be used.
    *
-   * @param operation                            the operation on which the policies will be applied
-   * @param parameterizedPolicies                list of {@link Policy} to chain together.
+   * @param operation the operation on which the policies will be applied
+   * @param parameterizedPolicies list of {@link Policy} to chain together.
    * @param operationPolicyParametersTransformer transformer from the operation parameters to a message and vice versa.
-   * @param operationPolicyProcessorFactory      factory for creating each {@link OperationPolicy} from a {@link Policy}
+   * @param operationPolicyProcessorFactory factory for creating each {@link OperationPolicy} from a {@link Policy}.
+   * @param completionCallbackScheduler the executor where the completion of the policy flux will happen.
+   * @param shutdownTimeout how long to wait for pending items to finish processing before actually completing the flux for the
+   *        policy.
    */
   public CompositeOperationPolicy(Component operation, List<Policy> parameterizedPolicies,
                                   Optional<OperationPolicyParametersTransformer> operationPolicyParametersTransformer,
-                                  OperationPolicyProcessorFactory operationPolicyProcessorFactory) {
+                                  OperationPolicyProcessorFactory operationPolicyProcessorFactory,
+                                  long shutdownTimeout, Scheduler completionCallbackScheduler) {
     super(parameterizedPolicies, operationPolicyParametersTransformer);
     this.operation = operation;
     this.operationPolicyProcessorFactory = operationPolicyProcessorFactory;
@@ -105,6 +112,9 @@ public class CompositeOperationPolicy
                                                         new RoundRobinFluxSinkSupplier<>(getRuntime().availableProcessors(),
                                                                                          factory));
         });
+
+    this.shutdownTimeout = shutdownTimeout;
+    this.completionCallbackScheduler = completionCallbackScheduler;
   }
 
   private final class OperationWithPoliciesFluxObjectFactory implements Supplier<FluxSink<CoreEvent>> {
@@ -135,44 +145,45 @@ public class CompositeOperationPolicy
   @Override
   protected Publisher<CoreEvent> applyNextOperation(Publisher<CoreEvent> eventPub, Policy lastPolicy) {
     FluxSinkRecorder<Either<Throwable, CoreEvent>> sinkRecorder = new FluxSinkRecorder<>();
-    final Flux<CoreEvent> doOnNext = from(eventPub)
-        .doOnNext(event -> {
-          OperationPolicyContext ctx = from(event);
-          OperationExecutionFunction operationExecutionFunction = ctx.getOperationExecutionFunction();
 
-          operationExecutionFunction.execute(resolveOperationParameters(event, ctx), event, new ExecutorCallback() {
-
-            @Override
-            public void complete(Object value) {
-              sinkRecorder.next(right(Throwable.class, (CoreEvent) value));
-            }
-
-            @Override
-            public void error(Throwable e) {
-              // if `sink.error` is called here, it will cancel the flux altogether. That's why an `Either` is used here, so the
-              // error can be propagated afterwards in a way consistent with our expected error handling.
-              sinkRecorder.next(left(mapError(e, event), CoreEvent.class));
-            }
-
-            private Throwable mapError(Throwable t, CoreEvent event) {
-              t = Exceptions.unwrap(t);
-              if (!(t instanceof MessagingException)) {
-                t = new MessagingException(event, t, operation);
-              }
-              return t;
-            }
-          });
-        })
-        .doOnComplete(() -> sinkRecorder.complete());
-
-    return subscribeFluxOnPublisherSubscription(create(sinkRecorder)
+    return from(propagateCompletion(from(eventPub), create(sinkRecorder)
         .map(result -> {
           result.applyLeft(t -> {
             throw propagate(t);
           });
           return result.getRight();
-        }), doOnNext)
-            .doOnNext(response -> from(response).setNextOperationResponse((InternalEvent) response));
+        }), pub -> from(pub)
+            .doOnNext(event -> {
+              OperationPolicyContext ctx = from(event);
+              OperationExecutionFunction operationExecutionFunction = ctx.getOperationExecutionFunction();
+
+              operationExecutionFunction.execute(resolveOperationParameters(event, ctx), event, new ExecutorCallback() {
+
+                @Override
+                public void complete(Object value) {
+                  sinkRecorder.next(right(Throwable.class, (CoreEvent) value));
+                }
+
+                @Override
+                public void error(Throwable e) {
+                  // if `sink.error` is called here, it will cancel the flux altogether. That's why an `Either` is used here, so
+                  // the error can be propagated afterwards in a way consistent with our expected error handling.
+                  sinkRecorder.next(left(mapError(e, event), CoreEvent.class));
+                }
+
+                private Throwable mapError(Throwable t, CoreEvent event) {
+                  t = Exceptions.unwrap(t);
+                  if (!(t instanceof MessagingException)) {
+                    t = new MessagingException(event, t, operation);
+                  }
+                  return t;
+                }
+              });
+            }), sinkRecorder::complete, sinkRecorder::error,
+                                    shutdownTimeout,
+                                    completionCallbackScheduler))
+                                        .doOnNext(response -> from(response)
+                                            .setNextOperationResponse((InternalEvent) response));
   }
 
   private Map<String, Object> resolveOperationParameters(CoreEvent event, OperationPolicyContext ctx) {
@@ -192,9 +203,9 @@ public class CompositeOperationPolicy
    * Always uses the stored result of {@code processNextOperation} so all the chains after the operation execution are executed
    * with the actual operation result and not a modified version from another policy.
    *
-   * @param policy        the policy to execute.
+   * @param policy the policy to execute.
    * @param nextProcessor the processor to execute when the policy next-processor gets executed
-   * @param eventPub      the event to use to execute the policy chain.
+   * @param eventPub the event to use to execute the policy chain.
    */
   @Override
   protected Publisher<CoreEvent> applyPolicy(Policy policy, ReactiveProcessor nextProcessor, Publisher<CoreEvent> eventPub) {
@@ -241,6 +252,7 @@ public class CompositeOperationPolicy
   public void dispose() {
     readWriteLock.withWriteLock(() -> {
       policySinks.invalidateAll();
+      completionCallbackScheduler.stop();
       disposed.set(true);
     });
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyManager.java
@@ -193,7 +193,11 @@ public class DefaultPolicyManager implements PolicyManager, Initialisable, Dispo
                  ? NO_POLICY_OPERATION
                  : new CompositeOperationPolicy(operation, innerKey,
                                                 lookupOperationParametersTransformer(outerKey.getFirst()),
-                                                operationPolicyProcessorFactory)));
+                                                operationPolicyProcessorFactory,
+                                                muleContext.getConfiguration().getShutdownTimeout(),
+                                                muleContext.getSchedulerService()
+                                                    .ioScheduler(muleContext.getSchedulerBaseConfig().withMaxConcurrentTasks(1)
+                                                        .withName(operation.getLocation().getLocation() + ".policy.flux.")))));
   }
 
   private Optional<OperationPolicyParametersTransformer> lookupOperationParametersTransformer(ComponentIdentifier componentIdentifier) {

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyManager.java
@@ -64,6 +64,21 @@ public class DefaultPolicyManager implements PolicyManager, Initialisable, Dispo
       (operationEvent, operationExecutionFunction, opParamProcessor, componentLocation, callback) -> operationExecutionFunction
           .execute(opParamProcessor.getOperationParameters(), operationEvent, callback);
 
+  /**
+   * @return A no-op policy that will directly execute the operation function.
+   */
+  public static OperationPolicy noPolicyOperation() {
+    return NO_POLICY_OPERATION;
+  }
+
+  /**
+   * @param policy the {@link OperationPolicy} to evaluate
+   * @return {@code true} if the provided policy is a no-op, {@code false} if a policy is actually applied.
+   */
+  public static boolean isNoPolicyOperation(OperationPolicy policy) {
+    return NO_POLICY_OPERATION.equals(policy);
+  }
+
   @Inject
   private ErrorTypeLocator errorTypeLocator;
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/DefaultPolicyManager.java
@@ -10,7 +10,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mule.runtime.api.notification.FlowConstructNotification.FLOW_CONSTRUCT_STOPPED;
 import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
-import static org.mule.runtime.core.internal.policy.SourcePolicyContext.SOURCE_POLICY_CONTEXT;
 
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.component.Component;
@@ -160,10 +159,10 @@ public class DefaultPolicyManager implements PolicyManager, Initialisable, Dispo
 
   @Override
   public PolicyPointcutParameters addSourcePointcutParametersIntoEvent(Component source, TypedValue<?> attributes,
-                                                                       InternalEvent.Builder eventBuilder) {
+                                                                       InternalEvent event) {
     final PolicyPointcutParameters sourcePolicyParams =
         policyPointcutParametersManager.createSourcePointcutParameters(source, attributes);
-    eventBuilder.addInternalParameter(SOURCE_POLICY_CONTEXT, new SourcePolicyContext(sourcePolicyParams));
+    event.setSourcePolicyContext(new SourcePolicyContext(sourcePolicyParams));
     return sourcePolicyParams;
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/OperationPolicyContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/OperationPolicyContext.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.core.internal.policy;
 
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.internal.message.EventInternalContext;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
 
@@ -15,22 +16,16 @@ import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExec
  *
  * @since 4.3.0
  */
-public class OperationPolicyContext {
+public class OperationPolicyContext implements EventInternalContext<OperationPolicyContext> {
 
   /**
-   * The key under which an instance of this class is stored as an internal parameter in a {@link InternalEvent}
-   */
-  public static final String OPERATION_POLICY_CONTEXT = "operation.policy.context";
-
-  /**
-   * Extracts an instance stored as an internal parameter in the given {@code result} under the {@link #OPERATION_POLICY_CONTEXT}
-   * key
+   * Extracts an instance stored as an internal parameter in the given {@code event}.
    *
    * @param event
    * @return an {@link OperationPolicyContext} or {@code null} if none was set on the event
    */
   public static OperationPolicyContext from(CoreEvent event) {
-    return ((InternalEvent) event).getInternalParameter(OPERATION_POLICY_CONTEXT);
+    return (OperationPolicyContext) ((InternalEvent) event).<OperationPolicyContext>getOperationPolicyContext();
   }
 
   private CoreEvent originalEvent;
@@ -45,6 +40,11 @@ public class OperationPolicyContext {
     this.operationParametersProcessor = operationParametersProcessor;
     this.operationExecutionFunction = operationExecutionFunction;
     this.operationCallerCallback = operationCallerCallback;
+  }
+
+  @Override
+  public OperationPolicyContext copy() {
+    return this;
   }
 
   public CoreEvent getOriginalEvent() {

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyManager.java
@@ -45,7 +45,7 @@ public interface PolicyManager {
    * @return the created source parameters.
    */
   PolicyPointcutParameters addSourcePointcutParametersIntoEvent(Component source, TypedValue<?> attributes,
-                                                                InternalEvent.Builder eventBuilder);
+                                                                InternalEvent event);
 
   /**
    * Creates a policy to be applied to an operation. The creation must have into consideration the {@code operationIdentifier} to

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/SourcePolicyContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/SourcePolicyContext.java
@@ -12,6 +12,7 @@ import org.mule.runtime.api.component.execution.CompletableCallback;
 import org.mule.runtime.api.functional.Either;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.policy.SourcePolicyParametersTransformer;
+import org.mule.runtime.core.internal.message.EventInternalContext;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 
@@ -23,12 +24,7 @@ import java.util.Optional;
  *
  * @since 4.3.0
  */
-public class SourcePolicyContext {
-
-  /**
-   * The key under which an instance of this class is stored as an internal parameter in a {@link InternalEvent}
-   */
-  public static final String SOURCE_POLICY_CONTEXT = "source.policy.context";
+public class SourcePolicyContext implements EventInternalContext<SourcePolicyContext> {
 
   /**
    * Extracts an instance stored as an internal parameter in the given {@code result} under the {@link #SOURCE_POLICY_CONTEXT} key
@@ -37,7 +33,7 @@ public class SourcePolicyContext {
    * @return an {@link SourcePolicyContext} or {@code null} if none was set on the event
    */
   public static SourcePolicyContext from(CoreEvent event) {
-    return ((InternalEvent) event).getInternalParameter(SOURCE_POLICY_CONTEXT);
+    return (SourcePolicyContext) ((InternalEvent) event).<SourcePolicyContext>getSourcePolicyContext();
   }
 
   private final PolicyPointcutParameters pointcutParameters;
@@ -57,6 +53,11 @@ public class SourcePolicyContext {
                         CompletableCallback<Either<SourcePolicyFailureResult, SourcePolicySuccessResult>> callback) {
     this.responseParametersProcessor = responseParametersProcessor;
     this.processCallback = callback;
+  }
+
+  @Override
+  public SourcePolicyContext copy() {
+    return this;
   }
 
   public PolicyPointcutParameters getPointcutParameters() {

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/TryScope.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/TryScope.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.internal.processor;
 
+import static java.lang.Thread.currentThread;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.of;
 import static org.mule.runtime.api.component.location.Location.builderFromStringRepresentation;
@@ -15,21 +16,26 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
+import static org.mule.runtime.core.api.rx.Exceptions.rxExceptionToMuleException;
+import static org.mule.runtime.core.api.rx.Exceptions.unwrap;
 import static org.mule.runtime.core.api.transaction.TransactionConfig.ACTION_ALWAYS_BEGIN;
 import static org.mule.runtime.core.api.transaction.TransactionConfig.ACTION_BEGIN_OR_JOIN;
 import static org.mule.runtime.core.api.transaction.TransactionConfig.ACTION_INDIFFERENT;
 import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTransactionActive;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.buildNewChainWithListOfProcessors;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.getProcessingStrategy;
+import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
 import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Flux.from;
+import static reactor.core.publisher.Mono.just;
+import static reactor.core.publisher.Mono.subscriberContext;
 
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.exception.FlowExceptionHandler;
-import org.mule.runtime.core.api.execution.ExecutionCallback;
 import org.mule.runtime.core.api.execution.ExecutionTemplate;
 import org.mule.runtime.core.api.processor.AbstractMessageProcessorOwner;
 import org.mule.runtime.core.api.processor.Processor;
@@ -47,6 +53,8 @@ import java.util.List;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 
+import reactor.util.context.Context;
+
 /**
  * Wraps the invocation of a list of nested processors {@link org.mule.runtime.core.api.processor.Processor} with a transaction.
  * If the {@link org.mule.runtime.core.api.transaction.TransactionConfig} is null then no transaction is used and the next
@@ -63,42 +71,66 @@ public class TryScope extends AbstractMessageProcessorOwner implements Scope {
 
   @Override
   public CoreEvent process(final CoreEvent event) throws MuleException {
-    if (nestedChain == null) {
-      return event;
-    }
-    final boolean txPrevoiuslyActive = isTransactionActive();
-    Transaction previousTx = TransactionCoordination.getInstance().getTransaction();
-    ExecutionTemplate<CoreEvent> executionTemplate =
-        createScopeTransactionalExecutionTemplate(muleContext, transactionConfig);
-    ExecutionCallback<CoreEvent> processingCallback = () -> {
-      Transaction currentTx = TransactionCoordination.getInstance().getTransaction();
-      // Whether there wasn't a tx and now there is, or if there is a newer one (if we have a nested tx, using xa)
-      // we must set the component location of this try scope
-      if ((!txPrevoiuslyActive && isTransactionActive()) || (txPrevoiuslyActive && previousTx != currentTx)) {
-        TransactionAdapter transaction = (TransactionAdapter) currentTx;
-        transaction.setComponentLocation(getLocation());
-      }
-      return nestedChain.process(event);
-    };
-
-    try {
-      return executionTemplate.execute(processingCallback);
-    } catch (MuleException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new DefaultMuleException(errorInvokingMessageProcessorWithinTransaction(nestedChain, transactionConfig), e);
-    }
+    return processToApply(event, this);
   }
 
   @Override
   public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
-    if (nestedChain == null) {
-      return publisher;
-    } else if (isTransactionActive() || transactionConfig.getAction() != ACTION_INDIFFERENT) {
-      return Scope.super.apply(publisher);
+    if (isTransactionActive() || transactionConfig.getAction() != ACTION_INDIFFERENT) {
+      ExecutionTemplate<CoreEvent> executionTemplate = createScopeTransactionalExecutionTemplate(muleContext, transactionConfig);
+      final I18nMessage txErrorMessage = errorInvokingMessageProcessorWithinTransaction(nestedChain, transactionConfig);
+
+      return subscriberContext()
+          .flatMapMany(ctx -> from(publisher)
+              .handle((event, sink) -> {
+                final boolean txPrevoiuslyActive = isTransactionActive();
+                Transaction previousTx = getCurrentTx();
+                try {
+                  sink.next(executionTemplate.execute(() -> {
+                    handlePreviousTransaction(txPrevoiuslyActive, previousTx, getCurrentTx());
+                    return processBlocking(ctx, event);
+                  }));
+                } catch (Exception e) {
+                  final Throwable unwrapped = unwrap(e);
+
+                  if (unwrapped instanceof MuleException) {
+                    sink.error(unwrapped);
+                  } else {
+                    sink.error(new DefaultMuleException(txErrorMessage, unwrapped));
+                  }
+                }
+              }));
     } else {
       return from(publisher).transform(nestedChain);
     }
+  }
+
+  private void handlePreviousTransaction(final boolean txPrevoiuslyActive, Transaction previousTx, Transaction currentTx) {
+    // Whether there wasn't a tx and now there is, or if there is a newer one (if we have a nested tx, using xa)
+    // we must set the component location of this try scope
+    if ((!txPrevoiuslyActive && isTransactionActive()) || (txPrevoiuslyActive && previousTx != currentTx)) {
+      TransactionAdapter transaction = (TransactionAdapter) currentTx;
+      transaction.setComponentLocation(getLocation());
+    }
+  }
+
+  private CoreEvent processBlocking(Context ctx, CoreEvent event) throws MuleException {
+    try {
+      return just(event)
+          .transform(nestedChain)
+          .onErrorStop()
+          .subscriberContext(ctx)
+          .block();
+    } catch (Throwable e) {
+      if (e.getCause() instanceof InterruptedException) {
+        currentThread().interrupt();
+      }
+      throw rxExceptionToMuleException(e);
+    }
+  }
+
+  private Transaction getCurrentTx() {
+    return TransactionCoordination.getInstance().getTransaction();
   }
 
   /**

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/OperationInnerProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/OperationInnerProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.processor.strategy;
+
+import org.mule.runtime.core.api.processor.ReactiveProcessor;
+
+/**
+ * Specialization of {@link ReactiveProcessor} that allows to perform certain optimizations when the processor is not
+ * asynchronous, as indicated by its {@link #isAsync()} method.
+ * </p>
+ * <b>IMPORTANT!</b> The processing strategy will delegate the parallel processing of events to the implementation, so it is
+ * required that implementations properly handle parallel processing.
+ *
+ * @since 4.3
+ */
+public interface OperationInnerProcessor extends ReactiveProcessor {
+
+  /**
+   * An async processor is one that eventually changes the thread where it is executing.
+   *
+   * @return {@code} if the processor is asynchronous.
+   */
+  boolean isAsync();
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/ProcessingStrategyDecorator.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/ProcessingStrategyDecorator.java
@@ -47,8 +47,13 @@ public abstract class ProcessingStrategyDecorator implements ProcessingStrategy,
   }
 
   @Override
-  public void registerInternalSink(Publisher<CoreEvent> flux, String sinkRepresentation) {
-    delegate.registerInternalSink(flux, sinkRepresentation);
+  public void registerInternalSink(Publisher<CoreEvent> publisher, String sinkRepresentation) {
+    delegate.registerInternalSink(publisher, sinkRepresentation);
+  }
+
+  @Override
+  public Publisher<CoreEvent> configureInternalPublisher(Publisher<CoreEvent> publisher) {
+    return delegate.configureInternalPublisher(publisher);
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
@@ -201,7 +201,8 @@ public class Foreach extends AbstractMessageProcessorOwner implements Initialisa
           }
         }))
         .takeLast(1)
-        .map(s -> CoreEvent.builder(currentEvent.get()).message(request.getMessage()).build())
+        .map(s -> CoreEvent.builder(currentEvent.get()).message(request.getMessage())
+            .itemSequenceInfo(request.getItemSequenceInfo()).build())
         .onErrorStop();
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessful.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessful.java
@@ -21,6 +21,7 @@ import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
 import org.mule.runtime.core.api.processor.AbstractMuleObjectOwner;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.internal.routing.UntilSuccessfulRouter.RetryContextInitializationException;
+import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.processor.Scope;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
@@ -45,6 +46,9 @@ public class UntilSuccessful extends AbstractMuleObjectOwner implements Scope {
 
   @Inject
   private ExtendedExpressionManager expressionManager;
+
+  @Inject
+  private ErrorTypeLocator errorTypeLocator;
 
   private String maxRetries = DEFAULT_RETRIES;
   private String millisBetweenRetries = DEFAULT_MILLIS_BETWEEN_RETRIES;
@@ -94,7 +98,7 @@ public class UntilSuccessful extends AbstractMuleObjectOwner implements Scope {
   @Override
   public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
     return new UntilSuccessfulRouter(this, publisher, nestedChain, expressionManager, shouldRetry, timer, maxRetries,
-                                     millisBetweenRetries).getDownstreamPublisher();
+                                     millisBetweenRetries, errorTypeLocator).getDownstreamPublisher();
   }
 
 

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -273,11 +273,6 @@ class UntilSuccessfulRouter {
     return e -> (e instanceof MessagingException && shouldRetry.test(((MessagingException) e).getEvent()));
   }
 
-  /**
-   * Returns a {@link MessagingException} that represents a retry exhausted error
-   * @param event {@link CoreEvent} that caused the exhaustion
-   * @return {@link MessagingException}
-   */
   private Function<Throwable, Throwable> getThrowableFunction(CoreEvent event) {
     return throwable -> {
       CoreEvent exhaustionCauseEvent = event;
@@ -285,7 +280,7 @@ class UntilSuccessfulRouter {
         exhaustionCauseEvent = ((MessagingException) throwable).getEvent();
       }
       Throwable exhaustionCause = getMessagingExceptionCause(throwable);
-      RetryPolicyExhaustedException retryExhaustedException =
+      Throwable retryExhaustedException =
           new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG_PREFIX, exhaustionCause.getMessage()),
                                             exhaustionCause, owner);
       CoreEvent retryExhaustedEvent = getRetryExhaustedEvent(exhaustionCauseEvent, retryExhaustedException);
@@ -293,14 +288,7 @@ class UntilSuccessfulRouter {
     };
   }
 
-  /**
-   * Creates a {@link CoreEvent} that represents a retry exhausted error
-   * @param exhaustionCauseEvent Failing event that caused the retry exhaustion
-   * @param retryExhaustedException {@link RetryPolicyExhaustedException} that will be returned by {@link CoreEvent#getError()}
-   * @return {@link CoreEvent}
-   */
-  private CoreEvent getRetryExhaustedEvent(CoreEvent exhaustionCauseEvent,
-                                           RetryPolicyExhaustedException retryExhaustedException) {
+  private CoreEvent getRetryExhaustedEvent(CoreEvent exhaustionCauseEvent, Throwable retryExhaustedException) {
     ErrorBuilder errorBuilder = ErrorBuilder.builder(retryExhaustedException)
         .errorType(retryExhaustedErrorType);
     return CoreEvent.builder(exhaustionCauseEvent).error(errorBuilder.build()).build();

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -24,6 +24,7 @@ import static reactor.util.context.Context.empty;
 
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.functional.Either;
+import org.mule.runtime.api.message.ErrorType;
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.core.api.el.ExpressionManagerSession;
 import org.mule.runtime.core.api.el.ExtendedExpressionManager;
@@ -37,7 +38,9 @@ import org.mule.runtime.core.internal.util.rx.ConditionalExecutorServiceDecorato
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -86,7 +89,7 @@ class UntilSuccessfulRouter {
   private Function<ExpressionManagerSession, Integer> delaySupplier;
   private Function<CoreEvent, ExpressionManagerSession> sessionSupplier;
 
-  private ErrorTypeLocator errorTypeLocator;
+  private ErrorType retryExhaustedErrorType;
 
   // When using an until successful scope in a blocking flow (for example, calling the owner flow with a Processor#process call),
   // this leads to a reactor completion signal being emitted while the event is being re-injected for retrials. This is solved by
@@ -97,7 +100,7 @@ class UntilSuccessfulRouter {
   UntilSuccessfulRouter(Component owner, Publisher<CoreEvent> publisher, MessageProcessorChain nestedChain,
                         ExtendedExpressionManager expressionManager, Predicate<CoreEvent> shouldRetry, Scheduler delayScheduler,
                         String maxRetries, String millisBetweenRetries, ErrorTypeLocator errorTypeLocator) {
-    this.errorTypeLocator = errorTypeLocator;
+    this.retryExhaustedErrorType = errorTypeLocator.lookupErrorType(RetryPolicyExhaustedException.class);
     this.owner = owner;
     this.shouldRetry = shouldRetry;
     this.delayScheduler = new ConditionalExecutorServiceDecorator(delayScheduler, s -> isTransactionActive());
@@ -188,8 +191,8 @@ class UntilSuccessfulRouter {
       } else { // Retries exhausted
         // Current context already pooped. No need to re-insert it
         LOGGER.error("Retry attempts exhausted. Failing...");
-        // Delete current context from event
         Throwable resolvedError = getThrowableFunction(ctx.event).apply(error);
+        // Delete current context from event
         eventWithCurrentContextDeleted(messagingError.getEvent());
         downstreamRecorder.next(left(resolvedError, CoreEvent.class));
         completeRouterIfNecessary();
@@ -299,7 +302,7 @@ class UntilSuccessfulRouter {
   private CoreEvent getRetryExhaustedEvent(CoreEvent exhaustionCauseEvent,
                                            RetryPolicyExhaustedException retryExhaustedException) {
     ErrorBuilder errorBuilder = ErrorBuilder.builder(retryExhaustedException)
-        .errorType(errorTypeLocator.lookupErrorType(retryExhaustedException));
+        .errorType(retryExhaustedErrorType);
     return CoreEvent.builder(exhaustionCauseEvent).error(errorBuilder.build()).build();
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.core.internal.routing;
 
 import static java.lang.Integer.parseInt;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mule.runtime.api.el.BindingContextUtils.NULL_BINDING_CONTEXT;
 import static org.mule.runtime.api.functional.Either.left;
@@ -38,6 +39,7 @@ import org.mule.runtime.core.internal.util.rx.ConditionalExecutorServiceDecorato
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -285,11 +287,12 @@ class UntilSuccessfulRouter {
         exhaustionCauseEvent = ((MessagingException) throwable).getEvent();
       }
       Throwable exhaustionCause = getMessagingExceptionCause(throwable);
-      RetryPolicyExhaustedException retryExhaustedException =
+      // TODO: Replace the singletonList with all the errors that occurred instead of the last one
+      RetryPolicyExhaustedException retryExhaustedExceptionCause =
           new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG_PREFIX, exhaustionCause.getMessage()),
-                                            exhaustionCause, owner);
-      CoreEvent retryExhaustedEvent = getRetryExhaustedEvent(exhaustionCauseEvent, retryExhaustedException);
-      return new MessagingException(retryExhaustedEvent, retryExhaustedException, owner);
+                                            exhaustionCause, owner, singletonList(exhaustionCauseEvent.getError().get()));
+      CoreEvent retryExhaustedEvent = getRetryExhaustedEvent(exhaustionCauseEvent, retryExhaustedExceptionCause);
+      return new MessagingException(retryExhaustedEvent, retryExhaustedExceptionCause, owner);
     };
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -7,7 +7,6 @@
 package org.mule.runtime.core.internal.routing;
 
 import static java.lang.Integer.parseInt;
-import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mule.runtime.api.el.BindingContextUtils.NULL_BINDING_CONTEXT;
 import static org.mule.runtime.api.functional.Either.left;
@@ -39,7 +38,6 @@ import org.mule.runtime.core.internal.util.rx.ConditionalExecutorServiceDecorato
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -287,12 +285,11 @@ class UntilSuccessfulRouter {
         exhaustionCauseEvent = ((MessagingException) throwable).getEvent();
       }
       Throwable exhaustionCause = getMessagingExceptionCause(throwable);
-      // TODO: Replace the singletonList with all the errors that occurred instead of the last one
-      RetryPolicyExhaustedException retryExhaustedExceptionCause =
+      RetryPolicyExhaustedException retryExhaustedException =
           new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG_PREFIX, exhaustionCause.getMessage()),
-                                            exhaustionCause, owner, singletonList(exhaustionCauseEvent.getError().get()));
-      CoreEvent retryExhaustedEvent = getRetryExhaustedEvent(exhaustionCauseEvent, retryExhaustedExceptionCause);
-      return new MessagingException(retryExhaustedEvent, retryExhaustedExceptionCause, owner);
+                                            exhaustionCause, owner);
+      CoreEvent retryExhaustedEvent = getRetryExhaustedEvent(exhaustionCauseEvent, retryExhaustedException);
+      return new MessagingException(retryExhaustedEvent, retryExhaustedException, owner);
     };
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/util/queue/PersistentXaTransactionContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/queue/PersistentXaTransactionContext.java
@@ -53,12 +53,11 @@ public class PersistentXaTransactionContext implements XaQueueTransactionContext
 
   public Serializable poll(QueueStore queue, long pollTimeout) throws InterruptedException {
     synchronized (queue) {
-      Serializable value = queue.peek();
-      if (value == null) {
-        return null;
+      Serializable value = queue.poll(pollTimeout);
+      if (value != null) {
+        this.transactionJournal.logRemove(xid, queue, value);
       }
-      this.transactionJournal.logRemove(xid, queue, value);
-      return queue.poll(pollTimeout);
+      return value;
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/util/rx/RxUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/rx/RxUtils.java
@@ -68,7 +68,9 @@ public class RxUtils {
                                                                     Flux<U> deferredSubscriber) {
     return triggeringSubscriber
         .compose(eventPub -> subscriberContext()
-            .flatMapMany(ctx -> eventPub.doOnSubscribe(s -> deferredSubscriber.subscriberContext(ctx).subscribe())));
+            .flatMapMany(ctx -> eventPub.doOnSubscribe(s -> deferredSubscriber
+                .subscriberContext(ctx)
+                .subscribe())));
   }
 
   /**

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/CompositeArtifactExtensionManagerTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/policy/CompositeArtifactExtensionManagerTestCase.java
@@ -11,7 +11,6 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -20,6 +19,7 @@ import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.Initialisable;
@@ -246,8 +246,8 @@ public class CompositeArtifactExtensionManagerTestCase extends AbstractMuleTestC
     ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
     ConfigurationInstance configurationInstance = mock(ConfigurationInstance.class);
     when(childConfigurationProvider.get(event)).thenReturn(configurationInstance);
-    when(childExtensionManager.getConfiguration(childExtension, operationModel, event)).thenReturn(
-                                                                                                   ofNullable(configurationInstance));
+    when(childExtensionManager.getConfigurationProvider(childExtension, operationModel, event))
+        .thenReturn(of(childConfigurationProvider));
     when(parentExtensionManager.getConfigurationProvider(childExtension, operationModel)).thenReturn(empty());
 
     Optional<ConfigurationInstance> configuration = extensionManager.getConfiguration(childExtension, operationModel, event);
@@ -266,9 +266,6 @@ public class CompositeArtifactExtensionManagerTestCase extends AbstractMuleTestC
                                                                                                childExtensionManager);
     CoreEvent event = mock(CoreEvent.class);
 
-    ConfigurationProvider childConfigurationProvider = mock(ConfigurationProvider.class);
-    ConfigurationInstance configurationInstance = mock(ConfigurationInstance.class);
-    when(childConfigurationProvider.get(event)).thenReturn(configurationInstance);
     when(childExtensionManager.getConfiguration(childExtension, operationModel, event)).thenReturn(empty());
     when(childExtensionManager.getConfigurationProvider(childExtension, operationModel)).thenReturn(empty());
     when(parentExtensionManager.getConfigurationProvider(childExtension, operationModel)).thenReturn(empty());

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
@@ -220,11 +220,8 @@ public abstract class AbstractDeploymentTestCase extends AbstractMuleTestCase {
   private TestModuleDiscoverer moduleDiscoverer;
 
   @Parameterized.Parameters(name = "Parallel: {0}")
-  public static List<Object[]> parameters() {
-    return asList(new Object[][] {
-        {false},
-        {true}
-    });
+  public static List<Boolean> params() {
+    return asList(false, true);
   }
 
   // Dynamically compiled classes and jars

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/construct/ConstructDefinitionParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/construct/ConstructDefinitionParser.java
@@ -6,38 +6,14 @@
  */
 package org.mule.runtime.module.extension.internal.config.dsl.construct;
 
-import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromChildCollectionConfiguration;
-import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromChildConfiguration;
-import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromFixedValue;
-import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromReferenceObject;
-import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromSimpleParameter;
-import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromSimpleReferenceParameter;
-import static org.mule.runtime.dsl.api.component.TypeDefinition.fromType;
-import static org.mule.runtime.extension.api.ExtensionConstants.TARGET_PARAMETER_NAME;
-import static org.mule.runtime.extension.api.ExtensionConstants.TARGET_VALUE_PARAMETER_NAME;
-import static org.mule.runtime.internal.dsl.DslConstants.CONFIG_ATTRIBUTE_NAME;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.construct.ConstructModel;
-import org.mule.runtime.api.meta.model.nested.NestableElementModel;
-import org.mule.runtime.api.meta.model.nested.NestedChainModel;
-import org.mule.runtime.api.meta.model.parameter.ParameterGroupModel;
-import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.config.ConfigurationException;
-import org.mule.runtime.core.api.processor.Processor;
-import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
-import org.mule.runtime.core.api.streaming.CursorProviderFactory;
-import org.mule.runtime.core.internal.policy.PolicyManager;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition.Builder;
-import org.mule.runtime.extension.api.dsl.syntax.DslElementSyntax;
 import org.mule.runtime.extension.api.dsl.syntax.resolver.DslSyntaxResolver;
 import org.mule.runtime.module.extension.internal.AbstractComponentDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingContext;
-import org.mule.runtime.module.extension.internal.runtime.operation.ComponentMessageProcessor;
 import org.mule.runtime.module.extension.internal.runtime.operation.ConstructMessageProcessor;
-
-import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ExtensionDefinitionParser} for parsing {@link ConstructMessageProcessor} instances through a

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/ImplicitConnectionProviderTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/ImplicitConnectionProviderTestCase.java
@@ -8,6 +8,7 @@ package org.mule.test.module.extension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+
 import org.mule.test.implicit.config.extension.extension.api.Counter;
 
 import org.junit.Test;

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/StatefulOperationTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/StatefulOperationTestCase.java
@@ -15,9 +15,9 @@ import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.test.heisenberg.extension.HeisenbergExtension;
 import org.mule.test.module.extension.internal.util.ExtensionsTestUtils;
 
-import org.junit.Test;
-
 import java.math.BigDecimal;
+
+import org.junit.Test;
 
 public class StatefulOperationTestCase extends AbstractExtensionFunctionalTestCase {
 

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/config/ConfigurationInjectionLifecycleTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/config/ConfigurationInjectionLifecycleTestCase.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.meta.Category.SELECT;
 import static org.mule.runtime.api.meta.ExternalLibraryType.NATIVE;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.getConfigurationInstanceFromRegistry;
+
 import org.mule.functional.junit4.ExtensionFunctionalTestCase;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.Initialisable;

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/streaming/AbstractBytesStreamingExtensionTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/streaming/AbstractBytesStreamingExtensionTestCase.java
@@ -45,11 +45,12 @@ import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
-import org.junit.Rule;
-import org.junit.Test;
 
 @Feature(STREAMING)
 @Story(BYTES_STREAMING)
@@ -352,4 +353,8 @@ public abstract class AbstractBytesStreamingExtensionTestCase extends AbstractSt
     return s -> s.equals(BARGAIN_SPELL);
   }
 
+  @Override
+  protected boolean isGracefulShutdown() {
+    return true;
+  }
 }

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-operation-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-operation-config.xml
@@ -70,7 +70,7 @@
     </flow>
 
     <flow name="expressionEnemy">
-        <heisenberg:get-enemy config-ref="heisenberg" index="#[mel:flowVars['enemy']]"/>
+        <heisenberg:get-enemy config-ref="heisenberg" index="#[vars.enemy]"/>
     </flow>
 
     <flow name="getInlineInfo">
@@ -148,7 +148,7 @@
     </flow>
 
     <flow name="knockManyByExpression">
-        <heisenberg:knock-many doors="#[mel:doors]"/>
+        <heisenberg:knock-many doors="#[vars.doors]"/>
     </flow>
 
     <flow name="callSaul">
@@ -244,7 +244,7 @@
                     <heisenberg:recursive-pojo/>
                 </heisenberg:childs>
                 <heisenberg:mapped-childs>
-                    <heisenberg:mapped-child key="someKey" value="#[mel:new org.mule.test.heisenberg.extension.model.RecursivePojo()"/>
+                    <heisenberg:mapped-child key="someKey" value="#[{} as Object {class: 'new org.mule.test.heisenberg.extension.model.RecursivePojo'}]"/>
                 </heisenberg:mapped-childs>
             </heisenberg:recursive-pojo>
         </heisenberg:approve>

--- a/modules/extensions-spring-support/src/test/resources/heisenberg-stateful-operation-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/heisenberg-stateful-operation-config.xml
@@ -6,7 +6,7 @@
                http://www.mulesoft.org/schema/mule/heisenberg http://www.mulesoft.org/schema/mule/heisenberg/current/mule-heisenberg.xsd">
 
     <heisenberg:config name="heisenberg"
-                       myName="#[mel:myName]"
+                       myName="#[vars.myName]"
                        age="50"
                        cancer="true"
                        dateOfBirth="1959-09-07T00:00:00"
@@ -50,11 +50,11 @@
     </heisenberg:config>
 
     <flow name="laundry">
-        <heisenberg:launder config-ref="heisenberg" amount="#[mel:payload]" />
+        <heisenberg:launder config-ref="heisenberg" amount="#[payload]" />
     </flow>
 
     <flow name="staticLaundry">
-        <heisenberg:launder config-ref="staticHeisenberg" amount="#[mel:payload]" />
+        <heisenberg:launder config-ref="staticHeisenberg" amount="#[payload]" />
     </flow>
 
 </mule>

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/policy/NoOpPolicyManager.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/policy/NoOpPolicyManager.java
@@ -10,7 +10,7 @@ import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
-import org.mule.runtime.core.internal.message.InternalEvent.Builder;
+import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.internal.policy.MessageSourceResponseParametersProcessor;
 import org.mule.runtime.core.internal.policy.NoSourcePolicy;
 import org.mule.runtime.core.internal.policy.OperationParametersProcessor;
@@ -39,7 +39,7 @@ public class NoOpPolicyManager implements PolicyManager {
 
   @Override
   public PolicyPointcutParameters addSourcePointcutParametersIntoEvent(Component source, TypedValue<?> attributes,
-                                                                       Builder eventBuilder) {
+                                                                       InternalEvent event) {
     return new PolicyPointcutParameters(source);
   }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
@@ -140,7 +140,6 @@ public abstract class ExtensionComponent<T extends ComponentModel> extends Abstr
   @Inject
   protected MuleMetadataService metadataService;
 
-  @Inject
   protected ConfigurationComponentLocator componentLocator;
 
   @Inject
@@ -589,5 +588,10 @@ public abstract class ExtensionComponent<T extends ComponentModel> extends Abstr
   @Inject
   public void setCacheIdGeneratorFactory(MetadataCacheIdGeneratorFactory<ComponentAst> cacheIdGeneratorFactory) {
     this.cacheIdGeneratorFactory = cacheIdGeneratorFactory;
+  }
+
+  @Inject
+  public void setComponentLocator(ConfigurationComponentLocator componentLocator) {
+    this.componentLocator = componentLocator;
   }
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.execution;
+
+import static java.util.function.Function.identity;
+
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.internal.message.EventInternalContext;
+import org.mule.runtime.core.internal.message.InternalEvent;
+import org.mule.runtime.core.internal.policy.DefaultPolicyManager;
+import org.mule.runtime.core.internal.policy.OperationPolicy;
+import org.mule.runtime.extension.api.runtime.config.ConfigurationInstance;
+import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import reactor.util.context.Context;
+
+/**
+ * Contains internal context handled by SDK operations.
+ *
+ * @since 4.3
+ */
+public class SdkInternalContext implements EventInternalContext<SdkInternalContext> {
+
+  /**
+   * Extracts an instance stored in the given {@code event}
+   *
+   * @param event
+   * @return an {@link SdkInternalContext} or {@code null} if none was set on the event
+   */
+  public static SdkInternalContext from(CoreEvent event) {
+    return (SdkInternalContext) ((InternalEvent) event).<SdkInternalContext>getSdkInternalContext();
+  }
+
+  private OperationExecutionParams operationExecutionParams;
+
+  private Function<Context, Context> innerChainSubscriberContextMapping = identity();
+
+  private Optional<ConfigurationInstance> configuration;
+
+  private Map<String, Object> resolutionResult;
+
+  private OperationPolicy policyToApply;
+
+  /**
+   * @return {@code true} if the policy to be applied is a no-op, {@code false} if a policy is actually applied.
+   */
+  public boolean isNoPolicyOperation() {
+    return DefaultPolicyManager.isNoPolicyOperation(getPolicyToApply());
+  }
+
+  public OperationExecutionParams getOperationExecutionParams() {
+    return operationExecutionParams;
+  }
+
+  public void setOperationExecutionParams(Optional<ConfigurationInstance> configuration, Map<String, Object> parameters,
+                                          CoreEvent operationEvent, ExecutorCallback callback) {
+    this.operationExecutionParams = new OperationExecutionParams(configuration, parameters, operationEvent, callback);
+  }
+
+  public Function<Context, Context> getInnerChainSubscriberContextMapping() {
+    return innerChainSubscriberContextMapping;
+  }
+
+  public void setInnerChainSubscriberContextMapping(Function<Context, Context> innerChainSubscriberContextMapping) {
+    this.innerChainSubscriberContextMapping = innerChainSubscriberContextMapping;
+  }
+
+  public Optional<ConfigurationInstance> getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(Optional<ConfigurationInstance> configuration) {
+    this.configuration = configuration;
+  }
+
+  public Map<String, Object> getResolutionResult() {
+    return resolutionResult;
+  }
+
+  public void setResolutionResult(Map<String, Object> resolutionResult) {
+    this.resolutionResult = resolutionResult;
+  }
+
+  public OperationPolicy getPolicyToApply() {
+    return policyToApply;
+  }
+
+  public void setPolicyToApply(OperationPolicy policyToApply) {
+    this.policyToApply = policyToApply;
+  }
+
+  @Override
+  public SdkInternalContext copy() {
+    return this;
+  }
+
+  public static final class OperationExecutionParams {
+
+    private final Optional<ConfigurationInstance> configuration;
+    private final Map<String, Object> parameters;
+    private final CoreEvent operationEvent;
+    private final ExecutorCallback callback;
+
+    public OperationExecutionParams(Optional<ConfigurationInstance> configuration, Map<String, Object> parameters,
+                                    CoreEvent operationEvent, ExecutorCallback callback) {
+      this.configuration = configuration;
+      this.parameters = parameters;
+      this.operationEvent = operationEvent;
+      this.callback = callback;
+    }
+
+    public Optional<ConfigurationInstance> getConfiguration() {
+      return configuration;
+    }
+
+    public Map<String, Object> getParameters() {
+      return parameters;
+    }
+
+    public CoreEvent getOperationEvent() {
+      return operationEvent;
+    }
+
+    public ExecutorCallback getCallback() {
+      return callback;
+    }
+
+  }
+
+
+}

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ConstructMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ConstructMessageProcessor.java
@@ -6,7 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.operation;
 
-import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE_ASYNC;
+import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE;
 
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.construct.ConstructModel;
@@ -49,15 +49,8 @@ public class ConstructMessageProcessor extends ComponentMessageProcessor<Constru
   }
 
   @Override
-  protected boolean isAsync() {
-    return true;
-  }
-
-  @Override
-  public ProcessingType getProcessingType() {
-    // If processing type is CPU_LITE and operation is non-blocking then use CPU_LITE_ASYNC processing type so that the Flow can
-    // return processing to a Flow thread.
-    return CPU_LITE_ASYNC;
+  public ProcessingType getInnerProcessingType() {
+    return CPU_LITE;
   }
 
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChainExecutor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChainExecutor.java
@@ -10,6 +10,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.function.Function.identity;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContextDontComplete;
+import static org.mule.runtime.module.extension.internal.runtime.execution.SdkInternalContext.from;
 import static reactor.core.publisher.Mono.from;
 
 import org.mule.runtime.api.message.Message;
@@ -17,13 +18,13 @@ import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.internal.exception.MessagingException;
-import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.core.privileged.processor.chain.HasMessageProcessors;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.runtime.route.Chain;
 import org.mule.runtime.module.extension.api.runtime.privileged.EventedResult;
+import org.mule.runtime.module.extension.internal.runtime.execution.SdkInternalContext;
 
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -38,8 +39,6 @@ import reactor.util.context.Context;
  * @since 4.0
  */
 public class ImmutableProcessorChainExecutor implements Chain, HasMessageProcessors {
-
-  public static final String INNER_CHAIN_CTX_MAPPING = "mule.sdk.innerChainContextMapping";
 
   /**
    * Processor that will be executed upon calling process
@@ -121,8 +120,11 @@ public class ImmutableProcessorChainExecutor implements Chain, HasMessageProcess
     }
 
     public void execute() {
-      final Function<Context, Context> innerChainCtxMapping =
-          ((InternalEvent) event).getInternalParameter(INNER_CHAIN_CTX_MAPPING);
+      final SdkInternalContext sdkInternalCtx = from(event);
+      Function<Context, Context> innerChainCtxMapping = identity();
+      if (sdkInternalCtx != null) {
+        innerChainCtxMapping = sdkInternalCtx.getInnerChainSubscriberContextMapping();
+      }
 
       from(processWithChildContextDontComplete(event, chain, ofNullable(chain.getLocation())))
           .doOnSuccess(this::handleSuccess)
@@ -133,7 +135,7 @@ public class ImmutableProcessorChainExecutor implements Chain, HasMessageProcess
               this.handleError(error, event);
             }
           })
-          .subscriberContext(innerChainCtxMapping != null ? innerChainCtxMapping : identity())
+          .subscriberContext(innerChainCtxMapping)
           .subscribe();
     }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessor.java
@@ -103,7 +103,7 @@ public class OperationMessageProcessor extends ComponentMessageProcessor<Operati
   }
 
   @Override
-  public ProcessingType getProcessingType() {
+  public ProcessingType getInnerProcessingType() {
     ProcessingType processingType = asProcessingType(componentModel.getExecutionType());
     if (processingType == CPU_LITE && !componentModel.isBlocking()) {
       // If processing type is CPU_LITE and operation is non-blocking then use CPU_LITE_ASYNC processing type so that the Flow can

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorPolicyProcessingStrategyTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorPolicyProcessingStrategyTestCase.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Optional.of;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
+import static org.mule.runtime.core.api.processor.ReactiveProcessor.ProcessingType.CPU_LITE_ASYNC;
+import static org.mule.tck.probe.PollingProber.probe;
+import static reactor.core.scheduler.Schedulers.fromExecutorService;
+
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.Location;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.meta.model.ComponentModel;
+import org.mule.runtime.api.meta.model.EnrichableModel;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.api.meta.model.XmlDslModel;
+import org.mule.runtime.core.api.construct.FlowConstruct;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.core.api.processor.ReactiveProcessor;
+import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
+import org.mule.runtime.core.internal.metadata.cache.MetadataCacheIdGeneratorFactory;
+import org.mule.runtime.core.internal.policy.OperationParametersProcessor;
+import org.mule.runtime.core.internal.policy.OperationPolicy;
+import org.mule.runtime.core.internal.policy.PolicyManager;
+import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
+import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor;
+import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
+import org.mule.runtime.module.extension.api.loader.java.property.CompletableComponentExecutorModelProperty;
+import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextAdapter;
+import org.mule.runtime.module.extension.internal.runtime.operation.ComponentMessageProcessor;
+import org.mule.runtime.module.extension.internal.runtime.operation.ExecutionMediator;
+import org.mule.runtime.module.extension.internal.runtime.resolver.ResolverSet;
+import org.mule.runtime.module.extension.internal.runtime.resolver.ResolverSetResult;
+import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolvingContext;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import reactor.core.publisher.Mono;
+
+public class ComponentMessageProcessorPolicyProcessingStrategyTestCase extends AbstractMuleContextTestCase {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ComponentMessageProcessorPolicyProcessingStrategyTestCase.class);
+
+  private static final OperationPolicy NO_POLICY_OPERATION =
+      (operationEvent, operationExecutionFunction, opParamProcessor, componentLocation, callback) -> operationExecutionFunction
+          .execute(opParamProcessor.getOperationParameters(), operationEvent, callback);
+
+  private ComponentMessageProcessor<ComponentModel> processor;
+  private Location mpRootContainerLocation;
+  private FlowConstruct rootContainer;
+  private ProcessingStrategy processingStrategy;
+
+  private ExtensionModel extensionModel;
+  private ComponentModel componentModel;
+
+  private ResolverSet resolverSet;
+  private ExtensionManager extensionManager;
+  private PolicyManager policyManager;
+
+  private final ExecutorService threadSwitcher = newFixedThreadPool(2);
+  private final AssertingExecutionMediator mediator = new AssertingExecutionMediator();
+
+  @Before
+  public void before() throws MuleException {
+    CoreEvent response = testEvent();
+
+    mpRootContainerLocation = mock(Location.class);
+
+    extensionModel = mock(ExtensionModel.class);
+    when(extensionModel.getXmlDslModel()).thenReturn(XmlDslModel.builder().setPrefix("mock").build());
+
+    componentModel = mock(ComponentModel.class, withSettings().extraInterfaces(EnrichableModel.class));
+    when((componentModel).getModelProperty(CompletableComponentExecutorModelProperty.class))
+        .thenReturn(of(new CompletableComponentExecutorModelProperty((cp, p) -> (ctx, callback) -> callback.complete(response))));
+    resolverSet = mock(ResolverSet.class);
+    when(resolverSet.resolve(any(ValueResolvingContext.class))).thenReturn(mock(ResolverSetResult.class));
+
+    extensionManager = mock(ExtensionManager.class);
+    policyManager = mock(PolicyManager.class);
+
+    processor = new ComponentMessageProcessor<ComponentModel>(extensionModel,
+                                                              componentModel, null, null, null,
+                                                              resolverSet, null, null,
+                                                              extensionManager,
+                                                              policyManager, null) {
+
+      @Override
+      protected void validateOperationConfiguration(ConfigurationProvider configurationProvider) {}
+
+      @Override
+      public ProcessingType getInnerProcessingType() {
+        return CPU_LITE_ASYNC;
+      }
+
+      @Override
+      protected ExecutionMediator createExecutionMediator() {
+        return mediator;
+      }
+
+      @Override
+      public ComponentLocation getLocation() {
+        return mock(ComponentLocation.class);
+      }
+
+      @Override
+      public Location getRootContainerLocation() {
+        return mpRootContainerLocation;
+      }
+
+    };
+
+    rootContainer = mock(FlowConstruct.class);
+    processingStrategy = mock(ProcessingStrategy.class);
+    when(processingStrategy.onProcessor(any(ReactiveProcessor.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(processingStrategy.configureInternalPublisher(any(Publisher.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    when(componentLocator.find(mpRootContainerLocation)).thenReturn(of(rootContainer));
+    when(rootContainer.getProcessingStrategy()).thenReturn(processingStrategy);
+
+    processor.setComponentLocator(componentLocator);
+    processor.setCacheIdGeneratorFactory(mock(MetadataCacheIdGeneratorFactory.class));
+
+    initialiseIfNeeded(processor, muleContext);
+    startIfNeeded(processor);
+  }
+
+  @After
+  public void after() throws MuleException {
+    stopIfNeeded(processor);
+    disposeIfNeeded(processor, LOGGER);
+    threadSwitcher.shutdownNow();
+  }
+
+  private static class AssertingExecutionMediator implements ExecutionMediator {
+
+    private Thread executionThread;
+    private boolean executed;
+
+    @Override
+    public void execute(CompletableComponentExecutor executor,
+                        ExecutionContextAdapter context,
+                        ExecutorCallback callback) {
+      executed = true;
+      executionThread = currentThread();
+      callback.complete("");
+    }
+  }
+
+  @Test
+  public void noOpPolicy() throws MuleException {
+    when(policyManager.createOperationPolicy(eq(processor), any(CoreEvent.class), any(OperationParametersProcessor.class)))
+        .thenReturn(NO_POLICY_OPERATION);
+
+    processor.process(testEvent());
+    assertThat(mediator.executed, is(true));
+    assertThat(mediator.executionThread, sameInstance(currentThread()));
+  }
+
+  @Test
+  public void policyChangesThreadBefore() throws MuleException {
+    AtomicReference<Thread> switchedRef = new AtomicReference<>();
+
+    when(policyManager.createOperationPolicy(eq(processor), any(CoreEvent.class), any(OperationParametersProcessor.class)))
+        .thenReturn((operationEvent, operationExecutionFunction, opParamProcessor, componentLocation, callback) -> {
+
+          threadSwitcher.execute(() -> {
+            switchedRef.set(currentThread());
+            operationExecutionFunction.execute(opParamProcessor.getOperationParameters(), operationEvent, callback);
+          });
+
+        });
+
+    processor.process(testEvent());
+
+    probe(() -> {
+      assertThat(mediator.executed, is(true));
+      assertThat(mediator.executionThread, sameInstance(switchedRef.get()));
+      return true;
+    });
+  }
+
+  @Test
+  public void policyChangesThreadAfter() throws MuleException {
+    when(policyManager.createOperationPolicy(eq(processor), any(CoreEvent.class), any(OperationParametersProcessor.class)))
+        .thenReturn((operationEvent, operationExecutionFunction, opParamProcessor, componentLocation, callback) -> {
+          operationExecutionFunction.execute(opParamProcessor.getOperationParameters(), operationEvent, new ExecutorCallback() {
+
+            @Override
+            public void error(Throwable e) {
+              threadSwitcher.execute(() -> {
+                callback.error(e);
+              });
+            }
+
+            @Override
+            public void complete(Object value) {
+              threadSwitcher.execute(() -> {
+                callback.complete(value);
+              });
+            }
+          });
+        });
+
+    processor.process(testEvent());
+
+    probe(() -> {
+      assertThat(mediator.executed, is(true));
+      assertThat(mediator.executionThread, sameInstance(currentThread()));
+      return true;
+    });
+  }
+
+  @Test
+  public void processingStrategyChangesThreadBefore() throws MuleException {
+    AtomicReference<Thread> switchedRef = new AtomicReference<>();
+
+    when(processingStrategy.onProcessor(any(ReactiveProcessor.class)))
+        .thenAnswer(inv -> {
+          return (ReactiveProcessor) t -> Mono.from(t)
+              .publishOn(fromExecutorService(threadSwitcher))
+              .doOnNext(e -> switchedRef.set(currentThread()))
+              .transform(inv.getArgument(0, ReactiveProcessor.class));
+        });
+
+    stopIfNeeded(processor);
+    disposeIfNeeded(processor, LOGGER);
+    initialiseIfNeeded(processor, muleContext);
+    startIfNeeded(processor);
+
+    when(policyManager.createOperationPolicy(eq(processor), any(CoreEvent.class), any(OperationParametersProcessor.class)))
+        .thenReturn((operationEvent, operationExecutionFunction, opParamProcessor, componentLocation, callback) -> {
+          operationExecutionFunction.execute(opParamProcessor.getOperationParameters(), operationEvent, callback);
+        });
+
+    processor.process(testEvent());
+    probe(() -> {
+      assertThat(mediator.executed, is(true));
+      assertThat(mediator.executionThread, sameInstance(switchedRef.get()));
+      return true;
+    });
+  }
+
+  @Test
+  public void processingStrategyChangesThreadAfter() throws MuleException {
+    when(processingStrategy.onProcessor(any(ReactiveProcessor.class)))
+        .thenAnswer(inv -> {
+          return (ReactiveProcessor) t -> Mono.from(t)
+              .transform(inv.getArgument(0, ReactiveProcessor.class))
+              .publishOn(fromExecutorService(threadSwitcher));
+        });
+
+    stopIfNeeded(processor);
+    disposeIfNeeded(processor, LOGGER);
+    initialiseIfNeeded(processor, muleContext);
+    startIfNeeded(processor);
+
+    when(policyManager.createOperationPolicy(eq(processor), any(CoreEvent.class), any(OperationParametersProcessor.class)))
+        .thenReturn((operationEvent, operationExecutionFunction, opParamProcessor, componentLocation, callback) -> {
+          operationExecutionFunction.execute(opParamProcessor.getOperationParameters(), operationEvent, callback);
+        });
+
+    processor.process(testEvent());
+    probe(() -> {
+      assertThat(mediator.executed, is(true));
+      assertThat(mediator.executionThread, sameInstance(currentThread()));
+      return true;
+    });
+  }
+}

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/AbstractOperationMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/AbstractOperationMessageProcessorTestCase.java
@@ -26,11 +26,16 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static org.mule.runtime.api.meta.model.operation.ExecutionType.BLOCKING;
 import static org.mule.runtime.api.meta.model.parameter.ParameterRole.BEHAVIOUR;
 import static org.mule.runtime.api.meta.model.parameter.ParameterRole.CONTENT;
 import static org.mule.runtime.api.util.ExtensionModelTestUtils.visitableMock;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CONNECTION_MANAGER;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STREAMING_MANAGER;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.runtime.core.internal.metadata.cache.MetadataCacheManager.METADATA_CACHE_MANAGER_KEY;
 import static org.mule.tck.MuleTestUtils.stubComponentExecutor;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
@@ -112,15 +117,20 @@ import java.util.Collections;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class AbstractOperationMessageProcessorTestCase extends AbstractMuleContextTestCase {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOperationMessageProcessorTestCase.class);
 
   protected static final String EXTENSION_NAMESPACE = "extension_namespace";
   protected static final String CONFIG_NAME = "config";
@@ -237,6 +247,7 @@ public abstract class AbstractOperationMessageProcessorTestCase extends Abstract
     when(extensionModel.getConfigurationModels()).thenReturn(asList(configurationModel));
     when(operationModel.getName()).thenReturn(getClass().getName());
     when(operationModel.isBlocking()).thenReturn(true);
+    when(operationModel.getExecutionType()).thenReturn(BLOCKING);
     when(extensionModel.getXmlDslModel()).thenReturn(XmlDslModel.builder().setPrefix("test-extension").build());
     when(operationModel.getOutput())
         .thenReturn(new ImmutableOutputModel("Message.Payload", toMetadataType(String.class), false, emptySet()));
@@ -379,6 +390,12 @@ public abstract class AbstractOperationMessageProcessorTestCase extends Abstract
     messageProcessor = setUpOperationMessageProcessor();
   }
 
+  @After
+  public void after() throws MuleException {
+    stopIfNeeded(messageProcessor);
+    disposeIfNeeded(messageProcessor, LOGGER);
+  }
+
   protected CoreEvent configureEvent() throws Exception {
     when(message.getPayload())
         .thenReturn(new TypedValue<>(TEST_PAYLOAD,
@@ -389,11 +406,14 @@ public abstract class AbstractOperationMessageProcessorTestCase extends Abstract
   }
 
   protected OperationMessageProcessor setUpOperationMessageProcessor() throws Exception {
+    after();
     OperationMessageProcessor messageProcessor = createOperationMessageProcessor();
     messageProcessor.setMuleContext(context);
     ((MuleContextWithRegistry) muleContext).getRegistry().registerObject(OBJECT_CONNECTION_MANAGER, connectionManagerAdapter);
-    muleContext.getInjector().inject(messageProcessor);
-    messageProcessor.initialise();
+
+    initialiseIfNeeded(messageProcessor, muleContext);
+    startIfNeeded(messageProcessor);
+
     return messageProcessor;
   }
 
@@ -407,7 +427,6 @@ public abstract class AbstractOperationMessageProcessorTestCase extends Abstract
 
   @Test
   public void start() throws Exception {
-    messageProcessor.start();
     verify((Startable) operationExecutor).start();
   }
 

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ProcessorChainExecutorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ProcessorChainExecutorTestCase.java
@@ -24,20 +24,22 @@ import org.mule.runtime.api.util.concurrent.Latch;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.internal.exception.MessagingException;
+import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.module.extension.api.runtime.privileged.EventedResult;
+import org.mule.runtime.module.extension.internal.runtime.execution.SdkInternalContext;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import reactor.core.publisher.Mono;
 
@@ -57,6 +59,7 @@ public class ProcessorChainExecutorTestCase extends AbstractMuleContextTestCase 
   @Before
   public void setUp() throws Exception {
     this.coreEvent = testEvent();
+    ((InternalEvent) this.coreEvent).setSdkInternalContext(new SdkInternalContext());
     when(chain.getLocation()).thenReturn(null);
     when(chain.apply(any())).thenAnswer(inv -> Mono.<CoreEvent>from(inv.getArgument(0))
         .map(event -> CoreEvent.builder(event)
@@ -69,7 +72,6 @@ public class ProcessorChainExecutorTestCase extends AbstractMuleContextTestCase 
   @Test
   public void testDoProcessSuccessOnce() throws InterruptedException {
     ImmutableProcessorChainExecutor chainExecutor = new ImmutableProcessorChainExecutor(coreEvent, chain);
-
 
     AtomicInteger successCalls = new AtomicInteger(0);
     AtomicInteger errorCalls = new AtomicInteger(0);

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/NestedProcessorValueResolverTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/NestedProcessorValueResolverTestCase.java
@@ -19,8 +19,10 @@ import static org.mockito.Mockito.when;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.route.Chain;
+import org.mule.runtime.module.extension.internal.runtime.execution.SdkInternalContext;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import org.junit.Before;
@@ -30,6 +32,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.reactivestreams.Publisher;
+
 import reactor.core.publisher.Mono;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,6 +47,7 @@ public class NestedProcessorValueResolverTestCase extends AbstractMuleContextTes
   @Before
   public void before() throws Exception {
     final CoreEvent testEvent = testEvent();
+    ((InternalEvent) testEvent).setSdkInternalContext(new SdkInternalContext());
     when(messageProcessor.process(any(CoreEvent.class))).thenReturn(testEvent);
     when(messageProcessor.apply(any(Publisher.class))).thenReturn(Mono.just(testEvent));
   }

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/PlatformManagedConnectionDescriptor.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/PlatformManagedConnectionDescriptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.oauth.api;
+
+import org.mule.api.annotation.Experimental;
+import org.mule.api.annotation.NoExtend;
+
+import java.util.Map;
+
+/**
+ * Describes the configuration of an OAuth connection managed by the Anypoint Platform.
+ * <p>
+ * Platform Managed OAuth is an experimental feature. It will only be enabled on selected environments and scenarios.
+ * Backwards compatibility is not guaranteed.
+ *
+ * @since 4.3.0
+ */
+@NoExtend
+@Experimental
+public interface PlatformManagedConnectionDescriptor {
+
+  /**
+   * @return the connection's unique id in the Anypoint Platform
+   */
+  String getId();
+
+  /**
+   * @return the URI that identifies this connection in the Anypoint Platform
+   */
+  String getUri();
+
+  /**
+   * @return The name that the user has given this connection in the Anypoint Platform
+   */
+  String getName();
+
+  /**
+   * Returns parameters additional to the standard OAuth ones that the user has configured for this connection. These usually
+   * correspond to custom parameters that the service provider accepts or requires on its requests, but may contain other
+   * parameters as well.
+   *
+   * @return A {@link Map} which keys are the parameter names
+   */
+  Map<String, Object> getParameters();
+}

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/PlatformManagedOAuthDancer.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/PlatformManagedOAuthDancer.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Allows to manipulate access and refresh tokens that are obtained and managed by the Anypoint Platform. Each instance is
- * preconfigured by an {@link OAuthPlatformManagedDancerBuilder} to point to a specific connection id.
+ * preconfigured by an {@link OAuthPlatformManagedDancerBuilder} to point to a specific connection URI.
  * <p>
  * Since the authorizations are performed by the platform, this dancer remains agnostic of the grant type that was used to
  * obtain them.
@@ -43,6 +43,12 @@ public interface PlatformManagedOAuthDancer {
    * @return a completable future that is complete when the token has been refreshed.
    */
   CompletableFuture<Void> refreshToken();
+
+  /**
+   * Obtains a {@link PlatformManagedConnectionDescriptor} which describes the connection this dancer accesses
+   * @return a {@link CompletableFuture} which returns a {@link PlatformManagedConnectionDescriptor}
+   */
+  CompletableFuture<PlatformManagedConnectionDescriptor> getConnectionDescriptor();
 
   /**
    * Clears the oauth context.

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/builder/OAuthPlatformManagedDancerBuilder.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/builder/OAuthPlatformManagedDancerBuilder.java
@@ -24,12 +24,12 @@ import org.mule.runtime.oauth.api.listener.PlatformManagedOAuthStateListener;
 public interface OAuthPlatformManagedDancerBuilder extends OAuthDancerBuilder<PlatformManagedOAuthDancer> {
 
   /**
-   * Sets the ID of the connection that is defined in the Anypoint Platform
+   * Sets the URI that identifies the connection that is defined in the Anypoint Platform
    *
-   * @param connectionId the id of the connection which token we want to obtain
+   * @param connectionUri the id of the connection which token we want to obtain
    * @return {@code this} builder
    */
-  OAuthPlatformManagedDancerBuilder connectionId(String connectionId);
+  OAuthPlatformManagedDancerBuilder connectionUri(String connectionUri);
 
   /**
    * Sets the ID of the organization that defined the connection in the Anypoint Platform

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/SpringConfigurationComponentLocator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/SpringConfigurationComponentLocator.java
@@ -11,6 +11,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 import static org.mule.runtime.core.api.util.ClassUtils.memoize;
+
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -79,7 +80,7 @@ public class SpringConfigurationComponentLocator implements ConfigurationCompone
    */
   @Override
   public Optional<Component> find(Location location) {
-    if (isTemplateLocationFunction.apply(location.getGlobalName())) {
+    if (location == null || isTemplateLocationFunction.apply(location.getGlobalName())) {
       return empty();
     }
     return ofNullable(componentsMap.get(location.toString()));

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,9 @@
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <formatterGoal>validate</formatterGoal>
         <oldMuleArtifactVersion>4.2.2</oldMuleArtifactVersion>
+        
+        <surefire.args.base>-Dfile.encoding=UTF-8 -javaagent:${settings.localRepository}/org/aspectj/aspectjweaver/${aspectjVersion}/aspectjweaver-${aspectjVersion}.jar -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile='${session.executionRootDirectory}/target/jacoco.exec'</surefire.args.base>
+        <surefire.args>${surefire.args.base}</surefire.args>
     </properties>
 
     <dependencies>
@@ -1572,7 +1575,7 @@
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
                         <workingDirectory>${project.build.directory}</workingDirectory>
-                        <argLine>-Dfile.encoding=UTF-8 -javaagent:${settings.localRepository}/org/aspectj/aspectjweaver/${aspectjVersion}/aspectjweaver-${aspectjVersion}.jar -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile='${session.executionRootDirectory}/target/jacoco.exec'</argLine>
+                        <argLine>${surefire.args}</argLine>
                         <trimStackTrace>false</trimStackTrace>
                         <excludes>
                             <!-- Surefire should be able to detect that classes are abstract but it seems it isn't -->
@@ -2003,6 +2006,15 @@
             </activation>
             <properties>
                 <vmtype>org.eclipse.jdt.internal.launching.macosx.MacOSXType</vmtype>
+            </properties>
+        </profile>
+        <profile>
+            <id>yourkit-agent</id>
+            <properties>
+                <!-- When using this profile, the location of the YourKit agent has to be provided with a vm argument -->
+                <!-- A typical agent location in OSX is like: -->
+                <!-- -Dyourkit.agent.path=/Applications/YourKit-Java-Profiler-2019.8.app/Contents/Resources/bin/mac/libyjpagent.dylib -->
+                <surefire.args>-agentpath:'${yourkit.agent.path}'=disablestacktelemetry,exceptions=disable,probe_disable=*,listen=all ${surefire.args.base}</surefire.args>
             </properties>
         </profile>
 		<profile>

--- a/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
@@ -37,6 +37,7 @@ import org.mule.runtime.api.util.Reference;
 import org.mule.runtime.extension.api.annotation.Extension;
 import org.mule.test.runner.classification.PatternExclusionsDependencyFilter;
 import org.mule.test.runner.classification.PatternInclusionsDependencyFilter;
+import org.mule.test.runner.utils.TroubleshootingUtils;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -159,6 +160,12 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
   @Override
   public ArtifactsUrlClassification classify(final ClassPathClassifierContext context) {
     checkNotNull(context, "context cannot be null");
+
+    try {
+      TroubleshootingUtils.copyRepoContentsToAuxJenkinsFolder();
+    } catch (IOException e) {
+      logger.debug(e.getMessage());
+    }
 
     logger.info("Running dependencies classification on: '{}' in order to build Mule class loaders", context.getRootArtifact());
 

--- a/tests/runner/src/main/java/org/mule/test/runner/api/DependencyResolver.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/DependencyResolver.java
@@ -8,6 +8,7 @@
 package org.mule.test.runner.api;
 
 import static com.google.common.base.Joiner.on;
+import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.aether.util.artifact.ArtifactIdUtils.toId;
@@ -17,9 +18,11 @@ import org.mule.maven.client.internal.AetherRepositoryState;
 import org.mule.maven.client.internal.AetherResolutionContext;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.eclipse.aether.RepositorySystem;
@@ -101,7 +104,7 @@ public class DependencyResolver {
     checkNotNull(artifact, "artifact cannot be null");
 
     final ArtifactDescriptorRequest request =
-        new ArtifactDescriptorRequest(artifact, resolutionContext.getRemoteRepositories(), null);
+        new ArtifactDescriptorRequest(artifact, resolveRepositories(), null);
     return repositoryState.getSystem().readArtifactDescriptor(repositoryState.getSession(), request);
   }
 
@@ -118,14 +121,7 @@ public class DependencyResolver {
     checkNotNull(artifact, "artifact cannot be null");
 
     final ArtifactDescriptorRequest request =
-        new ArtifactDescriptorRequest(artifact, resolutionContext.getRemoteRepositories(), null);
-    // Has to set authentication to these remote repositories as they may come from a pom descriptor
-    remoteRepositories.forEach(remoteRepository -> {
-      RemoteRepository authenticatedRemoteRepository = setAuthentication(remoteRepository);
-      if (!request.getRepositories().contains(authenticatedRemoteRepository)) {
-        request.addRepository(authenticatedRemoteRepository);
-      }
-    });
+        new ArtifactDescriptorRequest(artifact, resolveRepositories(remoteRepositories), null);
 
     return repositoryState.getSystem().readArtifactDescriptor(repositoryState.getSession(), request);
   }
@@ -140,7 +136,7 @@ public class DependencyResolver {
   public ArtifactResult resolveArtifact(Artifact artifact) throws ArtifactResolutionException {
     checkNotNull(artifact, "artifact cannot be null");
 
-    final ArtifactRequest request = new ArtifactRequest(artifact, resolutionContext.getRemoteRepositories(), null);
+    final ArtifactRequest request = new ArtifactRequest(artifact, resolveRepositories(), null);
     return repositoryState.getSystem().resolveArtifact(repositoryState.getSession(), request);
   }
 
@@ -156,14 +152,7 @@ public class DependencyResolver {
       throws ArtifactResolutionException {
     checkNotNull(artifact, "artifact cannot be null");
 
-    final ArtifactRequest request = new ArtifactRequest(artifact, resolutionContext.getRemoteRepositories(), null);
-    // Has to set authentication to these remote repositories as they may come from a pom descriptor
-    remoteRepositories.forEach(remoteRepository -> {
-      RemoteRepository authenticatedRemoteRepository = setAuthentication(remoteRepository);
-      if (!request.getRepositories().contains(authenticatedRemoteRepository)) {
-        request.addRepository(authenticatedRemoteRepository);
-      }
-    });
+    final ArtifactRequest request = new ArtifactRequest(artifact, resolveRepositories(remoteRepositories), null);
     return repositoryState.getSystem().resolveArtifact(repositoryState.getSession(), request);
   }
 
@@ -223,14 +212,7 @@ public class DependencyResolver {
     collectRequest.setRoot(root);
     collectRequest.setDependencies(directDependencies);
     collectRequest.setManagedDependencies(managedDependencies);
-    collectRequest.setRepositories(resolutionContext.getRemoteRepositories());
-    // Has to set authentication to these remote repositories as they may come from a pom descriptor
-    remoteRepositories.forEach(remoteRepository -> {
-      RemoteRepository authenticatedRemoteRepository = setAuthentication(remoteRepository);
-      if (!collectRequest.getRepositories().contains(authenticatedRemoteRepository)) {
-        collectRequest.addRepository(authenticatedRemoteRepository);
-      }
-    });
+    collectRequest.setRepositories(resolveRepositories(remoteRepositories));
 
     DependencyNode node;
     try {
@@ -275,11 +257,16 @@ public class DependencyResolver {
     return collectRequest.getRoot() + " -> " + collectRequest.getDependencies() + " < " + stringBuilder.toString();
   }
 
-  private RemoteRepository setAuthentication(RemoteRepository remoteRepository) {
-    RemoteRepository.Builder authenticated = new RemoteRepository.Builder(remoteRepository);
-    this.resolutionContext.getAuthenticatorSelector()
-        .ifPresent(authSelector -> authenticated.setAuthentication(authSelector.getAuthentication(remoteRepository)));
-    return authenticated.build();
+  private List<RemoteRepository> resolveRepositories() {
+    return resolveRepositories(emptyList());
+  }
+
+  private List<RemoteRepository> resolveRepositories(List<RemoteRepository> remoteRepositories) {
+    return repositoryState.getSystem().newResolutionRepositories(repositoryState.getSession(),
+                                                                 Stream
+                                                                     .of(remoteRepositories,
+                                                                         resolutionContext.getRemoteRepositories())
+                                                                     .flatMap(Collection::stream).collect(toList()));
   }
 
   private void logDependencyGraph(DependencyNode node, Object request) {

--- a/tests/test-extensions/reconnection-ext/src/main/java/org/mule/extension/test/extension/reconnection/ReconectionSource.java
+++ b/tests/test-extensions/reconnection-ext/src/main/java/org/mule/extension/test/extension/reconnection/ReconectionSource.java
@@ -6,6 +6,8 @@
  */
 package org.mule.extension.test.extension.reconnection;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.connection.ConnectionProvider;
 import org.mule.runtime.api.exception.MuleException;
@@ -16,6 +18,9 @@ import org.mule.runtime.extension.api.annotation.param.MediaType;
 import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.runtime.source.Source;
 import org.mule.runtime.extension.api.runtime.source.SourceCallback;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Inject;
 
@@ -28,34 +33,29 @@ public class ReconectionSource extends Source<ReconnectableConnection, Void> {
   @Inject
   SchedulerService schedulerService;
 
+  private final AtomicReference<ScheduledFuture<?>> scheduleWithFixedDelay = new AtomicReference<>();
+
   private Scheduler scheduler;
 
   @Override
   public void onStart(SourceCallback<ReconnectableConnection, Void> sourceCallback) throws MuleException {
-    ReconnectableConnection connection;
-    connection = connectionProvider.connect();
+    ReconnectableConnection connection = connectionProvider.connect();
     scheduler = schedulerService.ioScheduler();
-    scheduler.execute(() -> {
-      boolean shouldFinish = false;
-      while (!shouldFinish) {
-        try {
-          Thread.sleep(1000);
-        } catch (InterruptedException e) {
-          shouldFinish = true;
-        }
-        if (ReconnectableConnectionProvider.fail) {
-          sourceCallback.onConnectionException(new ConnectionException(new RuntimeException(), connection));
-          shouldFinish = true;
-        } else {
-          sourceCallback.handle(Result.<ReconnectableConnection, Void>builder().output(connection).build());
-        }
+    scheduleWithFixedDelay.set(scheduler.scheduleWithFixedDelay(() -> {
+      if (ReconnectableConnectionProvider.fail) {
+        sourceCallback.onConnectionException(new ConnectionException(new RuntimeException(), connection));
+        scheduleWithFixedDelay.get().cancel(true);
+      } else {
+        sourceCallback.handle(Result.<ReconnectableConnection, Void>builder().output(connection).build());
       }
-    });
+    }, 0, 1000, MILLISECONDS));
+
   }
 
   @Override
   public void onStop() {
     if (scheduler != null) {
+      scheduleWithFixedDelay.get().cancel(true);
       scheduler.stop();
     }
   }

--- a/tests/test-extensions/reconnection-ext/src/main/java/org/mule/extension/test/extension/reconnection/ReconnectableConnection.java
+++ b/tests/test-extensions/reconnection-ext/src/main/java/org/mule/extension/test/extension/reconnection/ReconnectableConnection.java
@@ -21,4 +21,9 @@ public final class ReconnectableConnection {
   public int getReconnectionAttempts() {
     return reconnectionAttempts;
   }
+
+  @Override
+  public String toString() {
+    return "ReconnectableConnection: " + reconnectionAttempts;
+  }
 }

--- a/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportLifecycleSchedulerDecorator.java
+++ b/tests/unit/src/main/java/org/mule/tck/SimpleUnitTestSupportLifecycleSchedulerDecorator.java
@@ -195,13 +195,13 @@ public class SimpleUnitTestSupportLifecycleSchedulerDecorator implements Schedul
   }
 
   protected void cancelStillActiveTasks() {
-    List<ScheduledFuture> stillaCtiveRecurrentTasks = recurrentTasks.stream()
+    List<ScheduledFuture> stillActiveRecurrentTasks = recurrentTasks.stream()
         .filter(recurrentTask -> !(recurrentTask.isDone() || recurrentTask.isCancelled())).collect(toList());
-    if (!stillaCtiveRecurrentTasks.isEmpty()) {
+    if (!stillActiveRecurrentTasks.isEmpty()) {
       LOGGER.warn("Scheduler '" + name + "' stopped while it still has active recurrent tasks:"
-          + stillaCtiveRecurrentTasks.toString());
+          + stillActiveRecurrentTasks.toString());
     }
-    stillaCtiveRecurrentTasks.forEach(recurrentTask -> recurrentTask.cancel(true));
+    stillActiveRecurrentTasks.forEach(recurrentTask -> recurrentTask.cancel(true));
   }
 
   @Override


### PR DESCRIPTION
Error handling resolves the MessagingExceptions by looking for the root cause (first Mule exception in the cause tree) and getting its ErrorType, unless the MessagingException event has an ErrorType defined. This fix involves the creation of a new CoreEvent that represents the retry exhausted error and has its Error set to MULE:RETRY_EXHAUSTED.