### PR TITLE
MULE-18138: Every time a connection is created/autowired, its class is

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/DefaultXASession.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/DefaultXASession.java
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class DefaultXASession<T extends AbstractXaTransactionContext> implements XAResource {
 
-  protected transient Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultXASession.class);
+
   private Xid localXid;
   private final AbstractXAResourceManager<T> resourceManager;
   private T localContext;
@@ -55,8 +56,8 @@ public abstract class DefaultXASession<T extends AbstractXaTransactionContext> i
 
   @Override
   public void start(Xid xid, int flags) throws XAException {
-    if (logger.isDebugEnabled()) {
-      logger.debug(new StringBuilder(128).append("Thread ").append(Thread.currentThread())
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(new StringBuilder(128).append("Thread ").append(Thread.currentThread())
           .append(flags == TMNOFLAGS ? " starts" : flags == TMJOIN ? " joins" : " resumes")
           .append(" work on behalf of transaction branch ").append(xid).toString());
     }
@@ -78,7 +79,7 @@ public abstract class DefaultXASession<T extends AbstractXaTransactionContext> i
           resourceManager.beginTransaction(localContext);
         } catch (Exception e) {
           // TODO MULE-863: Is logging necessary?
-          logger.error("Could not create new transactional resource", e);
+          LOGGER.error("Could not create new transactional resource", e);
           throw (XAException) new XAException(e.getMessage()).initCause(e);
         }
         break;
@@ -97,8 +98,8 @@ public abstract class DefaultXASession<T extends AbstractXaTransactionContext> i
 
   @Override
   public void end(Xid xid, int flags) throws XAException {
-    if (logger.isDebugEnabled()) {
-      logger.debug(new StringBuilder(128).append("Thread ").append(Thread.currentThread())
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(new StringBuilder(128).append("Thread ").append(Thread.currentThread())
           .append(flags == TMSUSPEND ? " suspends" : flags == TMFAIL ? " fails" : " ends")
           .append(" work on behalf of transaction branch ").append(xid).toString());
     }
@@ -139,14 +140,14 @@ public abstract class DefaultXASession<T extends AbstractXaTransactionContext> i
     }
     T context = resourceManager.getActiveTransactionalResource(xid);
     if (context == null) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Commit called without a transaction context");
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Commit called without a transaction context");
       }
       commitDanglingTransaction(xid, onePhase);
       return;
     }
-    if (logger.isDebugEnabled()) {
-      logger.debug("Committing transaction branch " + xid);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Committing transaction branch " + xid);
     }
     if (context.status == Status.STATUS_MARKED_ROLLBACK) {
       throw new XAException(XAException.XA_RBROLLBACK);
@@ -176,14 +177,14 @@ public abstract class DefaultXASession<T extends AbstractXaTransactionContext> i
     }
     AbstractTransactionContext context = resourceManager.getActiveTransactionalResource(xid);
     if (context == null) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Rollback called without a transaction context");
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Rollback called without a transaction context");
       }
       rollbackDandlingTransaction(xid);
       return;
     }
-    if (logger.isDebugEnabled()) {
-      logger.debug("Rolling back transaction branch " + xid);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Rolling back transaction branch " + xid);
     }
     try {
       resourceManager.rollbackTransaction(context);
@@ -206,8 +207,8 @@ public abstract class DefaultXASession<T extends AbstractXaTransactionContext> i
       throw new XAException(XAException.XAER_NOTA);
     }
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("Preparing transaction branch " + xid);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Preparing transaction branch " + xid);
     }
 
     if (context.status == Status.STATUS_MARKED_ROLLBACK) {
@@ -223,8 +224,8 @@ public abstract class DefaultXASession<T extends AbstractXaTransactionContext> i
 
   @Override
   public void forget(Xid xid) throws XAException {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Forgetting transaction branch " + xid);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Forgetting transaction branch " + xid);
     }
     AbstractTransactionContext context = resourceManager.getTransactionalResource(xid);
     if (context == null) {

--- a/core/src/main/java/org/mule/runtime/core/internal/util/queue/TransactionAwareQueueStore.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/queue/TransactionAwareQueueStore.java
@@ -6,15 +6,16 @@
  */
 package org.mule.runtime.core.internal.util.queue;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.privileged.store.DeserializationPostInitialisable;
 import org.mule.runtime.core.api.util.queue.Queue;
+import org.mule.runtime.core.privileged.store.DeserializationPostInitialisable;
 
 import java.io.Serializable;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Queue implementation that executes operations: - If there is no transaction context then executes the operation directly to the
@@ -23,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TransactionAwareQueueStore implements Queue {
 
-  protected transient Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger LOGGER = getLogger(TransactionAwareQueueStore.class);
 
   private final MuleContext muleContext;
   private final TransactionContextProvider transactionContextProvider;
@@ -130,7 +131,7 @@ public class TransactionAwareQueueStore implements Queue {
       }
       return item;
     } catch (Exception e) {
-      logger.warn("Unable to deserialize message", e);
+      LOGGER.warn("Unable to deserialize message", e);
       return null;
     }
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/util/queue/TransactionalQueueManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/queue/TransactionalQueueManager.java
@@ -31,11 +31,11 @@ public class TransactionalQueueManager extends AbstractQueueManager {
   private LocalTxQueueTransactionRecoverer localTxQueueTransactionRecoverer;
   private XaTxQueueTransactionJournal xaTransactionJournal;
   private XaTransactionRecoverer xaTransactionRecoverer;
-  private QueueXaResourceManager queueXaResourceManager = new QueueXaResourceManager();
+  private final QueueXaResourceManager queueXaResourceManager = new QueueXaResourceManager();
   // Due to current VMConnector and TransactionQueueManager relationship we must close all the recovered queues
   // since queue configuration is applied after recovery and not taking into consideration once queues are created
   // for recovery. See https://www.mulesoft.org/jira/browse/MULE-7420
-  private Map<String, RecoverableQueueStore> queuesAccessedForRecovery = new HashMap<>();
+  private final Map<String, RecoverableQueueStore> queuesAccessedForRecovery = new HashMap<>();
 
   /**
    * {@inheritDoc}
@@ -43,11 +43,12 @@ public class TransactionalQueueManager extends AbstractQueueManager {
    * @return an instance of {@link TransactionalQueueSession}
    */
   @Override
-  public synchronized QueueSession getQueueSession() {
+  public QueueSession getQueueSession() {
     return new TransactionalQueueSession(this, queueXaResourceManager, queueXaResourceManager, xaTransactionRecoverer,
                                          localTxTransactionJournal, getMuleContext());
   }
 
+  @Override
   protected DefaultQueueStore createQueueStore(String name, QueueConfiguration config) {
     return new DefaultQueueStore(name, getMuleContext(), config);
   }


### PR DESCRIPTION
looked up in the app classloader

Piggyback:

* Make loggers static fields so the logger is not created on each instance created
* Improve synchronization of queues infrastructure