### PR TITLE
MULE-18889: Export META-INF/services/* resources in lightweight

### DIFF
--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/LightweightClassLoaderModelBuilder.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/LightweightClassLoaderModelBuilder.java
@@ -9,6 +9,7 @@ package org.mule.runtime.module.deployment.impl.internal.maven;
 import static com.vdurmont.semver4j.Semver.SemverType.LOOSE;
 import static java.lang.String.format;
 import static java.lang.System.lineSeparator;
+import static java.util.Collections.singleton;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
@@ -50,10 +51,10 @@ import org.apache.maven.model.Plugin;
 public class LightweightClassLoaderModelBuilder extends ArtifactClassLoaderModelBuilder {
 
   private static final String POM = "pom";
-  private MavenClient mavenClient;
-  private Set<BundleDependency> nonProvidedDependencies;
+  private final MavenClient mavenClient;
+  private final Set<BundleDependency> nonProvidedDependencies;
   private File temporaryFolder;
-  private Map<Pair<String, String>, Boolean> sharedLibraryAlreadyExported = new HashMap<>();
+  private final Map<Pair<String, String>, Boolean> sharedLibraryAlreadyExported = new HashMap<>();
 
   public LightweightClassLoaderModelBuilder(File artifactFolder, BundleDescriptor artifactBundleDescriptor,
                                             MavenClient mavenClient, Set<BundleDependency> nonProvidedDependencies) {
@@ -130,6 +131,11 @@ public class LightweightClassLoaderModelBuilder extends ArtifactClassLoaderModel
     JarInfo jarInfo = fileJarExplorer.explore(resolvedBundleDependency.getBundleUri());
     this.exportingPackages(jarInfo.getPackages());
     this.exportingResources(jarInfo.getResources());
+
+    jarInfo.getServices()
+        .forEach(service -> this
+            .exportingResources(singleton("META-INF/services/" + service.getServiceInterface())));
+
     resolvedBundleDependency.getTransitiveDependencies()
         .forEach(this::exportBundleDependencyAndTransitiveDependencies);
   }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
@@ -257,6 +257,7 @@ public abstract class AbstractDeploymentTestCase extends AbstractMuleTestCase {
   protected static File loadsAppResourceCallbackClassFile;
   protected static File loadsAppResourceCallbackJarFile;
   protected static File pluginEcho1TestClassFile;
+  protected static File pluginEchoSpiTestClassFile;
 
   private static Boolean internalIsRunningTests;
 
@@ -323,6 +324,9 @@ public abstract class AbstractDeploymentTestCase extends AbstractMuleTestCase {
         .compile("loadsAppResourceCallback.jar");
     pluginEcho1TestClassFile =
         new SingleClassCompiler().dependingOn(barUtils1_0JarFile).compile(getResourceFile("/org/foo/Plugin1Echo.java"));
+
+    pluginEchoSpiTestClassFile =
+        new CompilerUtils.SingleClassCompiler().compile(getResourceFile("/org/foo/echo/PluginSpiEcho.java"));
 
     internalIsRunningTests =
         (Boolean) readDeclaredStaticField(ModuleDelegatingEntityResolver.class, "internalIsRunningTests", true);

--- a/modules/deployment/src/test/resources/org/foo/echo/PluginSpiEcho.java
+++ b/modules/deployment/src/test/resources/org/foo/echo/PluginSpiEcho.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.foo.echo;
+
+import org.mule.functional.api.component.EventCallback;
+import org.mule.runtime.api.component.AbstractComponent;
+import org.mule.runtime.core.api.event.CoreEvent;
+
+import java.util.ServiceLoader;
+
+import org.mule.runtime.core.api.MuleContext;
+
+import org.foo.EchoTest;
+
+public class PluginSpiEcho extends AbstractComponent implements EventCallback {
+
+  public void eventReceived(CoreEvent event, Object component, MuleContext muleContext) throws Exception {
+    System.out.println(muleContext.getExecutionClassLoader());
+    
+    new EchoTest().echo(ServiceLoader.load(org.foo.spi.SpiInterface.class, Thread.currentThread().getContextClassLoader()).iterator().next().value());
+  }
+}

--- a/modules/deployment/src/test/resources/org/foo/spi/META-INF/services/org.foo.spi.SpiInterface
+++ b/modules/deployment/src/test/resources/org/foo/spi/META-INF/services/org.foo.spi.SpiInterface
@@ -1,0 +1,1 @@
+org.foo.spi.impl.SpiImplementation

--- a/modules/deployment/src/test/resources/org/foo/spi/SpiInterface.java
+++ b/modules/deployment/src/test/resources/org/foo/spi/SpiInterface.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.foo.spi;
+
+public interface SpiInterface {
+
+  public String value();
+}

--- a/modules/deployment/src/test/resources/org/foo/spi/impl/SpiImplementation.java
+++ b/modules/deployment/src/test/resources/org/foo/spi/impl/SpiImplementation.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.foo.spi.impl;
+
+import org.foo.spi.SpiInterface;
+
+public class SpiImplementation implements SpiInterface {
+
+  public String value() {
+    return "SpiImplementation";
+  }
+}

--- a/modules/deployment/src/test/resources/plugin-using-app-spi-impl-config.xml
+++ b/modules/deployment/src/test/resources/plugin-using-app-spi-impl-config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
+
+    <flow name="main">
+        <test:processor>
+            <test:callback class="org.foo.echo.PluginSpiEcho"/>
+        </test:processor>
+    </flow>
+</mule>


### PR DESCRIPTION
deployments (#9558)

* To make it consistent with the `classloader-model.json` that is
generated by the packager for heavyweight deployments.