### PR TITLE
MULE-18828: Same MetadataCacheId when two configless operations have …

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/metadata/ComponentAstBasedMetadataCacheIdGenerator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/metadata/ComponentAstBasedMetadataCacheIdGenerator.java
@@ -18,7 +18,6 @@ import static org.mule.runtime.config.api.dsl.model.metadata.ComponentBasedIdHel
 import static org.mule.runtime.config.api.dsl.model.metadata.ComponentBasedIdHelper.resolveConfigName;
 import static org.mule.runtime.config.api.dsl.model.metadata.ComponentBasedIdHelper.sourceElementNameFromSimpleValue;
 import static org.mule.runtime.core.api.util.StringUtils.isBlank;
-
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.ObjectType;
 import org.mule.metadata.api.model.StringType;
@@ -154,6 +153,8 @@ public class ComponentAstBasedMetadataCacheIdGenerator implements MetadataCacheI
     List<MetadataCacheId> keyParts = new ArrayList<>();
 
     if (typeInformation.isDynamicType()) {
+      resolveDslTagNamespace(component).ifPresent(keyParts::add);
+
       resolveConfigId(component).ifPresent(keyParts::add);
 
       typeInformation.getResolverCategory()
@@ -183,6 +184,11 @@ public class ComponentAstBasedMetadataCacheIdGenerator implements MetadataCacheI
                                       .map(sourceElementName -> format("(%s):(%s)", getSourceElementName(component),
                                                                        sourceElementName))
                                       .orElse(format("(%s):(%s)", getSourceElementName(component), "Unknown Type"))));
+  }
+
+  private Optional<MetadataCacheId> resolveDslTagNamespace(ComponentAst elementModel) {
+    String namespace = elementModel.getIdentifier().getNamespace();
+    return of(new MetadataCacheId(namespace.toLowerCase().hashCode(), namespace));
   }
 
   private Optional<MetadataCacheId> doResolve(ComponentAst elementModel) {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/metadata/DslElementBasedMetadataCacheIdGenerator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/metadata/DslElementBasedMetadataCacheIdGenerator.java
@@ -150,6 +150,8 @@ public class DslElementBasedMetadataCacheIdGenerator implements MetadataCacheIdG
     List<MetadataCacheId> keyParts = new ArrayList<>();
 
     if (typeInformation.isDynamicType()) {
+      resolveDslTagNamespace(component).ifPresent(keyParts::add);
+
       resolveConfigId(component).ifPresent(keyParts::add);
 
       typeInformation.getResolverCategory()
@@ -206,6 +208,11 @@ public class DslElementBasedMetadataCacheIdGenerator implements MetadataCacheIdG
   private Optional<MetadataCacheId> resolveDslTagId(DslElementModel<?> elementModel) {
     return elementModel.getIdentifier()
         .map(id -> new MetadataCacheId(id.hashCode(), id.toString()));
+  }
+
+  private Optional<MetadataCacheId> resolveDslTagNamespace(DslElementModel<?> elementModel) {
+    return elementModel.getIdentifier()
+        .map(id -> new MetadataCacheId(id.getNamespace().toLowerCase().hashCode(), id.getNamespace()));
   }
 
   private Optional<MetadataCacheId> resolveConfigId(DslElementModel<?> elementModel) {


### PR DESCRIPTION
…exactly the same category and resolver names