### PR TITLE
Revert "MULE-18137: Scheduler default values are inconsistent (#8728)"

### DIFF
--- a/modules/spring-config/src/main/resources/META-INF/mule-core-common.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule-core-common.xsd
@@ -1531,10 +1531,10 @@
     <xsd:complexType name="fixedSchedulerType">
         <xsd:complexContent>
             <xsd:extension base="abstractSchedulingStrategyType">
-                <xsd:attribute name="frequency" type="substitutableLong" default="60000">
+                <xsd:attribute name="frequency" type="substitutableLong" default="1000">
                     <xsd:annotation>
                         <xsd:documentation>
-                            Polling frequency in milliseconds. Default frequency is 60000ms (1 minute).
+                            Polling frequency in milliseconds. Default frequency is 1000ms (1s).
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>


### PR DESCRIPTION
This reverts commit 8d0d49cc6b31c6d24996a5f77d200888f9c6cb47.