### PR TITLE
DEL-887: Fix tests-components and tooling-support-test-extension

### DIFF
--- a/modules/extensions-spring-support/pom.xml
+++ b/modules/extensions-spring-support/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>test-components</artifactId>
-            <version>${project.version}</version>
+            <version>${muleTestComponentsVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>

--- a/modules/tooling-support-parent/test-extension/pom.xml
+++ b/modules/tooling-support-parent/test-extension/pom.xml
@@ -81,6 +81,13 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,10 @@
         <muleMetadataModelVersion>1.4.0-SNAPSHOT</muleMetadataModelVersion>
         <metadataModelApiVersion>${muleMetadataModelVersion}</metadataModelApiVersion>
 
+        <!-- The tests/test-components artifacts is in the mule repo but as has the mule-modules-parent as parent
+         its version is not changed by the versions:set plugin -->
+        <muleTestComponentsVersion>4.4.0-SNAPSHOT</muleTestComponentsVersion>
+
         <!-- Test Extensions -->
 
         <!--Maven plugins versions-->
@@ -2017,6 +2021,7 @@
                                             <message>No Snapshots Allowed in Deps!</message>
                                             <excludes>
                                                 <exclude>org.mule.tests:test-components</exclude>
+                                                <exclude>org.mule.tooling:tooling-support-test-extension</exclude>
                                             </excludes>
                                         </requireReleaseDeps>
                                         <requireReleaseVersion>


### PR DESCRIPTION
- Fix tests-components version as it is not updated versions:set plugin because it has a different parent
- Fix tooling-support-test-extension to avoid deploying it during releases