### PR TITLE
Refresh the connection in case of exception

### DIFF
--- a/transports/jms/src/main/java/org/mule/transport/jms/MultiConsumerJmsMessageReceiver.java
+++ b/transports/jms/src/main/java/org/mule/transport/jms/MultiConsumerJmsMessageReceiver.java
@@ -153,9 +153,9 @@ public class MultiConsumerJmsMessageReceiver extends AbstractMessageReceiver
             @Override
             public void doWork(RetryContext context) throws Exception
             {
+                JmsConnector connector = (JmsConnector) MultiConsumerJmsMessageReceiver.this.connector;
                 try
                 {
-                    JmsConnector connector = (JmsConnector) MultiConsumerJmsMessageReceiver.this.connector;
                     if (connector.shouldRetryBrokerConnection())
                     {
                         MultiConsumerJmsMessageReceiver.this.closeConnectorSilently();
@@ -198,6 +198,7 @@ public class MultiConsumerJmsMessageReceiver extends AbstractMessageReceiver
                 }
                 catch (Exception e)
                 {
+                    connector.setShouldRetryBrokerConnection(true);
                     throw new Exception("Fail to connect", e);
                 }
             }


### PR DESCRIPTION
(SE-15717) In case of ConnectionClosedException, the source is trying to use the same connection to register subscribers.
This forces the source to create a new connection.