### PR TITLE
Fix/mule 18582 3.x

### DIFF
--- a/core/src/main/java/org/mule/api/retry/RetryPolicyTemplate.java
+++ b/core/src/main/java/org/mule/api/retry/RetryPolicyTemplate.java
@@ -32,4 +32,6 @@ public interface RetryPolicyTemplate
     RetryContext execute(RetryCallback callback, WorkManager workManager) throws Exception;
 
     boolean isSynchronous();
+
+    void cancelStart();
 }

--- a/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
+++ b/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
@@ -96,4 +96,9 @@ public class AsynchronousRetryTemplate implements RetryPolicyTemplate
     {
         return false;
     }
+
+    @Override
+    public void cancelStart() {
+        delegate.cancelStart();
+    }
 }

--- a/core/src/test/java/org/mule/retry/async/AsynchronousRetryTemplateTestCase.java
+++ b/core/src/test/java/org/mule/retry/async/AsynchronousRetryTemplateTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.retry.async;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.retry.RetryPolicyTemplate;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+public class AsynchronousRetryTemplateTestCase
+{
+
+    private RetryPolicyTemplate delegate;
+    private AsynchronousRetryTemplate asynchronousRetryTemplate;
+
+    @Before
+    public void setUp()
+    {
+        delegate = mock(RetryPolicyTemplate.class);
+        asynchronousRetryTemplate = new AsynchronousRetryTemplate(delegate);
+    }
+
+    @Test
+    public void testCancelStart()
+    {
+        // Given an asynchronous retry template with a delegate
+
+        // When cancelling start
+        asynchronousRetryTemplate.cancelStart();
+
+        // Then
+        verify(delegate, times(1)).cancelStart();
+    }
+
+}

--- a/core/src/test/java/org/mule/retry/policies/AbstractPolicyTemplateTestCase.java
+++ b/core/src/test/java/org/mule/retry/policies/AbstractPolicyTemplateTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.retry.policies;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.context.WorkManager;
+import org.mule.api.retry.RetryCallback;
+import org.mule.api.retry.RetryContext;
+import org.mule.api.retry.RetryNotifier;
+import org.mule.api.retry.RetryPolicy;
+import org.mule.retry.PolicyStatus;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class AbstractPolicyTemplateTestCase
+{
+
+    private AbstractPolicyTemplate abstractPolicyTemplate;
+    private RetryPolicy retryPolicy;
+    private RetryCallback retryCallback;
+    private WorkManager workManager;
+    private RetryNotifier retryNotifier;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        retryPolicy = mock(RetryPolicy.class);
+
+        abstractPolicyTemplate = new AbstractPolicyTemplate()
+        {
+            @Override
+            public RetryPolicy createRetryInstance()
+            {
+                return retryPolicy;
+            }
+        };
+
+        retryNotifier = mock(RetryNotifier.class);
+        abstractPolicyTemplate.setNotifier(retryNotifier);
+
+        retryCallback = mock(RetryCallback.class);
+
+        workManager = mock(WorkManager.class);
+    }
+
+    @Test
+    public void testCancelStart()
+    {
+        // Given a Policy based on the abstract policy template with a start that is not yet cancelled
+        assertThat(abstractPolicyTemplate.getCancelStart().get(), equalTo(false));
+
+        // When cancelling start
+        abstractPolicyTemplate.cancelStart();
+
+        // Then cancelStart is set to true
+        assertThat(abstractPolicyTemplate.getCancelStart().get(), equalTo(true));
+    }
+
+    @Test
+    public void executeCanceledStart() throws Exception
+    {
+        // Given a Policy based on the abstract policy template that should be executed forever but start is cancelled
+        doThrow(new Exception()).when(retryCallback).doWork(any(RetryContext.class));
+        when(retryPolicy.applyPolicy(any(Throwable.class))).thenReturn(PolicyStatus.policyOk());
+        abstractPolicyTemplate.cancelStart();
+
+        // When executing
+        abstractPolicyTemplate.execute(retryCallback, workManager);
+
+        // Then the policy stops executing
+    }
+
+}

--- a/modules/launcher/pom.xml
+++ b/modules/launcher/pom.xml
@@ -59,6 +59,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.transports</groupId>
+            <artifactId>mule-transport-sftp</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DefaultArtifactDeployer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DefaultArtifactDeployer.java
@@ -53,6 +53,7 @@ public class DefaultArtifactDeployer<T extends Artifact> implements ArtifactDepl
 
         try
         {
+            artifact.cancelStart();
             artifact.stop();
         }
         catch (Throwable t)

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DeploymentDirectoryWatcher.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DeploymentDirectoryWatcher.java
@@ -215,6 +215,7 @@ public class DeploymentDirectoryWatcher implements Runnable
     public void stop()
     {
         stopAppDirMonitorTimer();
+        cancelStart(applications);
 
         deploymentLock.lock();
         try
@@ -225,6 +226,22 @@ public class DeploymentDirectoryWatcher implements Runnable
         finally
         {
             deploymentLock.unlock();
+        }
+    }
+
+    private void cancelStart(List<? extends Artifact> artifacts) {
+        Collections.reverse(artifacts);
+
+        for (Artifact artifact : artifacts)
+        {
+            try
+            {
+                artifact.cancelStart();
+            }
+            catch (Throwable t)
+            {
+                logger.error(format("Error cancelling start for artifact '%s'", artifact), t);
+            }
         }
     }
 

--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
@@ -17,13 +17,13 @@ import org.mule.api.config.MuleProperties;
 import org.mule.api.context.notification.MuleContextNotificationListener;
 import org.mule.api.context.notification.ServerNotificationListener;
 import org.mule.api.lifecycle.Stoppable;
+import org.mule.api.transport.Connector;
 import org.mule.config.builders.ExtensionsManagerConfigurationBuilder;
 import org.mule.config.builders.SimpleConfigurationBuilder;
 import org.mule.context.DefaultMuleContextFactory;
 import org.mule.context.notification.MuleContextNotification;
 import org.mule.context.notification.NotificationException;
 import org.mule.lifecycle.phases.NotInLifecyclePhase;
-import org.mule.module.launcher.DeploymentPropertiesUtils;
 import org.mule.module.launcher.DeploymentInitException;
 import org.mule.module.launcher.DeploymentListener;
 import org.mule.module.launcher.DeploymentStartException;
@@ -31,7 +31,6 @@ import org.mule.module.launcher.DeploymentStopException;
 import org.mule.module.launcher.DisposableClassLoader;
 import org.mule.module.launcher.InstallException;
 import org.mule.module.launcher.MuleDeploymentService;
-import org.mule.module.launcher.MuleFoldersUtil;
 import org.mule.module.launcher.artifact.ArtifactClassLoader;
 import org.mule.module.launcher.artifact.MuleContextDeploymentListener;
 import org.mule.module.launcher.descriptor.ApplicationDescriptor;
@@ -449,6 +448,18 @@ public class DefaultMuleApplication implements Application
     public void setDeploymentProperties(Properties deploymentProperties)
     {
         this.deploymentProperties = deploymentProperties;        
+    }
+
+    @Override
+    public void cancelStart()
+    {
+        if(muleContext != null && muleContext.getRegistry() != null && !muleContext.getRegistry().lookupObjects(Connector.class).isEmpty())
+        {
+            for(Connector connector: muleContext.getRegistry().lookupObjects(Connector.class))
+            {
+                connector.getRetryPolicyTemplate().cancelStart();
+            }
+        }
     }
 
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
@@ -360,6 +360,8 @@ public class DefaultMuleApplication implements Application
     @Override
     public void stop()
     {
+        this.cancelStart();
+
         if (this.muleContext == null || !this.muleContext.getLifecycleManager().isDirectTransition(Stoppable.PHASE_NAME))
         {
             return;
@@ -457,9 +459,11 @@ public class DefaultMuleApplication implements Application
         {
             for(Connector connector: muleContext.getRegistry().lookupObjects(Connector.class))
             {
-                connector.getRetryPolicyTemplate().cancelStart();
+                if(connector.getRetryPolicyTemplate() != null)
+                {
+                    connector.getRetryPolicyTemplate().cancelStart();
+                }
             }
         }
     }
-
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/Artifact.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/Artifact.java
@@ -79,4 +79,9 @@ public interface Artifact<D extends ArtifactDescriptor>
      * @param deploymentProperties deployment properties
      */
     void setDeploymentProperties(Properties deploymentProperties);
+
+    /**
+     * Notifies all retry policies associated to the artifact to stop retrying
+     */
+    void cancelStart();
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/Artifact.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/Artifact.java
@@ -81,7 +81,7 @@ public interface Artifact<D extends ArtifactDescriptor>
     void setDeploymentProperties(Properties deploymentProperties);
 
     /**
-     * Notifies all retry policies associated to the artifact to stop retrying
+     * Cancels any ongoing process that prevents the startup fase from ending
      */
     void cancelStart();
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactWrapper.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactWrapper.java
@@ -168,4 +168,16 @@ public class ArtifactWrapper<T extends Artifact<D>, D extends ArtifactDescriptor
     {
         getDelegate().setDeploymentProperties(deploymentProperties);
     }
+
+    @Override
+    public void cancelStart() {
+        executeWithinArtifactClassLoader(new ArtifactAction()
+        {
+            @Override
+            public void execute()
+            {
+                delegate.cancelStart();
+            }
+        });
+    }
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactWrapper.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactWrapper.java
@@ -115,6 +115,7 @@ public class ArtifactWrapper<T extends Artifact<D>, D extends ArtifactDescriptor
             @Override
             public void execute()
             {
+                delegate.cancelStart();
                 delegate.stop();
             }
         });

--- a/modules/launcher/src/main/java/org/mule/module/launcher/domain/DefaultMuleDomain.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/domain/DefaultMuleDomain.java
@@ -303,6 +303,7 @@ public class DefaultMuleDomain implements Domain
             }
             if (this.muleContext != null)
             {
+                this.cancelStart();
                 this.muleContext.stop();
             }
         }
@@ -411,7 +412,10 @@ public class DefaultMuleDomain implements Domain
         {
             for (Connector connector : muleContext.getRegistry().lookupObjects(Connector.class))
             {
-                connector.getRetryPolicyTemplate().cancelStart();
+                if(connector.getRetryPolicyTemplate() != null)
+                {
+                    connector.getRetryPolicyTemplate().cancelStart();
+                }
             }
         }
     }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/domain/DefaultMuleDomain.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/domain/DefaultMuleDomain.java
@@ -17,17 +17,16 @@ import org.mule.api.config.ConfigurationBuilder;
 import org.mule.api.config.DomainMuleContextAwareConfigurationBuilder;
 import org.mule.api.context.MuleContextFactory;
 import org.mule.api.lifecycle.InitialisationException;
+import org.mule.api.transport.Connector;
 import org.mule.config.builders.AutoConfigurationBuilder;
 import org.mule.config.builders.SimpleConfigurationBuilder;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.context.DefaultMuleContextFactory;
-import org.mule.module.launcher.DeploymentPropertiesUtils;
 import org.mule.module.launcher.DeploymentInitException;
 import org.mule.module.launcher.DeploymentListener;
 import org.mule.module.launcher.DeploymentStartException;
 import org.mule.module.launcher.DeploymentStopException;
 import org.mule.module.launcher.MuleDeploymentService;
-import org.mule.module.launcher.MuleFoldersUtil;
 import org.mule.module.launcher.application.Application;
 import org.mule.module.launcher.application.NullDeploymentListener;
 import org.mule.module.launcher.artifact.ArtifactClassLoader;
@@ -404,5 +403,16 @@ public class DefaultMuleDomain implements Domain
     public void setDeploymentProperties(Properties deploymentProperties)
     {
         this.deploymentProperties = deploymentProperties;
+    }
+
+    @Override
+    public void cancelStart() {
+        if(muleContext != null && muleContext.getRegistry() != null && !muleContext.getRegistry().lookupObjects(Connector.class).isEmpty())
+        {
+            for (Connector connector : muleContext.getRegistry().lookupObjects(Connector.class))
+            {
+                connector.getRetryPolicyTemplate().cancelStart();
+            }
+        }
     }
 }

--- a/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentDirectoryWatcherTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentDirectoryWatcherTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mule.module.launcher.application.Application;
+import org.mule.module.launcher.domain.Domain;
+import org.mule.module.launcher.util.ObservableList;
+
+import java.util.ArrayList;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DeploymentDirectoryWatcherTestCase
+{
+
+    private ArchiveDeployer<Domain> domainArchiveDeployer;
+    private ArchiveDeployer<Application> applicationArchiveDeployer;
+    private ReentrantLock deploymentLock;
+    private ObservableList<Domain> domains;
+    private ArrayList<Application> applicationArrayList;
+    private ObservableList<Application> applications;
+    private DeploymentDirectoryWatcher deploymentDirectoryWatcher;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        domainArchiveDeployer = mock(ArchiveDeployer.class);
+        applicationArchiveDeployer = mock(ArchiveDeployer.class);
+        deploymentLock = mock(ReentrantLock.class);
+        domains = new ObservableList<>(new ArrayList<Domain>());
+        applicationArrayList = new ArrayList<>();
+        applications = new ObservableList<>(applicationArrayList);
+
+        deploymentDirectoryWatcher = new DeploymentDirectoryWatcher(domainArchiveDeployer, applicationArchiveDeployer, domains, applications, deploymentLock);
+
+    }
+
+    @Test
+    public void testStopOneApplicationCancelsStart()
+    {
+        // Given a deploymentDirectoryWatcher with one application
+        Application application = mock(Application.class);
+        applicationArrayList.add(application);
+
+        // When stopping
+        deploymentDirectoryWatcher.stop();
+
+        // Then cancel start is called for every application before requesting the lock
+        InOrder inOrder = inOrder(application, deploymentLock);
+        inOrder.verify(application).cancelStart();
+        inOrder.verify(deploymentLock).lock();
+    }
+
+    @Test
+    public void testStopThreeApplicationsCancelsStart()
+    {
+        // Given a deploymentDirectoryWatcher with one application
+        Application application1 = mock(Application.class);
+        applicationArrayList.add(application1);
+
+        Application application2 = mock(Application.class);
+        applicationArrayList.add(application2);
+
+        Application application3 = mock(Application.class);
+        applicationArrayList.add(application3);
+
+        // When stopping
+        deploymentDirectoryWatcher.stop();
+
+        // Then cancel start is called for every application before requesting the lock
+        InOrder inOrder = inOrder(application1, application2, application3, deploymentLock);
+        inOrder.verify(application3, times(1)).cancelStart();
+        inOrder.verify(application2, times(1)).cancelStart();
+        inOrder.verify(application1, times(1)).cancelStart();
+        inOrder.verify(deploymentLock).lock();
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentServiceTestCase.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mule.module.launcher.MuleDeploymentService.PARALLEL_DEPLOYMENT_PROPERTY;
 import static org.mule.module.launcher.application.ApplicationStatus.CREATED;
+import static org.mule.module.launcher.application.ApplicationStatus.DESTROYED;
 import static org.mule.module.launcher.application.ApplicationStatus.STARTED;
 import static org.mule.module.launcher.application.ApplicationStatus.STOPPED;
 import static org.mule.module.launcher.descriptor.PropertiesDescriptorParser.PROPERTY_CONFIG_RESOURCES;
@@ -47,6 +48,7 @@ import org.mule.api.lifecycle.Initialisable;
 import org.mule.api.lifecycle.InitialisationException;
 import org.mule.api.registry.MuleRegistry;
 import org.mule.api.registry.Registry;
+import org.mule.api.transport.Connector;
 import org.mule.config.StartupContext;
 import org.mule.module.http.internal.listener.DefaultHttpListenerConfig;
 import org.mule.module.launcher.application.Application;
@@ -94,6 +96,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -158,6 +163,7 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
     private final ApplicationFileBuilder httpAAppFileBuilder = new ApplicationFileBuilder("shared-http-app-a").definedBy("shared-http-a-app-config.xml").deployedWith("domain", "shared-http-domain");
     private final ApplicationFileBuilder httpBAppFileBuilder = new ApplicationFileBuilder("shared-http-app-b").definedBy("shared-http-b-app-config.xml").deployedWith("domain", "shared-http-domain");
     private final ApplicationFileBuilder badConfigAppFileBuilder = new ApplicationFileBuilder("bad-config-app").definedBy("bad-app-config.xml");
+    private final ApplicationFileBuilder retryPolicyForeverAppFileBuilder = new ApplicationFileBuilder("retry-policy-forever-app").definedBy("retry-policy-forever-app-config.xml");
 
     // Domain file builders
     private final DomainFileBuilder brokenDomainFileBuilder = new DomainFileBuilder("brokenDomain").corrupted();
@@ -176,6 +182,7 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
     protected File appsDir;
     protected File domainsDir;
     protected TestMuleDeploymentService deploymentService;
+    protected static TestMuleDeploymentService staticDeploymentService;
     protected DeploymentListener applicationDeploymentListener;
     protected DeploymentListener domainDeploymentListener;
     protected TestDeploymentListener testDeploymentListener = new TestDeploymentListener();
@@ -3877,5 +3884,108 @@ public class DeploymentServiceTestCase extends AbstractMuleContextTestCase
 
         // Application was deployed
         assertApplicationDeploymentSuccess(applicationDeploymentListener, applicationFileBuilder.getId());
+    }
+
+    @Test
+    public void reconnectForeverAplicationCanBeSttopedWhenCancelingStart() throws Exception
+    {
+        DeploymentListener mockDeploymentListener = spy(new DeploymentStatusTracker());
+        deploymentService.addDeploymentListener(mockDeploymentListener);
+        addPackedAppFromBuilder(retryPolicyForeverAppFileBuilder);
+
+        ExecutorService service = Executors.newFixedThreadPool(3);
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        // Aquire the deployment lock and start the application
+        service.submit(new DeployRetryPolicyForeverApplicationRunnable(latch));
+
+        // Cancel start so that retry policy forever will stop retrying and the stop the app when the deployment lock gets released
+        service.submit(new RetryPolicyApplicationCancelStartAndStopRunnable(latch));
+
+        latch.await();
+
+        // Check status
+        assertStatus(retryPolicyForeverAppFileBuilder.getId(), STOPPED);
+        staticDeploymentService.stop();
+        assertStatus(retryPolicyForeverAppFileBuilder.getId(), DESTROYED);
+
+        service.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        service.shutdown();
+    }
+
+    private class ApplicationReconnectingProbe implements Probe
+    {
+        @Override
+        public boolean isSatisfied()
+        {
+            return staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()) != null
+                    && staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()).getMuleContext() != null
+                    && staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()).getMuleContext().getRegistry() != null
+                    && !staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()).getMuleContext().getRegistry().lookupObjects(Connector.class).isEmpty()
+                    && staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()).getMuleContext().getRegistry().lookupObjects(Connector.class).iterator().next().getRetryPolicyTemplate() != null;
+        }
+
+        @Override
+        public String describeFailure()
+        {
+            return "Either the application, the connector or it's retry policy could not be found";
+        }
+    }
+
+    private class ApplicationStoppedProbe implements Probe
+    {
+        @Override
+        public boolean isSatisfied()
+        {
+            return STOPPED.equals(staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()).getStatus());
+        }
+
+        @Override
+        public String describeFailure()
+        {
+            return "Application didn't stop";
+        }
+    }
+
+    private class DeployRetryPolicyForeverApplicationRunnable implements Runnable
+    {
+        private final CountDownLatch latch;
+
+        public DeployRetryPolicyForeverApplicationRunnable(CountDownLatch latch)
+        {
+            this.latch = latch;
+        }
+
+        @Override
+        public void run()
+        {
+            staticDeploymentService = deploymentService;
+            deploymentService.start();
+            latch.countDown();
+        }
+    }
+
+    private class RetryPolicyApplicationCancelStartAndStopRunnable implements Runnable
+    {
+        private final CountDownLatch latch;
+
+        public RetryPolicyApplicationCancelStartAndStopRunnable(CountDownLatch latch)
+        {
+            this.latch = latch;
+        }
+
+        @Override
+        public void run()
+        {
+            PollingProber pollingProber = new PollingProber(7000, 300);
+
+            pollingProber.check(new ApplicationReconnectingProbe());
+
+            staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()).cancelStart();
+            staticDeploymentService.findApplication(retryPolicyForeverAppFileBuilder.getId()).stop();
+
+            pollingProber.check(new ApplicationStoppedProbe());
+            latch.countDown();
+        }
     }
 }

--- a/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationTestCase.java
@@ -9,6 +9,8 @@ package org.mule.module.launcher.application;
 import org.junit.Before;
 import org.junit.Test;
 import org.mule.api.MuleContext;
+import org.mule.api.lifecycle.LifecycleManager;
+import org.mule.api.lifecycle.Stoppable;
 import org.mule.api.registry.MuleRegistry;
 import org.mule.api.retry.RetryPolicyTemplate;
 import org.mule.api.transport.Connector;
@@ -86,6 +88,61 @@ public class DefaultMuleApplicationTestCase
         verify(retryPolicyTemplate3, times(1)).cancelStart();
         verify(retryPolicyTemplate4, times(1)).cancelStart();
         verify(retryPolicyTemplate5, times(1)).cancelStart();
+    }
+
+    @Test
+    public void testStopCancelStartFiveConectors()
+    {
+        // Given a default mule applicacion with 5 connectors that have retryPolicies
+        LifecycleManager lifecycleManager = mock(LifecycleManager.class);
+        when(lifecycleManager.isDirectTransition(Stoppable.PHASE_NAME)).thenReturn(true);
+        when(muleContext.getLifecycleManager()).thenReturn(lifecycleManager);
+
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate3 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate4 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate5 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When stopping
+        defaultMuleApplication.stop();
+
+        // Then connector's retry policies start is cancelled
+        verify(retryPolicyTemplate1, times(1)).cancelStart();
+        verify(retryPolicyTemplate2, times(1)).cancelStart();
+        verify(retryPolicyTemplate3, times(1)).cancelStart();
+        verify(retryPolicyTemplate4, times(1)).cancelStart();
+        verify(retryPolicyTemplate5, times(1)).cancelStart();
+    }
+
+    @Test
+    public void testCancelStartFiveConectorsWithNullRetryPolicies()
+    {
+        // Given a default mule applicacion with 5 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        Connector connector1 = mock(Connector.class);
+        connectors.add(connector1);
+        Connector connector2 = mock(Connector.class);
+        connectors.add(connector2);
+        Connector connector3 = mock(Connector.class);
+        connectors.add(connector3);
+        Connector connector4 = mock(Connector.class);
+        connectors.add(connector4);
+        Connector connector5 = mock(Connector.class);
+        connectors.add(connector5);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleApplication.cancelStart();
+
+        // Then no error occurs
+
     }
 
     private RetryPolicyTemplate addMockConnectorWithMockRetryPolicyToList(List<Connector> connectors)

--- a/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher.application;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.MuleContext;
+import org.mule.api.registry.MuleRegistry;
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.api.transport.Connector;
+import org.mule.module.launcher.descriptor.ApplicationDescriptor;
+import org.mule.module.launcher.domain.Domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultMuleApplicationTestCase
+{
+
+    private ApplicationDescriptor applicationDescriptor;
+    private ApplicationClassLoaderFactory applicationClassLoaderFactory;
+    private Domain domain;
+    private DefaultMuleApplication defaultMuleApplication;
+    private MuleContext muleContext;
+    private MuleRegistry muleRegistry;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        applicationDescriptor = mock(ApplicationDescriptor.class);
+        applicationClassLoaderFactory = mock(ApplicationClassLoaderFactory.class);
+        domain = mock(Domain.class);
+
+        defaultMuleApplication = new DefaultMuleApplication(applicationDescriptor, applicationClassLoaderFactory, domain);
+        muleContext = mock(MuleContext.class);
+        defaultMuleApplication.setMuleContext(muleContext);
+        muleRegistry = mock(MuleRegistry.class);
+        when(muleContext.getRegistry()).thenReturn(muleRegistry);
+    }
+
+    @Test
+    public void testCancelStartOneConector()
+    {
+        // Given a default mule applicacion with 1 connector that has retryPolicy
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate = addMockConnectorWithMockRetryPolicyToList(connectors);
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleApplication.cancelStart();
+
+        // Connectors's retry policy start is also cancelled
+        verify(retryPolicyTemplate).cancelStart();
+    }
+
+    @Test
+    public void testCancelStartFiveConectors()
+    {
+        // Given a default mule applicacion with 5 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate3 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate4 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate5 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleApplication.cancelStart();
+
+        // Then connector's retry policies start is also cancelled
+        verify(retryPolicyTemplate1, times(1)).cancelStart();
+        verify(retryPolicyTemplate2, times(1)).cancelStart();
+        verify(retryPolicyTemplate3, times(1)).cancelStart();
+        verify(retryPolicyTemplate4, times(1)).cancelStart();
+        verify(retryPolicyTemplate5, times(1)).cancelStart();
+    }
+
+    private RetryPolicyTemplate addMockConnectorWithMockRetryPolicyToList(List<Connector> connectors)
+    {
+        Connector connector = mock(Connector.class);
+        connectors.add(connector);
+
+        RetryPolicyTemplate retryPolicyTemplate = mock(RetryPolicyTemplate.class);
+        when(connector.getRetryPolicyTemplate()).thenReturn(retryPolicyTemplate);
+
+        return retryPolicyTemplate;
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/artifact/ArtifactWrapperTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/artifact/ArtifactWrapperTestCase.java
@@ -36,6 +36,20 @@ public class ArtifactWrapperTestCase
         verify(artifact).cancelStart();
     }
 
+    @Test
+    public void testCancelStartWhenStopping() throws IOException
+    {
+        // Given an artifact wrapper
+        ArtifactSubtype artifact = mock(ArtifactSubtype.class);
+        ArtifactWrapper<ArtifactSubtype, ArtifactSubtypeDescriptor> artifactWrapper = new ArtifactWrapper<>(artifact);
+
+        // When cancelling start
+        artifactWrapper.stop();
+
+        // Then the delegate is told to cancel start
+        verify(artifact).cancelStart();
+    }
+
     private class ArtifactSubtype implements Artifact<ArtifactSubtypeDescriptor>
     {
         @Override

--- a/modules/launcher/src/test/java/org/mule/module/launcher/artifact/ArtifactWrapperTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/artifact/ArtifactWrapperTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.artifact;
+
+import org.junit.Test;
+import org.mule.api.MuleContext;
+import org.mule.module.launcher.DeploymentStartException;
+import org.mule.module.launcher.InstallException;
+import org.mule.module.launcher.descriptor.ArtifactDescriptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ArtifactWrapperTestCase
+{
+    @Test
+    public void testCancelStart() throws IOException
+    {
+        // Given an artifact wrapper
+        ArtifactSubtype artifact = mock(ArtifactSubtype.class);
+        ArtifactWrapper<ArtifactSubtype, ArtifactSubtypeDescriptor> artifactWrapper = new ArtifactWrapper<>(artifact);
+
+        // When cancelling start
+        artifactWrapper.cancelStart();
+
+        // Then the delegate is told to cancel start
+        verify(artifact).cancelStart();
+    }
+
+    private class ArtifactSubtype implements Artifact<ArtifactSubtypeDescriptor>
+    {
+        @Override
+        public void install() throws InstallException
+        {
+
+        }
+
+        @Override
+        public void init()
+        {
+
+        }
+
+        @Override
+        public void start() throws DeploymentStartException
+        {
+
+        }
+
+        @Override
+        public void stop()
+        {
+
+        }
+
+        @Override
+        public void dispose()
+        {
+
+        }
+
+        @Override
+        public String getArtifactName()
+        {
+            return null;
+        }
+
+        @Override
+        public ArtifactSubtypeDescriptor getDescriptor()
+        {
+            return null;
+        }
+
+        @Override
+        public File[] getResourceFiles()
+        {
+            return new File[0];
+        }
+
+        @Override
+        public ArtifactClassLoader getArtifactClassLoader()
+        {
+            return null;
+        }
+
+        @Override
+        public MuleContext getMuleContext()
+        {
+            return null;
+        }
+
+        @Override
+        public void setDeploymentProperties(Properties deploymentProperties)
+        {
+
+        }
+
+        @Override
+        public void cancelStart()
+        {
+
+        }
+    }
+
+    private class ArtifactSubtypeDescriptor extends ArtifactDescriptor
+    {
+
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/domain/DefaultMuleDomainTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/domain/DefaultMuleDomainTestCase.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.MuleContext;
+import org.mule.api.context.MuleContextBuilder;
+import org.mule.api.context.MuleContextFactory;
+import org.mule.api.registry.MuleRegistry;
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.api.transport.Connector;
+import org.mule.module.launcher.artifact.ArtifactClassLoader;
+import org.mule.module.launcher.descriptor.DomainDescriptor;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mule.module.launcher.domain.Domain.DOMAIN_CONFIG_FILE_LOCATION;
+
+public class DefaultMuleDomainTestCase
+{
+    private static final MuleContextFactory muleContextFactory = mock(MuleContextFactory.class);
+    private DomainDescriptor domainDescriptor;
+    private DomainClassLoaderRepository domainClassLoaderRepository;
+    private DefaultMuleDomain defaultMuleDomain;
+    private MuleContext muleContext;
+    private MuleRegistry muleRegistry;
+
+    private URL resource;
+    private ArtifactClassLoader artifactClassLoader;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        domainDescriptor = mock(DomainDescriptor.class);
+        domainClassLoaderRepository = mock(DomainClassLoaderRepository.class);
+        artifactClassLoader = mock(ArtifactClassLoader.class);
+        when(domainClassLoaderRepository.getDomainClassLoader(domainDescriptor)).thenReturn(artifactClassLoader);
+        when(artifactClassLoader.findLocalResource(anyString())).thenReturn(null);
+        resource = getClass().getClassLoader().getResource("empty-domain-config.xml").toURI().toURL();
+        when(domainClassLoaderRepository.getDomainClassLoader(domainDescriptor)).thenReturn(artifactClassLoader);
+        when(artifactClassLoader.findLocalResource(DOMAIN_CONFIG_FILE_LOCATION)).thenReturn(resource);
+
+        muleContext = mock(MuleContext.class);
+        when(muleContextFactory.createMuleContext(any(List.class), any(MuleContextBuilder.class))).thenReturn(muleContext);
+
+        muleRegistry = mock(MuleRegistry.class);
+        when(muleContext.getRegistry()).thenReturn(muleRegistry);
+
+        defaultMuleDomain = new TestMuleDomain(domainClassLoaderRepository, domainDescriptor);
+        defaultMuleDomain.init();
+    }
+
+    @Test
+    public void testCancelStartOneConector()
+    {
+        // Given a default mule applicacion with 1 connector that has retryPolicy
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate = addMockConnectorWithMockRetryPolicyToList(connectors);
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleDomain.cancelStart();
+
+        // Connectors's retry policy start is also cancelled
+        verify(retryPolicyTemplate).cancelStart();
+    }
+
+    @Test
+    public void testCancelStartFiveConectors()
+    {
+        // Given a default mule applicacion with 5 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate3 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate4 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate5 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleDomain.cancelStart();
+
+        // Then connector's retry policies start is also cancelled
+        verify(retryPolicyTemplate1, times(1)).cancelStart();
+        verify(retryPolicyTemplate2, times(1)).cancelStart();
+        verify(retryPolicyTemplate3, times(1)).cancelStart();
+        verify(retryPolicyTemplate4, times(1)).cancelStart();
+        verify(retryPolicyTemplate5, times(1)).cancelStart();
+    }
+
+    private RetryPolicyTemplate addMockConnectorWithMockRetryPolicyToList(List<Connector> connectors)
+    {
+        Connector connector = mock(Connector.class);
+        connectors.add(connector);
+
+        RetryPolicyTemplate retryPolicyTemplate = mock(RetryPolicyTemplate.class);
+        when(connector.getRetryPolicyTemplate()).thenReturn(retryPolicyTemplate);
+
+        return retryPolicyTemplate;
+    }
+
+    private static final class TestMuleDomain extends DefaultMuleDomain
+    {
+
+        TestMuleDomain(DomainClassLoaderRepository domainClassLoaderRepository, DomainDescriptor descriptor)
+        {
+            super(domainClassLoaderRepository, descriptor);
+        }
+
+        @Override
+        protected MuleContextFactory getMuleContextFactory()
+        {
+            return muleContextFactory;
+        }
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/domain/DefaultMuleDomainTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/domain/DefaultMuleDomainTestCase.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.mule.api.MuleContext;
 import org.mule.api.context.MuleContextBuilder;
 import org.mule.api.context.MuleContextFactory;
+import org.mule.api.lifecycle.LifecycleManager;
+import org.mule.api.lifecycle.Stoppable;
 import org.mule.api.registry.MuleRegistry;
 import org.mule.api.retry.RetryPolicyTemplate;
 import org.mule.api.transport.Connector;
@@ -64,7 +66,7 @@ public class DefaultMuleDomainTestCase
     }
 
     @Test
-    public void testCancelStartOneConector()
+    public void testCancelStartOneConectorWithRetryPolicy()
     {
         // Given a default mule applicacion with 1 connector that has retryPolicy
         List<Connector> connectors = new ArrayList<>();
@@ -80,7 +82,7 @@ public class DefaultMuleDomainTestCase
     }
 
     @Test
-    public void testCancelStartFiveConectors()
+    public void testCancelStartFiveConectorsWithRetryPolicies()
     {
         // Given a default mule applicacion with 5 connectors that have retryPolicies
         List<Connector> connectors = new ArrayList<>();
@@ -97,6 +99,57 @@ public class DefaultMuleDomainTestCase
         defaultMuleDomain.cancelStart();
 
         // Then connector's retry policies start is also cancelled
+        verify(retryPolicyTemplate1, times(1)).cancelStart();
+        verify(retryPolicyTemplate2, times(1)).cancelStart();
+        verify(retryPolicyTemplate3, times(1)).cancelStart();
+        verify(retryPolicyTemplate4, times(1)).cancelStart();
+        verify(retryPolicyTemplate5, times(1)).cancelStart();
+    }
+
+    @Test
+    public void testCancelStartFiveConectorsWithNullRetryPolicies()
+    {
+        // Given a default mule applicacion with 5 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        Connector connector1 = mock(Connector.class);
+        connectors.add(connector1);
+        Connector connector2 = mock(Connector.class);
+        connectors.add(connector2);
+        Connector connector3 = mock(Connector.class);
+        connectors.add(connector3);
+        Connector connector4 = mock(Connector.class);
+        connectors.add(connector4);
+        Connector connector5 = mock(Connector.class);
+        connectors.add(connector5);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleDomain.cancelStart();
+
+        // Then no error occurs
+
+    }
+
+    @Test
+    public void testStopCancelStartFiveConectors()
+    {
+        // Given a default mule applicacion with 5 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate3 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate4 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate5 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When stopping
+        defaultMuleDomain.stop();
+
+        // Then connector's retry policies start is cancelled
         verify(retryPolicyTemplate1, times(1)).cancelStart();
         verify(retryPolicyTemplate2, times(1)).cancelStart();
         verify(retryPolicyTemplate3, times(1)).cancelStart();

--- a/modules/launcher/src/test/java/org/mule/module/launcher/domain/TestDomainWrapper.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/domain/TestDomainWrapper.java
@@ -136,4 +136,9 @@ public class TestDomainWrapper implements Domain
     {
         this.deploymentProperties = deploymentProperties;
     }
+
+    @Override
+    public void cancelStart() {
+        delegate.cancelStart();
+    }
 }

--- a/modules/launcher/src/test/resources/retry-policy-forever-app-config.xml
+++ b/modules/launcher/src/test/resources/retry-policy-forever-app-config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+                            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                            http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd
+                            http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <description>Reconnect Forever Mule Application</description>
+
+    <http:listener-config name="listenerConfig" host="localhost" port="9999"/>
+
+    <sftp:connector name="SFTP" validateConnections="true">
+        <reconnect-forever/>
+    </sftp:connector>
+    <flow name="sftp-reconnect-forever-workFlow">
+        <sftp:inbound-endpoint connector-ref="SFTP" host="localhost" port="22" user="test" password="test"
+                               responseTimeout="1000"/>
+        <logger message="fetched" level="INFO"/>
+    </flow>
+</mule>
+


### PR DESCRIPTION
MULE-18582: Application stuck in "starting" status forever when SFTP configured to "reconnect forever" if connection fails on startup

Added the possibility of canceling a deployment that for now would basically stop al connector's retry policies from retrying. This method should be called before requesting the deploymentLock to stop an application.