### PR TITLE
MULE-18687: Inconsistence between dancer state and refresh token valu…

### DIFF
--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/state/DefaultResourceOwnerOAuthContext.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/state/DefaultResourceOwnerOAuthContext.java
@@ -114,6 +114,9 @@ public final class DefaultResourceOwnerOAuthContext implements ResourceOwnerOAut
 
   @Override
   public void setDancerState(DancerState dancerState) {
+    if (dancerState == NO_TOKEN) {
+      this.accessToken = null;
+    }
     this.dancerState = dancerState;
   }
 

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/state/ResourceOwnerOAuthContextWithRefreshState.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/state/ResourceOwnerOAuthContextWithRefreshState.java
@@ -114,6 +114,9 @@ public final class ResourceOwnerOAuthContextWithRefreshState implements Resource
 
   @Override
   public void setDancerState(DancerState dancerState) {
+    if (dancerState == NO_TOKEN) {
+      this.accessToken = null;
+    }
     this.dancerState = dancerState;
   }
 


### PR DESCRIPTION
…e in OAuth context (#9223)

(cherry picked from commit 7b794123137b1b2b3a390145cf8b33566f85d06e)