### PR TITLE
MULE-18363: Decouple spring bean definition from ComponentAst (#8833)

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/LazyMuleArtifactContext.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/LazyMuleArtifactContext.java
@@ -63,7 +63,6 @@ import org.mule.runtime.ast.graph.api.ArtifactAstDependencyGraph;
 import org.mule.runtime.config.internal.dsl.model.NoSuchComponentModelException;
 import org.mule.runtime.config.internal.dsl.model.SpringComponentModel;
 import org.mule.runtime.config.internal.dsl.processor.ObjectTypeVisitor;
-import org.mule.runtime.config.internal.model.ComponentModel;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.bootstrap.ArtifactType;
 import org.mule.runtime.core.api.transaction.TransactionManagerFactory;
@@ -325,10 +324,9 @@ public class LazyMuleArtifactContext extends MuleArtifactContext
 
   @Override
   public void initializeComponents(ComponentLocationFilter filter, boolean applyStartPhase) {
-    applyLifecycle(createComponents(of(o -> {
-      ComponentModel componentModel = (ComponentModel) o;
-      if (componentModel.getComponentLocation() != null) {
-        return filter.accept(componentModel.getComponentLocation());
+    applyLifecycle(createComponents(of(componentModel -> {
+      if (componentModel.getLocation() != null) {
+        return filter.accept(componentModel.getLocation());
       }
       return false;
     }), empty(), applyStartPhase, getParentComponentModelInitializerAdapter(applyStartPhase)), applyStartPhase);

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/MuleArtifactContext.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/MuleArtifactContext.java
@@ -73,7 +73,6 @@ import org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory;
 import org.mule.runtime.config.internal.dsl.xml.XmlNamespaceInfoProviderSupplier;
 import org.mule.runtime.config.internal.editors.MulePropertyEditorRegistrar;
 import org.mule.runtime.config.internal.model.ApplicationModel;
-import org.mule.runtime.config.internal.model.ComponentModel;
 import org.mule.runtime.config.internal.processor.ComponentLocatorCreatePostProcessor;
 import org.mule.runtime.config.internal.processor.DiscardedOptionalBeanPostProcessor;
 import org.mule.runtime.config.internal.processor.LifecycleStatePostProcessor;
@@ -682,7 +681,7 @@ public class MuleArtifactContext extends AbstractRefreshableConfigApplicationCon
 
   @Override
   protected void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {
-    Optional<ComponentModel> configurationOptional =
+    Optional<ComponentAst> configurationOptional =
         applicationModel.findComponentDefinitionModel(CONFIGURATION_IDENTIFIER);
     if (configurationOptional.isPresent()) {
       return;

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/extension/xml/ComponentModelReaderHelper.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/extension/xml/ComponentModelReaderHelper.java
@@ -6,12 +6,7 @@
  */
 package org.mule.runtime.config.internal.dsl.model.extension.xml;
 
-import static java.lang.System.lineSeparator;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.commons.lang3.StringUtils.repeat;
-import static org.mule.runtime.core.privileged.execution.LocationExecutionContextProvider.maskPasswords;
-
+import org.mule.runtime.ast.api.ComponentAst;
 import org.mule.runtime.config.internal.model.ComponentModel;
 import org.mule.runtime.core.privileged.execution.LocationExecutionContextProvider;
 
@@ -28,26 +23,9 @@ class ComponentModelReaderHelper {
 
   private ComponentModelReaderHelper() {}
 
-  static String toXml(ComponentModel rootComponentModel) {
-    return toXml(rootComponentModel, 0);
-  }
-
-  static private String toXml(ComponentModel cm, int tab) {
-    final String spaces = repeat(" ", tab * 3);
-    final StringBuilder sb = new StringBuilder(spaces).append("<").append(cm.getIdentifier().toString());
-    cm.getRawParameters().forEach((id, value) -> sb.append(" ").append(id).append("=\"").append(value).append("\""));
-    if (cm.getInnerComponents().isEmpty() && isBlank(cm.getTextContent())) {
-      sb.append("/>");
-    } else {
-      sb.append(">");
-      cm.getInnerComponents()
-          .forEach(componentModel -> sb.append(lineSeparator()).append(toXml(componentModel, tab + 1)));
-      if (isNotBlank(cm.getTextContent())) {
-        sb.append("<![CDATA[").append(spaces).append(cm.getTextContent()).append("]]>");
-      }
-      sb.append(lineSeparator()).append(spaces).append("</").append(cm.getIdentifier().toString()).append(">");
-    }
-    return maskPasswords(sb.toString(), PASSWORD_MASK);
+  static String toXml(ComponentAst rootComponentModel) {
+    return rootComponentModel.getMetadata().getSourceCode()
+        .orElse("");
   }
 
 }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/CommonBeanDefinitionCreator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/CommonBeanDefinitionCreator.java
@@ -13,6 +13,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.beanutils.BeanUtils.copyProperty;
 import static org.mule.runtime.api.component.Component.ANNOTATIONS_PROPERTY_NAME;
 import static org.mule.runtime.api.component.Component.Annotations.SOURCE_ELEMENT_ANNOTATION_KEY;
+import static org.mule.runtime.ast.api.ComponentAst.BODY_RAW_PARAM_NAME;
 import static org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory.SPRING_PROTOTYPE_OBJECT;
 import static org.mule.runtime.config.internal.dsl.spring.PropertyComponentUtils.getPropertyValueFromPropertyComponent;
 import static org.mule.runtime.config.internal.model.ApplicationModel.ANNOTATIONS_ELEMENT_IDENTIFIER;
@@ -131,7 +132,7 @@ public class CommonBeanDefinitionCreator extends BeanDefinitionCreator {
             .forEach(annotationCdm -> previousAnnotations
                 .put(new QName(annotationCdm.getIdentifier().getNamespaceUri(),
                                annotationCdm.getIdentifier().getName()),
-                     ((ComponentModel) annotationCdm).getTextContent())));
+                     annotationCdm.getRawParameterValue(BODY_RAW_PARAM_NAME).orElse(null))));
   }
 
   private void processAnnotations(SpringComponentModel componentModel, BeanDefinitionBuilder beanDefinitionBuilder) {
@@ -217,7 +218,7 @@ public class CommonBeanDefinitionCreator extends BeanDefinitionCreator {
     }
     return componentModel.directChildrenStream()
         .filter(innerComponent -> innerComponent.getIdentifier().equals(MULE_PROPERTY_IDENTIFIER))
-        .map(springComponent -> getPropertyValueFromPropertyComponent((ComponentModel) springComponent))
+        .map(springComponent -> getPropertyValueFromPropertyComponent(springComponent))
         .collect(toMap(propValue -> propValue.getFirst(), propValue -> propValue.getSecond()));
   }
 
@@ -256,7 +257,7 @@ public class CommonBeanDefinitionCreator extends BeanDefinitionCreator {
               || identifier.equals(MULE_PROPERTIES_IDENTIFIER);
         })
         .forEach(propertyComponentModel -> {
-          Pair<String, Object> propertyValue = getPropertyValueFromPropertyComponent((ComponentModel) propertyComponentModel);
+          Pair<String, Object> propertyValue = getPropertyValueFromPropertyComponent(propertyComponentModel);
           beanDefinitionBuilder.addPropertyValue(propertyValue.getFirst(), propertyValue.getSecond());
         });
   }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/CommonBeanDefinitionCreator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/CommonBeanDefinitionCreator.java
@@ -218,7 +218,7 @@ public class CommonBeanDefinitionCreator extends BeanDefinitionCreator {
     }
     return componentModel.directChildrenStream()
         .filter(innerComponent -> innerComponent.getIdentifier().equals(MULE_PROPERTY_IDENTIFIER))
-        .map(springComponent -> getPropertyValueFromPropertyComponent(springComponent))
+        .map(PropertyComponentUtils::getPropertyValueFromPropertyComponent)
         .collect(toMap(propValue -> propValue.getFirst(), propValue -> propValue.getSecond()));
   }
 

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -14,6 +14,7 @@ import static org.mule.runtime.config.internal.dsl.spring.CommonBeanDefinitionCr
 
 import org.mule.runtime.api.meta.model.parameter.ParameterizedModel;
 import org.mule.runtime.ast.api.ComponentAst;
+import org.mule.runtime.ast.api.ComponentParameterAst;
 import org.mule.runtime.config.internal.dsl.model.SpringComponentModel;
 import org.mule.runtime.config.internal.model.ComponentModel;
 import org.mule.runtime.dsl.api.component.AttributeDefinition;
@@ -333,7 +334,7 @@ class ComponentConfigurationBuilder<T> {
               .filter(param -> !componentBuildingDefinition.getIgnoredConfigurationParameters()
                   .contains(param.getModel().getName()))
               .filter(param -> param.getRawValue() != null)
-              .collect(toMap(param -> param.getModel().getName(), param -> param.getRawValue())))
+              .collect(toMap(param -> param.getModel().getName(), ComponentParameterAst::getRawValue)))
           .orElse(null);
     }
 

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/CreateBeanDefinitionRequest.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/CreateBeanDefinitionRequest.java
@@ -44,7 +44,13 @@ public class CreateBeanDefinitionRequest {
 
     this.typeVisitorRetriever = new LazyValue<>(() -> {
       ObjectTypeVisitor objectTypeVisitor = new ObjectTypeVisitor(componentModel);
-      componentBuildingDefinition.getTypeDefinition().visit(objectTypeVisitor);
+
+      if (componentBuildingDefinition != null) {
+        componentBuildingDefinition.getTypeDefinition().visit(objectTypeVisitor);
+      } else {
+        objectTypeVisitor.onType(Object.class);
+      }
+
       return objectTypeVisitor;
     });
   }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/EagerObjectCreator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/EagerObjectCreator.java
@@ -17,6 +17,7 @@ import org.mule.runtime.api.ioc.ConfigurableObjectProvider;
 import org.mule.runtime.api.ioc.ObjectProvider;
 import org.mule.runtime.api.meta.model.parameter.ParameterizedModel;
 import org.mule.runtime.ast.api.ComponentAst;
+import org.mule.runtime.ast.api.ComponentParameterAst;
 import org.mule.runtime.config.api.dsl.processor.AbstractAttributeDefinitionVisitor;
 import org.mule.runtime.config.internal.dsl.model.SpringComponentModel;
 import org.mule.runtime.config.internal.factories.ConstantFactoryBean;
@@ -72,7 +73,7 @@ class EagerObjectCreator extends BeanDefinitionCreator {
             Map<String, String> parameters = componentModel.getModel(ParameterizedModel.class)
                 .map(pm -> componentModel.getParameters().stream()
                     .filter(param -> param.getRawValue() != null)
-                    .collect(toMap(param -> param.getModel().getName(), param -> param.getRawValue())))
+                    .collect(toMap(param -> param.getModel().getName(), ComponentParameterAst::getRawValue)))
                 .orElse(null);
 
             String attributeName = setterAttributeDefinition.getAttributeName();

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/PropertiesMapBeanDefinitionCreator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/PropertiesMapBeanDefinitionCreator.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.config.internal.dsl.spring;
 
+import static org.mule.runtime.ast.api.ComponentAst.BODY_RAW_PARAM_NAME;
 import static org.mule.runtime.config.internal.model.ApplicationModel.MULE_PROPERTIES_IDENTIFIER;
 import static org.mule.runtime.config.internal.model.ApplicationModel.MULE_PROPERTY_IDENTIFIER;
 import static org.mule.runtime.config.internal.model.ApplicationModel.VALUE_ATTRIBUTE;
@@ -17,7 +18,6 @@ import static org.springframework.beans.factory.xml.BeanDefinitionParserDelegate
 
 import org.mule.runtime.ast.api.ComponentAst;
 import org.mule.runtime.config.internal.dsl.model.SpringComponentModel;
-import org.mule.runtime.config.internal.model.ComponentModel;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -88,7 +88,7 @@ class PropertiesMapBeanDefinitionCreator extends BeanDefinitionCreator {
     ManagedList<Object> managedList = new ManagedList<>();
     componentModel.directChildrenStream().forEach(childComponent -> {
       if (childComponent.getIdentifier().getName().equals(VALUE_ATTRIBUTE)) {
-        managedList.add(((ComponentModel) childComponent).getTextContent());
+        managedList.add(childComponent.getRawParameterValue(BODY_RAW_PARAM_NAME).orElse(null));
       } else {
         managedList.add(new RuntimeBeanReference(childComponent.getRawParameterValue(BEAN_REF_ATTRIBUTE).orElse(null)));
       }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/PropertyComponentUtils.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/PropertyComponentUtils.java
@@ -12,7 +12,7 @@ import static org.mule.runtime.config.internal.model.ApplicationModel.MULE_PROPE
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.util.Pair;
-import org.mule.runtime.config.internal.model.ComponentModel;
+import org.mule.runtime.ast.api.ComponentAst;
 
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.ManagedMap;
@@ -37,41 +37,41 @@ public class PropertyComponentUtils {
    * @param propertyComponentModel the component model for spring:property, spring:properties or property.
    * @return a {@code PropertyValue} with the parsed content of the component.
    */
-  public static Pair<String, Object> getPropertyValueFromPropertyComponent(ComponentModel propertyComponentModel) {
-    Pair<String, Object> propertyValue;
+  public static Pair<String, Object> getPropertyValueFromPropertyComponent(ComponentAst propertyComponentModel) {
     String refKey = getReferenceAttributeName(propertyComponentModel.getIdentifier());
     String nameKey = getNameAttributeName(propertyComponentModel.getIdentifier());
-    if (propertyComponentModel.getInnerComponents().isEmpty()) {
-      Object value;
-      if (propertyComponentModel.getRawParameters().containsKey(refKey)) {
-        value = new RuntimeBeanReference(propertyComponentModel.getRawParameters().get(refKey));
-      } else {
-        value = propertyComponentModel.getRawParameters().get(VALUE_PARAMETER_NAME);
-      }
-      if (!propertyComponentModel.getRawParameters().containsKey(nameKey)) {
-        propertyValue = new Pair<>(PROPERTY_NAME_PROPERTY_ATTRIBUTE,
-                                   new RuntimeBeanReference(propertyComponentModel.getRawParameters().get("ref")));
-      } else {
-        propertyValue = new Pair<>(propertyComponentModel.getRawParameters().get(nameKey), value);
-      }
-    } else if (propertyComponentModel.getInnerComponents().get(0).getIdentifier().getName().equals("map")) {
-      ComponentModel springMap = propertyComponentModel.getInnerComponents().get(0);
-      ManagedMap<String, Object> propertiesMap = new ManagedMap<>();
-      springMap.getInnerComponents().stream().forEach(mapEntry -> {
-        Object value;
-        if (mapEntry.getRawParameters().containsKey(VALUE_PARAMETER_NAME)) {
-          value = mapEntry.getRawParameters().get(VALUE_PARAMETER_NAME);
-        } else {
-          value = new RuntimeBeanReference(mapEntry.getRawParameters().get(REFERENCE_MULE_PROPERTY_ATTRIBUTE));
-        }
-        propertiesMap.put(mapEntry.getRawParameters().get(PROPERTY_NAME_MULE_PROPERTY_ATTRIBUTE), value);
-      });
-      propertyValue = new Pair<>(propertyComponentModel.getComponentId().orElse(null), propertiesMap);
-    } else {
-      throw new MuleRuntimeException(createStaticMessage("Unrecognized property model identifier: "
-          + propertyComponentModel.getInnerComponents().get(0).getIdentifier()));
-    }
-    return propertyValue;
+
+    return propertyComponentModel.directChildrenStream()
+        .findFirst()
+        .map(springMap -> {
+          if (!springMap.getIdentifier().getName().equals("map")) {
+            throw new MuleRuntimeException(createStaticMessage("Unrecognized property model identifier: "
+                + springMap.getIdentifier()));
+          }
+
+          ManagedMap<String, Object> propertiesMap = new ManagedMap<>();
+          springMap.directChildrenStream().forEach(mapEntry -> {
+            Object value = mapEntry.getRawParameterValue(VALUE_PARAMETER_NAME)
+                .map(v -> (Object) v)
+                .orElseGet(() -> new RuntimeBeanReference(mapEntry.getRawParameterValue(REFERENCE_MULE_PROPERTY_ATTRIBUTE)
+                    .orElse(null)));
+
+            propertiesMap.put(mapEntry.getRawParameterValue(PROPERTY_NAME_MULE_PROPERTY_ATTRIBUTE).orElse(null), value);
+          });
+          return new Pair<>(propertyComponentModel.getComponentId().orElse(null), (Object) propertiesMap);
+        })
+        .orElseGet(() -> {
+          Object value = propertyComponentModel.getRawParameterValue(refKey)
+              .map(v -> (Object) new RuntimeBeanReference(v))
+              .orElseGet(() -> propertyComponentModel.getRawParameterValue(VALUE_PARAMETER_NAME)
+                  .orElse(null));
+
+          return propertyComponentModel.getRawParameterValue(nameKey)
+              .map(name -> new Pair<>(name, value))
+              .orElseGet(() -> new Pair<>(PROPERTY_NAME_PROPERTY_ATTRIBUTE,
+                                          new RuntimeBeanReference(propertyComponentModel.getRawParameterValue("ref")
+                                              .orElse(null))));
+        });
   }
 
   private static String getNameAttributeName(ComponentIdentifier identifier) {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/SimpleTypeBeanDefinitionCreator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/SimpleTypeBeanDefinitionCreator.java
@@ -7,12 +7,12 @@
 package org.mule.runtime.config.internal.dsl.spring;
 
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.ast.api.ComponentAst.BODY_RAW_PARAM_NAME;
 import static org.mule.runtime.dsl.api.component.DslSimpleType.isSimpleType;
 
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.ast.api.ComponentAst;
 import org.mule.runtime.config.internal.dsl.model.SpringComponentModel;
-import org.mule.runtime.config.internal.model.ComponentModel;
 import org.mule.runtime.dsl.api.component.TypeConverter;
 
 import java.util.Map;
@@ -37,22 +37,20 @@ class SimpleTypeBeanDefinitionCreator extends BeanDefinitionCreator {
                         CreateBeanDefinitionRequest createBeanDefinitionRequest) {
     Class<?> type = createBeanDefinitionRequest.retrieveTypeVisitor().getType();
     if (isSimpleType(type)) {
-      ComponentModel componentModel = (ComponentModel) createBeanDefinitionRequest.getComponentModel();
+      ComponentAst componentModel = createBeanDefinitionRequest.getComponentModel();
       createBeanDefinitionRequest.getSpringComponentModel().setType(type);
-      Map<String, String> parameters = componentModel.getRawParameters();
 
-      if (parameters.size() >= 2) {
-        // Component model has more than one parameter when it's supposed to have at most one parameter
-        return false;
-      }
-      if (componentModel.getTextContent() != null && !componentModel.getRawParameters().isEmpty()) {
+      final Optional<String> textContent = componentModel.getRawParameterValue(BODY_RAW_PARAM_NAME);
+      final Optional<String> valueParam = componentModel.getRawParameterValue("value");
+
+      if (textContent.isPresent() && valueParam.isPresent()) {
         // Component model has both a parameter and an inner content
         return false;
       }
 
-      final String value = componentModel.getTextContent() != null
-          ? componentModel.getTextContent()
-          : parameters.values().stream().findFirst().orElse(null);
+      String value = textContent
+          .orElseGet(() -> valueParam.orElse(null));
+
       if (value == null) {
         throw new MuleRuntimeException(createStaticMessage("Parameter at %s:%s must provide a non-empty value",
                                                            componentModel.getMetadata().getFileName()

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/model/ApplicationModel.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/model/ApplicationModel.java
@@ -790,9 +790,8 @@ public class ApplicationModel implements ArtifactAst {
     return new GlobalPropertyConfigurationPropertiesProvider(globalProperties);
   }
 
-  public Optional<ComponentModel> findComponentDefinitionModel(ComponentIdentifier componentIdentifier) {
+  public Optional<ComponentAst> findComponentDefinitionModel(ComponentIdentifier componentIdentifier) {
     return topLevelComponentsStream()
-        .map(cm -> (ComponentModel) cm)
         .filter(componentModel -> componentModel.getIdentifier().equals(componentIdentifier)).findFirst();
   }
 

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/extension/xml/ComponentModelReaderHelperTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/extension/xml/ComponentModelReaderHelperTestCase.java
@@ -23,7 +23,6 @@ import org.mule.runtime.config.internal.ModuleDelegatingEntityResolver;
 import org.mule.runtime.config.internal.dsl.model.ComponentModelReader;
 import org.mule.runtime.config.internal.dsl.model.config.ConfigurationPropertiesResolver;
 import org.mule.runtime.config.internal.dsl.xml.XmlNamespaceInfoProviderSupplier;
-import org.mule.runtime.config.internal.model.ComponentModel;
 import org.mule.runtime.core.api.util.xmlsecurity.XMLSecureFactories;
 import org.mule.runtime.dsl.api.xml.parser.ConfigLine;
 import org.mule.runtime.dsl.api.xml.parser.XmlConfigurationDocumentLoader;
@@ -39,7 +38,6 @@ import org.custommonkey.xmlunit.Difference;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
 import org.w3c.dom.Document;
-
 
 public class ComponentModelReaderHelperTestCase {
 
@@ -138,7 +136,7 @@ public class ComponentModelReaderHelperTestCase {
 
   private void compareXML(String inputXml, String expectedXml) throws Exception {
     ComponentAst componentModel = getComponentModel(inputXml);
-    String actualXml = ComponentModelReaderHelper.toXml((ComponentModel) componentModel);
+    String actualXml = ComponentModelReaderHelper.toXml(componentModel);
 
     setNormalizeWhitespace(true);
     setIgnoreWhitespace(true);

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/extension/xml/ComponentModelReaderHelperTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/dsl/model/extension/xml/ComponentModelReaderHelperTestCase.java
@@ -27,6 +27,7 @@ import org.mule.runtime.core.api.util.xmlsecurity.XMLSecureFactories;
 import org.mule.runtime.dsl.api.xml.parser.ConfigLine;
 import org.mule.runtime.dsl.api.xml.parser.XmlConfigurationDocumentLoader;
 import org.mule.runtime.dsl.internal.xml.parser.XmlApplicationParser;
+import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import java.io.InputStream;
 import java.util.List;
@@ -39,7 +40,7 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
-public class ComponentModelReaderHelperTestCase {
+public class ComponentModelReaderHelperTestCase extends AbstractMuleTestCase {
 
   @Test
   public void testSimpleApp() throws Exception {


### PR DESCRIPTION
* Addendum: use ComponentAst instead of ComponentModel in
`org.mule.runtime.config.internal.dsl`
* Addendum: Unify dsl source generation