### PR TITLE
MULE-18102: Concurrent flow reference instantiation issue

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/MuleArtifactContext.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/MuleArtifactContext.java
@@ -7,18 +7,15 @@
 package org.mule.runtime.config.internal;
 
 import static java.lang.String.format;
-import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptySet;
 import static java.util.Comparator.comparing;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.mule.runtime.api.component.AbstractComponent.ROOT_CONTAINER_NAME_KEY;
 import static org.mule.runtime.api.component.ComponentIdentifier.buildFromStringRepresentation;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
-import static org.mule.runtime.api.util.Preconditions.checkState;
 import static org.mule.runtime.config.api.dsl.CoreDslConstants.CONFIGURATION_IDENTIFIER;
 import static org.mule.runtime.config.api.dsl.CoreDslConstants.RAISE_ERROR_IDENTIFIER;
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.CORE_ERROR_NS;
@@ -26,7 +23,6 @@ import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.SPRING_SINGLETON_OBJECT;
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.TARGET_TYPE;
 import static org.mule.runtime.config.internal.dsl.spring.ComponentModelHelper.addAnnotation;
-import static org.mule.runtime.config.internal.dsl.spring.ComponentModelHelper.updateAnnotationValue;
 import static org.mule.runtime.config.internal.model.ApplicationModel.ERROR_MAPPING_IDENTIFIER;
 import static org.mule.runtime.config.internal.parsers.generic.AutoIdUtils.uniqueValue;
 import static org.mule.runtime.config.internal.util.ComponentBuildingDefinitionUtils.getArtifactComponentBuildingDefinitions;
@@ -49,7 +45,6 @@ import static org.springframework.context.annotation.AnnotationConfigUtils.CONFI
 import static org.springframework.context.annotation.AnnotationConfigUtils.REQUIRED_ANNOTATION_PROCESSOR_BEAN_NAME;
 
 import org.mule.runtime.api.artifact.Registry;
-import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.ConfigurationProperties;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
@@ -122,19 +117,15 @@ import javax.xml.parsers.SAXParserFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.PropertyValue;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.CglibSubclassingInstantiationStrategy;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
-import org.springframework.beans.factory.support.ManagedList;
-import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.annotation.ConfigurationClassPostProcessor;
 import org.springframework.context.annotation.ContextAnnotationAutowireCandidateResolver;
@@ -742,59 +733,6 @@ public class MuleArtifactContext extends AbstractRefreshableConfigApplicationCon
 
   public OptionalObjectsController getOptionalObjectsController() {
     return optionalObjectsController;
-  }
-
-  /**
-   * Returns a prototype chain of processors mutating the root container name of the set of beans created from that prototype
-   * object.
-   *
-   * @param name              the bean name
-   * @param rootContainerName the new root container name.
-   */
-  public synchronized void getPrototypeBeanWithRootContainer(String name, String rootContainerName) {
-    BeanDefinition beanDefinition = getBeanFactory().getBeanDefinition(name);
-    checkState(beanDefinition.isPrototype(), format("Bean with name %s is not a prototype", name));
-    updateBeanDefinitionRootContainerName(rootContainerName, beanDefinition);
-  }
-
-  private void updateBeanDefinitionRootContainerName(String rootContainerName, BeanDefinition beanDefinition) {
-    Class<?> beanClass = null;
-    try {
-      beanClass = currentThread().getContextClassLoader().loadClass(beanDefinition.getBeanClassName());
-    } catch (ClassNotFoundException e) {
-      // Nothing to do, spring will break because of this eventually
-    }
-
-    if (beanClass == null || Component.class.isAssignableFrom(beanClass)) {
-      updateAnnotationValue(ROOT_CONTAINER_NAME_KEY, rootContainerName, beanDefinition);
-    }
-
-    for (PropertyValue propertyValue : beanDefinition.getPropertyValues().getPropertyValueList()) {
-      Object value = propertyValue.getValue();
-      processBeanValue(rootContainerName, value);
-    }
-
-    for (ConstructorArgumentValues.ValueHolder valueHolder : beanDefinition.getConstructorArgumentValues()
-        .getGenericArgumentValues()) {
-      processBeanValue(rootContainerName, valueHolder.getValue());
-    }
-  }
-
-  private void processBeanValue(String rootContainerName, Object value) {
-    if (value instanceof BeanDefinition) {
-      updateBeanDefinitionRootContainerName(rootContainerName, (BeanDefinition) value);
-    } else if (value instanceof ManagedList) {
-      ManagedList managedList = (ManagedList) value;
-      for (int i = 0; i < managedList.size(); i++) {
-        Object itemValue = managedList.get(i);
-        if (itemValue instanceof BeanDefinition) {
-          updateBeanDefinitionRootContainerName(rootContainerName, (BeanDefinition) itemValue);
-        }
-      }
-    } else if (value instanceof ManagedMap) {
-      ManagedMap managedMap = (ManagedMap) value;
-      managedMap.forEach((key, mapValue) -> processBeanValue(rootContainerName, mapValue));
-    }
   }
 
   public Registry getRegistry() {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
@@ -100,6 +100,8 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
   @Inject
   private ConfigurationComponentLocator locator;
 
+  private static final Object referencedFlowLock = new Object();
+
   public void setName(String name) {
     this.refName = name;
   }
@@ -142,7 +144,10 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
                                            flowRefMessageProcessor);
     }
 
-    Component referencedFlow = getReferencedProcessor(name);
+    Component referencedFlow;
+    synchronized (referencedFlowLock) {
+      referencedFlow = getReferencedProcessor(name);
+    }
     if (referencedFlow == null) {
       throw new RoutePathNotFoundException(createStaticMessage("No flow/sub-flow with name '%s' found", name),
                                            flowRefMessageProcessor);

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.config.internal.factories;
 
+import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
@@ -13,6 +14,7 @@ import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.joining;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.config.internal.dsl.spring.ComponentModelHelper.updateAnnotationValue;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
@@ -66,7 +68,12 @@ import javax.xml.namespace.QName;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyValue;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
@@ -100,7 +107,7 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
   @Inject
   private ConfigurationComponentLocator locator;
 
-  private static final Object referencedFlowLock = new Object();
+  private static final Object referencedProcessorLock = new Object();
 
   public void setName(String name) {
     this.refName = name;
@@ -144,10 +151,7 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
                                            flowRefMessageProcessor);
     }
 
-    Component referencedFlow;
-    synchronized (referencedFlowLock) {
-      referencedFlow = getReferencedProcessor(name);
-    }
+    Component referencedFlow = getReferencedProcessor(name);
     if (referencedFlow == null) {
       throw new RoutePathNotFoundException(createStaticMessage("No flow/sub-flow with name '%s' found", name),
                                            flowRefMessageProcessor);
@@ -198,10 +202,15 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
   private Component getReferencedProcessor(String name) {
     if (applicationContext instanceof MuleArtifactContext) {
       MuleArtifactContext muleArtifactContext = (MuleArtifactContext) applicationContext;
-
       try {
-        if (muleArtifactContext.getBeanFactory().getBeanDefinition(name).isPrototype()) {
-          muleArtifactContext.getPrototypeBeanWithRootContainer(name, getRootContainerLocation().toString());
+        BeanDefinition processorBeanDefinition = muleArtifactContext.getBeanFactory().getBeanDefinition(name);
+        if (processorBeanDefinition.isPrototype()) {
+          // Synchronization between all FlowRefFactoryBean instances is needed to prevent root container inconsistencies
+          // (otherwise two FlowRefFactoryBean instances could mutate and instantiate the same prototype bean in parallel)
+          synchronized (referencedProcessorLock) {
+            updateBeanDefinitionRootContainerName(getRootContainerLocation().toString(), processorBeanDefinition);
+            return (Component) applicationContext.getBean(name);
+          }
         }
       } catch (NoSuchBeanDefinitionException e) {
         // Null is handled by the caller method
@@ -209,6 +218,46 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
       }
     }
     return (Component) applicationContext.getBean(name);
+  }
+
+  private void updateBeanDefinitionRootContainerName(String rootContainerName, BeanDefinition beanDefinition) {
+    Class<?> beanClass = null;
+    try {
+      beanClass = currentThread().getContextClassLoader().loadClass(beanDefinition.getBeanClassName());
+    } catch (ClassNotFoundException e) {
+      // Nothing to do, spring will break because of this eventually
+    }
+
+    if (beanClass == null || Component.class.isAssignableFrom(beanClass)) {
+      updateAnnotationValue(ROOT_CONTAINER_NAME_KEY, rootContainerName, beanDefinition);
+    }
+
+    for (PropertyValue propertyValue : beanDefinition.getPropertyValues().getPropertyValueList()) {
+      Object value = propertyValue.getValue();
+      processBeanValue(rootContainerName, value);
+    }
+
+    for (ConstructorArgumentValues.ValueHolder valueHolder : beanDefinition.getConstructorArgumentValues()
+        .getGenericArgumentValues()) {
+      processBeanValue(rootContainerName, valueHolder.getValue());
+    }
+  }
+
+  private void processBeanValue(String rootContainerName, Object value) {
+    if (value instanceof BeanDefinition) {
+      updateBeanDefinitionRootContainerName(rootContainerName, (BeanDefinition) value);
+    } else if (value instanceof ManagedList) {
+      ManagedList managedList = (ManagedList) value;
+      for (int i = 0; i < managedList.size(); i++) {
+        Object itemValue = managedList.get(i);
+        if (itemValue instanceof BeanDefinition) {
+          updateBeanDefinitionRootContainerName(rootContainerName, (BeanDefinition) itemValue);
+        }
+      }
+    } else if (value instanceof ManagedMap) {
+      ManagedMap managedMap = (ManagedMap) value;
+      managedMap.forEach((key, mapValue) -> processBeanValue(rootContainerName, mapValue));
+    }
   }
 
   @Override

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
@@ -107,8 +107,6 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
   @Inject
   private ConfigurationComponentLocator locator;
 
-  private static final Object referencedProcessorLock = new Object();
-
   public void setName(String name) {
     this.refName = name;
   }
@@ -207,7 +205,7 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
         if (processorBeanDefinition.isPrototype()) {
           // Synchronization between all FlowRefFactoryBean instances is needed to prevent root container inconsistencies
           // (otherwise two FlowRefFactoryBean instances could mutate and instantiate the same prototype bean in parallel)
-          synchronized (referencedProcessorLock) {
+          synchronized (applicationContext) {
             updateBeanDefinitionRootContainerName(getRootContainerLocation().toString(), processorBeanDefinition);
             return (Component) applicationContext.getBean(name);
           }


### PR DESCRIPTION
FlowRefFactoryBean relies on other beans in order to instantiate a flow. In the case of a subflow, SpringConfigurationComponentLocator is unable to handle a concurrent instantiation.
I tried to minimize as much as possible the amount of code that has to be synchronized in order to avoid the location overlaps.
