### PR TITLE
MULE-18102: Concurrent subflow instantiations are corrupting their inner processors location

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
@@ -103,6 +103,8 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
   @Inject
   private ConfigurationComponentLocator locator;
 
+  private static final Object referencedFlowLock = new Object();
+
   public void setName(String name) {
     this.refName = name;
   }
@@ -145,7 +147,10 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
                                            flowRefMessageProcessor);
     }
 
-    Component referencedFlow = getReferencedProcessor(name);
+    Component referencedFlow;
+    synchronized (referencedFlowLock) {
+      referencedFlow = getReferencedProcessor(name);
+    }
     if (referencedFlow == null) {
       throw new RoutePathNotFoundException(createStaticMessage("No flow/sub-flow with name '%s' found", name),
                                            flowRefMessageProcessor);

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
@@ -110,8 +110,6 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
   @Inject
   private ConfigurationComponentLocator locator;
 
-  private static final Object referencedProcessorLock = new Object();
-
   public void setName(String name) {
     this.refName = name;
   }
@@ -210,7 +208,7 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
         if (processorBeanDefinition.isPrototype()) {
           // Synchronization between all FlowRefFactoryBean instances is needed to prevent root container inconsistencies
           // (otherwise two FlowRefFactoryBean instances could mutate and instantiate the same prototype bean in parallel)
-          synchronized (referencedProcessorLock) {
+          synchronized (applicationContext) {
             updateBeanDefinitionRootContainerName(getRootContainerLocation().toString(), processorBeanDefinition);
             return (Component) applicationContext.getBean(name);
           }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
@@ -206,8 +206,8 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
       try {
         BeanDefinition processorBeanDefinition = muleArtifactContext.getBeanFactory().getBeanDefinition(name);
         if (processorBeanDefinition.isPrototype()) {
-          // Synchronization between all FlowRefFactoryBean instances is needed to prevent root container inconsistencies
-          // (otherwise two FlowRefFactoryBean instances could mutate and instantiate the same prototype bean in parallel)
+          // Application level synchronization between all FlowRefFactoryBean instances is needed
+          // (otherwise two FlowRefFactoryBean instances could try mutate and instantiate the same prototype bean in parallel)
           synchronized (applicationContext) {
             updateBeanDefinitionRootContainerName(getRootContainerLocation().toString(), processorBeanDefinition);
             return (Component) applicationContext.getBean(name);

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
@@ -7,28 +7,19 @@
 package org.mule.runtime.config.internal.factories;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static java.util.Collections.*;
+import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.*;
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.runtime.api.el.BindingContextUtils.NULL_BINDING_CONTEXT;
 import static org.mule.runtime.api.metadata.DataType.STRING;
@@ -38,6 +29,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.setMuleContextI
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.publisher.Mono.just;
 
@@ -46,13 +38,17 @@ import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.api.lifecycle.Disposable;
-import org.mule.runtime.api.lifecycle.Initialisable;
-import org.mule.runtime.api.lifecycle.Startable;
-import org.mule.runtime.api.lifecycle.Stoppable;
+import org.mule.runtime.api.lifecycle.*;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.app.declaration.api.ArtifactDeclaration;
+import org.mule.runtime.config.internal.MuleArtifactContext;
+import org.mule.runtime.config.internal.ObjectProviderAwareBeanFactory;
+import org.mule.runtime.config.internal.OptionalObjectsController;
+import org.mule.runtime.config.internal.dsl.model.CoreComponentBuildingDefinitionProvider;
+import org.mule.runtime.config.internal.dsl.spring.ObjectFactoryClassRepository;
 import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.config.bootstrap.ArtifactType;
 import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.context.MuleContextAware;
 import org.mule.runtime.core.api.el.ExtendedExpressionManager;
@@ -66,10 +62,12 @@ import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.core.privileged.routing.RoutePathNotFoundException;
 import org.mule.runtime.dsl.api.component.config.DefaultComponentLocation;
+import org.mule.runtime.dsl.api.ConfigResource;
+import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
-import java.util.List;
+import java.util.*;
 
 import javax.inject.Inject;
 
@@ -80,6 +78,9 @@ import org.junit.rules.ExpectedException;
 import org.mockito.MockSettings;
 import org.mockito.stubbing.Answer;
 import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 
 @SmallTest
@@ -102,7 +103,7 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
   private final Flow targetFlow = mock(Flow.class, INITIALIZABLE_MESSAGE_PROCESSOR);
   private final LifecycleState flowLifeCycleState = mock(LifecycleState.class);
   private final MessageProcessorChain targetSubFlow = mock(MessageProcessorChain.class, INITIALIZABLE_MESSAGE_PROCESSOR);
-  private final Processor targetSubFlowChild = (Processor) mock(Object.class, INITIALIZABLE_MESSAGE_PROCESSOR);
+  private final Processor targetSubFlowProcessor = (Processor) mock(Object.class, INITIALIZABLE_MESSAGE_PROCESSOR);
   private final SubflowMessageProcessorChainBuilder targetSubFlowChainBuilder = spy(new SubflowMessageProcessorChainBuilder());
   private final ApplicationContext applicationContext = mock(ApplicationContext.class);
   private ExtendedExpressionManager expressionManager;
@@ -115,29 +116,36 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
 
   @Before
   public void setup() throws MuleException {
+    // Events mocking
     result = testEvent();
+    // Mule context mocking
     mockMuleContext = mockContextWithServices();
-    expressionManager = mockMuleContext.getExpressionManager();
-    doReturn(true).when(expressionManager).isExpression(anyString());
-    when(targetFlow.apply(any(Publisher.class))).thenReturn(just(result));
-    when(targetFlow.referenced()).thenReturn(targetFlow);
-    // For flow lifecycle checks
-    when(flowLifeCycleState.isStarted()).thenReturn(true);
-    when(targetFlow.getLifecycleState()).thenReturn(flowLifeCycleState);
-
-    List<Processor> targetSubFlowProcessors = singletonList(targetSubFlowChild);
-    when(targetSubFlow.getMessageProcessors()).thenReturn(targetSubFlowProcessors);
-    targetSubFlowChainBuilder.chain(targetSubFlowProcessors);
-    when(targetSubFlowChild.apply(any(Publisher.class))).thenReturn(just(result));
-    when(targetSubFlow.apply(any(Publisher.class))).thenReturn(just(result));
-
     mockMuleContext.getInjector().inject(this);
-
     when(locator.find(any(Location.class))).thenReturn(of(mock(Flow.class)));
     when(locator.find(Location.builder().globalName("flow").build())).thenReturn(of(callerFlow));
+    // Main flow mocking
     when(callerFlow.getProcessingStrategy()).thenReturn(callerFlowProcessingStrategy);
-
     when(callerFlowProcessingStrategy.onProcessor(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArguments()[0]);
+    // Dynamic flowref mocking (this is reverted in static flowref tests)
+    expressionManager = mockMuleContext.getExpressionManager();
+    doReturn(true).when(expressionManager).isExpression(anyString());
+    doReturn(new TypedValue<>(PARSED_DYNAMIC_REFERENCED_FLOW, STRING)).when(expressionManager)
+            .evaluate(eq(FlowRefFactoryBeanTestCase.DYNAMIC_REFERENCED_FLOW), eq(DataType.STRING),
+                    eq(NULL_BINDING_CONTEXT), any(CoreEvent.class),
+                    any(ComponentLocation.class), eq(true));
+    // Referenced flow mocking
+    when(targetFlow.apply(any(Publisher.class))).thenReturn(just(result));
+    when(targetFlow.apply(any())).thenAnswer(successAnswer());
+    when(targetFlow.referenced()).thenReturn(targetFlow);
+    // Referenced flow lifecycle checks mocking
+    when(flowLifeCycleState.isStarted()).thenReturn(true);
+    when(targetFlow.getLifecycleState()).thenReturn(flowLifeCycleState);
+    // Referenced subflow mocking
+    List<Processor> targetSubFlowProcessors = singletonList(targetSubFlowProcessor);
+    when(targetSubFlow.getMessageProcessors()).thenReturn(targetSubFlowProcessors);
+    targetSubFlowChainBuilder.chain(targetSubFlowProcessors);
+    when(targetSubFlow.apply(any(Publisher.class))).thenReturn(just(result));
+    when(targetSubFlowProcessor.apply(any())).thenAnswer(successAnswer());
   }
 
   @Test
@@ -148,19 +156,19 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
     assertNotSame(targetFlow, getFlowRefProcessor(flowRefFactoryBean));
     assertNotSame(targetFlow, getFlowRefProcessor(flowRefFactoryBean));
 
-    verifyProcess(flowRefFactoryBean, targetFlow);
+    verifyProcess(flowRefFactoryBean, targetFlow, applicationContext);
     verifyLifecycle(targetFlow, 0);
   }
 
   @Test
   public void dynamicFlowRefFlow() throws Exception {
     // Inner MessageProcessor is used to resolve MP in runtime
-    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean(targetFlow, null);
+    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean(targetFlow, null, applicationContext);
 
     assertNotSame(targetFlow, getFlowRefProcessor(flowRefFactoryBean));
     assertNotSame(targetFlow, getFlowRefProcessor(flowRefFactoryBean));
 
-    verifyProcess(flowRefFactoryBean, targetFlow);
+    verifyProcess(flowRefFactoryBean, targetFlow, applicationContext);
     verifyLifecycle(targetFlow, 0);
   }
 
@@ -172,7 +180,7 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
     assertThat(targetSubFlow, not(equalTo(getFlowRefProcessor(flowRefFactoryBean))));
     assertThat(targetSubFlow, not(equalTo(getFlowRefProcessor(flowRefFactoryBean))));
 
-    verifyProcess(flowRefFactoryBean, targetSubFlowChild);
+    verifyProcess(flowRefFactoryBean, targetSubFlowProcessor, applicationContext);
     verify(targetSubFlowChainBuilder).setProcessingStrategy(argThat(ps -> {
       ReactiveProcessor pipeline = mock(ReactiveProcessor.class);
       ReactiveProcessor processor = mock(ReactiveProcessor.class);
@@ -186,13 +194,13 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
 
   @Test
   public void dynamicFlowRefSubFlow() throws Exception {
-    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean(targetSubFlow, targetSubFlowChainBuilder);
+    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean(targetSubFlow, targetSubFlowChainBuilder, applicationContext);
 
     // Inner MessageProcessor is used to resolve MP in runtime
     assertNotSame(targetSubFlow, getFlowRefProcessor(flowRefFactoryBean));
     assertNotSame(targetSubFlow, getFlowRefProcessor(flowRefFactoryBean));
 
-    verifyProcess(flowRefFactoryBean, targetSubFlowChild);
+    verifyProcess(flowRefFactoryBean, targetSubFlowProcessor, applicationContext);
     verify(targetSubFlowChainBuilder).setProcessingStrategy(argThat(ps -> {
       ReactiveProcessor pipeline = mock(ReactiveProcessor.class);
       ReactiveProcessor processor = mock(ReactiveProcessor.class);
@@ -210,7 +218,7 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
     MuleContextAware targetMuleContextAware = mock(MuleContextAware.class, INITIALIZABLE_MESSAGE_PROCESSOR);
     when(((Processor) targetMuleContextAware).apply(any(Publisher.class))).thenReturn(just(result));
 
-    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean((Processor) targetMuleContextAware, null);
+    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean((Processor) targetMuleContextAware, null, applicationContext);
     assertSame(result.getMessage(), getFlowRefProcessor(flowRefFactoryBean).process(event).getMessage());
 
     verify(targetMuleContextAware).setMuleContext(mockMuleContext);
@@ -227,6 +235,7 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
 
     when(targetMuleContextAwareAware.apply(any(Publisher.class)))
         .thenAnswer(invocationOnMock -> invocationOnMock.getArguments()[0]);
+    when(targetSubFlowConstructAware.apply(any())).thenAnswer(successAnswer());
 
     MessageProcessorChain targetSubFlowChain = mock(MessageProcessorChain.class, INITIALIZABLE_MESSAGE_PROCESSOR);
     when(targetSubFlowChain.apply(any(Publisher.class))).thenReturn(just(result));
@@ -235,7 +244,7 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
     SubflowMessageProcessorChainBuilder chainBuilder = new SubflowMessageProcessorChainBuilder();
     chainBuilder.chain(targetSubFlowProcessors);
 
-    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean(targetSubFlowChain, chainBuilder);
+    FlowRefFactoryBean flowRefFactoryBean = createDynamicFlowRefFactoryBean(targetSubFlowChain, chainBuilder, applicationContext);
     final Processor flowRefProcessor = getFlowRefProcessor(flowRefFactoryBean);
     just(event).transform(flowRefProcessor).block();
 
@@ -250,18 +259,129 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
 
   @Test
   public void dynamicFlowRefDoesNotExist() throws Exception {
-    doReturn(true).when(expressionManager).isExpression(anyString());
     doReturn(new TypedValue<>("other", STRING)).when(expressionManager).evaluate(eq(DYNAMIC_NON_EXISTANT), eq(DataType.STRING),
                                                                                  eq(NULL_BINDING_CONTEXT), any(CoreEvent.class),
                                                                                  any(ComponentLocation.class), eq(true));
 
     expectedException.expect(instanceOf(RoutePathNotFoundException.class));
-    getFlowRefProcessor(createFlowRefFactoryBean(DYNAMIC_NON_EXISTANT)).process(testEvent());
+    getFlowRefProcessor(createFlowRefFactoryBean(DYNAMIC_NON_EXISTANT, "flow", applicationContext)).process(testEvent());
   }
 
-  private FlowRefFactoryBean createFlowRefFactoryBean(String name) throws Exception {
+  @Test
+  public void concurrentDynamicSubFlowInstantiation() throws Exception {
+    // MuleArtifactContext stubbing
+    DefaultListableBeanFactory beanFactory = new ObjectProviderAwareBeanFactory(null);
+    MuleArtifactContext muleArtifactContext = spy(createMuleArtifactContextStub(beanFactory));
+    // BeanFactory stubbing (subFlow and subFlow processor factories)
+    ComponentBuildingDefinition subFlowComponentBuildingDefinition = new CoreComponentBuildingDefinitionProvider()
+            .getComponentBuildingDefinitions()
+            .stream()
+            .filter(componentBuildingDefinition -> componentBuildingDefinition.getComponentIdentifier().getName().equals("sub-flow"))
+            .findFirst()
+            .get();
+    BeanDefinition subFlowProcessorBeanDefinition = genericBeanDefinition(Processor.class, () -> {
+      Processor subFlowProcessor = (Processor) mock(Object.class, INITIALIZABLE_MESSAGE_PROCESSOR);
+      when(subFlowProcessor.apply(any())).thenAnswer(successAnswer());
+      return subFlowProcessor;
+    }).getBeanDefinition();
+    BeanDefinition subFlowBeanDefinition = genericBeanDefinition(new ObjectFactoryClassRepository()
+        .getObjectFactoryClass(subFlowComponentBuildingDefinition, SubflowMessageProcessorChainFactoryBean.class, Object.class, () -> true, empty()))
+      .addPropertyValue("name", PARSED_DYNAMIC_REFERENCED_FLOW)
+      .addPropertyValue("messageProcessors", subFlowProcessorBeanDefinition)
+      .setScope(BeanDefinition.SCOPE_PROTOTYPE)
+      .getBeanDefinition();
+    beanFactory.registerBeanDefinition(PARSED_DYNAMIC_REFERENCED_FLOW, subFlowBeanDefinition);
+    //Additional flow and processing strategy (needed to generate a concurrent subflow instantiation)
+    Flow concurrentCallerFlow = mock(Flow.class, INITIALIZABLE_MESSAGE_PROCESSOR);
+    ProcessingStrategy concurrentCallerFlowProcessingStrategy = mock(ProcessingStrategy.class);
+    when(locator.find(Location.builder().globalName("concurrentFlow").build())).thenReturn(of(concurrentCallerFlow));
+    when(concurrentCallerFlow.getProcessingStrategy()).thenReturn(concurrentCallerFlowProcessingStrategy);
+    when(concurrentCallerFlowProcessingStrategy.onProcessor(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArguments()[0]);
+    // Two flowRef dynamically pointing to the same subFlow
+    FlowRefFactoryBean flowRefFactoryBean = createFlowRefFactoryBean(DYNAMIC_REFERENCED_FLOW, "flow", muleArtifactContext);
+    FlowRefFactoryBean parallelFlowRefFactoryBean = createFlowRefFactoryBean(DYNAMIC_REFERENCED_FLOW, "concurrentFlow", muleArtifactContext);
+    // Events are sent to both flowRefs in parallel in order to trigger a concurrent subflow instantiation
+    Thread flowEvents = new Thread(() -> {
+        sendEventsThroughFlowRef(flowRefFactoryBean);
+    }, "Flow Events");
+    Thread parallelFlowEvents = new Thread(() -> {
+      sendEventsThroughFlowRef(parallelFlowRefFactoryBean);
+    }, "Parallel Flow Events");
+    flowEvents.start();
+    parallelFlowEvents.start();
+    flowEvents.join();
+    parallelFlowEvents.join();
+    // Assertions over each parent flow processing strategies
+    verify(callerFlowProcessingStrategy, times(2)).onProcessor(any());
+    verify(concurrentCallerFlowProcessingStrategy, times(2)).onProcessor(any());
+  }
+
+  private void sendEventsThroughFlowRef(FlowRefFactoryBean flowRefFactoryBean) {
+    try {
+      Processor flowRefProcessor = getFlowRefProcessor(flowRefFactoryBean);
+      initialiseIfNeeded(flowRefProcessor);
+      startIfNeeded(flowRefProcessor);
+      assertSame(result.getMessage(), just(newEvent()).cast(CoreEvent.class).transform(flowRefProcessor).block().getMessage());
+      assertSame(result.getMessage(), just(newEvent()).cast(CoreEvent.class).transform(flowRefProcessor).block().getMessage());
+      stopIfNeeded(flowRefProcessor);
+      disposeIfNeeded(flowRefProcessor, null);
+    } catch (Exception e) {
+      throw new RuntimeException("Error sending events to a flowRef", e);
+    }
+  }
+
+  private MuleArtifactContext createMuleArtifactContextStub(DefaultListableBeanFactory mockedBeanFactory) {
+    MuleArtifactContext muleArtifactContext = new MuleArtifactContext(mockMuleContext, new ConfigResource[0], new ArtifactDeclaration(),
+            mock(OptionalObjectsController.class), new HashMap<>(), ArtifactType.APP, new ArrayList<>(),
+            Optional.empty(), true, mock(CoreComponentBuildingDefinitionProvider.class)) {
+
+      @Override
+      protected DefaultListableBeanFactory createBeanFactory() {
+        return mockedBeanFactory;
+      }
+
+      @Override
+      protected void customizeBeanFactory(DefaultListableBeanFactory beanFactory) {
+        // Bean factory is mocked, so no bean registering here
+      }
+
+      @Override
+      protected void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {
+        // Bean factory is mocked, so no bean registering here
+      }
+
+      @Override
+      protected void registerBeanPostProcessors(ConfigurableListableBeanFactory beanFactory) {
+        // Bean factory is mocked, so no bean registering here
+      }
+
+      @Override
+      protected void invokeBeanFactoryPostProcessors(ConfigurableListableBeanFactory beanFactory) {
+        // Bean factory is mocked, so no bean invocation here
+      }
+
+      @Override
+      protected void registerListeners() {
+        // Bean factory is mocked, so no bean registering here
+      }
+
+      @Override
+      protected void finishBeanFactoryInitialization(ConfigurableListableBeanFactory beanFactory) {
+        // Bean factory is mocked, so no bean registering here
+      }
+
+      @Override
+      protected void finishRefresh() {
+        // Bean factory is mocked, so no nothing to do here
+      }
+    };
+    muleArtifactContext.refresh();
+    return muleArtifactContext;
+  }
+
+  private FlowRefFactoryBean createFlowRefFactoryBean(String referencedFlowName, String flowRefLocation, ApplicationContext applicationContext) throws Exception {
     FlowRefFactoryBean flowRefFactoryBean = new FlowRefFactoryBean();
-    flowRefFactoryBean.setName(name);
+    flowRefFactoryBean.setName(referencedFlowName);
     flowRefFactoryBean.setAnnotations(singletonMap(LOCATION_KEY, DefaultComponentLocation.from("flow")));
     flowRefFactoryBean.setApplicationContext(applicationContext);
     mockMuleContext.getInjector().inject(flowRefFactoryBean);
@@ -276,38 +396,17 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
     } else {
       when(applicationContext.getBean(eq(STATIC_REFERENCED_FLOW))).thenReturn(target);
     }
-
-    if (target instanceof MessageProcessorChain) {
-      Processor processor = ((MessageProcessorChain) target).getMessageProcessors().get(0);
-      when(processor.apply(any())).thenAnswer(successAnswer());
-    } else {
-      when(target.apply(any())).thenAnswer(successAnswer());
-    }
-
-    return createFlowRefFactoryBean(STATIC_REFERENCED_FLOW);
+    return createFlowRefFactoryBean(STATIC_REFERENCED_FLOW, "flow", applicationContext);
   }
 
-  private FlowRefFactoryBean createDynamicFlowRefFactoryBean(Processor target, Object targetBuilder)
+  private FlowRefFactoryBean createDynamicFlowRefFactoryBean(Processor target, Object targetBuilder, ApplicationContext applicationContext)
       throws Exception {
-    doReturn(true).when(expressionManager).isExpression(anyString());
-    doReturn(new TypedValue<>(PARSED_DYNAMIC_REFERENCED_FLOW, STRING)).when(expressionManager)
-        .evaluate(eq(DYNAMIC_REFERENCED_FLOW), eq(DataType.STRING),
-                  eq(NULL_BINDING_CONTEXT), any(CoreEvent.class),
-                  any(ComponentLocation.class), eq(true));
     if (targetBuilder != null) {
-      when(applicationContext.getBean(eq(PARSED_DYNAMIC_REFERENCED_FLOW))).thenReturn(targetBuilder);
+      doReturn(targetBuilder).when(applicationContext).getBean(eq(PARSED_DYNAMIC_REFERENCED_FLOW));
     } else {
-      when(applicationContext.getBean(eq(PARSED_DYNAMIC_REFERENCED_FLOW))).thenReturn(target);
+      doReturn(target).when(applicationContext).getBean(eq(PARSED_DYNAMIC_REFERENCED_FLOW));
     }
-
-    if (target instanceof MessageProcessorChain) {
-      Processor processor = ((MessageProcessorChain) target).getMessageProcessors().get(0);
-      when(processor.apply(any())).thenAnswer(successAnswer());
-    } else {
-      when(target.apply(any())).thenAnswer(successAnswer());
-    }
-
-    return createFlowRefFactoryBean(DYNAMIC_REFERENCED_FLOW);
+    return createFlowRefFactoryBean(FlowRefFactoryBeanTestCase.DYNAMIC_REFERENCED_FLOW, "flow", applicationContext);
   }
 
   private Answer<?> successAnswer() {
@@ -320,21 +419,11 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
     };
   }
 
-  private void verifyProcess(FlowRefFactoryBean flowRefFactoryBean, Processor target)
+  private void verifyProcess(FlowRefFactoryBean flowRefFactoryBean, Processor target, ApplicationContext applicationContext)
       throws Exception {
-    Processor flowRefProcessor = getFlowRefProcessor(flowRefFactoryBean);
-    initialiseIfNeeded(flowRefProcessor);
-    startIfNeeded(flowRefProcessor);
-
-    assertSame(result.getMessage(), just(newEvent()).cast(CoreEvent.class).transform(flowRefProcessor).block().getMessage());
-    assertSame(result.getMessage(), just(newEvent()).cast(CoreEvent.class).transform(flowRefProcessor).block().getMessage());
-
+    sendEventsThroughFlowRef(flowRefFactoryBean);
     verify(applicationContext).getBean(anyString());
-
     verify(target, times(2)).apply(any(Publisher.class));
-
-    stopIfNeeded(flowRefProcessor);
-    disposeIfNeeded(flowRefProcessor, null);
   }
 
   private void verifyLifecycle(Processor target, int lifecycleRounds)

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
@@ -40,6 +40,8 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.setMuleContextI
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
+import static org.mule.test.allure.AllureConstants.ComponentsFeature.CORE_COMPONENTS;
+import static org.mule.test.allure.AllureConstants.ComponentsFeature.FlowReferenceStory.FLOW_REFERENCE;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.publisher.Mono.just;
@@ -297,8 +299,8 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
   }
 
   @Test()
-  @Feature(AllureConstants.SpringConfiguration.SPRING_CONFIGURATION)
-  @Story(AllureConstants.SpringConfiguration.ComponentFactories.COMPONENT_FACTORIES)
+  @Feature(CORE_COMPONENTS)
+  @Story(FLOW_REFERENCE)
   public void concurrentDynamicSubFlowInstantiation() throws Exception {
     // MuleArtifactContext stubbing
     DefaultListableBeanFactory beanFactory = new ObjectProviderAwareBeanFactory(null);

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
@@ -80,7 +80,6 @@ import org.mule.runtime.core.internal.processor.chain.SubflowMessageProcessorCha
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.core.privileged.routing.RoutePathNotFoundException;
-import org.mule.runtime.dsl.api.component.config.DefaultComponentLocation;
 import org.mule.runtime.dsl.api.ConfigResource;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition;
 import org.mule.tck.junit4.AbstractMuleTestCase;

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
@@ -39,6 +39,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNee
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.setMuleContextIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
+import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.from;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
 import static org.mule.test.allure.AllureConstants.ComponentsFeature.CORE_COMPONENTS;
 import static org.mule.test.allure.AllureConstants.ComponentsFeature.FlowReferenceStory.FLOW_REFERENCE;
@@ -93,13 +94,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.MockSettings;
 import org.mockito.stubbing.Answer;
-import org.mule.test.allure.AllureConstants;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -465,7 +466,7 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
       throws Exception {
     FlowRefFactoryBean flowRefFactoryBean = new FlowRefFactoryBean();
     flowRefFactoryBean.setName(referencedFlowName);
-    flowRefFactoryBean.setAnnotations(singletonMap(LOCATION_KEY, DefaultComponentLocation.from("flow")));
+    flowRefFactoryBean.setAnnotations(singletonMap(LOCATION_KEY, from(flowRefLocation)));
     flowRefFactoryBean.setApplicationContext(applicationContext);
     mockMuleContext.getInjector().inject(flowRefFactoryBean);
     return flowRefFactoryBean;
@@ -495,7 +496,7 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
 
   private Answer<?> successAnswer() {
     return invocation -> {
-      return from(invocation.getArgument(0))
+      return Mono.from(invocation.getArgument(0))
           .cast(CoreEvent.class)
           .doOnNext(event -> ((BaseEventContext) event.getContext())
               .success(CoreEvent.builder(event).message(result.getMessage()).variables(result.getVariables()).build()))

--- a/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
+++ b/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
@@ -508,6 +508,18 @@ public interface AllureConstants {
 
   }
 
+  interface SpringConfiguration {
+
+    String SPRING_CONFIGURATION = "Spring configuration";
+
+    interface ComponentFactories {
+
+      String COMPONENT_FACTORIES = "Component factories story";
+
+    }
+
+  }
+
   interface ConfigurationProperties {
 
     String CONFIGURATION_PROPERTIES = "Configuration properties";

--- a/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
+++ b/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
@@ -508,18 +508,6 @@ public interface AllureConstants {
 
   }
 
-  interface SpringConfiguration {
-
-    String SPRING_CONFIGURATION = "Spring configuration";
-
-    interface ComponentFactories {
-
-      String COMPONENT_FACTORIES = "Component factories story";
-
-    }
-
-  }
-
   interface ConfigurationProperties {
 
     String CONFIGURATION_PROPERTIES = "Configuration properties";

--- a/tests/unit/src/main/java/org/mule/tck/util/MuleContextUtils.java
+++ b/tests/unit/src/main/java/org/mule/tck/util/MuleContextUtils.java
@@ -30,7 +30,6 @@ import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.ConfigurationProperties;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.Location;
-import org.mule.runtime.api.config.custom.CustomizationService;
 import org.mule.runtime.api.deployment.management.ComponentInitialStateManager;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
 import org.mule.runtime.api.exception.MuleException;
@@ -50,7 +49,6 @@ import org.mule.runtime.core.api.streaming.StreamingManager;
 import org.mule.runtime.core.api.transformer.Transformer;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.api.util.UUID;
-import org.mule.runtime.core.internal.config.CustomServiceRegistry;
 import org.mule.runtime.core.internal.context.DefaultMuleContext;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.runtime.core.internal.exception.OnErrorPropagateHandler;
@@ -223,8 +221,6 @@ public class MuleContextUtils {
         mock(ConfigurationComponentLocator.class, withSettings().lenient());
     when(configurationComponentLocator.find(any(Location.class))).thenReturn(empty());
     when(configurationComponentLocator.find(any(ComponentIdentifier.class))).thenReturn(emptyList());
-
-    when(muleContext.getCustomizationService()).thenReturn(mock(CustomizationService.class, withSettings().extraInterfaces(CustomServiceRegistry.class)));
 
     try {
       when(registry.lookupObject(NotificationListenerRegistry.class)).thenReturn(notificationListenerRegistry);

--- a/tests/unit/src/main/java/org/mule/tck/util/MuleContextUtils.java
+++ b/tests/unit/src/main/java/org/mule/tck/util/MuleContextUtils.java
@@ -30,6 +30,7 @@ import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.ConfigurationProperties;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.component.location.Location;
+import org.mule.runtime.api.config.custom.CustomizationService;
 import org.mule.runtime.api.deployment.management.ComponentInitialStateManager;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
 import org.mule.runtime.api.exception.MuleException;
@@ -49,11 +50,13 @@ import org.mule.runtime.core.api.streaming.StreamingManager;
 import org.mule.runtime.core.api.transformer.Transformer;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.api.util.UUID;
+import org.mule.runtime.core.internal.config.CustomServiceRegistry;
 import org.mule.runtime.core.internal.context.DefaultMuleContext;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.runtime.core.internal.exception.OnErrorPropagateHandler;
 import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.internal.registry.MuleRegistry;
+import org.mule.runtime.core.internal.registry.MuleRegistryHelper;
 import org.mule.runtime.core.privileged.PrivilegedMuleContext;
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
@@ -171,7 +174,7 @@ public class MuleContextUtils {
 
     StreamingManager streamingManager = mock(StreamingManager.class, RETURNS_DEEP_STUBS);
     try {
-      MuleRegistry registry = mock(MuleRegistry.class, withSettings().lenient());
+      MuleRegistry registry = mock(MuleRegistryHelper.class, withSettings().lenient());
       when(muleContext.getRegistry()).thenReturn(registry);
       ComponentInitialStateManager componentInitialStateManager =
           mock(ComponentInitialStateManager.class, withSettings().lenient());
@@ -220,6 +223,8 @@ public class MuleContextUtils {
         mock(ConfigurationComponentLocator.class, withSettings().lenient());
     when(configurationComponentLocator.find(any(Location.class))).thenReturn(empty());
     when(configurationComponentLocator.find(any(ComponentIdentifier.class))).thenReturn(emptyList());
+
+    when(muleContext.getCustomizationService()).thenReturn(mock(CustomizationService.class, withSettings().extraInterfaces(CustomServiceRegistry.class)));
 
     try {
       when(registry.lookupObject(NotificationListenerRegistry.class)).thenReturn(notificationListenerRegistry);


### PR DESCRIPTION
Prototype bean modifications for dynamic subflow instantiation are now synchronized over Spring ApplicationContext instance.

A test case has been added that depends on certain level of concurrency (fails most of the runs if the fix is reverted).