### PR TITLE
MULE-18261: Processed wrapped in a Mono should always recognize itself

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.core.privileged.processor;
 
-import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/MessageProcessorsTestCase.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.privileged.processor;
 
+import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -24,6 +25,7 @@ import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.privileged.processor.MessageProcessors.WITHIN_PROCESS_WITH_CHILD_CONTEXT;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.applyWithChildContext;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.applyWithChildContextDontPropagateErrors;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.getProcessingStrategy;
@@ -38,6 +40,7 @@ import static reactor.core.publisher.Mono.empty;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.publisher.Mono.just;
 
+import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.event.EventContext;
@@ -71,11 +74,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
 
 import io.qameta.allure.Issue;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
+import reactor.util.context.Context;
 
 @SmallTest
 public class MessageProcessorsTestCase extends AbstractMuleContextTestCase {
@@ -236,6 +241,28 @@ public class MessageProcessorsTestCase extends AbstractMuleContextTestCase {
 
     assertThat(((BaseEventContext) result.getContext()).isComplete(), is(true));
     assertThat(completed.get(), is(true));
+  }
+
+  @Test
+  public void processWrappedInAMonoAlwaysRecognizesItselfAsAProcessWithChildContext() {
+    AtomicBoolean completed = new AtomicBoolean();
+    ((BaseEventContext) (input.getContext())).onComplete((e, t) -> completed.set(true));
+
+    final CoreEvent result = from(MessageProcessors.process(input,
+                                                            pub -> Flux
+                                                                .from(applyWithChildContext(pub, eventPub -> Flux.from(eventPub)
+                                                                    .subscriberContext(ctx -> subscriberContextRecognizesChildContext(ctx)),
+                                                                                            Optional.empty()))))
+                                                                                                .block();
+
+    assertThat(((BaseEventContext) result.getContext()).isComplete(), is(true));
+    assertThat(completed.get(), is(true));
+  }
+
+
+  private Context subscriberContextRecognizesChildContext(Context ctx) {
+    assertThat(ctx.get(WITHIN_PROCESS_WITH_CHILD_CONTEXT), is(true));
+    return ctx;
   }
 
   @Test

--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/MessageProcessors.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/MessageProcessors.java
@@ -72,7 +72,7 @@ import reactor.core.publisher.Mono;
 public class MessageProcessors {
 
   public static final String WITHIN_PROCESS_TO_APPLY = "messageProcessors.withinProcessToApply";
-  private static final String WITHIN_PROCESS_WITH_CHILD_CONTEXT = "messageProcessors.withinProcessWithChildContext";
+  protected static final String WITHIN_PROCESS_WITH_CHILD_CONTEXT = "messageProcessors.withinProcessWithChildContext";
   private static final Logger LOGGER = LoggerFactory.getLogger(MessageProcessors.class);
 
   private MessageProcessors() {
@@ -483,7 +483,8 @@ public class MessageProcessors {
     return Flux.from(eventChildCtxPub)
         .compose(eventPub -> subscriberContext()
             .flatMapMany(ctx -> {
-              if (ctx.getOrDefault(WITHIN_PROCESS_WITH_CHILD_CONTEXT, false)) {
+              if (ctx.getOrDefault(WITHIN_PROCESS_WITH_CHILD_CONTEXT, false)
+                  || ctx.getOrDefault(WITHIN_PROCESS_TO_APPLY, false)) {
                 // This is a workaround for https://github.com/reactor/reactor-core/issues/1705
                 // If this processor is already wrapped in a Mono, there is no gain in using a Flux, and this way the issue
                 // mentioned above is avoided.


### PR DESCRIPTION
with a child context