### PR TITLE
MULE-18986: Upgrade bcprov-ext-jdk15on artifact name

### DIFF
--- a/modules/pgp/pom.xml
+++ b/modules/pgp/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-ext-jdk15on</artifactId>
+            <artifactId>bcprov-ext-jdk15to18</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1168,7 +1168,7 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-ext-jdk15on</artifactId>
+                <artifactId>bcprov-ext-jdk15to18</artifactId>
                 <version>${bouncycastleVersion}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Bouncy Castle has changed [bcprov-jdk15on](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on) artifact name since 1.67 to [bcprov-ext-jdk15to18](https://mvnrepository.com/search?q=bcprov-ext-jdk15to18)