### PR TITLE
MULE-11790: Adding descriptor for test-oauth-extension

### DIFF
--- a/tests/test-extensions/test-oauth-extension/src/main/resources/META-INF/mule-artifact/mule-artifact.json
+++ b/tests/test-extensions/test-oauth-extension/src/main/resources/META-INF/mule-artifact/mule-artifact.json
@@ -1,0 +1,25 @@
+{
+  "minMuleVersion": "4.3.0",
+  "requiredProduct": "MULE",
+  "extensionModelLoaderDescriptor": {
+    "id": "java",
+    "attributes": {
+      "type": "org.mule.test.oauth.TestOAuthExtension",
+      "version": "4.4.0-SNAPSHOT"
+    }
+  },
+  "name": "oauth-extension",
+  "classLoaderModelLoaderDescriptor": {
+    "id": "mule",
+    "attributes": {
+      "exportedPackages": [
+      ],
+      "exportedResources": [
+      ]
+    }
+  },
+  "bundleDescriptorLoader": {
+    "id": "mule",
+    "attributes": {}
+  }
+}

--- a/tests/test-extensions/test-oauth-extension/src/main/resources/META-INF/mule-artifact/mule-artifact.json
+++ b/tests/test-extensions/test-oauth-extension/src/main/resources/META-INF/mule-artifact/mule-artifact.json
@@ -13,6 +13,7 @@
     "id": "mule",
     "attributes": {
       "exportedPackages": [
+        "org.mule.test.oauth"
       ],
       "exportedResources": [
       ]


### PR DESCRIPTION
Adding mule-artifact.json descriptor so it can be used in other projects for testing.