### PR TITLE
MULE-18159: Plugins declared in mule-domain cannot resolve classes neither resources from application on operations/sources

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/util/CompositeClassLoader.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/CompositeClassLoader.java
@@ -45,16 +45,25 @@ public class CompositeClassLoader extends ClassLoader {
   }
 
   @Override
-  public Class<?> loadClass(String name) throws ClassNotFoundException {
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    Class<?> result = null;
     ClassNotFoundException firstException = null;
     for (ClassLoader classLoader : delegates) {
       try {
-        return classLoader.loadClass(name);
+        result = classLoader.loadClass(name);
+        break;
       } catch (ClassNotFoundException e) {
         firstException = e;
       }
     }
-    throw firstException;
+    if (result == null) {
+      throw firstException;
+    }
+
+    if (resolve) {
+      resolveClass(result);
+    }
+    return result;
   }
 
   @Override

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/classloader/MuleClassLoaderResourceNotFoundExceptionFactory.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/classloader/MuleClassLoaderResourceNotFoundExceptionFactory.java
@@ -12,6 +12,7 @@ import static java.lang.System.lineSeparator;
 import static org.mule.runtime.api.util.collection.Collectors.toImmutableList;
 import static org.mule.runtime.core.api.util.ClassLoaderResourceNotFoundExceptionFactory.getClassNotFoundErrorMessage;
 import static org.mule.runtime.core.api.util.ClassLoaderResourceNotFoundExceptionFactory.getResourceNotFoundErrorMessage;
+import static org.mule.runtime.deployment.model.internal.artifact.CompositeClassLoaderArtifactFinder.findClassLoader;
 
 import java.util.List;
 import java.util.function.BiFunction;
@@ -22,6 +23,7 @@ import org.mule.runtime.api.i18n.I18nMessageFactory;
 import org.mule.runtime.container.internal.FilteringContainerClassLoader;
 import org.mule.runtime.core.api.exception.ResourceNotFoundException;
 import org.mule.runtime.core.api.util.ClassLoaderResourceNotFoundExceptionFactory;
+import org.mule.runtime.core.internal.util.CompositeClassLoader;
 import org.mule.runtime.deployment.model.api.application.ApplicationClassLoader;
 import org.mule.runtime.deployment.model.internal.application.MuleApplicationClassLoader;
 import org.mule.runtime.deployment.model.internal.domain.MuleSharedDomainClassLoader;
@@ -86,6 +88,9 @@ public class MuleClassLoaderResourceNotFoundExceptionFactory implements ClassLoa
                                         BiFunction<String, ClassLoader, T> genericExceptionProviderFunction,
                                         BiFunction<String, ClassLoaderNode, T> detailedExceptionProviderFunction) {
     ClassLoader contextClassLoader = classLoader;
+    if (contextClassLoader instanceof CompositeClassLoader) {
+      contextClassLoader = findClassLoader((CompositeClassLoader) contextClassLoader);
+    }
     if (contextClassLoader instanceof ArtifactClassLoader) {
       ArtifactClassLoader artifactClassLoader = (ArtifactClassLoader) contextClassLoader;
       ClassLoaderNode classLoaderNode = createClassLoaderNode(artifactClassLoader);

--- a/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/artifact/CompositeClassLoaderArtifactFinder.java
+++ b/modules/deployment-model/src/main/java/org/mule/runtime/deployment/model/internal/artifact/CompositeClassLoaderArtifactFinder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.deployment.model.internal.artifact;
+
+import org.mule.runtime.core.internal.util.CompositeClassLoader;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.classloader.ArtifactClassLoader;
+
+/**
+ * Finds the first {@link ClassLoader} in an {@link CompositeClassLoader} that should be used when loading classes and resources
+ *
+ * @since 4.3
+ */
+public class CompositeClassLoaderArtifactFinder {
+
+  public static ClassLoader findClassLoader(CompositeClassLoader compositeClassLoader) {
+    ClassLoader firstClassLoader = compositeClassLoader.getDelegates().get(0);
+    // Obtains the first artifact class loader that is not a plugin
+    for (ClassLoader delegate : compositeClassLoader.getDelegates()) {
+      if (delegate instanceof ArtifactClassLoader && !isPluginClassLoader(delegate)) {
+        return delegate;
+      }
+    }
+    return firstClassLoader;
+  }
+
+  private static boolean isPluginClassLoader(ClassLoader loggerClassLoader) {
+    return ((ArtifactClassLoader) loggerClassLoader).getArtifactDescriptor() instanceof ArtifactPluginDescriptor;
+  }
+
+}

--- a/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/internal/artifact/CompositeClassLoaderArtifactFinderTestCase.java
+++ b/modules/deployment-model/src/test/java/org/mule/runtime/deployment/model/internal/artifact/CompositeClassLoaderArtifactFinderTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.deployment.model.internal.artifact;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.deployment.model.internal.artifact.CompositeClassLoaderArtifactFinder.findClassLoader;
+
+import org.junit.Test;
+import org.mule.runtime.core.internal.util.CompositeClassLoader;
+import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
+import org.mule.runtime.deployment.model.api.domain.DomainDescriptor;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
+import org.mule.runtime.module.artifact.api.classloader.MuleDeployableArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
+import org.mule.tck.size.SmallTest;
+
+@SmallTest
+public class CompositeClassLoaderArtifactFinderTestCase {
+
+  private static final ArtifactDescriptor pluginDescriptor = new ArtifactPluginDescriptor("my-plugin");
+  private static final ArtifactDescriptor appDescriptor = new ApplicationDescriptor("my-app");
+  private static final ArtifactDescriptor domainDescriptor = new DomainDescriptor("my-domain");
+
+  @Test
+  public void appClassLoader() {
+    ClassLoader appClassLoader = mockArtifactClassLoader(appDescriptor);
+    CompositeClassLoader compositeClassLoader =
+        new CompositeClassLoader(mockArtifactClassLoader(pluginDescriptor), appClassLoader);
+
+    assertThat(findClassLoader(compositeClassLoader), equalTo(appClassLoader));
+  }
+
+  @Test
+  public void domainClassLoader() {
+    ClassLoader domainClassLoader = mockArtifactClassLoader(domainDescriptor);
+    CompositeClassLoader compositeClassLoader =
+        new CompositeClassLoader(mockArtifactClassLoader(pluginDescriptor), domainClassLoader);
+
+    assertThat(findClassLoader(compositeClassLoader), equalTo(domainClassLoader));
+  }
+
+  @Test
+  public void firstDelegateIfNoArtifactClassLoaderFound() {
+    ClassLoader pluginClassLoader = mockArtifactClassLoader(pluginDescriptor);
+    CompositeClassLoader compositeClassLoader = new CompositeClassLoader(pluginClassLoader);
+
+    assertThat(findClassLoader(compositeClassLoader), equalTo(pluginClassLoader));
+  }
+
+  private static ClassLoader mockArtifactClassLoader(ArtifactDescriptor descriptor) {
+    MuleDeployableArtifactClassLoader classLoader = mock(MuleDeployableArtifactClassLoader.class);
+    when(classLoader.getArtifactDescriptor()).thenReturn(descriptor);
+    return classLoader;
+  }
+
+}

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/DefaultConnectionProviderObjectBuilder.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/DefaultConnectionProviderObjectBuilder.java
@@ -113,7 +113,7 @@ public class DefaultConnectionProviderObjectBuilder<C> extends ConnectionProvide
     final ClassLoader appRegionClassLoader = muleContext.getExecutionClassLoader().getParent();
 
     return ClassLoaderConnectionProviderWrapper
-        .newInstance(provider, new CompositeClassLoader(appRegionClassLoader, extensionClassLoader));
+        .newInstance(provider, new CompositeClassLoader(extensionClassLoader, appRegionClassLoader));
   }
 
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/GeneratedMethodComponentExecutor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/GeneratedMethodComponentExecutor.java
@@ -24,6 +24,7 @@ import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.meta.model.parameter.ParameterGroupModel;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.context.MuleContextAware;
+import org.mule.runtime.core.internal.util.CompositeClassLoader;
 import org.mule.runtime.extension.api.runtime.operation.ExecutionContext;
 import org.mule.runtime.module.extension.internal.runtime.exception.SdkMethodInvocationException;
 import org.mule.runtime.module.extension.internal.runtime.execution.executor.MethodExecutor;
@@ -153,7 +154,8 @@ public class GeneratedMethodComponentExecutor<M extends ComponentModel>
     return ec -> {
       Thread thread = Thread.currentThread();
       ClassLoader currentClassLoader = thread.getContextClassLoader();
-      setContextClassLoader(thread, currentClassLoader, extensionClassLoader);
+      final CompositeClassLoader compositeClassLoader = new CompositeClassLoader(extensionClassLoader, currentClassLoader);
+      setContextClassLoader(thread, currentClassLoader, compositeClassLoader);
       try {
         final Object[] resolved = getParameterValues(ec, method.getParameterTypes());
 
@@ -164,7 +166,7 @@ public class GeneratedMethodComponentExecutor<M extends ComponentModel>
         }
         return resolvedParams;
       } finally {
-        setContextClassLoader(thread, extensionClassLoader, currentClassLoader);
+        setContextClassLoader(thread, compositeClassLoader, currentClassLoader);
       }
     };
   }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/DefaultExecutionMediator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/DefaultExecutionMediator.java
@@ -23,6 +23,7 @@ import org.mule.runtime.api.meta.model.declaration.fluent.ConfigurationDeclarati
 import org.mule.runtime.core.api.execution.ExecutionTemplate;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
 import org.mule.runtime.core.api.util.func.CheckedBiFunction;
+import org.mule.runtime.core.internal.util.CompositeClassLoader;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationStats;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
@@ -201,11 +202,12 @@ public final class DefaultExecutionMediator<M extends ComponentModel> implements
       }
       final Thread currentThread = Thread.currentThread();
       final ClassLoader currentClassLoader = currentThread.getContextClassLoader();
-      setContextClassLoader(currentThread, currentClassLoader, extensionClassLoader);
+      final CompositeClassLoader compositeClassLoader = new CompositeClassLoader(extensionClassLoader, currentClassLoader);
+      setContextClassLoader(currentThread, currentClassLoader, compositeClassLoader);
       try {
         executor.execute(context, callback);
       } finally {
-        setContextClassLoader(currentThread, extensionClassLoader, currentClassLoader);
+        setContextClassLoader(currentThread, compositeClassLoader, currentClassLoader);
       }
     }
   }

--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelector.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/ArtifactAwareContextSelector.java
@@ -9,10 +9,13 @@ package org.mule.runtime.module.launcher.log4j2;
 import static com.github.benmanes.caffeine.cache.Caffeine.newBuilder;
 import static java.lang.ClassLoader.getSystemClassLoader;
 import static java.lang.Thread.currentThread;
+import static org.mule.runtime.deployment.model.internal.artifact.CompositeClassLoaderArtifactFinder.findClassLoader;
 
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.core.internal.util.CompositeClassLoader;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.deployment.model.api.policy.PolicyTemplateDescriptor;
+import org.mule.runtime.deployment.model.internal.artifact.CompositeClassLoaderArtifactFinder;
 import org.mule.runtime.deployment.model.internal.domain.MuleSharedDomainClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.ArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
@@ -116,7 +119,7 @@ class ArtifactAwareContextSelector implements ContextSelector, Disposable {
 
   private static ClassLoader getLoggerClassLoader(ClassLoader loggerClassLoader) {
     if (loggerClassLoader instanceof CompositeClassLoader) {
-      return getLoggerClassLoader(((CompositeClassLoader) loggerClassLoader).getDelegates().get(0));
+      return getLoggerClassLoader(findClassLoader((CompositeClassLoader) loggerClassLoader));
     }
 
     // Obtains the first artifact class loader in the hierarchy


### PR DESCRIPTION
When a plugin is declared in a domain it will belong to the domain region class loader and it will have as its parent the domain region class loader.
So, whenever an operation/source of the plugin is invoked by Runtime/SDK the TCCL will set the plugin class loader. Therefore if the plugin wants to load a class or resource from the application it will not be able to do that as it will ended up delegating the domain region class loader and this one has not visibility over the application. Be aware that the operation/source will be present in the application and not in the domain.
In order to solve this we have discussed different alternatives:
* Add an API to load resources and classes from the application, this will not work for cases like external libraries used by the plugin that use SPI or other mechanism to load resources/classes
* Set as not supported, in particular cases like Java Module which doesn't have a configuration and should be declared in an application's scope only
* Or do what we have done here, basically SDK when invoking a method for a plugin it will change the TCCL to be a composite class loader that delegates first to the plugin class loader and if not present try it with the TCCL set by the Runtime which would be defined by where the component is defined (domain or application).