### PR TITLE
MULE-18041: Extension error handling improvements

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
@@ -208,8 +208,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
                                                 suppressIfPresent(CONNECTION_EXCEPTION,
-                                                                  CONNECTION_EXCEPTION.getClass(),
-                                                                  false));
+                                                                  CONNECTION_EXCEPTION.getClass()));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
@@ -224,7 +223,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
                                                 suppressIfPresent(CONNECTION_EXCEPTION,
-                                                                  CONNECTION_EXCEPTION.getClass(), true));
+                                                                  CONNECTION_EXCEPTION.getClass()));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
@@ -240,7 +239,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
                                                 suppressIfPresent(new MessagingException(createStaticMessage("CONNECTION PROBLEM"),
                                                                                          event),
-                                                                  MessagingException.class, true));
+                                                                  MessagingException.class));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());

--- a/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
@@ -210,7 +210,8 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
                                                 SuppressedMuleException.suppressIfPresent(CONNECTION_EXCEPTION,
-                                                                                          CONNECTION_EXCEPTION.getClass(), false));
+                                                                                          CONNECTION_EXCEPTION.getClass(),
+                                                                                          false));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
@@ -224,8 +225,8 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
   public void resolveSuppressedMuleExceptionLoggingCause() {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
-            SuppressedMuleException.suppressIfPresent(CONNECTION_EXCEPTION,
-                    CONNECTION_EXCEPTION.getClass(), true));
+                                                SuppressedMuleException.suppressIfPresent(CONNECTION_EXCEPTION,
+                                                                                          CONNECTION_EXCEPTION.getClass(), true));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
@@ -239,8 +240,10 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
   public void resolveSuppressedMessagingExceptionLoggingCause() {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
-            SuppressedMuleException.suppressIfPresent(new MessagingException(createStaticMessage("CONNECTION PROBLEM"), event),
-                    MessagingException.class, true));
+                                                SuppressedMuleException
+                                                    .suppressIfPresent(new MessagingException(createStaticMessage("CONNECTION PROBLEM"),
+                                                                                              event),
+                                                                       MessagingException.class, true));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());

--- a/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
@@ -9,15 +9,16 @@ package org.mule.runtime.core.api.util;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.mule.runtime.api.exception.MuleExceptionInfo.INFO_CAUSED_BY_KEY;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.internal.component.ComponentAnnotations.ANNOTATION_NAME;
 import static org.mule.runtime.internal.exception.SuppressedMuleException.suppressIfPresent;
+import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Issue;
@@ -57,10 +58,9 @@ import javax.xml.namespace.QName;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mule.test.allure.AllureConstants;
 
 @SmallTest
-@Feature(AllureConstants.ErrorHandlingFeature.ERROR_HANDLING)
+@Feature(ERROR_HANDLING)
 public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
 
   private static final String ERROR_MESSAGE = "Messaging Error Message";
@@ -214,7 +214,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
     assertExceptionErrorType(resolved, expected);
     assertExceptionMessage(resolved.getMessage(), "DISPATCH PROBLEM");
-    assertThat(resolved.getInfo().get(MuleExceptionInfo.INFO_CAUSED_BY_KEY), is(nullValue()));
+    assertExceptionMessage(resolved.getInfo().get(INFO_CAUSED_BY_KEY).toString(), "CONNECTION PROBLEM");
   }
 
   @Test
@@ -229,7 +229,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
     assertExceptionErrorType(resolved, expected);
     assertExceptionMessage(resolved.getMessage(), "DISPATCH PROBLEM");
-    assertExceptionMessage(resolved.getInfo().get(MuleExceptionInfo.INFO_CAUSED_BY_KEY).toString(), "CONNECTION PROBLEM");
+    assertExceptionMessage(resolved.getInfo().get(INFO_CAUSED_BY_KEY).toString(), "CONNECTION PROBLEM");
   }
 
   @Test
@@ -245,7 +245,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
     assertExceptionErrorType(resolved, expected);
     assertExceptionMessage(resolved.getMessage(), "DISPATCH PROBLEM");
-    assertExceptionMessage(resolved.getInfo().get(MuleExceptionInfo.INFO_CAUSED_BY_KEY).toString(), "CONNECTION PROBLEM");
+    assertExceptionMessage(resolved.getInfo().get(INFO_CAUSED_BY_KEY).toString(), "CONNECTION PROBLEM");
   }
 
   private void assertExceptionMessage(String result, String expected) {

--- a/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
@@ -12,16 +12,15 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.internal.component.ComponentAnnotations.ANNOTATION_NAME;
+import static org.mule.runtime.internal.exception.SuppressedMuleException.suppressIfPresent;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Issue;
-import io.qameta.allure.Story;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -47,7 +46,6 @@ import org.mule.runtime.core.internal.util.MessagingExceptionResolver;
 import org.mule.runtime.core.privileged.connector.DispatchException;
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.processor.AnnotatedProcessor;
-import org.mule.runtime.internal.exception.SuppressedMuleException;
 import org.mule.tck.integration.transformer.ValidateResponse;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -209,7 +207,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
   public void resolveSuppressedMuleException() {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
-                                                SuppressedMuleException.suppressIfPresent(CONNECTION_EXCEPTION,
+                                                suppressIfPresent(CONNECTION_EXCEPTION,
                                                                                           CONNECTION_EXCEPTION.getClass(),
                                                                                           false));
     MessagingException me = newMessagingException(exception, event, processor);
@@ -225,7 +223,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
   public void resolveSuppressedMuleExceptionLoggingCause() {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
-                                                SuppressedMuleException.suppressIfPresent(CONNECTION_EXCEPTION,
+                                                suppressIfPresent(CONNECTION_EXCEPTION,
                                                                                           CONNECTION_EXCEPTION.getClass(), true));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
@@ -240,8 +238,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
   public void resolveSuppressedMessagingExceptionLoggingCause() {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
-                                                SuppressedMuleException
-                                                    .suppressIfPresent(new MessagingException(createStaticMessage("CONNECTION PROBLEM"),
+                                                suppressIfPresent(new MessagingException(createStaticMessage("CONNECTION PROBLEM"),
                                                                                               event),
                                                                        MessagingException.class, true));
     MessagingException me = newMessagingException(exception, event, processor);

--- a/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
@@ -200,7 +200,8 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
   public void resolveSuppressedMuleException() {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
-                                                new SuppressedMuleException(CONNECTION_EXCEPTION));
+                                                SuppressedMuleException.suppressIfPresent(CONNECTION_EXCEPTION,
+                                                                                          CONNECTION_EXCEPTION.getClass()));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());

--- a/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/util/MessagingExceptionResolverTestCase.java
@@ -208,8 +208,8 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
                                                 suppressIfPresent(CONNECTION_EXCEPTION,
-                                                                                          CONNECTION_EXCEPTION.getClass(),
-                                                                                          false));
+                                                                  CONNECTION_EXCEPTION.getClass(),
+                                                                  false));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
@@ -224,7 +224,7 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
                                                 suppressIfPresent(CONNECTION_EXCEPTION,
-                                                                                          CONNECTION_EXCEPTION.getClass(), true));
+                                                                  CONNECTION_EXCEPTION.getClass(), true));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());
@@ -239,8 +239,8 @@ public class MessagingExceptionResolverTestCase extends AbstractMuleTestCase {
     ErrorType expected = DISPATCH;
     Throwable exception = new DispatchException(createStaticMessage("DISPATCH PROBLEM"), new ValidateResponse(),
                                                 suppressIfPresent(new MessagingException(createStaticMessage("CONNECTION PROBLEM"),
-                                                                                              event),
-                                                                       MessagingException.class, true));
+                                                                                         event),
+                                                                  MessagingException.class, true));
     MessagingException me = newMessagingException(exception, event, processor);
     MessagingExceptionResolver anotherResolver = new MessagingExceptionResolver(new TestProcessor());
     MessagingException resolved = anotherResolver.resolve(me, locator, emptyList());

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
@@ -97,6 +97,9 @@ public class MessagingException extends EventProcessingException {
     extractMuleMessage(event);
     this.failingComponent = failingComponent;
     setMessage(generateMessage(getI18nMessage(), null));
+    if (cause instanceof MuleException) {
+      ((MuleException) cause).getInfo().forEach(this::addInfo);
+    }
   }
 
   protected String generateMessage(I18nMessage message, MuleContext muleContext) {

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
@@ -87,7 +87,7 @@ public class MessagingException extends EventProcessingException {
     super(original.getI18nMessage(), event, original.getCause());
     this.failingComponent = original.getFailingComponent();
     this.handled = original.handled();
-    putAll(original.getInfo());
+    addAllInfo(original.getInfo());
     extractMuleMessage(event);
     setMessage(original.getMessage());
   }
@@ -98,7 +98,7 @@ public class MessagingException extends EventProcessingException {
     this.failingComponent = failingComponent;
     setMessage(generateMessage(getI18nMessage(), null));
     if (cause instanceof MuleException) {
-      putAll(((MuleException) cause).getInfo());
+      addAllInfo(((MuleException) cause).getInfo());
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
@@ -87,7 +87,7 @@ public class MessagingException extends EventProcessingException {
     super(original.getI18nMessage(), event, original.getCause());
     this.failingComponent = original.getFailingComponent();
     this.handled = original.handled();
-    original.getInfo().forEach(this::addInfo);
+    addInfo(original.getInfo());
     extractMuleMessage(event);
     setMessage(original.getMessage());
   }
@@ -98,7 +98,7 @@ public class MessagingException extends EventProcessingException {
     this.failingComponent = failingComponent;
     setMessage(generateMessage(getI18nMessage(), null));
     if (cause instanceof MuleException) {
-      ((MuleException) cause).getInfo().forEach(this::addInfo);
+      addInfo(((MuleException) cause).getInfo());
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
@@ -87,7 +87,7 @@ public class MessagingException extends EventProcessingException {
     super(original.getI18nMessage(), event, original.getCause());
     this.failingComponent = original.getFailingComponent();
     this.handled = original.handled();
-    addInfo(original.getInfo());
+    putAll(original.getInfo());
     extractMuleMessage(event);
     setMessage(original.getMessage());
   }
@@ -98,7 +98,7 @@ public class MessagingException extends EventProcessingException {
     this.failingComponent = failingComponent;
     setMessage(generateMessage(getI18nMessage(), null));
     if (cause instanceof MuleException) {
-      addInfo(((MuleException) cause).getInfo());
+      putAll(((MuleException) cause).getInfo());
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -15,18 +15,16 @@ import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.metadata.DataType.NUMBER;
 import static org.mule.runtime.core.api.retry.policy.SimpleRetryPolicyTemplate.RETRY_COUNT_FOREVER;
 import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTransactionActive;
-import static org.mule.runtime.core.api.util.ExceptionUtils.extractOfType;
 import static org.mule.runtime.core.api.util.ExceptionUtils.getMessagingExceptionCause;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.applyWithChildContext;
+import static org.mule.runtime.internal.exception.SuppressedMuleException.suppressIfPresent;
 import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.Exceptions.propagate;
-import static reactor.core.publisher.Mono.first;
 import static reactor.core.publisher.Mono.subscriberContext;
 import static reactor.util.context.Context.empty;
 
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.connection.ConnectionException;
-import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.functional.Either;
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.core.api.el.ExpressionManagerSession;
@@ -39,7 +37,6 @@ import org.mule.runtime.core.internal.event.EventInternalContextResolver;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.rx.FluxSinkRecorder;
 import org.mule.runtime.core.internal.util.rx.ConditionalExecutorServiceDecorator;
-import org.mule.runtime.internal.exception.SuppressedMuleException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -281,7 +278,7 @@ class UntilSuccessfulRouter {
       Throwable retryPolicyExhaustionCause = getMessagingExceptionCause(throwable);
       // ConnectionException is treated in a way that prioritize it's error type over any other (see ErrorTypeLocator#getErrorTypeFromException)
       retryPolicyExhaustionCause =
-          SuppressedMuleException.suppressIfPresent(retryPolicyExhaustionCause, ConnectionException.class, false);
+          suppressIfPresent(retryPolicyExhaustionCause, ConnectionException.class, false);
       if (throwable instanceof MessagingException) {
         exceptionEvent = ((MessagingException) throwable).getEvent();
       }

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -281,7 +281,7 @@ class UntilSuccessfulRouter {
       Throwable retryPolicyExhaustionCause = getMessagingExceptionCause(throwable);
       // ConnectionException is treated in a way that prioritize it's error type over any other (see ErrorTypeLocator#getErrorTypeFromException)
       retryPolicyExhaustionCause =
-          SuppressedMuleException.suppressIfPresent(retryPolicyExhaustionCause, ConnectionException.class);
+          SuppressedMuleException.suppressIfPresent(retryPolicyExhaustionCause, ConnectionException.class, false);
       if (throwable instanceof MessagingException) {
         exceptionEvent = ((MessagingException) throwable).getEvent();
       }

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -287,7 +287,8 @@ class UntilSuccessfulRouter {
       }
       return new MessagingException(exceptionEvent,
                                     new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG_PREFIX,
-                                            retryPolicyExhaustionCause.getMessage()),
+                                                                                          retryPolicyExhaustionCause
+                                                                                              .getMessage()),
                                                                       retryPolicyExhaustionCause, owner),
                                     owner);
     };

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -15,7 +15,6 @@ import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.metadata.DataType.NUMBER;
 import static org.mule.runtime.core.api.retry.policy.SimpleRetryPolicyTemplate.RETRY_COUNT_FOREVER;
 import static org.mule.runtime.core.api.transaction.TransactionCoordination.isTransactionActive;
-import static org.mule.runtime.core.api.util.ExceptionUtils.getMessagingExceptionCause;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.applyWithChildContext;
 import static org.mule.runtime.internal.exception.SuppressedMuleException.suppressIfPresent;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -279,14 +278,14 @@ class UntilSuccessfulRouter {
       // Prevent any MuleException from replacing the retry exhausted error message or error type
       // (see MessagingExceptionResolver#findRoot)
       Throwable retryPolicyExhaustionCause =
-          suppressIfPresent(getMessagingExceptionCause(throwable), MuleException.class);
+          suppressIfPresent(throwable, MuleException.class);
       RetryPolicyExhaustedException retryPolicyExhaustedException =
           new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG),
                                             retryPolicyExhaustionCause,
                                             owner);
-      // Info about the cause is added. Note that if a MuleException has been suppressed, it will later overwrite this
+      // Info about the cause is added. Note that if a MuleException has been suppressed, it will later overwrite this value
       // (see ExceptionHelper#getRootMuleException)
-      retryPolicyExhaustedException.addInfo(MuleExceptionInfo.INFO_CAUSED_BY_KEY, retryPolicyExhaustionCause.getMessage());
+      retryPolicyExhaustedException.addInfo(MuleExceptionInfo.INFO_CAUSED_BY_KEY, retryPolicyExhaustionCause);
       if (throwable instanceof MessagingException) {
         exceptionEvent = ((MessagingException) throwable).getEvent();
       }

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/UntilSuccessfulRouter.java
@@ -24,7 +24,6 @@ import static reactor.util.context.Context.empty;
 
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.api.exception.MuleExceptionInfo;
 import org.mule.runtime.api.functional.Either;
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.core.api.el.ExpressionManagerSession;
@@ -283,9 +282,6 @@ class UntilSuccessfulRouter {
           new RetryPolicyExhaustedException(createStaticMessage(UNTIL_SUCCESSFUL_MSG),
                                             retryPolicyExhaustionCause,
                                             owner);
-      // Info about the cause is added. Note that if a MuleException has been suppressed, it will later overwrite this value
-      // (see ExceptionHelper#getRootMuleException)
-      retryPolicyExhaustedException.addInfo(MuleExceptionInfo.INFO_CAUSED_BY_KEY, retryPolicyExhaustionCause);
       if (throwable instanceof MessagingException) {
         exceptionEvent = ((MessagingException) throwable).getEvent();
       }

--- a/modules/extensions-support/pom.xml
+++ b/modules/extensions-support/pom.xml
@@ -122,6 +122,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-allure</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Test Extensions dependencies -->
         <dependency>
             <groupId>org.mule.tests</groupId>

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
@@ -117,7 +117,7 @@ public class ModuleExceptionHandler {
     // For subclasses of ModuleException, we use it as it already contains additional information
     if (throwable.getClass().equals(ModuleException.class)) {
       return throwable.getCause() != null
-          ? SuppressedMuleException.suppressIfPresent(throwable.getCause(), MessagingException.class)
+          ? SuppressedMuleException.suppressIfPresent(throwable.getCause(), MessagingException.class, true)
           : new MuleRuntimeException(createStaticMessage(throwable.getMessage()));
     } else {
       return throwable;

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
@@ -118,7 +118,7 @@ public class ModuleExceptionHandler {
     // For subclasses of ModuleException, we use it as it already contains additional information
     if (throwable.getClass().equals(ModuleException.class)) {
       return throwable.getCause() != null
-          ? suppressIfPresent(throwable.getCause(), MessagingException.class, true)
+          ? suppressIfPresent(throwable.getCause(), MessagingException.class)
           : new MuleRuntimeException(createStaticMessage(throwable.getMessage()));
     } else {
       return throwable;

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
@@ -117,25 +117,11 @@ public class ModuleExceptionHandler {
     // For subclasses of ModuleException, we use it as it already contains additional information
     if (throwable.getClass().equals(ModuleException.class)) {
       return throwable.getCause() != null
-          ? throwable.getCause()
+          ? SuppressedMuleException.suppressIfPresent(throwable.getCause(), MessagingException.class)
           : new MuleRuntimeException(createStaticMessage(throwable.getMessage()));
     } else {
-      return suppressMessagingException(throwable);
+      return throwable;
     }
   }
 
-  private Throwable suppressMessagingException(Throwable throwable) {
-    Throwable cause = throwable;
-    while (cause != null && !(cause instanceof SuppressedMuleException)) {
-      if (cause instanceof MessagingException) {
-        return new SuppressedMuleException(throwable, (MessagingException) cause);
-      }
-      cause = getExceptionReader(cause).getCause(cause);
-      // Address some misbehaving exceptions, avoid endless loop
-      if (throwable == cause) {
-        break;
-      }
-    }
-    return throwable;
-  }
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
@@ -8,11 +8,13 @@ package org.mule.runtime.module.extension.internal.runtime.exception;
 
 import static com.github.benmanes.caffeine.cache.Caffeine.newBuilder;
 import static org.mule.runtime.api.component.ComponentIdentifier.builder;
-import static org.mule.runtime.api.exception.ExceptionHelper.getExceptionReader;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.internal.exception.SuppressedMuleException.suppressIfPresent;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.getExtensionsNamespace;
 
-import org.mule.runtime.api.exception.*;
+import org.mule.runtime.api.exception.ErrorTypeRepository;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.exception.TypedException;
 import org.mule.runtime.api.message.ErrorType;
 import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.meta.model.ExtensionModel;
@@ -26,7 +28,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import org.mule.runtime.internal.exception.SuppressedMuleException;
 
 /**
  * Handler of {@link ModuleException ModuleExceptions}, which given a {@link Throwable} checks whether the exceptions is
@@ -117,7 +118,7 @@ public class ModuleExceptionHandler {
     // For subclasses of ModuleException, we use it as it already contains additional information
     if (throwable.getClass().equals(ModuleException.class)) {
       return throwable.getCause() != null
-          ? SuppressedMuleException.suppressIfPresent(throwable.getCause(), MessagingException.class, true)
+          ? suppressIfPresent(throwable.getCause(), MessagingException.class, true)
           : new MuleRuntimeException(createStaticMessage(throwable.getMessage()));
     } else {
       return throwable;

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandler.java
@@ -121,8 +121,7 @@ public class ModuleExceptionHandler {
           ? suppressIfPresent(throwable.getCause(), MessagingException.class)
           : new MuleRuntimeException(createStaticMessage(throwable.getMessage()));
     } else {
-      return throwable;
+      return suppressIfPresent(throwable, MessagingException.class);
     }
   }
-
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/exception/ModuleExceptionHandlerTestCase.java
@@ -168,7 +168,7 @@ public class ModuleExceptionHandlerTestCase extends AbstractMuleTestCase {
     Throwable exception = handler.processException(moduleException);
 
     assertThat(exception.getCause(), is(instanceOf(SuppressedMuleException.class)));
-    assertThat(((SuppressedMuleException) exception.getCause()).getSuppressedMuleException(),
+    assertThat(((SuppressedMuleException) exception.getCause()).getSuppressedException(),
                is(instanceOf(MessagingException.class)));
   }
 


### PR DESCRIPTION
This changes aim to fix error type issues where the error thrown by an extension gets replaced by a different one. Prior to this fix, if an extension makes a call to a second one and wraps the potential exception, that error thrown by the "child" extension will replace the one that the "parent" extension is throwing.
Cause has been reduced to the existence of a nested MessagingException due to the repeated processing of the exception by the core. Logic has been added in order to suppress that nested exception. It's message is stored as a new MuleExceptionInfo property ("Caused By"), that will be logged as part of the error only if it has a value.