### PR TITLE
MULE-18455: test cases added for 413 and 414 status code  (#8940)

### DIFF
--- a/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerUrlTooLongTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/functional/listener/HttpListenerUrlTooLongTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.http.functional.listener;
+
+import org.apache.http.client.fluent.Response;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.junit4.rule.DynamicPort;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.repeat;
+import static org.apache.http.client.fluent.Request.Get;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.module.http.api.HttpConstants.HttpStatus.REQUEST_URI_TOO_LONG;
+
+public class HttpListenerUrlTooLongTestCase extends FunctionalTestCase
+{
+
+    @Rule
+    public DynamicPort listenPort = new DynamicPort("port");
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "http-listener-url-too-long-config.xml";
+    }
+
+
+    @Test
+    public void returnsRequestUriTooLong() throws Exception
+    {
+        final Response response = Get(getListenerUrl(repeat("path", 3000)))
+            .execute();
+
+        assertThat(response.returnResponse().getStatusLine().getStatusCode(), is(REQUEST_URI_TOO_LONG.getStatusCode()));
+    }
+
+
+    private String getListenerUrl(String path)
+    {
+        return format("http://localhost:%s/%s", listenPort.getNumber(), path);
+    }
+}

--- a/modules/http/src/test/resources/http-listener-url-too-long-config.xml
+++ b/modules/http/src/test/resources/http-listener-url-too-long-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <http:listener-config name="listenerConfig" host="localhost" port="${port}" />
+
+    <flow name="inbound">
+        <http:listener config-ref="listenerConfig"  path="*"/>
+        <set-payload value="#['Should return 414!']"/>
+    </flow>
+</mule>


### PR DESCRIPTION
* MULE-18455: a request with a long header must respond with a 413