### PR TITLE
MULE-18938: Inner chains of SDK operations started eagerly even if the

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/scopes/AbstractScopeExecutionTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/scopes/AbstractScopeExecutionTestCase.java
@@ -34,8 +34,8 @@ public abstract class AbstractScopeExecutionTestCase extends AbstractExtensionFu
   public SystemProperty maxRedelivery = new SystemProperty("killingReason", KILL_REASON);
 
   @Override
-  protected String[] getConfigFiles() {
-    return new String[] {"scopes/heisenberg-scope-config.xml"};
+  protected String getConfigFile() {
+    return "scopes/heisenberg-scope-config.xml";
   }
 
   @Override

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/scopes/ScopeExecutionTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/scopes/ScopeExecutionTestCase.java
@@ -23,6 +23,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.qameta.allure.Issue;
+
 public class ScopeExecutionTestCase extends AbstractScopeExecutionTestCase {
 
   @Rule
@@ -153,4 +155,12 @@ public class ScopeExecutionTestCase extends AbstractScopeExecutionTestCase {
     String result = (String) flowRunner("scopeWithMuleAllowedStereotype").run().getMessage().getPayload().getValue();
     assertThat(result, is("Ok"));
   }
+
+  @Test
+  @Issue("MULE-18938")
+  public void scopeChainLazilyStarted() throws Exception {
+    String result = (String) flowRunner("scopeChainLazilyStarted").run().getMessage().getPayload().getValue();
+    assertThat(result, is("newPayload"));
+  }
+
 }

--- a/modules/extensions-spring-support/src/test/resources/scopes/heisenberg-scope-config.xml
+++ b/modules/extensions-spring-support/src/test/resources/scopes/heisenberg-scope-config.xml
@@ -2,10 +2,12 @@
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:heisenberg="http://www.mulesoft.org/schema/mule/heisenberg"
       xmlns:petstore="http://www.mulesoft.org/schema/mule/petstore"
+      xmlns:test-components="http://www.mulesoft.org/schema/mule/test-components"
       xmlns="http://www.mulesoft.org/schema/mule/core"
       xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
                http://www.mulesoft.org/schema/mule/heisenberg http://www.mulesoft.org/schema/mule/heisenberg/current/mule-heisenberg.xsd
-               http://www.mulesoft.org/schema/mule/petstore http://www.mulesoft.org/schema/mule/petstore/current/mule-petstore.xsd">
+               http://www.mulesoft.org/schema/mule/petstore http://www.mulesoft.org/schema/mule/petstore/current/mule-petstore.xsd
+               http://www.mulesoft.org/schema/mule/test-components http://www.mulesoft.org/schema/mule/test-components/current/mule-test-components.xsd">
     <configuration-properties file="heisenberg.properties"/>
 
     <heisenberg:config name="heisenberg"
@@ -74,6 +76,17 @@
         <heisenberg:always-fails-wrapper>
             <logger message="#[payload]"/>
         </heisenberg:always-fails-wrapper>
+    </flow>
+
+    <flow name="scopeChainLazilyStarted" initialState="stopped">
+        <heisenberg:tap-phones>
+            <test-components:non-blocking/>
+            <heisenberg:tap-phones>
+                <test-components:non-blocking/>
+                <set-variable variableName="varName" value="varValue"/>
+                <set-payload value="#['newPayload']"/>
+            </heisenberg:tap-phones>
+        </heisenberg:tap-phones>
     </flow>
 
     <flow name="failWithConnectivityErrorFromOtherExtension">

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -102,6 +102,7 @@ import org.mule.runtime.core.internal.util.rx.FluxSinkSupplier;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.exception.EventProcessingException;
+import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationInstance;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor;
@@ -207,6 +208,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
   protected final String target;
   protected final String targetValue;
   protected final RetryPolicyTemplate retryPolicyTemplate;
+  protected final MessageProcessorChain nestedChain;
 
   private Optional<TransactionConfig> transactionConfig;
   private final long outerFluxTerminationTimeout;
@@ -261,6 +263,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
                                    ResolverSet resolverSet,
                                    CursorProviderFactory cursorProviderFactory,
                                    RetryPolicyTemplate retryPolicyTemplate,
+                                   MessageProcessorChain nestedChain,
                                    ExtensionManager extensionManager,
                                    PolicyManager policyManager,
                                    ReflectionCache reflectionCache,
@@ -273,6 +276,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
     this.targetValue = targetValue;
     this.policyManager = policyManager;
     this.retryPolicyTemplate = retryPolicyTemplate;
+    this.nestedChain = nestedChain;
     this.reflectionCache = reflectionCache;
     this.resultTransformer = resultTransformer;
     this.hasNestedChain = hasNestedChain(componentModel);
@@ -592,6 +596,10 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
       componentExecutor = createComponentExecutor(componentDecoratorFactory);
       executionMediator = createExecutionMediator();
       initialiseIfNeeded(componentExecutor, true, muleContext);
+
+      if (nestedChain != null) {
+        initialiseIfNeeded(nestedChain, muleContext);
+      }
 
       resolvedProcessorRepresentation = getRepresentation();
 
@@ -1007,6 +1015,10 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
   public void doStart() throws MuleException {
     startIfNeeded(componentExecutor);
 
+    if (nestedChain != null) {
+      startIfNeeded(nestedChain);
+    }
+
     if (ownedProcessingStrategy) {
       startIfNeeded(processingStrategy);
     }
@@ -1020,6 +1032,9 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
   @Override
   public void doStop() throws MuleException {
+    if (nestedChain != null) {
+      stopIfNeeded(nestedChain);
+    }
     stopIfNeeded(componentExecutor);
     stopInnerFlux();
 
@@ -1056,6 +1071,9 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
   @Override
   public void doDispose() {
+    if (nestedChain != null) {
+      disposeIfNeeded(nestedChain, LOGGER);
+    }
     disposeIfNeeded(componentExecutor, LOGGER);
     if (ownedProcessingStrategy) {
       disposeIfNeeded(processingStrategy, LOGGER);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessorBuilder.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessorBuilder.java
@@ -22,6 +22,7 @@ import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
 import org.mule.runtime.core.api.streaming.CursorProviderFactory;
 import org.mule.runtime.core.internal.policy.PolicyManager;
+import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
 import org.mule.runtime.module.extension.internal.runtime.ExtensionComponent;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.ExtensionConnectionSupplier;
@@ -54,6 +55,7 @@ public abstract class ComponentMessageProcessorBuilder<M extends ComponentModel,
   protected String targetValue;
   protected CursorProviderFactory cursorProviderFactory;
   protected RetryPolicyTemplate retryPolicyTemplate;
+  protected MessageProcessorChain nestedChain;
   protected boolean lazyModeEnabled;
 
   public ComponentMessageProcessorBuilder(ExtensionModel extensionModel,
@@ -146,8 +148,8 @@ public abstract class ComponentMessageProcessorBuilder<M extends ComponentModel,
     return this;
   }
 
-  public ComponentMessageProcessorBuilder<M, P> setNestedProcessors(RetryPolicyTemplate retryPolicyTemplate) {
-    this.retryPolicyTemplate = retryPolicyTemplate;
+  public ComponentMessageProcessorBuilder<M, P> setNestedChain(MessageProcessorChain nestedChain) {
+    this.nestedChain = nestedChain;
     return this;
   }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ConstructMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ConstructMessageProcessor.java
@@ -16,6 +16,7 @@ import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
 import org.mule.runtime.core.api.streaming.CursorProviderFactory;
 import org.mule.runtime.core.internal.policy.PolicyManager;
 import org.mule.runtime.core.internal.processor.ParametersResolverProcessor;
+import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
 import org.mule.runtime.module.extension.internal.runtime.resolver.ResolverSet;
 import org.mule.runtime.module.extension.internal.util.ReflectionCache;
@@ -36,12 +37,14 @@ public class ConstructMessageProcessor extends ComponentMessageProcessor<Constru
                                    ResolverSet resolverSet,
                                    CursorProviderFactory cursorProviderFactory,
                                    RetryPolicyTemplate retryPolicyTemplate,
+                                   MessageProcessorChain nestedChain,
                                    ExtensionManager extensionManager,
                                    PolicyManager policyManager,
                                    ReflectionCache reflectionCache,
                                    long terminationTimeout) {
     super(extensionModel, constructModel, configurationProvider, target, targetValue, resolverSet, cursorProviderFactory,
-          retryPolicyTemplate, extensionManager, policyManager, reflectionCache, null, terminationTimeout);
+          retryPolicyTemplate, nestedChain,
+          extensionManager, policyManager, reflectionCache, null, terminationTimeout);
   }
 
   @Override

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ConstructMessageProcessorBuilder.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ConstructMessageProcessorBuilder.java
@@ -39,7 +39,7 @@ public final class ConstructMessageProcessorBuilder
     return new ConstructMessageProcessor(extensionModel, operationModel,
                                          getConfigurationProvider(), target, targetValue,
                                          arguments,
-                                         cursorProviderFactory, retryPolicyTemplate,
+                                         cursorProviderFactory, retryPolicyTemplate, nestedChain,
                                          extensionManager,
                                          policyManager,
                                          reflectionCache,

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChainExecutor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChainExecutor.java
@@ -31,6 +31,9 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import reactor.util.context.Context;
 
 /**
@@ -39,6 +42,8 @@ import reactor.util.context.Context;
  * @since 4.0
  */
 public class ImmutableProcessorChainExecutor implements Chain, HasMessageProcessors {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ImmutableProcessorChainExecutor.class);
 
   /**
    * Processor that will be executed upon calling process
@@ -132,6 +137,7 @@ public class ImmutableProcessorChainExecutor implements Chain, HasMessageProcess
             if (error instanceof MessagingException) {
               this.handleError(error, ((MessagingException) error).getEvent());
             } else {
+              LOGGER.error("Exception in nested chain", error);
               this.handleError(error, event);
             }
           })

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OAuthOperationMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OAuthOperationMessageProcessor.java
@@ -16,6 +16,7 @@ import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
 import org.mule.runtime.core.api.streaming.CursorProviderFactory;
 import org.mule.runtime.core.internal.exception.EnrichedErrorMapping;
 import org.mule.runtime.core.internal.policy.PolicyManager;
+import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.connectivity.oauth.AccessTokenExpiredException;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
@@ -48,14 +49,15 @@ public class OAuthOperationMessageProcessor extends OperationMessageProcessor {
                                         ResolverSet resolverSet,
                                         CursorProviderFactory cursorProviderFactory,
                                         RetryPolicyTemplate retryPolicyTemplate,
+                                        MessageProcessorChain nestedChain,
                                         ExtensionManager extensionManager,
                                         PolicyManager policyManager,
                                         ReflectionCache reflectionCache,
                                         DefaultExecutionMediator.ResultTransformer resultTransformer,
                                         long outerFluxTerminationTimeout) {
     super(extensionModel, operationModel, configurationProvider, target, targetValue, errorMappings, resolverSet,
-          cursorProviderFactory, retryPolicyTemplate, extensionManager, policyManager, reflectionCache, resultTransformer,
-          outerFluxTerminationTimeout);
+          cursorProviderFactory, retryPolicyTemplate, nestedChain,
+          extensionManager, policyManager, reflectionCache, resultTransformer, outerFluxTerminationTimeout);
   }
 
   @Override

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessor.java
@@ -30,6 +30,7 @@ import org.mule.runtime.core.api.streaming.CursorProviderFactory;
 import org.mule.runtime.core.internal.exception.EnrichedErrorMapping;
 import org.mule.runtime.core.internal.exception.ErrorMappingsAware;
 import org.mule.runtime.core.internal.policy.PolicyManager;
+import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
 import org.mule.runtime.module.extension.internal.metadata.EntityMetadataMediator;
 import org.mule.runtime.module.extension.internal.runtime.operation.DefaultExecutionMediator.ResultTransformer;
@@ -62,11 +63,13 @@ public class OperationMessageProcessor extends ComponentMessageProcessor<Operati
                                    ResolverSet resolverSet,
                                    CursorProviderFactory cursorProviderFactory,
                                    RetryPolicyTemplate retryPolicyTemplate,
+                                   MessageProcessorChain nestedChain,
                                    ExtensionManager extensionManager,
                                    PolicyManager policyManager,
                                    ReflectionCache reflectionCache) {
     this(extensionModel, operationModel, configurationProvider, target, targetValue, errorMappings, resolverSet,
-         cursorProviderFactory, retryPolicyTemplate, extensionManager, policyManager, reflectionCache, null, -1);
+         cursorProviderFactory, retryPolicyTemplate, nestedChain,
+         extensionManager, policyManager, reflectionCache, null, -1);
   }
 
   public OperationMessageProcessor(ExtensionModel extensionModel,
@@ -78,14 +81,15 @@ public class OperationMessageProcessor extends ComponentMessageProcessor<Operati
                                    ResolverSet resolverSet,
                                    CursorProviderFactory cursorProviderFactory,
                                    RetryPolicyTemplate retryPolicyTemplate,
+                                   MessageProcessorChain nestedChain,
                                    ExtensionManager extensionManager,
                                    PolicyManager policyManager,
                                    ReflectionCache reflectionCache,
                                    ResultTransformer resultTransformer,
                                    long terminationTimeout) {
     super(extensionModel, operationModel, configurationProvider, target, targetValue, resolverSet,
-          cursorProviderFactory, retryPolicyTemplate, extensionManager, policyManager, reflectionCache,
-          resultTransformer, terminationTimeout);
+          cursorProviderFactory, retryPolicyTemplate, nestedChain,
+          extensionManager, policyManager, reflectionCache, resultTransformer, terminationTimeout);
     this.entityMetadataMediator = new EntityMetadataMediator(operationModel);
     this.errorMappings = errorMappings;
   }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorBuilder.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorBuilder.java
@@ -67,12 +67,14 @@ public final class OperationMessageProcessorBuilder
     if (supportsOAuth) {
       return new OAuthOperationMessageProcessor(extensionModel, operationModel, configurationProvider, target, targetValue,
                                                 errorMappings, arguments, cursorProviderFactory, retryPolicyTemplate,
+                                                nestedChain,
                                                 extensionManager, policyManager, reflectionCache, resultTransformer,
                                                 terminationTimeout);
     } else {
       return new OperationMessageProcessor(extensionModel, operationModel, configurationProvider, target, targetValue,
-                                           errorMappings, arguments, cursorProviderFactory, retryPolicyTemplate, extensionManager,
-                                           policyManager, reflectionCache, resultTransformer, terminationTimeout);
+                                           errorMappings, arguments, cursorProviderFactory, retryPolicyTemplate, nestedChain,
+                                           extensionManager, policyManager, reflectionCache, resultTransformer,
+                                           terminationTimeout);
     }
   }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/resolver/ProcessorChainValueResolver.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/resolver/ProcessorChainValueResolver.java
@@ -47,18 +47,32 @@ public final class ProcessorChainValueResolver implements ValueResolver<Chain> {
 
   private final MessageProcessorChain chain;
 
-  public ProcessorChainValueResolver(MuleContext ctx, final MessageProcessorChain delegate) {
-    this.chain = new LazyInitializerChainDecorator(ctx, delegate);
+  /**
+   * Creates a resolver for the provided chain executor. The lifecycle of the provided {@code chain} must be managed by the owner
+   * of the chain.
+   *
+   * @param chain the chain to create an executor for
+   */
+  public ProcessorChainValueResolver(final MessageProcessorChain chain) {
+    this.chain = chain;
+  }
+
+  /**
+   * Creates a resolver for a new chain executor with the give {@code processors}, tying the lifecycle of that chain to the
+   * lifecycle of the provided {@code muleContext}.
+   *
+   * @param ctx the context to tie the lifecycle of the chain to be created to
+   * @param processors the processors that will be part of the chain to create an executor for
+   */
+  public ProcessorChainValueResolver(MuleContext ctx, List<Processor> processors) {
+    // TODO MULE-18939 lifecycle of this chain must be managed by its owner, not the muleContext
+    this(new LazyInitializerChainDecorator(ctx, newChain(empty(), processors)));
 
     try {
       registerObject(ctx, new ObjectNameHelper(ctx).getUniqueName(""), this.chain);
     } catch (Exception e) {
       throw new MuleRuntimeException(createStaticMessage("Could not register nested MessageProcessorChain"), e);
     }
-  }
-
-  public ProcessorChainValueResolver(MuleContext ctx, List<Processor> processors) {
-    this(ctx, newChain(empty(), processors));
   }
 
   /**

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorPolicyProcessingStrategyTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorPolicyProcessingStrategyTestCase.java
@@ -128,7 +128,7 @@ public class ComponentMessageProcessorPolicyProcessingStrategyTestCase extends A
 
     processor = new ComponentMessageProcessor<ComponentModel>(extensionModel,
                                                               componentModel, null, null, null,
-                                                              resolverSet, null, null,
+                                                              resolverSet, null, null, null,
                                                               extensionManager,
                                                               policyManager, null, null,
                                                               muleContext.getConfiguration().getShutdownTimeout()) {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ComponentMessageProcessorTestCase.java
@@ -91,7 +91,7 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
 
     processor = new ComponentMessageProcessor<ComponentModel>(extensionModel,
                                                               componentModel, null, null, null,
-                                                              resolverSet, null, null,
+                                                              resolverSet, null, null, null,
                                                               extensionManager,
                                                               mockPolicyManager, null, null,
                                                               muleContext.getConfiguration().getShutdownTimeout()) {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/OperationMessageProcessorTestCase.java
@@ -100,12 +100,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.reflect.TypeToken;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+
+import com.google.common.reflect.TypeToken;
 
 @SmallTest
 public class OperationMessageProcessorTestCase extends AbstractOperationMessageProcessorTestCase {
@@ -127,7 +128,8 @@ public class OperationMessageProcessorTestCase extends AbstractOperationMessageP
 
     OperationMessageProcessor operationMessageProcessor =
         new OperationMessageProcessor(extensionModel, operationModel, configurationProvider, target, targetValue, emptyList(),
-                                      resolverSet, cursorStreamProviderFactory, new NoRetryPolicyTemplate(), extensionManager,
+                                      resolverSet, cursorStreamProviderFactory, new NoRetryPolicyTemplate(), null,
+                                      extensionManager,
                                       mockPolicyManager, reflectionCache, null,
                                       muleContext.getConfiguration().getShutdownTimeout());
     operationMessageProcessor.setAnnotations(getFlowComponentLocationAnnotations(FLOW_NAME));

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/NestedProcessorValueResolverTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/resolver/NestedProcessorValueResolverTestCase.java
@@ -26,17 +26,20 @@ import org.mule.runtime.module.extension.internal.runtime.execution.SdkInternalC
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.reactivestreams.Publisher;
 
 import reactor.core.publisher.Mono;
 
-@RunWith(MockitoJUnitRunner.class)
 public class NestedProcessorValueResolverTestCase extends AbstractMuleContextTestCase {
+
+  @Rule
+  public MockitoRule mockitorule = MockitoJUnit.rule();
 
   @Mock(lenient = true)
   private MessageProcessorChain messageProcessor;
@@ -54,7 +57,7 @@ public class NestedProcessorValueResolverTestCase extends AbstractMuleContextTes
 
   @Test
   public void yieldsNestedProcessor() throws Exception {
-    ProcessorChainValueResolver resolver = new ProcessorChainValueResolver(muleContext, messageProcessor);
+    ProcessorChainValueResolver resolver = new ProcessorChainValueResolver(messageProcessor);
     final CoreEvent event = testEvent();
 
     Chain nestedProcessor = resolver.resolve(ValueResolvingContext.builder(event)
@@ -77,7 +80,7 @@ public class NestedProcessorValueResolverTestCase extends AbstractMuleContextTes
 
   @Test
   public void alwaysGivesDifferentInstances() throws Exception {
-    ProcessorChainValueResolver resolver = new ProcessorChainValueResolver(muleContext, messageProcessor);
+    ProcessorChainValueResolver resolver = new ProcessorChainValueResolver(messageProcessor);
     ValueResolvingContext ctx = ValueResolvingContext.builder(testEvent()).withExpressionManager(expressionManager).build();
     Chain resolved1 = resolver.resolve(ctx);
     Chain resolved2 = resolver.resolve(ctx);
@@ -87,7 +90,7 @@ public class NestedProcessorValueResolverTestCase extends AbstractMuleContextTes
 
   @Test
   public void chainIsCalledAsNonBlocking() throws Exception {
-    ProcessorChainValueResolver resolver = new ProcessorChainValueResolver(muleContext, messageProcessor);
+    ProcessorChainValueResolver resolver = new ProcessorChainValueResolver(messageProcessor);
 
     Chain resolve = resolver.resolve(ValueResolvingContext.builder(testEvent())
         .withExpressionManager(expressionManager)


### PR DESCRIPTION
containing flow has initialState=“stopped”