### PR TITLE
MULE-17894: RETRY_EXHAUSTED ErrorType gets replaced by the ErrorType that caused the exhaustion

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
@@ -6,19 +6,34 @@
  */
 package org.mule.runtime.core.api.retry.policy;
 
+import org.mule.runtime.api.exception.ComposedErrorException;
+import org.mule.runtime.api.exception.ErrorMessageAwareException;
+import org.mule.runtime.api.message.Error;
+import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.lifecycle.FatalException;
 import org.mule.runtime.api.i18n.I18nMessage;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This exception is thrown when a Retry policy has made all the retry attempts it wants to make and is still failing.
  */
-public final class RetryPolicyExhaustedException extends FatalException {
+public final class RetryPolicyExhaustedException extends FatalException
+    implements ComposedErrorException {
 
   /** Serial version */
   private static final long serialVersionUID = 3300563235465630595L;
 
+  private final List<Error> errors = new ArrayList<>();
+
   public RetryPolicyExhaustedException(I18nMessage message, Object component) {
     super(message, component);
+  }
+
+  public RetryPolicyExhaustedException(I18nMessage message, Object component, List<Error> errors) {
+    super(message, component);
+    this.errors.addAll(errors);
   }
 
   public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component) {
@@ -27,5 +42,10 @@ public final class RetryPolicyExhaustedException extends FatalException {
 
   public RetryPolicyExhaustedException(Throwable cause, Object component) {
     super(cause, component);
+  }
+
+  @Override
+  public List<Error> getErrors() {
+    return errors;
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
+++ b/core/src/main/java/org/mule/runtime/core/api/retry/policy/RetryPolicyExhaustedException.java
@@ -6,34 +6,19 @@
  */
 package org.mule.runtime.core.api.retry.policy;
 
-import org.mule.runtime.api.exception.ComposedErrorException;
-import org.mule.runtime.api.exception.ErrorMessageAwareException;
-import org.mule.runtime.api.message.Error;
-import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.lifecycle.FatalException;
 import org.mule.runtime.api.i18n.I18nMessage;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This exception is thrown when a Retry policy has made all the retry attempts it wants to make and is still failing.
  */
-public final class RetryPolicyExhaustedException extends FatalException
-    implements ComposedErrorException {
+public final class RetryPolicyExhaustedException extends FatalException {
 
   /** Serial version */
   private static final long serialVersionUID = 3300563235465630595L;
 
-  private final List<Error> errors = new ArrayList<>();
-
   public RetryPolicyExhaustedException(I18nMessage message, Object component) {
     super(message, component);
-  }
-
-  public RetryPolicyExhaustedException(I18nMessage message, Object component, List<Error> errors) {
-    super(message, component);
-    this.errors.addAll(errors);
   }
 
   public RetryPolicyExhaustedException(I18nMessage message, Throwable cause, Object component) {
@@ -42,10 +27,5 @@ public final class RetryPolicyExhaustedException extends FatalException
 
   public RetryPolicyExhaustedException(Throwable cause, Object component) {
     super(cause, component);
-  }
-
-  @Override
-  public List<Error> getErrors() {
-    return errors;
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessful.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessful.java
@@ -21,6 +21,7 @@ import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
 import org.mule.runtime.core.api.processor.AbstractMuleObjectOwner;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.internal.routing.UntilSuccessfulRouter.RetryContextInitializationException;
+import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.processor.Scope;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
@@ -45,6 +46,9 @@ public class UntilSuccessful extends AbstractMuleObjectOwner implements Scope {
 
   @Inject
   private ExtendedExpressionManager expressionManager;
+
+  @Inject
+  private ErrorTypeLocator errorTypeLocator;
 
   private String maxRetries = DEFAULT_RETRIES;
   private String millisBetweenRetries = DEFAULT_MILLIS_BETWEEN_RETRIES;
@@ -94,7 +98,7 @@ public class UntilSuccessful extends AbstractMuleObjectOwner implements Scope {
   @Override
   public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
     return new UntilSuccessfulRouter(this, publisher, nestedChain, expressionManager, shouldRetry, timer, maxRetries,
-                                     millisBetweenRetries).getDownstreamPublisher();
+                                     millisBetweenRetries, errorTypeLocator).getDownstreamPublisher();
   }
 
 

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -89,7 +89,7 @@ class UntilSuccessfulRouter {
   private Function<ExpressionManagerSession, Integer> delaySupplier;
   private Function<CoreEvent, ExpressionManagerSession> sessionSupplier;
 
-  private ErrorType retryExhaustedErrorType;
+  private final ErrorType retryExhaustedErrorType;
 
   // When using an until successful scope in a blocking flow (for example, calling the owner flow with a Processor#process call),
   // this leads to a reactor completion signal being emitted while the event is being re-injected for retrials. This is solved by


### PR DESCRIPTION
Error handling resolves the MessagingExceptions by looking for the root cause (first Mule exception in the cause tree) and getting its ErrorType, unless the MessagingException event has an ErrorType defined. This fix involves the creation of a new CoreEvent that represents the retry exhausted error and has its Error set to MULE:RETRY_EXHAUSTED.