### PR TITLE
MULE-18582: Application stuck in "starting" status forever when SFTP configured to "reconnect forever" if connection fails on startup

### DIFF
--- a/core/src/main/java/org/mule/api/retry/RetryPolicyTemplate.java
+++ b/core/src/main/java/org/mule/api/retry/RetryPolicyTemplate.java
@@ -32,4 +32,6 @@ public interface RetryPolicyTemplate
     RetryContext execute(RetryCallback callback, WorkManager workManager) throws Exception;
 
     boolean isSynchronous();
+
+    void stopRetrying();
 }

--- a/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
+++ b/core/src/main/java/org/mule/retry/async/AsynchronousRetryTemplate.java
@@ -96,4 +96,9 @@ public class AsynchronousRetryTemplate implements RetryPolicyTemplate
     {
         return false;
     }
+
+    @Override
+    public void stopRetrying() {
+        delegate.stopRetrying();
+    }
 }

--- a/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
+++ b/core/src/main/java/org/mule/retry/policies/AbstractPolicyTemplate.java
@@ -21,6 +21,7 @@ import org.mule.retry.notifiers.ConnectNotifier;
 
 import java.io.InterruptedIOException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,6 +37,8 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
     private Map<Object, Object> metaInfo;
 
     private MuleContext muleContext;
+
+    private AtomicBoolean stopRetrying = new AtomicBoolean(false);
 
     private volatile boolean lastRetryInterrupted = false;
 
@@ -98,7 +101,7 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
                     }
                 }
             }
-            while (status.isOk());
+            while (status.isOk() && !stopRetrying.get());
 
             context.setFailed(cause);
 
@@ -122,7 +125,7 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
             }
         }
     }
-    
+
     public RetryNotifier getNotifier()
     {
         return notifier;
@@ -153,5 +156,16 @@ public abstract class AbstractPolicyTemplate implements RetryPolicyTemplate, Mul
     public boolean isSynchronous()
     {
         return true;
+    }
+
+    protected AtomicBoolean isStopRetrying()
+    {
+        return stopRetrying;
+    }
+
+    @Override
+    public void stopRetrying()
+    {
+        stopRetrying.compareAndSet(false, true);
     }
 }

--- a/core/src/test/java/org/mule/retry/async/AsynchronousRetryTemplateTestCase.java
+++ b/core/src/test/java/org/mule/retry/async/AsynchronousRetryTemplateTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.retry.async;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.retry.RetryPolicyTemplate;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+public class AsynchronousRetryTemplateTestCase
+{
+
+    private RetryPolicyTemplate delegate;
+    private AsynchronousRetryTemplate asynchronousRetryTemplate;
+
+    @Before
+    public void setUp()
+    {
+        delegate = mock(RetryPolicyTemplate.class);
+        asynchronousRetryTemplate = new AsynchronousRetryTemplate(delegate);
+    }
+
+    @Test
+    public void testCancelStart()
+    {
+        // Given an asynchronous retry template with a delegate
+
+        // When cancelling start
+        asynchronousRetryTemplate.stopRetrying();
+
+        // Then
+        verify(delegate, times(1)).stopRetrying();
+    }
+
+}

--- a/core/src/test/java/org/mule/retry/policies/AbstractPolicyTemplateTestCase.java
+++ b/core/src/test/java/org/mule/retry/policies/AbstractPolicyTemplateTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.retry.policies;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.context.WorkManager;
+import org.mule.api.retry.RetryCallback;
+import org.mule.api.retry.RetryContext;
+import org.mule.api.retry.RetryNotifier;
+import org.mule.api.retry.RetryPolicy;
+import org.mule.retry.PolicyStatus;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class AbstractPolicyTemplateTestCase
+{
+
+    private AbstractPolicyTemplate abstractPolicyTemplate;
+    private RetryPolicy retryPolicy;
+    private RetryCallback retryCallback;
+    private WorkManager workManager;
+    private RetryNotifier retryNotifier;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        retryPolicy = mock(RetryPolicy.class);
+
+        abstractPolicyTemplate = new AbstractPolicyTemplate()
+        {
+            @Override
+            public RetryPolicy createRetryInstance()
+            {
+                return retryPolicy;
+            }
+        };
+
+        retryNotifier = mock(RetryNotifier.class);
+        abstractPolicyTemplate.setNotifier(retryNotifier);
+
+        retryCallback = mock(RetryCallback.class);
+
+        workManager = mock(WorkManager.class);
+    }
+
+    @Test
+    public void testCancelStart()
+    {
+        // Given a Policy based on the abstract policy template with a start that is not yet cancelled
+        assertThat(abstractPolicyTemplate.isStopRetrying().get(), equalTo(false));
+
+        // When cancelling start
+        abstractPolicyTemplate.stopRetrying();
+
+        // Then cancelStart is set to true
+        assertThat(abstractPolicyTemplate.isStopRetrying().get(), equalTo(true));
+    }
+
+    @Test
+    public void executeCanceledStart() throws Exception
+    {
+        // Given a Policy based on the abstract policy template that should be executed forever but start is cancelled
+        doThrow(new Exception()).when(retryCallback).doWork(any(RetryContext.class));
+        when(retryPolicy.applyPolicy(any(Throwable.class))).thenReturn(PolicyStatus.policyOk());
+        abstractPolicyTemplate.stopRetrying();
+
+        // When executing
+        abstractPolicyTemplate.execute(retryCallback, workManager);
+
+        // Then the policy stops executing
+    }
+
+}

--- a/modules/launcher/pom.xml
+++ b/modules/launcher/pom.xml
@@ -55,6 +55,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mule.transports</groupId>
+            <artifactId>mule-transport-sftp</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DefaultArtifactDeployer.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DefaultArtifactDeployer.java
@@ -75,6 +75,7 @@ public class DefaultArtifactDeployer<T extends Artifact> implements ArtifactDepl
 
         try
         {
+            artifact.cancelStart();
             artifact.stop();
         }
         catch (Throwable t)

--- a/modules/launcher/src/main/java/org/mule/module/launcher/DeploymentDirectoryWatcher.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/DeploymentDirectoryWatcher.java
@@ -213,6 +213,7 @@ public class DeploymentDirectoryWatcher implements Runnable
     public void stop()
     {
         stopAppDirMonitorTimer();
+        cancelStart(applications);
 
         deploymentLock.lock();
         try
@@ -223,6 +224,22 @@ public class DeploymentDirectoryWatcher implements Runnable
         finally
         {
             deploymentLock.unlock();
+        }
+    }
+
+    private void cancelStart(List<? extends Artifact> artifacts) {
+        Collections.reverse(artifacts);
+
+        for (Artifact artifact : artifacts)
+        {
+            try
+            {
+                artifact.cancelStart();
+            }
+            catch (Throwable t)
+            {
+                logger.error(format("Error cancelling start for artifact '%s'", artifact), t);
+            }
         }
     }
 

--- a/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/application/DefaultMuleApplication.java
@@ -16,6 +16,7 @@ import org.mule.api.config.MuleProperties;
 import org.mule.api.context.notification.MuleContextNotificationListener;
 import org.mule.api.context.notification.ServerNotificationListener;
 import org.mule.api.lifecycle.Stoppable;
+import org.mule.api.transport.Connector;
 import org.mule.config.builders.ExtensionsManagerConfigurationBuilder;
 import org.mule.config.builders.SimpleConfigurationBuilder;
 import org.mule.context.DefaultMuleContextFactory;
@@ -340,6 +341,8 @@ public class DefaultMuleApplication implements Application
     @Override
     public void stop()
     {
+        this.cancelStart();
+
         if (this.muleContext == null || !this.muleContext.getLifecycleManager().isDirectTransition(Stoppable.PHASE_NAME))
         {
             return;
@@ -419,4 +422,18 @@ public class DefaultMuleApplication implements Application
         muleContext = null;
     }
 
+    @Override
+    public void cancelStart()
+    {
+        if(muleContext != null && muleContext.getRegistry() != null && !muleContext.getRegistry().lookupObjects(Connector.class).isEmpty())
+        {
+            for(Connector connector: muleContext.getRegistry().lookupObjects(Connector.class))
+            {
+                if(connector.getRetryPolicyTemplate() != null)
+                {
+                    connector.getRetryPolicyTemplate().stopRetrying();
+                }
+            }
+        }
+    }
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/Artifact.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/Artifact.java
@@ -71,4 +71,9 @@ public interface Artifact<D extends ArtifactDescriptor>
      * @return MuleContext created from the artifact configurations files.
      */
     MuleContext getMuleContext();
+
+    /**
+     * Cancels any ongoing process that prevents the startup fase from ending
+     */
+    void cancelStart();
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactWrapper.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/artifact/ArtifactWrapper.java
@@ -114,6 +114,7 @@ public class ArtifactWrapper<T extends Artifact<D>, D extends ArtifactDescriptor
             @Override
             public void execute()
             {
+                delegate.cancelStart();
                 delegate.stop();
             }
         });
@@ -160,5 +161,17 @@ public class ArtifactWrapper<T extends Artifact<D>, D extends ArtifactDescriptor
     private interface ArtifactAction
     {
         void execute();
+    }
+
+    @Override
+    public void cancelStart() {
+        executeWithinArtifactClassLoader(new ArtifactAction()
+        {
+            @Override
+            public void execute()
+            {
+                delegate.cancelStart();
+            }
+        });
     }
 }

--- a/modules/launcher/src/main/java/org/mule/module/launcher/domain/DefaultMuleDomain.java
+++ b/modules/launcher/src/main/java/org/mule/module/launcher/domain/DefaultMuleDomain.java
@@ -16,6 +16,7 @@ import org.mule.api.config.ConfigurationBuilder;
 import org.mule.api.config.DomainMuleContextAwareConfigurationBuilder;
 import org.mule.api.context.MuleContextFactory;
 import org.mule.api.lifecycle.InitialisationException;
+import org.mule.api.transport.Connector;
 import org.mule.config.builders.AutoConfigurationBuilder;
 import org.mule.config.i18n.CoreMessages;
 import org.mule.context.DefaultMuleContextFactory;
@@ -294,6 +295,7 @@ public class DefaultMuleDomain implements Domain
             }
             if (this.muleContext != null)
             {
+                this.cancelStart();
                 this.muleContext.stop();
             }
         }
@@ -382,5 +384,19 @@ public class DefaultMuleDomain implements Domain
     protected MuleContextFactory getMuleContextFactory ()
     {
          return new DefaultMuleContextFactory();
+    }
+
+    @Override
+    public void cancelStart() {
+        if(muleContext != null && muleContext.getRegistry() != null && !muleContext.getRegistry().lookupObjects(Connector.class).isEmpty())
+        {
+            for (Connector connector : muleContext.getRegistry().lookupObjects(Connector.class))
+            {
+                if(connector.getRetryPolicyTemplate() != null)
+                {
+                    connector.getRetryPolicyTemplate().stopRetrying();
+                }
+            }
+        }
     }
 }

--- a/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentDirectoryWatcherTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/DeploymentDirectoryWatcherTestCase.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mule.module.launcher.application.Application;
+import org.mule.module.launcher.domain.Domain;
+import org.mule.module.launcher.util.ObservableList;
+
+import java.util.ArrayList;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+public class DeploymentDirectoryWatcherTestCase
+{
+
+    private ArchiveDeployer<Domain> domainArchiveDeployer;
+    private ArchiveDeployer<Application> applicationArchiveDeployer;
+    private ReentrantLock deploymentLock;
+    private ObservableList<Domain> domains;
+    private ArrayList<Application> applicationArrayList;
+    private ObservableList<Application> applications;
+    private DeploymentDirectoryWatcher deploymentDirectoryWatcher;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        domainArchiveDeployer = mock(ArchiveDeployer.class);
+        applicationArchiveDeployer = mock(ArchiveDeployer.class);
+        deploymentLock = mock(ReentrantLock.class);
+        domains = new ObservableList<>(new ArrayList<Domain>());
+        applicationArrayList = new ArrayList<>();
+        applications = new ObservableList<>(applicationArrayList);
+
+        deploymentDirectoryWatcher = new DeploymentDirectoryWatcher(domainArchiveDeployer, applicationArchiveDeployer, domains, applications, deploymentLock);
+
+    }
+
+    @Test
+    public void testStopOneApplicationCancelsStart()
+    {
+        // Given a deploymentDirectoryWatcher with one application
+        Application application = mock(Application.class);
+        applicationArrayList.add(application);
+
+        // When stopping
+        deploymentDirectoryWatcher.stop();
+
+        // Then cancel start is called for every application before requesting the lock
+        InOrder inOrder = inOrder(application, deploymentLock);
+        inOrder.verify(application).cancelStart();
+        inOrder.verify(deploymentLock).lock();
+    }
+
+    @Test
+    public void testStopThreeApplicationsCancelsStart()
+    {
+        // Given a deploymentDirectoryWatcher with one application
+        Application application1 = mock(Application.class);
+        applicationArrayList.add(application1);
+
+        Application application2 = mock(Application.class);
+        applicationArrayList.add(application2);
+
+        Application application3 = mock(Application.class);
+        applicationArrayList.add(application3);
+
+        // When stopping
+        deploymentDirectoryWatcher.stop();
+
+        // Then cancel start is called for every application before requesting the lock
+        InOrder inOrder = inOrder(application1, application2, application3, deploymentLock);
+        inOrder.verify(application3, times(1)).cancelStart();
+        inOrder.verify(application2, times(1)).cancelStart();
+        inOrder.verify(application1, times(1)).cancelStart();
+        inOrder.verify(deploymentLock).lock();
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/application/DefaultMuleApplicationTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher.application;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.MuleContext;
+import org.mule.api.lifecycle.LifecycleManager;
+import org.mule.api.lifecycle.Stoppable;
+import org.mule.api.registry.MuleRegistry;
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.api.transport.Connector;
+import org.mule.module.launcher.descriptor.ApplicationDescriptor;
+import org.mule.module.launcher.domain.Domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultMuleApplicationTestCase
+{
+
+    private ApplicationDescriptor applicationDescriptor;
+    private ApplicationClassLoaderFactory applicationClassLoaderFactory;
+    private Domain domain;
+    private DefaultMuleApplication defaultMuleApplication;
+    private MuleContext muleContext;
+    private MuleRegistry muleRegistry;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        applicationDescriptor = mock(ApplicationDescriptor.class);
+        applicationClassLoaderFactory = mock(ApplicationClassLoaderFactory.class);
+        domain = mock(Domain.class);
+
+        defaultMuleApplication = new DefaultMuleApplication(applicationDescriptor, applicationClassLoaderFactory, domain);
+        muleContext = mock(MuleContext.class);
+        defaultMuleApplication.setMuleContext(muleContext);
+        muleRegistry = mock(MuleRegistry.class);
+        when(muleContext.getRegistry()).thenReturn(muleRegistry);
+    }
+
+    @Test
+    public void testCancelStartOneConnector()
+    {
+        // Given a default mule application with 1 connector that has retryPolicy
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate = addMockConnectorWithMockRetryPolicyToList(connectors);
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleApplication.cancelStart();
+
+        // Connectors's retry policy start is also cancelled
+        verify(retryPolicyTemplate).stopRetrying();
+    }
+
+    @Test
+    public void testCancelStartTwoConnectors()
+    {
+        // Given a default mule application with 2 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleApplication.cancelStart();
+
+        // Then connector's retry policies start is also cancelled
+        verify(retryPolicyTemplate1, times(1)).stopRetrying();
+        verify(retryPolicyTemplate2, times(1)).stopRetrying();
+
+    }
+
+    @Test
+    public void testStopCancelStartTwoConnectors()
+    {
+        // Given a default mule application with 2 connectors that have retryPolicies
+        LifecycleManager lifecycleManager = mock(LifecycleManager.class);
+        when(lifecycleManager.isDirectTransition(Stoppable.PHASE_NAME)).thenReturn(true);
+        when(muleContext.getLifecycleManager()).thenReturn(lifecycleManager);
+
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When stopping
+        defaultMuleApplication.stop();
+
+        // Then connector's retry policies start is cancelled
+        verify(retryPolicyTemplate1, times(1)).stopRetrying();
+        verify(retryPolicyTemplate2, times(1)).stopRetrying();
+    }
+
+    @Test
+    public void testCancelStartTwoConnectorsWithNullRetryPolicies()
+    {
+        // Given a default mule application with 2 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        Connector connector1 = mock(Connector.class);
+        connectors.add(connector1);
+        Connector connector2 = mock(Connector.class);
+        connectors.add(connector2);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleApplication.cancelStart();
+
+        // Then no error occurs
+
+    }
+
+    private RetryPolicyTemplate addMockConnectorWithMockRetryPolicyToList(List<Connector> connectors)
+    {
+        Connector connector = mock(Connector.class);
+        connectors.add(connector);
+
+        RetryPolicyTemplate retryPolicyTemplate = mock(RetryPolicyTemplate.class);
+        when(connector.getRetryPolicyTemplate()).thenReturn(retryPolicyTemplate);
+
+        return retryPolicyTemplate;
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/artifact/ArtifactWrapperTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/artifact/ArtifactWrapperTestCase.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.module.launcher.artifact;
+
+import org.junit.Test;
+import org.mule.api.MuleContext;
+import org.mule.module.launcher.DeploymentStartException;
+import org.mule.module.launcher.InstallException;
+import org.mule.module.launcher.descriptor.ArtifactDescriptor;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ArtifactWrapperTestCase
+{
+    @Test
+    public void testCancelStart() throws IOException
+    {
+        // Given an artifact wrapper
+        ArtifactSubtype artifact = mock(ArtifactSubtype.class);
+        ArtifactWrapper<ArtifactSubtype, ArtifactSubtypeDescriptor> artifactWrapper = new ArtifactWrapper<>(artifact);
+
+        // When cancelling start
+        artifactWrapper.cancelStart();
+
+        // Then the delegate is told to cancel start
+        verify(artifact).cancelStart();
+    }
+
+    @Test
+    public void testCancelStartWhenStopping() throws IOException
+    {
+        // Given an artifact wrapper
+        ArtifactSubtype artifact = mock(ArtifactSubtype.class);
+        ArtifactWrapper<ArtifactSubtype, ArtifactSubtypeDescriptor> artifactWrapper = new ArtifactWrapper<>(artifact);
+
+        // When cancelling start
+        artifactWrapper.stop();
+
+        // Then the delegate is told to cancel start
+        verify(artifact).cancelStart();
+    }
+
+    private class ArtifactSubtype implements Artifact<ArtifactSubtypeDescriptor>
+    {
+        @Override
+        public void install() throws InstallException
+        {
+
+        }
+
+        @Override
+        public void init()
+        {
+
+        }
+
+        @Override
+        public void start() throws DeploymentStartException
+        {
+
+        }
+
+        @Override
+        public void stop()
+        {
+
+        }
+
+        @Override
+        public void dispose()
+        {
+
+        }
+
+        @Override
+        public String getArtifactName()
+        {
+            return null;
+        }
+
+        @Override
+        public ArtifactSubtypeDescriptor getDescriptor()
+        {
+            return null;
+        }
+
+        @Override
+        public File[] getResourceFiles()
+        {
+            return new File[0];
+        }
+
+        @Override
+        public ArtifactClassLoader getArtifactClassLoader()
+        {
+            return null;
+        }
+
+        @Override
+        public MuleContext getMuleContext()
+        {
+            return null;
+        }
+
+        @Override
+        public void cancelStart()
+        {
+
+        }
+    }
+
+    private class ArtifactSubtypeDescriptor extends ArtifactDescriptor
+    {
+
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/domain/DefaultMuleDomainTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/domain/DefaultMuleDomainTestCase.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.launcher.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.api.MuleContext;
+import org.mule.api.context.MuleContextBuilder;
+import org.mule.api.context.MuleContextFactory;
+import org.mule.api.registry.MuleRegistry;
+import org.mule.api.retry.RetryPolicyTemplate;
+import org.mule.api.transport.Connector;
+import org.mule.module.launcher.artifact.ArtifactClassLoader;
+import org.mule.module.launcher.descriptor.DomainDescriptor;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mule.module.launcher.domain.Domain.DOMAIN_CONFIG_FILE_LOCATION;
+
+public class DefaultMuleDomainTestCase
+{
+    private static final MuleContextFactory muleContextFactory = mock(MuleContextFactory.class);
+    private DomainDescriptor domainDescriptor;
+    private DomainClassLoaderRepository domainClassLoaderRepository;
+    private DefaultMuleDomain defaultMuleDomain;
+    private MuleContext muleContext;
+    private MuleRegistry muleRegistry;
+
+    private URL resource;
+    private ArtifactClassLoader artifactClassLoader;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        domainDescriptor = mock(DomainDescriptor.class);
+        domainClassLoaderRepository = mock(DomainClassLoaderRepository.class);
+        artifactClassLoader = mock(ArtifactClassLoader.class);
+        when(domainClassLoaderRepository.getDomainClassLoader(domainDescriptor)).thenReturn(artifactClassLoader);
+        when(artifactClassLoader.findLocalResource(anyString())).thenReturn(null);
+        resource = getClass().getClassLoader().getResource("empty-domain-config.xml").toURI().toURL();
+        when(domainClassLoaderRepository.getDomainClassLoader(domainDescriptor)).thenReturn(artifactClassLoader);
+        when(artifactClassLoader.findLocalResource(DOMAIN_CONFIG_FILE_LOCATION)).thenReturn(resource);
+
+        muleContext = mock(MuleContext.class);
+        when(muleContextFactory.createMuleContext(any(List.class), any(MuleContextBuilder.class))).thenReturn(muleContext);
+
+        muleRegistry = mock(MuleRegistry.class);
+        when(muleContext.getRegistry()).thenReturn(muleRegistry);
+
+        defaultMuleDomain = new TestMuleDomain(domainClassLoaderRepository, domainDescriptor);
+        defaultMuleDomain.init();
+    }
+
+    @Test
+    public void testCancelStartOneConnectorWithRetryPolicy()
+    {
+        // Given a default mule application with 1 connector that has retryPolicy
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate = addMockConnectorWithMockRetryPolicyToList(connectors);
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleDomain.cancelStart();
+
+        // Connectors's retry policy start is also cancelled
+        verify(retryPolicyTemplate).stopRetrying();
+    }
+
+    @Test
+    public void testCancelStartTwoConnectorsWithRetryPolicies()
+    {
+        // Given a default mule application with 2 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleDomain.cancelStart();
+
+        // Then connector's retry policies start is also cancelled
+        verify(retryPolicyTemplate1, times(1)).stopRetrying();
+        verify(retryPolicyTemplate2, times(1)).stopRetrying();
+    }
+
+    @Test
+    public void testCancelStartTwoConnectorsWithNullRetryPolicies()
+    {
+        // Given a default mule application with 2 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        Connector connector1 = mock(Connector.class);
+        connectors.add(connector1);
+        Connector connector2 = mock(Connector.class);
+        connectors.add(connector2);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When cancelling start
+        defaultMuleDomain.cancelStart();
+
+        // Then no error occurs
+
+    }
+
+    @Test
+    public void testStopCancelStartTwoConnectors()
+    {
+        // Given a default mule application with 5 connectors that have retryPolicies
+        List<Connector> connectors = new ArrayList<>();
+
+        RetryPolicyTemplate retryPolicyTemplate1 = addMockConnectorWithMockRetryPolicyToList(connectors);
+        RetryPolicyTemplate retryPolicyTemplate2 = addMockConnectorWithMockRetryPolicyToList(connectors);
+
+        when(muleRegistry.lookupObjects(Connector.class)).thenReturn(connectors);
+
+        // When stopping
+        defaultMuleDomain.stop();
+
+        // Then connector's retry policies start is cancelled
+        verify(retryPolicyTemplate1, times(1)).stopRetrying();
+        verify(retryPolicyTemplate2, times(1)).stopRetrying();
+    }
+
+    private RetryPolicyTemplate addMockConnectorWithMockRetryPolicyToList(List<Connector> connectors)
+    {
+        Connector connector = mock(Connector.class);
+        connectors.add(connector);
+
+        RetryPolicyTemplate retryPolicyTemplate = mock(RetryPolicyTemplate.class);
+        when(connector.getRetryPolicyTemplate()).thenReturn(retryPolicyTemplate);
+
+        return retryPolicyTemplate;
+    }
+
+    private static final class TestMuleDomain extends DefaultMuleDomain
+    {
+
+        TestMuleDomain(DomainClassLoaderRepository domainClassLoaderRepository, DomainDescriptor descriptor)
+        {
+            super(domainClassLoaderRepository, descriptor);
+        }
+
+        @Override
+        protected MuleContextFactory getMuleContextFactory()
+        {
+            return muleContextFactory;
+        }
+    }
+}

--- a/modules/launcher/src/test/java/org/mule/module/launcher/domain/TestDomainWrapper.java
+++ b/modules/launcher/src/test/java/org/mule/module/launcher/domain/TestDomainWrapper.java
@@ -122,4 +122,9 @@ public class TestDomainWrapper implements Domain
     {
         this.failOnDispose = true;
     }
+
+    @Override
+    public void cancelStart() {
+        delegate.cancelStart();
+    }
 }

--- a/modules/launcher/src/test/resources/retry-policy-forever-app-config.xml
+++ b/modules/launcher/src/test/resources/retry-policy-forever-app-config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:sftp="http://www.mulesoft.org/schema/mule/sftp" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+                            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                            http://www.mulesoft.org/schema/mule/sftp http://www.mulesoft.org/schema/mule/sftp/current/mule-sftp.xsd
+                            http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <description>Reconnect Forever Mule Application</description>
+
+    <http:listener-config name="listenerConfig" host="localhost" port="9999"/>
+
+    <sftp:connector name="SFTP" validateConnections="true">
+        <reconnect-forever/>
+    </sftp:connector>
+    <flow name="sftp-reconnect-forever-workFlow">
+        <sftp:inbound-endpoint connector-ref="SFTP" host="localhost" port="22" user="test" password="test"
+                               responseTimeout="1000"/>
+        <logger message="fetched" level="INFO"/>
+    </flow>
+</mule>
+


### PR DESCRIPTION
Added the "cancelStart" method to deployables in order to stop things like a reconnect forever policy that will never succeed. The cancelStart should be called before attempting to stop and artifact so that the "start" will be able to finish and release the locks that would prevent the "stop" from executing.

(cherry picked from commit b468e396e3715f3653a6c8739399d0e32be3d7a6)