### PR TITLE
MULE-18725: WS Consumer does not report correct error path when mule-http fails

### DIFF
--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/WSConsumer.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/WSConsumer.java
@@ -146,7 +146,7 @@ public class WSConsumer implements MessageProcessor, Initialisable, MuleContextA
 
         chainBuilder.chain(createSoapHeadersPropertiesRemoverMessageProcessor());
 
-        chainBuilder.chain(config.createOutboundMessageProcessor());
+        chainBuilder.chain(config.createOutboundMessageProcessor(this));
 
         return chainBuilder.build();
     }

--- a/modules/ws/src/main/java/org/mule/module/ws/consumer/WSConsumerConfig.java
+++ b/modules/ws/src/main/java/org/mule/module/ws/consumer/WSConsumerConfig.java
@@ -9,9 +9,12 @@ package org.mule.module.ws.consumer;
 
 import static javax.wsdl.WSDLException.OTHER_ERROR;
 import static org.mule.MessageExchangePattern.REQUEST_RESPONSE;
+import static org.mule.api.LocatedMuleException.INFO_LOCATION_KEY;
 import static org.mule.api.config.MuleProperties.OBJECT_CONNECTOR_MESSAGE_PROCESSOR_LOCATOR;
 import static org.mule.module.http.api.HttpConstants.Methods.POST;
 import static org.mule.module.http.api.client.HttpRequestOptionsBuilder.newOptions;
+
+import org.mule.api.MessagingException;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -70,6 +73,11 @@ public class WSConsumerConfig implements MuleContextAware
      */
     public MessageProcessor createOutboundMessageProcessor() throws MuleException
     {
+        return createOutboundMessageProcessor(null);
+    }
+
+    public MessageProcessor createOutboundMessageProcessor(MessageProcessor messageProcessor) throws MuleException
+    {
         Preconditions.checkState(StringUtils.isNotEmpty(serviceAddress), "No serviceAddress provided in WS consumer config");
 
         if (connectorConfig != null && connector != null)
@@ -79,7 +87,7 @@ public class WSConsumerConfig implements MuleContextAware
 
         if (useHttpModule())
         {
-            return createHttpRequester();
+            return createHttpRequester(messageProcessor);
         }
         else
         {
@@ -127,8 +135,10 @@ public class WSConsumerConfig implements MuleContextAware
         return muleContext.getEndpointFactory().getOutboundEndpoint(builder);
     }
 
-    private MessageProcessor createHttpRequester() throws MuleException
+    private MessageProcessor createHttpRequester(MessageProcessor messageProcessor) throws MuleException
     {
+        final MessageProcessor callerMessageProcessor = messageProcessor;
+
         return new MessageProcessor()
         {
             private HttpRequestOptions requestOptions;
@@ -138,7 +148,16 @@ public class WSConsumerConfig implements MuleContextAware
             {
                 ConnectorOperationLocator connectorOperationLocator = muleContext.getRegistry().get(OBJECT_CONNECTOR_MESSAGE_PROCESSOR_LOCATOR);
                 MessageProcessor messageProcessor = connectorOperationLocator.locateConnectorOperation(serviceAddress, getRequestOptions(), REQUEST_RESPONSE);
-                return messageProcessor.process(event);
+
+                try
+                {
+                    return messageProcessor.process(event);
+                }
+                catch (MessagingException e)
+                {
+                    e.getInfo().remove(INFO_LOCATION_KEY);
+                    throw new MessagingException(event, e, callerMessageProcessor);
+                }
             }
 
             private HttpRequestOptions getRequestOptions()

--- a/modules/ws/src/test/java/org/mule/module/ws/functional/WSConsumerHttpRequesterFailureTestCase.java
+++ b/modules/ws/src/test/java/org/mule/module/ws/functional/WSConsumerHttpRequesterFailureTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.ws.functional;
+
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import org.mule.api.MessagingException;
+import org.mule.construct.Flow;
+import org.mule.module.ws.consumer.WSConsumer;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.text.IsEmptyString.isEmptyString;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.fail;
+import static org.mule.api.LocatedMuleException.INFO_LOCATION_KEY;
+
+/**
+ * This test case verifies that a HTTP Requester that fails is correctly caught and handled by
+ * the WSConsumerConfig, placing the WSConsumer Message Processor as the element path on the exception info.
+ */
+public class WSConsumerHttpRequesterFailureTestCase extends AbstractWSConsumerFunctionalTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "ws-consumer-http-requester-failure-test-case.xml";
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> parameters()
+    {
+        // Change default behavior of AbstractWSConsumerFunctionalTestCase as this test only uses the new connector.
+        return Arrays.asList(new Object[][] { new Object[]{false} });
+    }
+
+    @Test
+    public void invalidHttpRequestConfigThrowsExceptionWithElementPath() throws Exception
+    {
+        Flow flow = (Flow) getFlowConstruct("clientInvalidHttpRequestConfig");
+
+        try
+        {
+            flow.process(getTestEvent(ECHO_REQUEST));
+            fail();
+        }
+        catch (MessagingException ex)
+        {
+            String element = ex.getInfo().get(INFO_LOCATION_KEY).toString();
+
+            assertThat(element, not(nullValue()));
+            assertThat(element, not(isEmptyString()));
+            assertThat(ex.getFailingMessageProcessor(), is(instanceOf(WSConsumer.class)));
+        }
+    }
+
+}

--- a/modules/ws/src/test/resources/ws-consumer-http-requester-failure-test-case.xml
+++ b/modules/ws/src/test/resources/ws-consumer-http-requester-failure-test-case.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:ws="http://www.mulesoft.org/schema/mule/ws"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+               http://www.mulesoft.org/schema/mule/ws http://www.mulesoft.org/schema/mule/ws/current/mule-ws.xsd">
+
+    <http:request-config host="localhost" port="${port}" name="customInvalidConfig" responseTimeout="${timeout}">
+    </http:request-config>
+
+    <ws:consumer-config wsdlLocation="Test.wsdl" service="TestService" port="TestPort"
+                        serviceAddress="http://localhost:${port}/services/TestEmptyResponse"
+                        name="wsConfigInvalidHttpRequest" connectorConfig="customInvalidConfig"/>
+
+    <flow name="clientInvalidHttpRequestConfig">
+        <set-variable variableName="password" value="invalidPassword" />
+        <ws:consumer config-ref="wsConfigInvalidHttpRequest" operation="echo" />
+    </flow>
+
+</mule>


### PR DESCRIPTION
from PR: https://github.com/mulesoft/mule/pull/9341

- Jenkins job: https://jenkins-onprem.build.msap.io/job/Mule-runtime/view/3.x.x/job/mule/view/change-requests/job/PR-9355/
- Sonar: https://sonarqube.kbuild.msap.io/dashboard?branch=fix%2FMULE-18725-3.9.x&id=mule-runtime-mule