### PR TITLE
MULE-18601: MetadataCacheKeyGenerator based on ArtifactAST is including

### DIFF
--- a/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/model/AbstractDslModelTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/model/AbstractDslModelTestCase.java
@@ -11,7 +11,6 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -325,14 +324,6 @@ public abstract class AbstractDslModelTestCase extends AbstractMuleTestCase {
         .build());
     when(extension.getSubTypes()).thenReturn(emptySet());
     when(extension.getImportedTypes()).thenReturn(emptySet());
-    when(extension.getXmlDslModel()).thenReturn(XmlDslModel.builder()
-        .setXsdFileName(EMPTY)
-        .setPrefix(NAMESPACE)
-        .setNamespace(NAMESPACE_URI)
-        .setSchemaLocation(SCHEMA_LOCATION)
-        .setSchemaVersion(EMPTY)
-        .build());
-
     when(extension.getConfigurationModels()).thenReturn(asList(configuration));
     when(extension.getConfigurationModel(anyString())).thenReturn(of(configuration));
     when(extension.getOperationModels()).thenReturn(asList(operation, anotherOperation));

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/model/ModelBasedMetadataCacheKeyGeneratorTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/dsl/model/ModelBasedMetadataCacheKeyGeneratorTestCase.java
@@ -13,6 +13,7 @@ import static java.util.Optional.of;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEFAULTS;
@@ -87,6 +88,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
+import io.qameta.allure.Issue;
 
 public class ModelBasedMetadataCacheKeyGeneratorTestCase extends AbstractDslModelTestCase {
 
@@ -270,6 +273,29 @@ public class ModelBasedMetadataCacheKeyGeneratorTestCase extends AbstractDslMode
     LOGGER.debug(otherKeyParts.toString());
 
     assertThat(keyParts, not(otherKeyParts));
+
+  }
+
+  @Test
+  @Issue("MULE-18601")
+  public void configurationNestedParamsCountedTwiceForHash() throws Exception {
+
+    MetadataCacheId keyParts = getIdForComponent(getBaseApp());
+    LOGGER.debug(keyParts.toString());
+
+    assertThat(keyParts.getParts(), hasSize(3));
+    assertThat(keyParts.getParts().get(0).getParts(), hasSize(2));
+    assertThat(keyParts.getParts().get(0).getParts().get(0).getParts(), hasSize(0));
+
+    final MetadataCacheId configurationPart = keyParts.getParts().get(0).getParts().get(1);
+    assertThat(configurationPart.getSourceElementName().get(), is("configuration"));
+    assertThat(configurationPart.getParts(), hasSize(2));
+    assertThat(configurationPart.getParts().get(0).getParts(), hasSize(2));
+    assertThat(configurationPart.getParts().get(0).getParts().get(0).getParts(), hasSize(0));
+    assertThat(configurationPart.getParts().get(0).getParts().get(0).getParts(), hasSize(0));
+    assertThat(configurationPart.getParts().get(1).getParts(), hasSize(0));
+    assertThat(keyParts.getParts().get(1).getParts(), hasSize(0));
+    assertThat(keyParts.getParts().get(2).getParts(), hasSize(0));
 
   }
 


### PR DESCRIPTION
parameters as part of the hash when it shouldn't