### PR TITLE
CMTS-39: Allow to set a SystemProperty to enable logs for declaration…

### DIFF
--- a/modules/tooling-support-parent/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/config/DefaultDeclarationSessionBuilder.java
+++ b/modules/tooling-support-parent/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/config/DefaultDeclarationSessionBuilder.java
@@ -6,6 +6,9 @@
  */
 package org.mule.runtime.module.tooling.internal.config;
 
+import static java.lang.Boolean.valueOf;
+import static java.lang.System.getProperty;
+import static org.mule.runtime.core.api.config.MuleDeploymentProperties.MULE_FORCE_TOOLING_APP_LOGS_DEPLOYMENT_PROPERTY;
 import static org.mule.runtime.core.api.config.MuleDeploymentProperties.MULE_LAZY_INIT_DEPLOYMENT_PROPERTY;
 import static org.mule.runtime.core.api.config.MuleDeploymentProperties.MULE_MUTE_APP_LOGS_DEPLOYMENT_PROPERTY;
 import org.mule.runtime.module.deployment.impl.internal.application.DefaultApplicationFactory;
@@ -31,7 +34,9 @@ public class DefaultDeclarationSessionBuilder
   @Override
   protected Map<String, String> forcedDeploymentProperties() {
     return ImmutableMap.<String, String>builder()
-        .put(MULE_MUTE_APP_LOGS_DEPLOYMENT_PROPERTY, TRUE)
+        // System Property for user allow to force enable logs, but internal property is meant to disable logs if it is true
+        .put(MULE_MUTE_APP_LOGS_DEPLOYMENT_PROPERTY,
+             String.valueOf(!valueOf(getProperty(MULE_FORCE_TOOLING_APP_LOGS_DEPLOYMENT_PROPERTY, "false"))))
         .put(MULE_LAZY_INIT_DEPLOYMENT_PROPERTY, TRUE)
         .build();
   }


### PR DESCRIPTION
… sessions.

By default logs related to code that would be executed in the context of the "application" are muted, this is in order to prevent having in MULE_HOME/logs for each application that is deployed when resolving services for MTS.

We won't allow clients of MTS to pass this property as deployment property but we would expect the Runtime in which we are going to resolve the services to be "enabled" to write logs for these temporary applications that are attached to the declaration session when resolving services like ValueProvider, SampleData, Metadata, TestConnectivity.

```-M-Dmule.application.deployment.lazyInit.forceLog=true```  and in case if logger level needs to be adjusted for the connector's packages the MULE_HOME/conf/log4j2.xml  as the "application" deployed by MTS doesn't have a log4j2.xml configuration and Mule's one would be considered.
