### PR TITLE
MULE-18573: CursorProvider key collision at CursorProvider cache (#9271)

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ForeachTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ForeachTestCase.java
@@ -8,10 +8,12 @@ package org.mule.runtime.core.internal.routing;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -19,26 +21,32 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.ExpectedException.none;
+import static org.mockito.Mockito.mock;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.DataType.MULE_MESSAGE;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.internal.routing.Foreach.DEFAULT_COUNTER_VARIABLE;
 import static org.mule.runtime.core.internal.routing.Foreach.DEFAULT_ROOT_MESSAGE_VARIABLE;
+import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.junit4.matcher.DataTypeCompatibilityMatcher.assignableTo;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import io.qameta.allure.Issue;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.TypedValue;
+import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.message.InternalMessage;
+import org.mule.runtime.core.internal.streaming.ManagedCursorProvider;
 import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.runtime.core.privileged.processor.InternalProcessor;
 import org.mule.tck.SensingNullMessageProcessor;
@@ -60,6 +68,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ForeachTestCase extends AbstractReactiveProcessorTestCase {
 
@@ -410,6 +419,53 @@ public class ForeachTestCase extends AbstractReactiveProcessorTestCase {
 
     assertThat(variables.get(DEFAULT_COUNTER_VARIABLE).getDataType(), equalTo(DataType.builder().type(Integer.class).build()));
     assertThat(variables.get(DEFAULT_COUNTER_VARIABLE).getValue(), equalTo(2));
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void muleMessageContainingACursorStreamShouldBeManagedByCursorManager() throws Exception {
+    AtomicReference<CoreEvent> eventReference = new AtomicReference<>();
+    foreach = createForeach();
+    InternalTestProcessor capturedEventProcessor = event -> {
+      eventReference.set(event);
+      return event;
+    };
+    foreach.setMessageProcessors(asList(capturedEventProcessor));
+    initialiseIfNeeded(foreach, muleContext);
+
+    CursorProvider cursorProvider = mock(CursorStreamProvider.class);
+
+    CoreEvent input = eventBuilder(muleContext).message(of(singletonList(of(cursorProvider)))).build();
+    CoreEvent result = process(foreach, input);
+
+    assertThat(result.getMessage(), equalTo(input.getMessage()));
+    assertThat(eventReference.get().getMessage().getPayload().getValue(), is(instanceOf(ManagedCursorProvider.class)));
+    ManagedCursorProvider managedCursorProvider =
+        (ManagedCursorProvider) eventReference.get().getMessage().getPayload().getValue();
+    assertThat(unwrap(managedCursorProvider), is(sameInstance(cursorProvider)));
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void cursorStreamShouldBeManagedByCursorManager() throws Exception {
+    AtomicReference<CoreEvent> eventReference = new AtomicReference<>();
+    foreach = createForeach();
+    InternalTestProcessor capturedEventProcessor = event -> {
+      eventReference.set(event);
+      return event;
+    };
+    foreach.setMessageProcessors(asList(capturedEventProcessor));
+    initialiseIfNeeded(foreach, muleContext);
+
+    CursorProvider cursorProvider = mock(CursorStreamProvider.class);
+    CoreEvent input = eventBuilder(muleContext).message(of(singletonList(cursorProvider))).build();
+    CoreEvent result = process(foreach, input);
+
+    assertThat(result.getMessage(), equalTo(input.getMessage()));
+    assertThat(eventReference.get().getMessage().getPayload().getValue(), is(instanceOf(ManagedCursorProvider.class)));
+    ManagedCursorProvider managedCursorProvider =
+        (ManagedCursorProvider) eventReference.get().getMessage().getPayload().getValue();
+    assertThat(unwrap(managedCursorProvider), is(sameInstance(cursorProvider)));
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
@@ -40,7 +40,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-
 import io.qameta.allure.Issue;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.event.Event;

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ParallelForEachTestCase.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
 import static org.mule.runtime.api.metadata.DataType.MULE_MESSAGE_LIST;
+import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.tck.MuleTestUtils.APPLE_FLOW;
 import static org.mule.test.allure.AllureConstants.RoutersFeature.ROUTERS;
@@ -39,6 +40,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+
+import io.qameta.allure.Issue;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.event.Event;
 import org.mule.runtime.api.exception.MuleException;
@@ -46,6 +49,8 @@ import org.mule.runtime.api.message.ErrorType;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.scheduler.Scheduler;
+import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
 import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
@@ -53,6 +58,7 @@ import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair;
 import org.mule.runtime.core.internal.routing.forkjoin.CollectListForkJoinStrategyFactory;
+import org.mule.runtime.core.internal.streaming.ManagedCursorProvider;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.tck.SensingNullMessageProcessor;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
@@ -174,6 +180,32 @@ public class ParallelForEachTestCase extends AbstractMuleContextTestCase {
     assertThat(List.class.isAssignableFrom(typedValue.getDataType().getType()), is(true));
     List<Message> resultList = (List<Message>) typedValue.getValue();
     assertThat(resultList, hasSize(2));
+  }
+
+  @Test
+  @Description("Cursor provider should be managed by cursor manager inside parallel-foreach.")
+  @Issue("MULE-18573")
+  public void cursorStreamShouldBeManagedByCursorManager() throws Exception {
+    CursorProvider cursorProvider = mock(CursorStreamProvider.class);
+    CoreEvent original = getEventBuilder().message(Message.of(singletonList(cursorProvider))).build();
+
+    MessageProcessorChain nested = newChain(empty(), event -> event);
+    nested.setMuleContext(muleContext);
+    router.setMessageProcessors(singletonList(nested));
+
+    muleContext.getInjector().inject(router);
+    router.setAnnotations(getAppleFlowComponentLocationAnnotations());
+    router.initialise();
+
+    Event result = router.process(original);
+
+    assertThat(result.getMessage().getPayload().getValue(), instanceOf(List.class));
+    List<Message> resultList = (List<Message>) result.getMessage().getPayload().getValue();
+    assertThat(resultList, hasSize(1));
+
+    assertThat(resultList.get(0).getPayload().getValue(), is(instanceOf(ManagedCursorProvider.class)));
+    ManagedCursorProvider managedCursorProvider = (ManagedCursorProvider) resultList.get(0).getPayload().getValue();
+    assertThat(unwrap(managedCursorProvider), is(sameInstance(cursorProvider)));
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/CursorManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/CursorManagerTestCase.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
 import static org.mule.tck.probe.PollingProber.check;
 
 import org.mule.runtime.api.streaming.CursorProvider;
@@ -77,6 +78,7 @@ public class CursorManagerTestCase extends AbstractMuleTestCase {
     executorService = Executors.newFixedThreadPool(threadCount);
 
     final CursorProvider cursorProvider = mock(CursorStreamProvider.class);
+    IdentifiableCursorProvider identifiableCursorProvider = IdentifiableCursorProviderDecorator.of(cursorProvider);
 
     for (int i = 0; i < threadCount; i++) {
       executorService.submit(() -> {
@@ -85,7 +87,7 @@ public class CursorManagerTestCase extends AbstractMuleTestCase {
         } catch (InterruptedException e) {
           // doesn't matter
         }
-        CursorProvider managed = cursorManager.manage(cursorProvider, ctx);
+        CursorProvider managed = cursorManager.manage(identifiableCursorProvider, ctx);
         synchronized (managedProviders) {
           managedProviders.add(managed);
         }
@@ -98,7 +100,7 @@ public class CursorManagerTestCase extends AbstractMuleTestCase {
     assertThat(managedProviders.get(0), is(instanceOf(ManagedCursorProvider.class)));
 
     ManagedCursorProvider managedProvider = (ManagedCursorProvider) managedProviders.get(0);
-    assertThat(managedProvider.getDelegate(), is(sameInstance(cursorProvider)));
+    assertThat(unwrap(managedProvider), is(sameInstance(cursorProvider)));
     assertThat(managedProviders.stream().allMatch(p -> p == managedProvider), is(true));
 
     verify(ghostBuster).track(managedProvider);

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/CursorUtilTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/CursorUtilTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
+import static org.mule.test.allure.AllureConstants.StreamingFeature.STREAMING;
+import static org.mule.test.allure.AllureConstants.StreamingFeature.StreamingStory.STREAM_MANAGEMENT;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
+import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import org.junit.Test;
+
+@Feature(STREAMING)
+@Story(STREAM_MANAGEMENT)
+public class CursorUtilTestCase extends AbstractMuleTestCase {
+
+  @Test
+  @Issue("MULE-18573")
+  public void unwrapNonDecoratedProvider() {
+    CursorProvider provider = mock(CursorProvider.class);
+    assertThat(unwrap(provider), is(sameInstance(provider)));
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void unwrapOneLevelDecorator() {
+    CursorProvider provider = mock(CursorProvider.class);
+    CursorProviderDecorator decorator = mock(CursorProviderDecorator.class);
+    when(decorator.getDelegate()).thenReturn(provider);
+
+    assertThat(unwrap(decorator), is(sameInstance(provider)));
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void unwrap42thLevelDecorator() {
+    CursorProvider provider = mock(CursorProvider.class);
+    CursorProviderDecorator decorator = mock(CursorProviderDecorator.class);
+    when(decorator.getDelegate()).thenReturn(provider);
+
+    for (int i = 0; i < 41; i++) {
+      CursorProviderDecorator newDecorator = mock(CursorProviderDecorator.class);
+      when(newDecorator.getDelegate()).thenReturn(decorator);
+      decorator = newDecorator;
+    }
+
+    assertThat(unwrap(decorator), is(sameInstance(provider)));
+  }
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/IdentifiableCursorProviderDecoratorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/IdentifiableCursorProviderDecoratorTestCase.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
+import static org.mule.test.allure.AllureConstants.StreamingFeature.STREAMING;
+import static org.mule.test.allure.AllureConstants.StreamingFeature.StreamingStory.STREAM_MANAGEMENT;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
+import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.runtime.api.streaming.object.CursorIteratorProvider;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@Feature(STREAMING)
+@Story(STREAM_MANAGEMENT)
+public class IdentifiableCursorProviderDecoratorTestCase extends AbstractMuleTestCase {
+
+  private static List<Integer> COLLECTED_IDS;
+  private static AtomicInteger FAKE_ID_GENERATOR = new AtomicInteger(2000);
+
+  @BeforeClass
+  public static void beforeClass() {
+    COLLECTED_IDS = new LinkedList<>();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    try {
+      Set<Integer> uniqueIds = new HashSet<>(COLLECTED_IDS);
+      assertThat(uniqueIds, hasSize(COLLECTED_IDS.size()));
+    } finally {
+      COLLECTED_IDS = null;
+    }
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void decorateSimpleCursorStreamProvider() {
+    CursorStreamProvider provider = mock(CursorStreamProvider.class);
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(provider);
+    assertThat(decorator.getDelegate(), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorStreamProvider.class)));
+    getId(decorator);
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void decorateSimpleCursorStreamProviderTwice() {
+    CursorStreamProvider provider = mock(CursorStreamProvider.class);
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(provider);
+    assertThat(decorator.getDelegate(), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorStreamProvider.class)));
+
+    IdentifiableCursorProviderDecorator decoratorTwice = IdentifiableCursorProviderDecorator.of(decorator);
+    assertThat(decoratorTwice.getDelegate(), is(sameInstance(provider)));
+    assertThat(decoratorTwice, is(instanceOf(CursorStreamProvider.class)));
+    assertThat(decoratorTwice, is(sameInstance(decorator)));
+
+    getId(decorator);
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void decorateSimpleCursorIteratorProvider() {
+    CursorIteratorProvider provider = mock(CursorIteratorProvider.class);
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(provider);
+    assertThat(decorator.getDelegate(), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorIteratorProvider.class)));
+    getId(decorator);
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void decorateSimpleCursorIteratorProviderTwice() {
+    CursorIteratorProvider provider = mock(CursorIteratorProvider.class);
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(provider);
+    assertThat(decorator.getDelegate(), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorIteratorProvider.class)));
+
+    IdentifiableCursorProviderDecorator decoratorTwice = IdentifiableCursorProviderDecorator.of(decorator);
+    assertThat(decoratorTwice.getDelegate(), is(sameInstance(provider)));
+    assertThat(decoratorTwice, is(instanceOf(CursorIteratorProvider.class)));
+    assertThat(decoratorTwice, is(sameInstance(decorator)));
+    getId(decorator);
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void decorateIdentifiableCursorStreamProvider() {
+    IdentifiableCursorProvider provider =
+        mock(IdentifiableCursorProvider.class, withSettings().extraInterfaces(CursorStreamProvider.class));
+    final int id = FAKE_ID_GENERATOR.incrementAndGet();
+    when(provider.getId()).thenReturn(id);
+
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(provider);
+    assertThat(decorator.getDelegate(), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorStreamProvider.class)));
+    assertThat(getId(provider), is(id));
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void decorateIdentifiableCursorIteratorProvider() {
+    IdentifiableCursorProvider provider =
+        mock(IdentifiableCursorProvider.class, withSettings().extraInterfaces(CursorIteratorProvider.class));
+    final int id = FAKE_ID_GENERATOR.incrementAndGet();
+    when(provider.getId()).thenReturn(id);
+
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(provider);
+    assertThat(decorator.getDelegate(), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorIteratorProvider.class)));
+    assertThat(getId(decorator), is(id));
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void doubleDecorateCursorStreamProvider() {
+    CursorStreamProvider provider = mock(CursorStreamProvider.class);
+    CursorProviderDecorator firstDecorator =
+        mock(CursorProviderDecorator.class, withSettings().extraInterfaces(CursorStreamProvider.class));
+    when(firstDecorator.getDelegate()).thenReturn(provider);
+
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(firstDecorator);
+    assertThat(decorator.getDelegate(), is(sameInstance(firstDecorator)));
+    assertThat(decorator, is(instanceOf(CursorStreamProvider.class)));
+    getId(decorator);
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void doubleDecorateIdentifiableCursorStreamProvider() {
+    CursorStreamProvider provider = mock(CursorStreamProvider.class);
+    CursorProviderDecorator firstDecorator =
+        mock(CursorProviderDecorator.class,
+             withSettings().extraInterfaces(CursorStreamProvider.class, IdentifiableCursorProvider.class));
+    final int id = FAKE_ID_GENERATOR.incrementAndGet();
+    when(firstDecorator.getDelegate()).thenReturn(provider);
+    when(((IdentifiableCursorProvider) firstDecorator).getId()).thenReturn(id);
+
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(firstDecorator);
+    assertThat(unwrap(decorator), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorStreamProvider.class)));
+    assertThat(getId(decorator), is(id));
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void doubleDecorateCursorIteratorProvider() {
+    CursorIteratorProvider provider = mock(CursorIteratorProvider.class);
+    CursorProviderDecorator firstDecorator =
+        mock(CursorProviderDecorator.class, withSettings().extraInterfaces(CursorIteratorProvider.class));
+    when(firstDecorator.getDelegate()).thenReturn(provider);
+
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(firstDecorator);
+    assertThat(decorator.getDelegate(), is(sameInstance(firstDecorator)));
+    assertThat(decorator, is(instanceOf(CursorIteratorProvider.class)));
+    getId(decorator);
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void doubleDecorateIdentifiableCursorIteratorProvider() {
+    CursorIteratorProvider provider = mock(CursorIteratorProvider.class);
+    CursorProviderDecorator firstDecorator =
+        mock(CursorProviderDecorator.class,
+             withSettings().extraInterfaces(CursorIteratorProvider.class, IdentifiableCursorProvider.class));
+
+    final int id = FAKE_ID_GENERATOR.incrementAndGet();
+    when(firstDecorator.getDelegate()).thenReturn(provider);
+    when(((IdentifiableCursorProvider) firstDecorator).getId()).thenReturn(id);
+
+    IdentifiableCursorProviderDecorator decorator = IdentifiableCursorProviderDecorator.of(firstDecorator);
+    assertThat(unwrap(decorator), is(sameInstance(provider)));
+    assertThat(decorator, is(instanceOf(CursorIteratorProvider.class)));
+    assertThat(getId(decorator), is(id));
+  }
+
+  private int getId(IdentifiableCursorProvider provider) {
+    int id = provider.getId();
+    COLLECTED_IDS.add(id);
+
+    return id;
+  }
+}
+

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/StreamingGhostBusterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/streaming/StreamingGhostBusterTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import static java.lang.System.gc;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
+import static org.mule.runtime.core.internal.streaming.IdentifiableCursorProviderDecorator.of;
+import static org.mule.tck.probe.PollingProber.DEFAULT_POLLING_INTERVAL;
+import static org.mule.tck.probe.PollingProber.check;
+import static org.mule.test.allure.AllureConstants.StreamingFeature.STREAMING;
+import static org.mule.test.allure.AllureConstants.StreamingFeature.StreamingStory.STREAM_MANAGEMENT;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
+import org.junit.Test;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.runtime.core.internal.streaming.bytes.ManagedCursorStreamProvider;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import java.lang.ref.WeakReference;
+
+@Feature(STREAMING)
+@Story(STREAM_MANAGEMENT)
+public class StreamingGhostBusterTestCase extends AbstractMuleContextTestCase {
+
+  private static final int GC_POLLING_TIMEOUT = 10000;
+
+  private StreamingGhostBuster ghostBuster;
+
+  @Override
+  protected void doSetUp() throws Exception {
+    ghostBuster = new StreamingGhostBuster();
+    initialiseIfNeeded(ghostBuster, true, muleContext);
+    startIfNeeded(ghostBuster);
+  }
+
+  @Override
+  protected void doTearDown() throws MuleException {
+    ghostBuster.stop();
+    ghostBuster.dispose();
+  }
+
+  @Test
+  @Issue("MULE-18573")
+  public void releaseResourcesWhenReferenceIsCollected() {
+    MutableStreamingStatistics statistics = mock(MutableStreamingStatistics.class);
+    CursorStreamProvider provider = mock(CursorStreamProvider.class);
+    ManagedCursorStreamProvider managedCursorProvider = new ManagedCursorStreamProvider(of(provider), statistics);
+
+    WeakReference<ManagedCursorProvider> reference = ghostBuster.track(managedCursorProvider);
+
+    // Force GC collection
+    managedCursorProvider = null;
+
+    check(GC_POLLING_TIMEOUT, DEFAULT_POLLING_INTERVAL, () -> {
+      gc();
+      assertThat(reference.get(), is(nullValue()));
+      verify(provider).releaseResources();
+      return true;
+    });
+  }
+
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/Foreach.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
 import static org.mule.runtime.api.metadata.DataType.fromObject;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
+import static org.mule.runtime.core.api.util.StreamingUtils.updateTypedValueForStreaming;
 import static org.mule.runtime.core.internal.routing.ExpressionSplittingStrategy.DEFAULT_SPLIT_EXPRESSION;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.getProcessingStrategy;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
@@ -33,6 +34,7 @@ import org.mule.runtime.core.api.event.CoreEvent.Builder;
 import org.mule.runtime.core.api.processor.AbstractMessageProcessorOwner;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
+import org.mule.runtime.core.api.streaming.StreamingManager;
 import org.mule.runtime.core.internal.exception.MessagingException;
 import org.mule.runtime.core.internal.routing.outbound.EventBuilderConfigurer;
 import org.mule.runtime.core.internal.routing.outbound.EventBuilderConfigurerIterator;
@@ -77,6 +79,9 @@ public class Foreach extends AbstractMessageProcessorOwner implements Initialisa
 
   @Inject
   protected ExpressionManager expressionManager;
+
+  @Inject
+  protected StreamingManager streamingManager;
 
   private List<Processor> messageProcessors;
   private String expression = DEFAULT_SPLIT_EXPRESSION;
@@ -173,10 +178,13 @@ public class Foreach extends AbstractMessageProcessorOwner implements Initialisa
             });
           } else if (typedValue.getValue() instanceof Message) {
             // If value is a Message then use it directly conserving attributes and properties.
-            partEventBuilder.message((Message) typedValue.getValue());
+            Message message = (Message) typedValue.getValue();
+            TypedValue managedValue = updateTypedValueForStreaming(message.getPayload(), currentEvent.get(), streamingManager);
+            partEventBuilder.message(Message.builder(message).payload(managedValue).build());
           } else {
             // Otherwise create a new message
-            partEventBuilder.message(Message.builder().payload(typedValue).build());
+            TypedValue managedValue = updateTypedValueForStreaming(typedValue, currentEvent.get(), streamingManager);
+            partEventBuilder.message(Message.builder().payload(managedValue).build());
           }
 
           return Mono

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/ParallelForEach.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/ParallelForEach.java
@@ -9,6 +9,7 @@ package org.mule.runtime.core.internal.routing;
 
 import static java.util.Collections.singletonList;
 import static org.mule.runtime.core.api.processor.strategy.AsyncProcessingStrategyFactory.DEFAULT_MAX_CONCURRENCY;
+import static org.mule.runtime.core.api.util.StreamingUtils.updateTypedValueForStreaming;
 import static org.mule.runtime.core.internal.routing.ExpressionSplittingStrategy.DEFAULT_SPLIT_EXPRESSION;
 import static org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair.of;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
@@ -19,6 +20,7 @@ import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.Processor;
+import org.mule.runtime.core.api.streaming.StreamingManager;
 import org.mule.runtime.core.internal.routing.forkjoin.CollectListForkJoinStrategyFactory;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 
@@ -27,6 +29,8 @@ import org.reactivestreams.Publisher;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+
+import javax.inject.Inject;
 
 /**
  * <p>
@@ -43,6 +47,9 @@ import java.util.Optional;
  * @since 4.2.0
  */
 public class ParallelForEach extends AbstractForkJoinRouter {
+
+  @Inject
+  protected StreamingManager streamingManager;
 
   private String collectionExpression = DEFAULT_SPLIT_EXPRESSION;
   private SplittingStrategy<CoreEvent, Iterator<TypedValue<?>>> splittingStrategy;
@@ -61,7 +68,10 @@ public class ParallelForEach extends AbstractForkJoinRouter {
   @Override
   protected Publisher<ForkJoinStrategy.RoutingPair> getRoutingPairs(CoreEvent event) {
     return fromIterable(() -> splittingStrategy.split(event))
-        .map(partTypedValue -> CoreEvent.builder(event).message(Message.builder().payload(partTypedValue).build()).build())
+        .map(partTypedValue -> {
+          TypedValue managedValue = updateTypedValueForStreaming(partTypedValue, event, streamingManager);
+          return CoreEvent.builder(event).message(Message.builder().payload(managedValue).build()).build();
+        })
         .map(partEvent -> of(partEvent, nestedChain));
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorManager.java
@@ -6,24 +6,33 @@
  */
 package org.mule.runtime.core.internal.streaming;
 
+import static java.lang.Boolean.getBoolean;
 import static java.lang.System.identityHashCode;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.api.util.MuleSystemProperties.STREAMING_VERBOSE_PROPERTY;
+import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
+import static org.slf4j.LoggerFactory.getLogger;
 
+import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.streaming.Cursor;
 import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.runtime.api.streaming.bytes.CursorStream;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.runtime.api.streaming.object.CursorIterator;
 import org.mule.runtime.api.streaming.object.CursorIteratorProvider;
 import org.mule.runtime.core.internal.streaming.bytes.ManagedCursorStreamProvider;
 import org.mule.runtime.core.internal.streaming.object.ManagedCursorIteratorProvider;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 
 import java.lang.ref.WeakReference;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.slf4j.Logger;
 
 /**
  * Keeps track of active {@link Cursor cursors} and their {@link CursorProvider providers}
@@ -31,6 +40,9 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
  * @since 4.0
  */
 public class CursorManager {
+
+  public static final boolean STREAMING_VERBOSE = getBoolean(STREAMING_VERBOSE_PROPERTY);
+  private static final Logger LOGGER = getLogger(CursorManager.class);
 
   private final LoadingCache<BaseEventContext, EventStreamingState> registry =
       Caffeine.newBuilder()
@@ -61,14 +73,17 @@ public class CursorManager {
    * @param ownerContext the root context of the event that created the provider
    * @return a {@link CursorProvider}
    */
-  public CursorProvider manage(CursorProvider provider, BaseEventContext ownerContext) {
+  public CursorProvider manage(final CursorProvider provider, BaseEventContext ownerContext) {
+    CursorProvider innerDelegate = unwrap(provider);
+    IdentifiableCursorProvider identifiable = IdentifiableCursorProviderDecorator.of(provider);
+
     ManagedCursorProvider managedProvider;
-    if (provider instanceof CursorStreamProvider) {
-      managedProvider = new ManagedCursorStreamProvider(provider, statistics);
-    } else if (provider instanceof CursorIteratorProvider) {
-      managedProvider = new ManagedCursorIteratorProvider(provider, statistics);
+    if (innerDelegate instanceof CursorStreamProvider) {
+      managedProvider = new ManagedCursorStreamProvider((IdentifiableCursorProvider<CursorStream>) identifiable, statistics);
+    } else if (innerDelegate instanceof CursorIteratorProvider) {
+      managedProvider = new ManagedCursorIteratorProvider((IdentifiableCursorProvider<CursorIterator>) identifiable, statistics);
     } else {
-      throw new MuleRuntimeException(createStaticMessage("Unknown cursor provider type: " + provider.getClass().getName()));
+      throw new MuleRuntimeException(createStaticMessage("Unknown cursor provider type: " + innerDelegate.getClass().getName()));
     }
 
     return registry.get(ownerContext).addProvider(managedProvider);
@@ -88,19 +103,19 @@ public class CursorManager {
     private final Cache<Integer, WeakReference<ManagedCursorProvider>> providers = Caffeine.newBuilder().build();
 
     private ManagedCursorProvider addProvider(ManagedCursorProvider provider) {
-      final int hash = identityHashCode(provider.getDelegate());
-      ManagedCursorProvider managedProvider = getOrAddManagedProvider(provider, hash);
+      final int id = provider.getId();
+      ManagedCursorProvider managedProvider = getOrAddManagedProvider(provider, id);
 
       // This can happen when a foreach component splits a text document using a stream.
       // Iteration N might try to manage the same root provider that was already managed in iteration N-1, but the
       // managed decorator from that previous iteration has been collected, which causes the weak reference to yield
       // a null value. In which case we simply track it again.
       if (managedProvider == null) {
-        synchronized (provider.getDelegate()) {
-          managedProvider = getOrAddManagedProvider(provider, hash);
+        synchronized (unwrap(provider)) {
+          managedProvider = getOrAddManagedProvider(provider, id);
           if (managedProvider == null) {
-            providers.invalidate(hash);
-            managedProvider = getOrAddManagedProvider(provider, hash);
+            providers.invalidate(id);
+            managedProvider = getOrAddManagedProvider(provider, id);
           }
         }
       }
@@ -109,7 +124,15 @@ public class CursorManager {
     }
 
     private ManagedCursorProvider getOrAddManagedProvider(ManagedCursorProvider provider, int hash) {
-      return providers.get(hash, k -> ghostBuster.track(provider)).get();
+      return providers.get(hash, k -> {
+        if (STREAMING_VERBOSE) {
+          CursorProvider innerDelegate = unwrap(provider);
+          Optional<ComponentLocation> originatingLocation = provider.getOriginatingLocation();
+          LOGGER.info("Added ManagedCursorProvider: {} for delegate: {} opened by: {}", k, identityHashCode(innerDelegate),
+                      originatingLocation.map(ComponentLocation::getLocation).orElse("unknown"));
+        }
+        return ghostBuster.track(provider);
+      }).get();
     }
 
     private void dispose() {

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorProviderDecorator.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorProviderDecorator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.streaming.Cursor;
+import org.mule.runtime.api.streaming.CursorProvider;
+
+import java.util.Optional;
+
+/**
+ * Base class for applying the decorator pattern over instances of a {@link CursorProvider}.
+ * <p>
+ * All decorators <b>MUST</b> extend this class so that the framework can leverage the {@link #getDelegate()} method in order
+ * to traverse the decorators chain in order to asses if certain behaviors are already applied or to reach the originally wrapped
+ * instance.
+ *
+ * @param <T> the generic {@link Cursor} type as defined in {@link CursorProvider}
+ * @since 4.4, 4.3.1, 4.2.3
+ */
+public abstract class CursorProviderDecorator<T extends Cursor> implements CursorProvider<T> {
+
+  protected final CursorProvider<T> delegate;
+
+  public CursorProviderDecorator(CursorProvider<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  /**
+   * @return The wrapped instance. Might actually be another {@link CursorProviderDecorator}
+   */
+  public CursorProvider<T> getDelegate() {
+    return delegate;
+  }
+
+  @Override
+  public T openCursor() {
+    return delegate.openCursor();
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public void releaseResources() {
+    delegate.releaseResources();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return delegate.isClosed();
+  }
+
+  @Override
+  public Optional<ComponentLocation> getOriginatingLocation() {
+    return delegate.getOriginatingLocation();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return delegate.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return delegate.hashCode();
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorUtils.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/CursorUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import org.mule.runtime.api.streaming.Cursor;
+import org.mule.runtime.api.streaming.CursorProvider;
+
+/**
+ * Utilities for handling {@link Cursor cursors}
+ *
+ * @since 4.4, 4.3.1, 4.2.3
+ */
+public final class CursorUtils {
+
+  private CursorUtils() {}
+
+  /**
+   * Used to get the original {@link CursorProvider} when {@link CursorProviderDecorator} is used.
+   * <p>
+   * If {@code cursorProvider} is a decorator, then the {@link CursorProviderDecorator#getDelegate()} will be invoked
+   * recursively until a non-decorator delegate is found. If {@code cursorProvider} is not a decorator, then that same instance
+   * is returned.
+   *
+   * @param cursorProvider a provider which may or may not be a {@link CursorProviderDecorator}
+   * @param <T>            the generic {@link Cursor} type as defined in {@link CursorProvider}
+   * @return a non-decorator {@link CursorProvider}
+   */
+  public static <T extends Cursor> CursorProvider<T> unwrap(CursorProvider<T> cursorProvider) {
+    while (cursorProvider instanceof CursorProviderDecorator) {
+      cursorProvider = ((CursorProviderDecorator<T>) cursorProvider).getDelegate();
+    }
+
+    return cursorProvider;
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/IdentifiableCursorProvider.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/IdentifiableCursorProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import org.mule.runtime.api.streaming.Cursor;
+import org.mule.runtime.api.streaming.CursorProvider;
+
+/**
+ * A Cursor provider that contains an ID that can unequivocally identifies it.
+ *
+ * @param <T> the generic {@link Cursor} type as defined in {@link CursorProvider}
+ * @since 4.3.0 - 4.2.3
+ */
+public interface IdentifiableCursorProvider<T extends Cursor> extends CursorProvider<T> {
+
+  /**
+   * @return the provider's id.
+   */
+  int getId();
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/IdentifiableCursorProviderDecorator.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/IdentifiableCursorProviderDecorator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.streaming;
+
+import static java.lang.Integer.MIN_VALUE;
+
+import org.mule.runtime.api.streaming.Cursor;
+import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.runtime.api.streaming.bytes.CursorStream;
+import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.runtime.api.streaming.object.CursorIterator;
+import org.mule.runtime.api.streaming.object.CursorIteratorProvider;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A decorator that turns any {@link CursorProvider} into an {@link IdentifiableCursorProvider}.
+ * <p>
+ * If the decoratee is already an {@link IdentifiableCursorProvider} or ({@link CursorProviderDecorator} of one), then this
+ * decorator will yield the same id as the input identifiable provider. If this is not the case, an ID will be generaetd.
+ * <p>
+ * Instances are to be created through the {@link #of(CursorProvider)} factory method.
+ *
+ * @param <T> the generic {@link Cursor} type as defined in {@link CursorProvider}
+ * @since 4.4, 4.3.1, 4.2.3
+ */
+public abstract class IdentifiableCursorProviderDecorator<T extends Cursor> extends CursorProviderDecorator<T>
+    implements IdentifiableCursorProvider<T> {
+
+  private static final transient AtomicInteger ID_GENERATOR = new AtomicInteger(MIN_VALUE);
+
+  private final int id;
+
+  /**
+   * Creates a new decorator for the given {@code cursorProvider}.
+   * <p>
+   * If the {@code cursorProvider} is already an {@link IdentifiableCursorProvider}, then the returned decorator will yield the
+   * same id as the input {@code cursorProvider}. If {@code cursorProvider} is a {@link CursorProviderDecorator}, then the
+   * {@link CursorProviderDecorator#getDelegate()} will be recursively be tested to find if any delegate in the chain is
+   * identifiable. If such delegate is found, then the same {@code id} will be reused. Otherwise, one will be generated.
+   *
+   * @param cursorProvider the decoratee
+   * @param <T>            the generic {@link Cursor} type
+   * @return a new decorator.
+   */
+  public static <T extends Cursor> IdentifiableCursorProviderDecorator<T> of(CursorProvider<T> cursorProvider) {
+    final CursorProvider<T> root = cursorProvider;
+    if (cursorProvider instanceof IdentifiableCursorProviderDecorator) {
+      return (IdentifiableCursorProviderDecorator<T>) cursorProvider;
+    }
+    Integer id = null;
+    do {
+      if (cursorProvider instanceof IdentifiableCursorProvider) {
+        id = ((IdentifiableCursorProvider<T>) cursorProvider).getId();
+        break;
+      }
+
+      if (cursorProvider instanceof CursorProviderDecorator) {
+        cursorProvider = ((CursorProviderDecorator<T>) cursorProvider).getDelegate();
+      }
+    } while (cursorProvider instanceof CursorProviderDecorator);
+
+    if (id == null) {
+      id = ID_GENERATOR.incrementAndGet();
+    }
+
+    if (cursorProvider instanceof CursorStreamProvider) {
+      return (IdentifiableCursorProviderDecorator<T>) new IdentifiableCursorStreamProviderDecorator(
+                                                                                                    (CursorStreamProvider) root,
+                                                                                                    id);
+    } else {
+      return (IdentifiableCursorProviderDecorator<T>) new IdentifiableCursorIteratorProviderDecorator(
+                                                                                                      (CursorIteratorProvider) root,
+                                                                                                      id);
+    }
+  }
+
+  private IdentifiableCursorProviderDecorator(CursorProvider<T> delegate, int id) {
+    super(delegate);
+    this.id = id;
+  }
+
+  @Override
+  public int getId() {
+    return id;
+  }
+
+  private static class IdentifiableCursorStreamProviderDecorator extends IdentifiableCursorProviderDecorator<CursorStream>
+      implements CursorStreamProvider {
+
+    public IdentifiableCursorStreamProviderDecorator(CursorStreamProvider delegate, int id) {
+      super(delegate, id);
+    }
+  }
+
+
+  private static class IdentifiableCursorIteratorProviderDecorator extends IdentifiableCursorProviderDecorator<CursorIterator>
+      implements CursorIteratorProvider {
+
+    public IdentifiableCursorIteratorProviderDecorator(CursorIteratorProvider delegate, int id) {
+      super(delegate, id);
+    }
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/ManagedCursorProvider.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/ManagedCursorProvider.java
@@ -21,15 +21,17 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see CursorManager
  * @since 4.0
  */
-public abstract class ManagedCursorProvider<T extends Cursor> implements CursorProvider<T> {
+public abstract class ManagedCursorProvider<T extends Cursor> extends CursorProviderDecorator<T>
+    implements IdentifiableCursorProvider<T> {
 
-  private final CursorProvider<T> delegate;
   private final Set<Cursor> cursors = newSetFromMap(new ConcurrentHashMap<>());
   private final MutableStreamingStatistics statistics;
   private final CursorProviderJanitor janitor;
+  private final int id;
 
-  protected ManagedCursorProvider(CursorProvider<T> delegate, MutableStreamingStatistics statistics) {
-    this.delegate = delegate;
+  protected ManagedCursorProvider(IdentifiableCursorProvider<T> delegate, MutableStreamingStatistics statistics) {
+    super(delegate);
+    id = delegate.getId();
     this.janitor = new CursorProviderJanitor(delegate, cursors, statistics);
     this.statistics = statistics;
     statistics.incrementOpenProviders();
@@ -52,10 +54,6 @@ public abstract class ManagedCursorProvider<T extends Cursor> implements CursorP
     return managedCursor;
   }
 
-  public CursorProvider<T> getDelegate() {
-    return delegate;
-  }
-
   /**
    * Returns a managed version of the {@code cursor}. How will that cursor be managed depends on each
    * implementation. Although it is possible that the same input {@code cursor} is returned, the assumption
@@ -71,6 +69,11 @@ public abstract class ManagedCursorProvider<T extends Cursor> implements CursorP
     janitor.releaseResources();
   }
 
+  @Override
+  public int getId() {
+    return id;
+  }
+
   public CursorProviderJanitor getJanitor() {
     return janitor;
   }
@@ -78,10 +81,5 @@ public abstract class ManagedCursorProvider<T extends Cursor> implements CursorP
   @Override
   public void close() {
     janitor.close();
-  }
-
-  @Override
-  public boolean isClosed() {
-    return delegate.isClosed();
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/bytes/ManagedCursorStreamProvider.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/bytes/ManagedCursorStreamProvider.java
@@ -6,9 +6,9 @@
  */
 package org.mule.runtime.core.internal.streaming.bytes;
 
-import org.mule.runtime.api.streaming.CursorProvider;
 import org.mule.runtime.api.streaming.bytes.CursorStream;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.runtime.core.internal.streaming.IdentifiableCursorProvider;
 import org.mule.runtime.core.internal.streaming.ManagedCursorProvider;
 import org.mule.runtime.core.internal.streaming.MutableStreamingStatistics;
 
@@ -22,7 +22,8 @@ public class ManagedCursorStreamProvider extends ManagedCursorProvider<CursorStr
   /**
    * {@inheritDoc}
    */
-  public ManagedCursorStreamProvider(CursorProvider<CursorStream> delegate, MutableStreamingStatistics statistics) {
+  public ManagedCursorStreamProvider(IdentifiableCursorProvider<CursorStream> delegate,
+                                     MutableStreamingStatistics statistics) {
     super(delegate, statistics);
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/object/ManagedCursorIteratorProvider.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/object/ManagedCursorIteratorProvider.java
@@ -6,9 +6,9 @@
  */
 package org.mule.runtime.core.internal.streaming.object;
 
-import org.mule.runtime.api.streaming.CursorProvider;
 import org.mule.runtime.api.streaming.object.CursorIterator;
 import org.mule.runtime.api.streaming.object.CursorIteratorProvider;
+import org.mule.runtime.core.internal.streaming.IdentifiableCursorProvider;
 import org.mule.runtime.core.internal.streaming.ManagedCursorProvider;
 import org.mule.runtime.core.internal.streaming.MutableStreamingStatistics;
 
@@ -22,7 +22,8 @@ public class ManagedCursorIteratorProvider extends ManagedCursorProvider<CursorI
   /**
    * {@inheritDoc}
    */
-  public ManagedCursorIteratorProvider(CursorProvider<CursorIterator> delegate, MutableStreamingStatistics statistics) {
+  public ManagedCursorIteratorProvider(IdentifiableCursorProvider<CursorIterator> delegate,
+                                       MutableStreamingStatistics statistics) {
     super(delegate, statistics);
   }
 
@@ -33,5 +34,4 @@ public class ManagedCursorIteratorProvider extends ManagedCursorProvider<CursorI
   protected CursorIterator managedCursor(CursorIterator cursor) {
     return new ManagedCursorIterator(this, cursor, getJanitor());
   }
-
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -38,6 +39,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNee
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
 import static org.mule.runtime.core.internal.event.EventQuickCopy.quickCopy;
 import static org.mule.runtime.core.internal.interception.DefaultInterceptionEvent.INTERCEPTION_RESOLVED_CONTEXT;
+import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
 import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
 import static org.mule.runtime.extension.api.ExtensionConstants.TARGET_PARAMETER_NAME;
 import static org.mule.runtime.extension.api.ExtensionConstants.TARGET_VALUE_PARAMETER_NAME;
@@ -66,6 +68,7 @@ import org.mule.runtime.api.metadata.MapDataType;
 import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.api.metadata.MetadataKey;
 import org.mule.runtime.api.metadata.MetadataKeysContainer;
+import org.mule.runtime.api.streaming.CursorProvider;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
 import org.mule.runtime.core.api.construct.FlowConstruct;
 import org.mule.runtime.core.api.el.ExpressionManager;
@@ -99,6 +102,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -106,9 +111,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
@@ -137,7 +139,7 @@ public class OperationMessageProcessorTestCase extends AbstractOperationMessageP
 
   @Test
   public void operationContextIsWellFormed() throws Exception {
-    ArgumentCaptor<ExecutionContext> operationContextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
+    ArgumentCaptor<ExecutionContext> operationContextCaptor = forClass(ExecutionContext.class);
     messageProcessor.process(event);
 
     verify(operationExecutor).execute(operationContextCaptor.capture());
@@ -393,7 +395,7 @@ public class OperationMessageProcessorTestCase extends AbstractOperationMessageP
     when(configurationInstance.getValue()).thenReturn(defaultConfigInstance);
     when(extensionManager.getConfiguration(extensionModel, operationModel, event)).thenReturn(of(configurationInstance));
 
-    ArgumentCaptor<ExecutionContext> operationContextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
+    ArgumentCaptor<ExecutionContext> operationContextCaptor = forClass(ExecutionContext.class);
     messageProcessor.process(event);
     verify(operationExecutor).execute(operationContextCaptor.capture());
 
@@ -485,7 +487,10 @@ public class OperationMessageProcessorTestCase extends AbstractOperationMessageP
     when(operationExecutor.execute(any())).thenReturn(just(inputStream));
 
     messageProcessor.process(event);
-    verify(streamingManager).manage(same(provider), any(EventContext.class));
+    ArgumentCaptor<CursorProvider> providerCaptor = forClass(CursorProvider.class);
+    verify(streamingManager).manage(providerCaptor.capture(), any(EventContext.class));
+
+    assertThat(unwrap(providerCaptor.getValue()), is(sameInstance(provider)));
   }
 
   private void assertProcessingType(ExecutionType executionType, ProcessingType expectedProcessingType) {


### PR DESCRIPTION
(cherry picked from commit a7fa47e0c1c002b34e16e77f4853c51cdc19609a)