### PR TITLE
MULE-18661: Use componentId flag from Parameter model instead of

### DIFF
--- a/tests/test-policies/src/test/java/org/mule/test/policy/PolicyTestCase.java
+++ b/tests/test-policies/src/test/java/org/mule/test/policy/PolicyTestCase.java
@@ -37,7 +37,6 @@ import org.mule.runtime.policy.api.PolicyPointcutParameters;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,7 +55,6 @@ public class PolicyTestCase extends MuleArtifactFunctionalTestCase {
 
   @Inject
   private SchedulerService schedulerService;
-  private CountDownLatch messageSentTimer;
 
   @Override
   protected String getConfigFile() {
@@ -89,7 +87,6 @@ public class PolicyTestCase extends MuleArtifactFunctionalTestCase {
   @Before
   public void setUp() {
     processorWasDisposed.set(false);
-    messageSentTimer = new CountDownLatch(1);
   }
 
   @Test

--- a/tests/test-policies/src/test/resources/test-policy-config.xml
+++ b/tests/test-policies/src/test/resources/test-policy-config.xml
@@ -15,7 +15,7 @@
         <processor ref="disposeListener"/>
     </flow>
 
-    <test-policy:proxy>
+    <test-policy:proxy name="policy">
         <test-policy:source>
             <set-variable variableName="sourceState" value="before"/>
             <test-policy:execute-next/>


### PR DESCRIPTION
hardcoding `name`

* Fix tests