### PR TITLE
MULE-18085: Change whitelist validation to run on compile stage in place of test stage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1659,7 +1659,7 @@
 
                     <executions>
                         <execution>
-                            <phase>verify</phase>
+                            <phase>package</phase>
                             <goals>
                                 <goal>verify</goal>
                             </goals>


### PR DESCRIPTION
- binding verify goal of mule-assembly-verifier plugin to Maven's
package phase so that it gets executed in the compile stage of our
Jenkins pipeline