### PR TITLE
MULE-18521: Unignore test backpressureOnInnerCpuIntensiveSchedulerBusy

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamEmitterProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamEmitterProcessingStrategyTestCase.java
@@ -61,6 +61,8 @@ import org.mule.runtime.core.internal.construct.FlowBackPressureRequiredSchedule
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.processor.strategy.ProactorStreamEmitterProcessingStrategyFactory.ProactorStreamEmitterProcessingStrategy;
 import org.mule.tck.TriggerableMessageSource;
+import org.mule.tck.junit4.FlakinessDetectorTestRunner;
+import org.mule.tck.junit4.FlakyTest;
 import org.mule.tck.testmodels.mule.TestTransaction;
 
 import java.util.ArrayList;
@@ -75,6 +77,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 
 import io.qameta.allure.Description;
@@ -84,13 +87,14 @@ import io.qameta.allure.Story;
 
 @Feature(PROCESSING_STRATEGIES)
 @Story(PROACTOR)
+@RunWith(FlakinessDetectorTestRunner.class)
 public class ProactorStreamEmitterProcessingStrategyTestCase extends AbstractProcessingStrategyTestCase {
 
   @Rule
   public ExpectedException expectedException = none();
 
-  public ProactorStreamEmitterProcessingStrategyTestCase(Mode mode) {
-    super(mode);
+  public ProactorStreamEmitterProcessingStrategyTestCase() {
+    super(SOURCE);
   }
 
   @Override
@@ -489,7 +493,7 @@ public class ProactorStreamEmitterProcessingStrategyTestCase extends AbstractPro
   }
 
   @Test
-  @Ignore("MULE-18521")
+  @FlakyTest(times = 200)
   public void backpressureOnInnerCpuIntensiveSchedulerBusy() throws Exception {
     assumeThat(mode, is(SOURCE));
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamEmitterProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamEmitterProcessingStrategyTestCase.java
@@ -61,8 +61,6 @@ import org.mule.runtime.core.internal.construct.FlowBackPressureRequiredSchedule
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.processor.strategy.ProactorStreamEmitterProcessingStrategyFactory.ProactorStreamEmitterProcessingStrategy;
 import org.mule.tck.TriggerableMessageSource;
-import org.mule.tck.junit4.FlakinessDetectorTestRunner;
-import org.mule.tck.junit4.FlakyTest;
 import org.mule.tck.testmodels.mule.TestTransaction;
 
 import java.util.ArrayList;
@@ -77,7 +75,6 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 
 import io.qameta.allure.Description;
@@ -87,14 +84,13 @@ import io.qameta.allure.Story;
 
 @Feature(PROCESSING_STRATEGIES)
 @Story(PROACTOR)
-@RunWith(FlakinessDetectorTestRunner.class)
 public class ProactorStreamEmitterProcessingStrategyTestCase extends AbstractProcessingStrategyTestCase {
 
   @Rule
   public ExpectedException expectedException = none();
 
-  public ProactorStreamEmitterProcessingStrategyTestCase() {
-    super(SOURCE);
+  public ProactorStreamEmitterProcessingStrategyTestCase(Mode mode) {
+    super(mode);
   }
 
   @Override
@@ -493,7 +489,7 @@ public class ProactorStreamEmitterProcessingStrategyTestCase extends AbstractPro
   }
 
   @Test
-  @FlakyTest(times = 200)
+  @Ignore("MULE-18521")
   public void backpressureOnInnerCpuIntensiveSchedulerBusy() throws Exception {
     assumeThat(mode, is(SOURCE));
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamEmitterProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/ProactorStreamEmitterProcessingStrategyTestCase.java
@@ -489,7 +489,6 @@ public class ProactorStreamEmitterProcessingStrategyTestCase extends AbstractPro
   }
 
   @Test
-  @Ignore("MULE-18521")
   public void backpressureOnInnerCpuIntensiveSchedulerBusy() throws Exception {
     assumeThat(mode, is(SOURCE));
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamEmitterProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamEmitterProcessingStrategyTestCase.java
@@ -25,6 +25,7 @@ import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
 import org.mule.runtime.core.internal.processor.strategy.AbstractProcessingStrategyTestCase.TransactionAwareProcessingStrategyTestCase;
 import org.mule.runtime.core.internal.processor.strategy.TransactionAwareProactorStreamEmitterProcessingStrategyFactory.TransactionAwareProactorStreamEmitterProcessingStrategy;
+import org.mule.tck.junit4.FlakinessDetectorTestRunner;
 import org.mule.tck.testmodels.mule.TestTransaction;
 
 import java.util.Collection;
@@ -36,20 +37,20 @@ import org.junit.After;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
+@RunWith(FlakinessDetectorTestRunner.class)
 @Feature(PROCESSING_STRATEGIES)
 @Story(DEFAULT)
 public class TransactionAwareProactorStreamEmitterProcessingStrategyTestCase
     extends ProactorStreamEmitterProcessingStrategyTestCase
     implements TransactionAwareProcessingStrategyTestCase {
 
-  public TransactionAwareProactorStreamEmitterProcessingStrategyTestCase(Mode mode) {
-    super(mode);
+  public TransactionAwareProactorStreamEmitterProcessingStrategyTestCase() {
+    super();
   }
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Mode> parameters() {
-    return asList(new Mode[] {Mode.FLOW, SOURCE});
+    return asList(Mode.FLOW, SOURCE);
   }
 
   @After

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamEmitterProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamEmitterProcessingStrategyTestCase.java
@@ -25,7 +25,6 @@ import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
 import org.mule.runtime.core.internal.processor.strategy.AbstractProcessingStrategyTestCase.TransactionAwareProcessingStrategyTestCase;
 import org.mule.runtime.core.internal.processor.strategy.TransactionAwareProactorStreamEmitterProcessingStrategyFactory.TransactionAwareProactorStreamEmitterProcessingStrategy;
-import org.mule.tck.junit4.FlakinessDetectorTestRunner;
 import org.mule.tck.testmodels.mule.TestTransaction;
 
 import java.util.Collection;
@@ -37,20 +36,20 @@ import org.junit.After;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(FlakinessDetectorTestRunner.class)
+@RunWith(Parameterized.class)
 @Feature(PROCESSING_STRATEGIES)
 @Story(DEFAULT)
 public class TransactionAwareProactorStreamEmitterProcessingStrategyTestCase
     extends ProactorStreamEmitterProcessingStrategyTestCase
     implements TransactionAwareProcessingStrategyTestCase {
 
-  public TransactionAwareProactorStreamEmitterProcessingStrategyTestCase() {
-    super();
+  public TransactionAwareProactorStreamEmitterProcessingStrategyTestCase(Mode mode) {
+    super(mode);
   }
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Mode> parameters() {
-    return asList(Mode.FLOW, SOURCE);
+    return asList(new Mode[] {Mode.FLOW, SOURCE});
   }
 
   @After


### PR DESCRIPTION
I'm just activating the flakiness detector in this PR because I'm not able to reproduce the error locally