### PR TITLE
MULE-17447: ResourceReleaser should be loaded and invoked only if any of the classes to be released has been loaded - Fix test (#8222)

### DIFF
--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/MySqlDriverLookupTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/MySqlDriverLookupTestCase.java
@@ -94,6 +94,9 @@ public class MySqlDriverLookupTestCase extends AbstractMuleTestCase {
                                     new URL[] {ClassUtils.getResource(mySqlDriverJarname, this.getClass())},
                                     currentThread().getContextClassLoader(), testLookupPolicy)) {
       artifactClassLoader.setResourceReleaserClassLocation(MYSQL_RESOURCE_RELEASER_CLASS_LOCATION);
+      // Force to load a Driver class so the jdbc resource releaser is created and executed
+      artifactClassLoader.loadClass(TestDriver.class.getName());
+
       artifactClassLoader.dispose();
       assertThat(foundClassname, is(classnameBeingTested));
     }


### PR DESCRIPTION
(cherry picked from commit 72b6503643654b024649268522f434c5b0599659)