### PR TITLE
Revert "MULE-18137: Scheduler default values are inconsistent (#8728)"

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
@@ -10,9 +10,12 @@ package org.mule.runtime.config.internal.dsl.model;
 import static java.lang.Boolean.parseBoolean;
 import static java.util.Arrays.asList;
 import static java.util.Optional.ofNullable;
+import static java.lang.String.format;
+import static java.lang.System.getProperty;
 import static org.apache.commons.lang3.ArrayUtils.addAll;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.tx.TransactionType.LOCAL;
+import static org.mule.runtime.api.util.MuleSystemProperties.DEFAULT_SCHEDULER_FIXED_FREQUENCY;
 import static org.mule.runtime.api.util.Preconditions.checkState;
 import static org.mule.runtime.config.api.dsl.model.ComponentBuildingDefinitionProviderUtils.createNewInstance;
 import static org.mule.runtime.config.api.dsl.model.ComponentBuildingDefinitionProviderUtils.getMuleMessageTransformerBaseBuilder;
@@ -509,7 +512,9 @@ public class CoreComponentBuildingDefinitionProvider implements ComponentBuildin
 
     componentBuildingDefinitions.add(baseDefinition.withIdentifier(FIXED_FREQUENCY_STRATEGY_ELEMENT_IDENTIFIER)
         .withTypeDefinition(fromType(FixedFrequencyScheduler.class))
-        .withSetterParameterDefinition("frequency", fromSimpleParameter("frequency").build())
+        .withSetterParameterDefinition("frequency", fromSimpleParameter("frequency")
+            .withDefaultValue(getDefaultSchedulerFixedFrequency())
+            .build())
         .withSetterParameterDefinition("startDelay", fromSimpleParameter("startDelay").build())
         .withSetterParameterDefinition("timeUnit", fromSimpleParameter("timeUnit").build()).build());
 
@@ -1026,6 +1031,17 @@ public class CoreComponentBuildingDefinitionProvider implements ComponentBuildin
                                        fromMultipleDefinitions(addAll(commonTransformerParameters, configurationAttributes))
                                            .build())
         .asPrototype();
+  }
+
+  private long getDefaultSchedulerFixedFrequency() {
+    String freq = getProperty(DEFAULT_SCHEDULER_FIXED_FREQUENCY, "1000");
+    try {
+      return Long.valueOf(freq);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          format("Invalid value for System Property %s. A long number was expected but '%s' found instead",
+                 DEFAULT_SCHEDULER_FIXED_FREQUENCY, freq));
+    }
   }
 
   private List<ComponentBuildingDefinition> getStreamingDefinitions() {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java
@@ -1039,8 +1039,8 @@ public class CoreComponentBuildingDefinitionProvider implements ComponentBuildin
       return Long.valueOf(freq);
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
-          format("Invalid value for System Property %s. A long number was expected but '%s' found instead",
-                 DEFAULT_SCHEDULER_FIXED_FREQUENCY, freq));
+                                         format("Invalid value for System Property %s. A long number was expected but '%s' found instead",
+                                                DEFAULT_SCHEDULER_FIXED_FREQUENCY, freq));
     }
   }
 

--- a/modules/spring-config/src/main/resources/META-INF/mule-core-common.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule-core-common.xsd
@@ -1524,10 +1524,10 @@
     <xsd:complexType name="fixedSchedulerType">
         <xsd:complexContent>
             <xsd:extension base="abstractSchedulingStrategyType">
-                <xsd:attribute name="frequency" type="substitutableLong" default="60000">
+                <xsd:attribute name="frequency" type="substitutableLong" default="1000">
                     <xsd:annotation>
                         <xsd:documentation>
-                            Polling frequency in milliseconds. Default frequency is 60000ms (1 minute).
+                            Polling frequency in milliseconds. Default frequency is 1000ms (1s).
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>

--- a/modules/spring-config/src/main/resources/META-INF/mule-core-common.xsd
+++ b/modules/spring-config/src/main/resources/META-INF/mule-core-common.xsd
@@ -1524,7 +1524,7 @@
     <xsd:complexType name="fixedSchedulerType">
         <xsd:complexContent>
             <xsd:extension base="abstractSchedulingStrategyType">
-                <xsd:attribute name="frequency" type="substitutableLong" default="1000">
+                <xsd:attribute name="frequency" type="substitutableLong">
                     <xsd:annotation>
                         <xsd:documentation>
                             Polling frequency in milliseconds. Default frequency is 1000ms (1s).


### PR DESCRIPTION
This was [already reverted](https://github.com/mulesoft/mule/commit/04f629d334) on `support/4.3.x`

For further information see [this comment](https://www.mulesoft.org/jira/browse/MULE-18137?focusedCommentId=387637&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-387637)

This reverts commit 28b090ddf5f1383ca8fbf17e30225e7b1137b83b.