### PR TITLE
MULE-19042: fix until successful on async events (#9841)

### DIFF
--- a/core/src/main/java/org/mule/DefaultMuleEvent.java
+++ b/core/src/main/java/org/mule/DefaultMuleEvent.java
@@ -544,7 +544,7 @@ public class DefaultMuleEvent implements MuleEvent, ThreadSafeAccess, Deserializ
     {
         return transacted
                || isFlowConstructSynchronous()
-               || exchangePattern.hasResponse() && !isFlowConstructNonBlockingProcessingStrategy()
+               || (exchangePattern.hasResponse() && !isFlowConstructNonBlockingProcessingStrategy())
                || message.getProperty(MuleProperties.MULE_FORCE_SYNC_PROPERTY,
                                       PropertyScope.INBOUND, Boolean.FALSE);
     }
@@ -1174,6 +1174,32 @@ public class DefaultMuleEvent implements MuleEvent, ThreadSafeAccess, Deserializ
         return eventCopy;
     }
 
+    /**
+     * This method does a complete deep copy of the event and set the Synchronicity.
+     *
+     * This method should be used whenever the event is going to be executed
+     * in a different context and changes to that event must not effect the source event.
+     *
+     * @param event the event that must be copied
+     * @return the copied event
+     */
+    public static MuleEvent copyWithSynchronicity(MuleEvent event, boolean synchronous)
+    {
+        MuleMessage messageCopy = (MuleMessage) ((ThreadSafeAccess) event.getMessage()).newThreadCopy();
+        DefaultMuleEvent eventCopy = new DefaultMuleEvent(messageCopy, event, new DefaultMuleSession(
+                event.getSession()), synchronous);
+        eventCopy.flowVariables = ((DefaultMuleEvent) event).flowVariables.clone();
+        ((DefaultMuleMessage) messageCopy).setInvocationProperties(eventCopy.flowVariables);
+        ((DefaultMuleMessage) messageCopy).resetAccessControl();
+        return eventCopy;
+    }
+
+    public DefaultMuleEvent(MuleMessage message, MuleEvent rewriteEvent, MuleSession session, boolean synchronous)
+    {
+        this(message, rewriteEvent, rewriteEvent.getFlowConstruct(), session, synchronous);
+
+    }
+
     @Override
     public Set<String> getFlowVariableNames()
     {
@@ -1433,4 +1459,5 @@ public class DefaultMuleEvent implements MuleEvent, ThreadSafeAccess, Deserializ
     {
         return processorsTrace;
     }
+
 }

--- a/core/src/main/java/org/mule/routing/AbstractUntilSuccessfulProcessingStrategy.java
+++ b/core/src/main/java/org/mule/routing/AbstractUntilSuccessfulProcessingStrategy.java
@@ -7,6 +7,8 @@
 package org.mule.routing;
 
 import static org.mule.util.ClassUtils.isConsumable;
+
+import org.mule.DefaultMuleEvent;
 import org.mule.DefaultMuleMessage;
 import org.mule.VoidMuleEvent;
 import org.mule.api.MessagingException;
@@ -43,10 +45,16 @@ public abstract class AbstractUntilSuccessfulProcessingStrategy implements Until
      * @return the response from the route if there's no ack expression. If there's ack expression
      * then a message with the response event but with a payload defined by the ack expression.
      */
-    protected MuleEvent processEvent(final MuleEvent event)
+    protected MuleEvent processEvent(MuleEvent event)
     {
         MuleEvent returnEvent;
         boolean inputEventHasExceptionPayload = event.getMessage().getExceptionPayload() != null;
+
+        if(event instanceof DefaultMuleEvent)
+        {
+            event = DefaultMuleEvent.copyWithSynchronicity(event, true);
+        }
+
         try
         {
             returnEvent = untilSuccessfulConfiguration.getRoute().process(event);

--- a/tests/integration/src/test/java/org/mule/test/routing/UntilSuccessfulAsyncEventTestCase.java
+++ b/tests/integration/src/test/java/org/mule/test/routing/UntilSuccessfulAsyncEventTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.routing;
+
+import org.junit.Test;
+import org.mule.construct.Flow;
+import org.mule.tck.junit4.FunctionalTestCase;
+import org.mule.tck.probe.PollingProber;
+import org.mule.tck.probe.Probe;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.tck.functional.InvocationCountMessageProcessor.getNumberOfInvocationsFor;
+
+public class UntilSuccessfulAsyncEventTestCase extends FunctionalTestCase
+{
+
+    @Override
+    protected String getConfigFile()
+    {
+        return "until-successful-with-poll-test.xml";
+    }
+
+    @Test
+    public void executeAsynchronouslyDoingRetries() throws Exception
+    {
+        Flow flow = (Flow) getFlowConstruct("poll-until-successfulFlow");
+        flow.start();
+        new PollingProber(10000, 1000).check(new Probe()
+        {
+            public boolean isSatisfied()
+            {
+                return getNumberOfInvocationsFor("untilSuccessful") == 6;
+            }
+
+            public String describeFailure()
+            {
+                return "INVOCATIONS: " + getNumberOfInvocationsFor("untilSuccessful");
+            }
+        });
+        assertThat(getNumberOfInvocationsFor("exceptionStrategy"), is(1));
+    }
+}

--- a/tests/integration/src/test/resources/until-successful-with-poll-test.xml
+++ b/tests/integration/src/test/resources/until-successful-with-poll-test.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:test="http://www.mulesoft.org/schema/mule/test"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+       http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+       http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd
+       http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
+
+    <spring:bean name="counter" class="java.util.concurrent.atomic.AtomicInteger" />
+
+    <flow name="poll-until-successfulFlow" initialState="stopped">
+        <poll>
+            <fixed-frequency-scheduler frequency="30000000" startDelay="1000"/>
+            <set-payload value="dummy"/>
+        </poll>
+        <until-successful maxRetries="5" millisBetweenRetries="100" synchronous="true">
+            <processor-chain>
+                <test:invocation-counter name="untilSuccessful"/>
+                <test:component throwException="true"/>
+            </processor-chain>
+        </until-successful>
+        <rollback-exception-strategy>
+            <test:invocation-counter name="exceptionStrategy"/>
+        </rollback-exception-strategy>
+    </flow>
+
+
+</mule>


### PR DESCRIPTION
* MULE-19042: fix until successful on async events

* fix until successful

* rename method

(cherry picked from commit c3f9c36a8f2fb7c697ea4696c45addb00190e0ed)