### PR TITLE
MULE-17993: Response callback not called when source policy fails with

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/policy/NoSourcePolicyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/policy/NoSourcePolicyTestCase.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.internal.execution.SourcePolicyTestUtils.block;
@@ -31,7 +32,6 @@ import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import java.util.Map;
 
-import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -115,12 +115,14 @@ public class NoSourcePolicyTestCase extends AbstractMuleTestCase {
     Either<SourcePolicyFailureResult, SourcePolicySuccessResult> result =
         block(callback -> noSourcePolicy.process(initialEvent, respParametersProcessor, callback));
 
+    verify(initialEvent.getContext()).error(result.getLeft().getMessagingException());
+
     assertThat(result.getRight(), nullValue());
-    assertThat(result.getLeft().getMessagingException().getEvent().getMessage(), Is.is(initialEvent.getMessage()));
-    assertThat(result.getLeft().getMessagingException().getEvent().getContext(), Is.is(initialEvent.getContext()));
+    assertThat(result.getLeft().getMessagingException().getEvent().getMessage(), is(initialEvent.getMessage()));
+    assertThat(result.getLeft().getMessagingException().getEvent().getContext(), is(initialEvent.getContext()));
     assertThat(result.getLeft().getMessagingException().getEvent().getSecurityContext(),
-               Is.is(initialEvent.getSecurityContext()));
-    assertThat(result.getLeft().getMessagingException().getEvent().getError(), not(Is.is(empty())));
+               is(initialEvent.getSecurityContext()));
+    assertThat(result.getLeft().getMessagingException().getEvent().getError(), not(is(empty())));
     assertThat(result.getLeft().getErrorResponseParameters().get(), is(errorParameters));
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/CommonSourcePolicy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/CommonSourcePolicy.java
@@ -79,6 +79,8 @@ class CommonSourcePolicy {
             ? (() -> sourcePolicyParametersTransformer.get().fromMessageToErrorResponseParameters(sourceEvent.getMessage()))
             : (() -> respParamProcessor.getFailedExecutionResponseParametersFunction().apply(sourceEvent));
 
+        ((BaseEventContext) sourceEvent.getContext()).error(me);
+
         SourcePolicyFailureResult result = new SourcePolicyFailureResult(me, errorParameters);
         callback.complete(left(result));
       }


### PR DESCRIPTION
`Source policy already disposed`