### PR TITLE
MULE-18064: Subscription context not propagated to error handlers

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
@@ -40,7 +40,7 @@ public abstract class AbstractErrorHandlerTestCase extends AbstractMuleContextTe
     this.verbose = verbose;
   }
 
-  @Parameters
+  @Parameters(name = "{0}")
   public static Collection<Object> data() {
     return asList(new VerboseExceptions(true),
                   new VerboseExceptions(false));

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandlerTestCase.java
@@ -252,6 +252,7 @@ public class OnErrorPropagateHandlerTestCase extends AbstractErrorHandlerTestCas
     router.accept(mockException);
 
     assertThat(thownRef.get().getCause(), not(instanceOf(AssertionError.class)));
+    assertThat(thownRef.get(), sameInstance(mockException));
   }
 
   private Processor createChagingEventMessageProcessor(final CoreEvent lastEventCreated) {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/execution/FlowProcessMediatorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/execution/FlowProcessMediatorTestCase.java
@@ -157,7 +157,7 @@ public class FlowProcessMediatorTestCase extends AbstractMuleContextTestCase {
       return null;
     })
         .when(flowErrorHandlerRouter).accept(any(Exception.class));
-    when(exceptionHandler.router(any(Consumer.class), propagateConsumerCaptor.capture()))
+    when(exceptionHandler.router(any(Function.class), any(Consumer.class), propagateConsumerCaptor.capture()))
         .thenReturn(flowErrorHandlerRouter);
 
     when(((AbstractFlowConstruct) flow).getExceptionListener()).thenReturn(exceptionHandler);

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorTestCase.java
@@ -25,8 +25,8 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNee
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
 import static org.mule.tck.MuleTestUtils.createAndRegisterFlow;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 import static org.mule.tck.util.MuleContextUtils.getNotificationDispatcher;
-import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.util.concurrent.Latch;
@@ -151,7 +151,7 @@ public class AsyncDelegateMessageProcessorTestCase extends AbstractReactiveProce
   }
 
   @Test
-  @Ignore("Does this case actually make sense?")
+  @Ignore("Does this case actually make sense? Async has to run in an independent context, so propagation from the parent is not a wanted thing.")
   public void subscriberContextPropagation() throws Exception {
     final ContextPropagationChecker contextPropagationChecker = new ContextPropagationChecker();
 
@@ -160,12 +160,7 @@ public class AsyncDelegateMessageProcessorTestCase extends AbstractReactiveProce
     initialiseIfNeeded(async, true, muleContext);
     async.start();
 
-    final CoreEvent result = just(testEvent())
-        .transform(async)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(testEvent(), async, contextPropagationChecker);
     asyncEntryLatch.countDown();
     assertThat(latch.await(LOCK_TIMEOUT, MILLISECONDS), is(true));
   }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
@@ -12,8 +12,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mule.functional.junit4.matchers.ThrowableMessageMatcher.hasMessage;
@@ -22,9 +20,9 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.management.stats.RouterStatistics.TYPE_OUTBOUND;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
-import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
@@ -157,12 +155,7 @@ public class ChoiceRouterTestCase extends AbstractReactiveProcessorTestCase {
     choiceRouter.addRoute(payloadZapExpression(), mp);
     initialise();
 
-    final CoreEvent result = just(zapEvent())
-        .transform(choiceRouter)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(zapEvent(), choiceRouter, contextPropagationChecker);
   }
 
   @Test
@@ -174,12 +167,7 @@ public class ChoiceRouterTestCase extends AbstractReactiveProcessorTestCase {
     choiceRouter.setDefaultRoute(mp);
     initialise();
 
-    final CoreEvent result = just(fooEvent())
-        .transform(choiceRouter)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(fooEvent(), choiceRouter, contextPropagationChecker);
   }
 
   private void initialise() throws InitialisationException {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/FirstSuccessfulTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/FirstSuccessfulTestCase.java
@@ -7,8 +7,9 @@
 package org.mule.runtime.core.internal.routing;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Mockito.mock;
@@ -16,9 +17,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.tck.MuleTestUtils.createErrorMock;
+import static reactor.core.publisher.Flux.just;
 
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
@@ -32,10 +32,12 @@ import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.runtime.core.privileged.event.DefaultMuleSession;
 import org.mule.runtime.core.privileged.event.MuleSession;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
-import org.mule.runtime.core.privileged.routing.CouldNotRouteOutboundMessageException;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.processor.ContextPropagationChecker;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class FirstSuccessfulTestCase extends AbstractMuleContextTestCase {
 
@@ -73,6 +75,20 @@ public class FirstSuccessfulTestCase extends AbstractMuleContextTestCase {
     fs.initialise();
     expectedException.expect(NullPointerException.class);
     fs.process(testEvent());
+  }
+
+  @Test
+  public void subscriberContextPropagation() throws Exception {
+    final ContextPropagationChecker contextPropagationChecker = new ContextPropagationChecker();
+
+    FirstSuccessful fs = createFirstSuccessfulRouter(contextPropagationChecker);
+
+    final CoreEvent result = just(testEvent())
+        .transform(fs)
+        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
+        .blockFirst();
+
+    assertThat(result, not(nullValue()));
   }
 
   private FirstSuccessful createFirstSuccessfulRouter(Processor... processors) throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/FirstSuccessfulTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/FirstSuccessfulTestCase.java
@@ -8,8 +8,6 @@ package org.mule.runtime.core.internal.routing;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Mockito.mock;
@@ -17,7 +15,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.tck.MuleTestUtils.createErrorMock;
-import static reactor.core.publisher.Flux.just;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.exception.DefaultMuleException;
@@ -83,12 +81,7 @@ public class FirstSuccessfulTestCase extends AbstractMuleContextTestCase {
 
     FirstSuccessful fs = createFirstSuccessfulRouter(contextPropagationChecker);
 
-    final CoreEvent result = just(testEvent())
-        .transform(fs)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(testEvent(), fs, contextPropagationChecker);
   }
 
   private FirstSuccessful createFirstSuccessfulRouter(Processor... processors) throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ForeachTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ForeachTestCase.java
@@ -16,8 +16,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -30,11 +28,11 @@ import static org.mule.runtime.core.internal.routing.Foreach.DEFAULT_COUNTER_VAR
 import static org.mule.runtime.core.internal.routing.Foreach.DEFAULT_ROOT_MESSAGE_VARIABLE;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.junit4.matcher.DataTypeCompatibilityMatcher.assignableTo;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ForeachStory.FOR_EACH;
 import static org.slf4j.LoggerFactory.getLogger;
-import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.ItemSequenceInfo;
@@ -482,12 +480,8 @@ public class ForeachTestCase extends AbstractReactiveProcessorTestCase {
 
     simpleForeach = createForeach(singletonList(contextPropagationChecker));
 
-    final CoreEvent result = just(eventBuilder(muleContext).message(of(asList("1", "2", "3"))).build())
-        .transform(simpleForeach)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(eventBuilder(muleContext).message(of(asList("1", "2", "3"))).build(), simpleForeach,
+                             contextPropagationChecker);
   }
 
   private CoreEvent processInChain(Processor processor, CoreEvent event) throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
@@ -15,8 +15,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,11 +26,11 @@ import static org.mule.runtime.api.component.location.ConfigurationComponentLoca
 import static org.mule.runtime.api.metadata.DataType.MULE_MESSAGE_LIST;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ParallelForEachStory.PARALLEL_FOR_EACH;
 import static reactor.core.publisher.Flux.from;
-import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.event.Event;
@@ -237,12 +235,8 @@ public class ParallelForEachTestCase extends AbstractMuleContextTestCase {
     router.setAnnotations(getAppleFlowComponentLocationAnnotations());
     router.initialise();
 
-    final CoreEvent result = just(eventBuilder(muleContext).message(Message.of(asList("1", "2", "3"))).build())
-        .transform(router)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(eventBuilder(muleContext).message(Message.of(asList("1", "2", "3"))).build(), router,
+                             contextPropagationChecker);
   }
 
   private CoreEvent createListEvent() throws MuleException {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/RoundRobinTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/RoundRobinTestCase.java
@@ -11,6 +11,8 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -25,6 +27,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
+import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
@@ -39,6 +42,7 @@ import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.event.DefaultMuleSession;
 import org.mule.runtime.core.privileged.event.MuleSession;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.processor.ContextPropagationChecker;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -128,6 +132,26 @@ public class RoundRobinTestCase extends AbstractMuleContextTestCase {
 
     assertThat(route2.getCount(), is(0));
     assertThat(route1.getCount(), is(1));
+  }
+
+  @Test
+  public void subscriberContextPropagation() throws MuleException {
+    final ContextPropagationChecker contextPropagationChecker = new ContextPropagationChecker();
+
+    roundRobin.setAnnotations(getAppleFlowComponentLocationAnnotations());
+    List<Processor> routes = new ArrayList<>(1);
+    routes.add(contextPropagationChecker);
+    routes.forEach(r -> roundRobin.addRoute(r));
+
+    initialiseIfNeeded(roundRobin, muleContext);
+    startIfNeeded(roundRobin);
+
+    final CoreEvent result = just(testEvent())
+        .transform(roundRobin)
+        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
+        .blockFirst();
+
+    assertThat(result, not(nullValue()));
   }
 
   class TestDriver implements Runnable {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/RoundRobinTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/RoundRobinTestCase.java
@@ -11,8 +11,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -25,9 +23,9 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNee
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.tck.MuleTestUtils.getTestFlow;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
-import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
@@ -146,12 +144,7 @@ public class RoundRobinTestCase extends AbstractMuleContextTestCase {
     initialiseIfNeeded(roundRobin, muleContext);
     startIfNeeded(roundRobin);
 
-    final CoreEvent result = just(testEvent())
-        .transform(roundRobin)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(testEvent(), roundRobin, contextPropagationChecker);
   }
 
   class TestDriver implements Runnable {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ScatterGatherRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ScatterGatherRouterTestCase.java
@@ -16,6 +16,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,6 +34,7 @@ import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ScatterGatherStory.SCATTER_GATHER;
 import static reactor.core.publisher.Flux.from;
+import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.component.ConfigurationProperties;
 import org.mule.runtime.api.component.location.Location;
@@ -49,20 +52,21 @@ import org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair;
 import org.mule.runtime.core.internal.routing.forkjoin.CollectMapForkJoinStrategyFactory;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.processor.ContextPropagationChecker;
 
 import java.io.StringBufferInputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import io.qameta.allure.Description;
-import io.qameta.allure.Feature;
-import io.qameta.allure.Story;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
 
 @Feature(ROUTERS)
 @Story(SCATTER_GATHER)
@@ -71,14 +75,14 @@ public class ScatterGatherRouterTestCase extends AbstractMuleContextTestCase {
   @Rule
   public ExpectedException expectedException = none();
 
-  private ScatterGatherRouter router = new ScatterGatherRouter();
-  private ForkJoinStrategyFactory mockForkJoinStrategyFactory = mock(ForkJoinStrategyFactory.class);
-  private ConfigurationProperties configurationProperties = mock(ConfigurationProperties.class);
+  private final ScatterGatherRouter router = new ScatterGatherRouter();
+  private final ForkJoinStrategyFactory mockForkJoinStrategyFactory = mock(ForkJoinStrategyFactory.class);
+  private final ConfigurationProperties configurationProperties = mock(ConfigurationProperties.class);
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
     when(componentLocator.find(Location.builder().globalName(APPLE_FLOW).build())).thenReturn(of(mock(Flow.class)));
-    when(configurationProperties.resolveBooleanProperty(MULE_LAZY_INIT_DEPLOYMENT_PROPERTY)).thenReturn(Optional.of(false));
+    when(configurationProperties.resolveBooleanProperty(MULE_LAZY_INIT_DEPLOYMENT_PROPERTY)).thenReturn(of(false));
 
     Map<String, Object> registryObjects = new HashMap<>();
     registryObjects.put(REGISTRY_KEY, componentLocator);
@@ -235,4 +239,22 @@ public class ScatterGatherRouterTestCase extends AbstractMuleContextTestCase {
     assertThat(router.isDelayErrors(), equalTo(true));
   }
 
+  @Test
+  public void subscriberContextPropagation() throws MuleException {
+    final ContextPropagationChecker contextPropagationCheckerA = new ContextPropagationChecker();
+    final ContextPropagationChecker contextPropagationCheckerB = new ContextPropagationChecker();
+
+    muleContext.getInjector().inject(router);
+    router.setRoutes(asList(newChain(empty(), contextPropagationCheckerA),
+                            newChain(empty(), contextPropagationCheckerB)));
+    router.setAnnotations(getAppleFlowComponentLocationAnnotations());
+    router.initialise();
+
+    final CoreEvent result = just(testEvent())
+        .transform(router)
+        .subscriberContext(contextPropagationCheckerA.contextPropagationFlag())
+        .blockFirst();
+
+    assertThat(result, not(nullValue()));
+  }
 }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ScatterGatherRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ScatterGatherRouterTestCase.java
@@ -16,8 +16,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,10 +29,10 @@ import static org.mule.runtime.core.api.config.MuleDeploymentProperties.MULE_LAZ
 import static org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair.of;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ScatterGatherStory.SCATTER_GATHER;
 import static reactor.core.publisher.Flux.from;
-import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.component.ConfigurationProperties;
 import org.mule.runtime.api.component.location.Location;
@@ -250,11 +248,7 @@ public class ScatterGatherRouterTestCase extends AbstractMuleContextTestCase {
     router.setAnnotations(getAppleFlowComponentLocationAnnotations());
     router.initialise();
 
-    final CoreEvent result = just(testEvent())
-        .transform(router)
-        .subscriberContext(contextPropagationCheckerA.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(testEvent(), router, contextPropagationCheckerA);
+    assertContextPropagation(testEvent(), router, contextPropagationCheckerB);
   }
 }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
@@ -13,10 +13,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -28,6 +28,7 @@ import static org.mule.runtime.core.api.transaction.TransactionCoordination.getI
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
 import static org.mule.tck.MuleTestUtils.createAndRegisterFlow;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.construct.Flow;
@@ -42,6 +43,7 @@ import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.privileged.processor.InternalProcessor;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.processor.ContextPropagationChecker;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
@@ -344,6 +346,29 @@ public class UntilSuccessfulTestCase extends AbstractMuleContextTestCase {
     untilSuccessful.start();
 
     assertNoRetryContextAfterScopeExecutions(4);
+  }
+
+  @Test
+  public void subscriberContextPropagation() throws MuleException {
+    final ContextPropagationChecker contextPropagationChecker = new ContextPropagationChecker();
+
+    untilSuccessful = new UntilSuccessful();
+    // untilSuccessful.setMaxRetries("1");
+    untilSuccessful.setAnnotations(getAppleFlowComponentLocationAnnotations());
+    //
+    // targetMessageProcessor = new ConfigurableMessageProcessor();
+    untilSuccessful.setMessageProcessors(singletonList(contextPropagationChecker));
+    muleContext.getInjector().inject(untilSuccessful);
+
+    untilSuccessful.initialise();
+    untilSuccessful.start();
+
+    final CoreEvent result = just(eventBuilder(muleContext).message(of("1")).build())
+        .transform(untilSuccessful)
+        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
+        .blockFirst();
+
+    assertThat(result, not(nullValue()));
   }
 
   protected void assertNoRetryContextAfterScopeExecutions(int expectedExecutions) throws MuleException {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
@@ -353,10 +353,7 @@ public class UntilSuccessfulTestCase extends AbstractMuleContextTestCase {
     final ContextPropagationChecker contextPropagationChecker = new ContextPropagationChecker();
 
     untilSuccessful = new UntilSuccessful();
-    // untilSuccessful.setMaxRetries("1");
     untilSuccessful.setAnnotations(getAppleFlowComponentLocationAnnotations());
-    //
-    // targetMessageProcessor = new ConfigurableMessageProcessor();
     untilSuccessful.setMessageProcessors(singletonList(contextPropagationChecker));
     muleContext.getInjector().inject(untilSuccessful);
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/UntilSuccessfulTestCase.java
@@ -27,8 +27,8 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.transaction.TransactionCoordination.getInstance;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
 import static org.mule.tck.MuleTestUtils.createAndRegisterFlow;
+import static org.mule.tck.processor.ContextPropagationChecker.assertContextPropagation;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
-import static reactor.core.publisher.Flux.just;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.construct.Flow;
@@ -360,12 +360,7 @@ public class UntilSuccessfulTestCase extends AbstractMuleContextTestCase {
     untilSuccessful.initialise();
     untilSuccessful.start();
 
-    final CoreEvent result = just(eventBuilder(muleContext).message(of("1")).build())
-        .transform(untilSuccessful)
-        .subscriberContext(contextPropagationChecker.contextPropagationFlag())
-        .blockFirst();
-
-    assertThat(result, not(nullValue()));
+    assertContextPropagation(eventBuilder(muleContext).message(of("1")).build(), untilSuccessful, contextPropagationChecker);
   }
 
   protected void assertNoRetryContextAfterScopeExecutions(int expectedExecutions) throws MuleException {

--- a/core/src/main/java/org/mule/runtime/core/api/exception/BaseExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/BaseExceptionHandler.java
@@ -41,12 +41,16 @@ public abstract class BaseExceptionHandler implements FlowExceptionHandler {
   protected abstract void onError(Exception exception);
 
   @Override
-  public void routeError(Exception error, Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Routing error in '" + this.toString() + "'...");
-    }
+  public Consumer<Exception> router(Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
+    final Consumer<Exception> router = FlowExceptionHandler.super.router(continueCallback, propagateCallback);
+    return error -> {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Routing error in '" + this.toString() + "'...");
+      }
 
-    onError(error);
-    FlowExceptionHandler.super.routeError(error, continueCallback, propagateCallback);
+      onError(error);
+      router.accept(error);
+    };
   }
+
 }

--- a/core/src/main/java/org/mule/runtime/core/api/exception/BaseExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/BaseExceptionHandler.java
@@ -11,6 +11,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import org.mule.runtime.core.api.event.CoreEvent;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -41,8 +42,10 @@ public abstract class BaseExceptionHandler implements FlowExceptionHandler {
   protected abstract void onError(Exception exception);
 
   @Override
-  public Consumer<Exception> router(Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
-    final Consumer<Exception> router = FlowExceptionHandler.super.router(continueCallback, propagateCallback);
+  public Consumer<Exception> router(Function<Publisher<CoreEvent>, Publisher<CoreEvent>> publisherPostProcessor,
+                                    Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
+    final Consumer<Exception> router =
+        FlowExceptionHandler.super.router(publisherPostProcessor, continueCallback, propagateCallback);
     return error -> {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Routing error in '" + this.toString() + "'...");

--- a/core/src/main/java/org/mule/runtime/core/api/exception/DisjunctiveErrorTypeMatcher.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/DisjunctiveErrorTypeMatcher.java
@@ -9,13 +9,14 @@ package org.mule.runtime.core.api.exception;
 import org.mule.runtime.api.message.ErrorType;
 
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class DisjunctiveErrorTypeMatcher implements ErrorTypeMatcher {
 
   List<ErrorTypeMatcher> errorTypeMatchers;
 
   public DisjunctiveErrorTypeMatcher(List<ErrorTypeMatcher> errorTypeMatchers) {
-    this.errorTypeMatchers = errorTypeMatchers;
+    this.errorTypeMatchers = new CopyOnWriteArrayList<>(errorTypeMatchers);
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
@@ -74,5 +74,20 @@ public interface FlowExceptionHandler extends Function<Exception, Publisher<Core
                           Consumer<Throwable> propagateCallback) {
     propagateCallback.accept(error);
   }
+
+  /**
+   * Provides a router for an error towards the destination error handler, calling the corresponding callback in case of failure
+   * or success.
+   *
+   * @param continueCallback the callback called in case the error is successfully handled
+   * @param propagateCallback the callback is called in case the error-handling fails
+   * @return the router for an error.
+   *
+   * @since 4.3
+   */
+  default Consumer<Exception> router(Consumer<CoreEvent> continueCallback,
+                                     Consumer<Throwable> propagateCallback) {
+    return error -> routeError(error, continueCallback, propagateCallback);
+  }
 }
 

--- a/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
@@ -65,13 +65,15 @@ public interface FlowExceptionHandler extends Function<Exception, Publisher<Core
    * Provides a router for an error towards the destination error handler, calling the corresponding callback in case of failure
    * or success.
    *
+   * @param publisherPostProcessor allows to modify the publisher that will handle the error.
    * @param continueCallback the callback called in case the error is successfully handled
    * @param propagateCallback the callback is called in case the error-handling fails
    * @return the router for an error.
    *
    * @since 4.3
    */
-  default Consumer<Exception> router(Consumer<CoreEvent> continueCallback,
+  default Consumer<Exception> router(Function<Publisher<CoreEvent>, Publisher<CoreEvent>> publisherPostProcessor,
+                                     Consumer<CoreEvent> continueCallback,
                                      Consumer<Throwable> propagateCallback) {
     return error -> propagateCallback.accept(error);
   }

--- a/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/FlowExceptionHandler.java
@@ -31,7 +31,7 @@ public interface FlowExceptionHandler extends Function<Exception, Publisher<Core
    * @param exception which occurred
    * @param event which was being processed when the exception occurred
    * @return new event to route on to the rest of the flow, generally with ExceptionPayload set on the message
-   * @deprecated Use {@link FlowExceptionHandler#routeError(Exception, Consumer, Consumer)}
+   * @deprecated Use {@link FlowExceptionHandler#router(Consumer, Consumer)}
    */
   @Deprecated
   CoreEvent handleException(Exception exception, CoreEvent event);
@@ -39,7 +39,7 @@ public interface FlowExceptionHandler extends Function<Exception, Publisher<Core
   /**
    * @param exception the exception to handle
    * @return the publisher with the handling result
-   * @deprecated Use {@link FlowExceptionHandler#routeError(Exception, Consumer, Consumer)}
+   * @deprecated Use {@link FlowExceptionHandler#router(Consumer, Consumer)}
    */
   @Override
   @Deprecated
@@ -62,20 +62,6 @@ public interface FlowExceptionHandler extends Function<Exception, Publisher<Core
   }
 
   /**
-   * Routes the error towards the destination error handler, calling the corresponding callback in case of failure or success.
-   *
-   * @param error the {@link Exception} to route
-   * @param continueCallback the callback called in case the error is successfully handled
-   * @param propagateCallback the callback is called in case the error-handling fails
-   *
-   * @since 4.3
-   */
-  default void routeError(Exception error, Consumer<CoreEvent> continueCallback,
-                          Consumer<Throwable> propagateCallback) {
-    propagateCallback.accept(error);
-  }
-
-  /**
    * Provides a router for an error towards the destination error handler, calling the corresponding callback in case of failure
    * or success.
    *
@@ -87,7 +73,7 @@ public interface FlowExceptionHandler extends Function<Exception, Publisher<Core
    */
   default Consumer<Exception> router(Consumer<CoreEvent> continueCallback,
                                      Consumer<Throwable> propagateCallback) {
-    return error -> routeError(error, continueCallback, propagateCallback);
+    return error -> propagateCallback.accept(error);
   }
 }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -174,8 +174,9 @@ abstract class AbstractEventContext implements BaseEventContext {
         LOGGER.debug("{} handling messaging exception.", this);
       }
 
-      exceptionHandler.routeError((MessagingException) throwable, handled -> success(handled),
-                                  rethrown -> responseDone(left(rethrown)));
+      exceptionHandler.router(handled -> success(handled),
+                              rethrown -> responseDone(left(rethrown)))
+          .accept((Exception) throwable);
     } else {
       responseDone(left(throwable));
     }

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.internal.event;
 
+import static com.google.common.base.Functions.identity;
 import static java.lang.String.format;
 import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
@@ -174,7 +175,7 @@ abstract class AbstractEventContext implements BaseEventContext {
         LOGGER.debug("{} handling messaging exception.", this);
       }
 
-      exceptionHandler.router(handled -> success(handled),
+      exceptionHandler.router(identity(), handled -> success(handled),
                               rethrown -> responseDone(left(rethrown)))
           .accept((Exception) throwable);
     } else {

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
@@ -36,6 +36,7 @@ import org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 import javax.inject.Inject;
@@ -201,7 +202,7 @@ public class ErrorHandler extends AbstractMuleObjectOwner<MessagingExceptionHand
   }
 
   public void setExceptionListeners(List<MessagingExceptionHandlerAcceptor> exceptionListeners) {
-    this.exceptionListeners = exceptionListeners;
+    this.exceptionListeners = new CopyOnWriteArrayList<>(exceptionListeners);
   }
 
   public List<MessagingExceptionHandlerAcceptor> getExceptionListeners() {

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
@@ -124,25 +124,6 @@ public class ErrorHandler extends AbstractMuleObjectOwner<MessagingExceptionHand
   }
 
   @Override
-  public void routeError(Exception error, Consumer<CoreEvent> continueCallback,
-                         Consumer<Throwable> propagateCallback) {
-    MessagingException messagingError = (MessagingException) error;
-    CoreEvent event = messagingError.getEvent();
-    try {
-      for (MessagingExceptionHandlerAcceptor errorListener : exceptionListeners) {
-        if (errorListener.accept(event)) {
-          errorListener.routeError(error, continueCallback, propagateCallback);
-          return;
-        }
-      }
-      throw new MuleRuntimeException(createStaticMessage(MUST_ACCEPT_ANY_EVENT_MESSAGE));
-    } catch (Exception e) {
-      propagateCallback.accept(messagingExceptionResolver.resolve(new MessagingException(event, e, this),
-                                                                  errorTypeLocator, exceptionContextProviders));
-    }
-  }
-
-  @Override
   public Publisher<CoreEvent> apply(Exception exception) {
     if (exception instanceof MessagingException) {
       CoreEvent event = ((MessagingException) exception).getEvent();

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import javax.inject.Inject;
 
@@ -98,11 +99,12 @@ public class ErrorHandler extends AbstractMuleObjectOwner<MessagingExceptionHand
   }
 
   @Override
-  public Consumer<Exception> router(Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
+  public Consumer<Exception> router(Function<Publisher<CoreEvent>, Publisher<CoreEvent>> publisherPostProcessor,
+                                    Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
     Map<MessagingExceptionHandlerAcceptor, Consumer<Exception>> routers = new HashMap<>();
 
     for (MessagingExceptionHandlerAcceptor errorListener : exceptionListeners) {
-      routers.put(errorListener, errorListener.router(continueCallback, propagateCallback));
+      routers.put(errorListener, errorListener.router(publisherPostProcessor, continueCallback, propagateCallback));
     }
 
     return error -> {

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorHandler.java
@@ -35,7 +35,9 @@ import org.mule.runtime.core.privileged.exception.MessagingExceptionHandlerAccep
 import org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
@@ -93,6 +95,32 @@ public class ErrorHandler extends AbstractMuleObjectOwner<MessagingExceptionHand
       }
     }
     throw new MuleRuntimeException(createStaticMessage(MUST_ACCEPT_ANY_EVENT_MESSAGE));
+  }
+
+  @Override
+  public Consumer<Exception> router(Consumer<CoreEvent> continueCallback, Consumer<Throwable> propagateCallback) {
+    Map<MessagingExceptionHandlerAcceptor, Consumer<Exception>> routers = new HashMap<>();
+
+    for (MessagingExceptionHandlerAcceptor errorListener : exceptionListeners) {
+      routers.put(errorListener, errorListener.router(continueCallback, propagateCallback));
+    }
+
+    return error -> {
+      MessagingException messagingError = (MessagingException) error;
+      CoreEvent event = messagingError.getEvent();
+      try {
+        for (MessagingExceptionHandlerAcceptor errorListener : exceptionListeners) {
+          if (errorListener.accept(event)) {
+            routers.get(errorListener).accept(error);
+            return;
+          }
+        }
+        throw new MuleRuntimeException(createStaticMessage(MUST_ACCEPT_ANY_EVENT_MESSAGE));
+      } catch (Exception e) {
+        propagateCallback.accept(messagingExceptionResolver.resolve(new MessagingException(event, e, this),
+                                                                    errorTypeLocator, exceptionContextProviders));
+      }
+    };
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorContinueHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorContinueHandler.java
@@ -14,6 +14,7 @@ import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.api.message.Error;
 import org.mule.runtime.api.message.ErrorType;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.exception.ErrorTypeMatcher;
@@ -102,6 +103,7 @@ public class OnErrorContinueHandler extends TemplateOnErrorHandler {
   }
 
   private boolean sourceError(CoreEvent event) {
-    return event.getError().filter(error -> sourceErrorMatcher.match(error.getErrorType())).isPresent();
+    final Optional<Error> error = event.getError();
+    return error.isPresent() && sourceErrorMatcher.match(error.get().getErrorType());
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/execution/FlowProcessMediator.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/execution/FlowProcessMediator.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.core.internal.execution;
 
 import static java.util.Collections.emptyMap;
+import static java.util.function.Function.identity;
 import static org.mule.runtime.api.component.execution.CompletableCallback.always;
 import static org.mule.runtime.api.functional.Either.left;
 import static org.mule.runtime.api.functional.Either.right;
@@ -379,7 +380,7 @@ public class FlowProcessMediator implements Initialisable {
                                 });
 
     ctx.flowConstruct.getExceptionListener()
-        .router(event -> terminationCallback.accept(messagingException),
+        .router(identity(), event -> terminationCallback.accept(messagingException),
                 error -> terminationCallback.accept(messagingException))
         .accept(messagingException);
   }

--- a/core/src/main/java/org/mule/runtime/core/privileged/exception/TemplateOnErrorHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/exception/TemplateOnErrorHandler.java
@@ -215,7 +215,8 @@ public abstract class TemplateOnErrorHandler extends AbstractExceptionListener
   }
 
   private String getParameterId(CoreEvent event) {
-    return event.getContext().getId() + "_" + toString();
+    final String id = event.getContext().getId();
+    return (id != null ? id : "(null)").concat("_").concat(toString());
   }
 
   private BiConsumer<Throwable, Object> onRoutingError() {
@@ -414,7 +415,7 @@ public abstract class TemplateOnErrorHandler extends AbstractExceptionListener
   }
 
   private boolean acceptsExpression(CoreEvent event) {
-    return when.map(expr -> expressionManager.evaluateBoolean(expr, event, getLocation())).orElse(true);
+    return !when.isPresent() || when.map(expr -> expressionManager.evaluateBoolean(expr, event, getLocation())).orElse(true);
   }
 
   protected Function<CoreEvent, CoreEvent> afterRouting() {

--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChain.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChain.java
@@ -89,6 +89,7 @@ import org.slf4j.Logger;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
 /**
@@ -171,23 +172,28 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
     if (messagingExceptionHandler != null) {
       final FluxSinkRecorder<Either<MessagingException, CoreEvent>> errorSwitchSinkSinkRef = new FluxSinkRecorder<>();
 
-      final Consumer<Exception> errorRouter = messagingExceptionHandler
-          .router(handled -> errorSwitchSinkSinkRef.next(right(handled)),
-                  rethrown -> errorSwitchSinkSinkRef.next(left((MessagingException) rethrown, CoreEvent.class)));
+      return Mono.subscriberContext()
+          .flatMapMany(ctx -> {
+            final Consumer<Exception> errorRouter = messagingExceptionHandler
+                .router(pub -> from(pub).subscriberContext(ctx),
+                        handled -> errorSwitchSinkSinkRef.next(right(handled)),
+                        rethrown -> errorSwitchSinkSinkRef.next(left((MessagingException) rethrown, CoreEvent.class)));
 
-      final Flux<Either<MessagingException, CoreEvent>> upstream =
-          from(doApply(publisher, (context, throwable) -> errorRouter.accept(throwable)))
-              // This Either here is used to propagate errors. If the error is sent directly through the merged Flux,
-              // it will be cancelled, ignoring the onErrorcontinue of the parent Flux.
-              .map(event -> right(MessagingException.class, event))
-              .doOnNext(r -> errorSwitchSinkSinkRef.next(r))
-              .doOnError(t -> errorSwitchSinkSinkRef.error(t))
-              .doOnComplete(() -> errorSwitchSinkSinkRef.complete());
+            final Flux<Either<MessagingException, CoreEvent>> upstream =
+                from(doApply(publisher, (context, throwable) -> errorRouter.accept(throwable)))
+                    // This Either here is used to propagate errors. If the error is sent directly through the merged Flux,
+                    // it will be cancelled, ignoring the onErrorcontinue of the parent Flux.
+                    .map(event -> right(MessagingException.class, event))
+                    .doOnNext(r -> errorSwitchSinkSinkRef.next(r))
+                    .doOnError(t -> errorSwitchSinkSinkRef.error(t))
+                    .doOnComplete(() -> errorSwitchSinkSinkRef.complete());
 
-      return subscribeFluxOnPublisherSubscription(create(errorSwitchSinkSinkRef)
-          .map(result -> result.reduce(me -> {
-            throw propagateWrappingFatal(me);
-          }, response -> response)), upstream);
+            return subscribeFluxOnPublisherSubscription(create(errorSwitchSinkSinkRef)
+                .map(result -> result.reduce(me -> {
+                  throw propagateWrappingFatal(me);
+                }, response -> response)), upstream);
+          });
+
     } else {
       return doApply(publisher, (context, throwable) -> context.error(throwable));
     }

--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChain.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/chain/AbstractMessageProcessorChain.java
@@ -35,6 +35,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.Exceptions.propagate;
 import static reactor.core.publisher.Flux.create;
 import static reactor.core.publisher.Flux.from;
+import static reactor.core.publisher.Mono.subscriberContext;
 import static reactor.core.publisher.Operators.lift;
 
 import org.mule.runtime.api.artifact.Registry;
@@ -89,7 +90,6 @@ import org.slf4j.Logger;
 
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
 /**
@@ -172,7 +172,7 @@ abstract class AbstractMessageProcessorChain extends AbstractExecutableComponent
     if (messagingExceptionHandler != null) {
       final FluxSinkRecorder<Either<MessagingException, CoreEvent>> errorSwitchSinkSinkRef = new FluxSinkRecorder<>();
 
-      return Mono.subscriberContext()
+      return subscriberContext()
           .flatMapMany(ctx -> {
             final Consumer<Exception> errorRouter = messagingExceptionHandler
                 .router(pub -> from(pub).subscriberContext(ctx),

--- a/tests/unit/src/main/java/org/mule/tck/junit4/rule/VerboseExceptions.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/rule/VerboseExceptions.java
@@ -40,4 +40,9 @@ public class VerboseExceptions extends ExternalResource {
     System.setProperty(MULE_VERBOSE_EXCEPTIONS, Boolean.toString(verbose));
     refreshVerboseExceptions();
   }
+
+  @Override
+  public String toString() {
+    return "VerboseExceptions: " + verboseExceptions.getValue();
+  }
 }

--- a/tests/unit/src/main/java/org/mule/tck/processor/ContextPropagationChecker.java
+++ b/tests/unit/src/main/java/org/mule/tck/processor/ContextPropagationChecker.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tck.processor;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static reactor.core.publisher.Flux.from;
+import static reactor.core.publisher.Mono.subscriberContext;
+
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.processor.Processor;
+
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+
+import reactor.util.context.Context;
+
+public class ContextPropagationChecker implements Processor {
+
+  @Override
+  public CoreEvent process(CoreEvent event) throws MuleException {
+    fail("Need `apply` to be called instead of `process`.");
+    return event;
+  }
+
+  @Override
+  public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
+    return subscriberContext()
+        .flatMapMany(ctx -> from(publisher)
+            .doOnNext(e -> assertThat(ctx.getOrEmpty("ctxPropagated").orElse(false), is(true))));
+  }
+
+  public Function<Context, Context> contextPropagationFlag() {
+    return ctx -> ctx.put("ctxPropagated", true);
+  }
+}

--- a/tests/unit/src/main/java/org/mule/tck/processor/ContextPropagationChecker.java
+++ b/tests/unit/src/main/java/org/mule/tck/processor/ContextPropagationChecker.java
@@ -6,10 +6,13 @@
  */
 package org.mule.tck.processor;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static reactor.core.publisher.Flux.from;
+import static reactor.core.publisher.Flux.just;
 import static reactor.core.publisher.Mono.subscriberContext;
 
 import org.mule.runtime.api.exception.MuleException;
@@ -22,7 +25,14 @@ import org.reactivestreams.Publisher;
 
 import reactor.util.context.Context;
 
+/**
+ * Processor to use in unit test cases in order to assert that subscription context is properly propagated.
+ *
+ * @since 4.3
+ */
 public class ContextPropagationChecker implements Processor {
+
+  private static final String CTX_PROPAGATED_KEY = "ctxPropagated";
 
   @Override
   public CoreEvent process(CoreEvent event) throws MuleException {
@@ -34,10 +44,25 @@ public class ContextPropagationChecker implements Processor {
   public Publisher<CoreEvent> apply(Publisher<CoreEvent> publisher) {
     return subscriberContext()
         .flatMapMany(ctx -> from(publisher)
-            .doOnNext(e -> assertThat(ctx.getOrEmpty("ctxPropagated").orElse(false), is(true))));
+            .doOnNext(e -> assertThat(ctx.getOrEmpty(CTX_PROPAGATED_KEY).orElse(false), is(true))));
   }
 
   public Function<Context, Context> contextPropagationFlag() {
-    return ctx -> ctx.put("ctxPropagated", true);
+    return ctx -> ctx.put(CTX_PROPAGATED_KEY, true);
+  }
+
+  /**
+   *
+   * @param event the event to test with
+   * @param routerOrScope the router or scope containing {@code checker} to validate.
+   * @param checker the processor that validates the context
+   */
+  public static final void assertContextPropagation(CoreEvent event, Processor routerOrScope, ContextPropagationChecker checker) {
+    final CoreEvent result = just(event)
+        .transform(routerOrScope)
+        .subscriberContext(checker.contextPropagationFlag())
+        .blockFirst();
+
+    assertThat(result, not(nullValue()));
   }
 }


### PR DESCRIPTION
* Add coverage of context propagation to most routers/scopes
* piggyback minor perf improvements