### PR TITLE
MULE-16994: Use of cache instead of WeakHashMap to avoid infinite loop

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleInterceptor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleInterceptor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.core.internal.lifecycle;
 
+import static com.google.common.cache.CacheBuilder.newBuilder;
+
 import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.lifecycle.Startable;
@@ -14,8 +16,8 @@ import org.mule.runtime.core.internal.lifecycle.phases.LifecyclePhase;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.WeakHashMap;
 
+import org.mule.runtime.core.internal.lifecycle.phases.LifecyclePhase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,8 +32,8 @@ public class DefaultLifecycleInterceptor implements LifecycleInterceptor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLifecycleInterceptor.class);
 
-  private Map<Object, Object> trackingPhaseFailureObjects = new WeakHashMap<>();
-  private Map<Object, Object> processedObjects = new WeakHashMap<>();
+  private Map<Object, Object> trackingPhaseFailureObjects = newBuilder().weakKeys().weakValues().<Object, Object>build().asMap();
+  private Map<Object, Object> processedObjects = newBuilder().weakKeys().weakValues().<Object, Object>build().asMap();
 
   private final String initialPhase;
   private final String finalPhase;


### PR DESCRIPTION
in DefaultLifecycleInterceptor. (#7970)

(cherry picked from commit 74199672773e9169a5bc936fdc3b7b6f5caf1d9b)