### PR TITLE
MULE-19089: WMQ Outbound with transacted in a request-response contex…

### DIFF
--- a/core/src/main/java/org/mule/api/transport/RequestResponseOutboundEndpointCantRunTransacted.java
+++ b/core/src/main/java/org/mule/api/transport/RequestResponseOutboundEndpointCantRunTransacted.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.api.transport;
+
+/*
+    Connector implementing this interface will throw an exception when a DefaultOutboundEndpoint with a transaction and
+    Request-Response exchange pattern is called.
+ */
+public interface RequestResponseOutboundEndpointCantRunTransacted {
+}

--- a/core/src/main/java/org/mule/endpoint/DefaultOutboundEndpoint.java
+++ b/core/src/main/java/org/mule/endpoint/DefaultOutboundEndpoint.java
@@ -8,6 +8,7 @@ package org.mule.endpoint;
 
 import org.mule.MessageExchangePattern;
 import org.mule.VoidMuleEvent;
+import org.mule.api.DefaultMuleException;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -24,6 +25,7 @@ import org.mule.api.lifecycle.Initialisable;
 import org.mule.api.processor.MessageProcessor;
 import org.mule.api.retry.RetryPolicyTemplate;
 import org.mule.api.transaction.TransactionConfig;
+import org.mule.api.transport.RequestResponseOutboundEndpointCantRunTransacted;
 import org.mule.api.transport.Connector;
 import org.mule.processor.AbstractRedeliveryPolicy;
 import org.mule.transport.AbstractConnector;
@@ -105,6 +107,12 @@ public class DefaultOutboundEndpoint extends AbstractEndpoint implements Outboun
         }
         else
         {
+            if(getConnector() instanceof RequestResponseOutboundEndpointCantRunTransacted)
+            {
+                throw new DefaultMuleException("Request-reply in a transactional context " +
+                        "will never commit the transaction. " +
+                        "Either use no-transaction or one-way.");
+            }
             return result;
         }
     }


### PR DESCRIPTION
…t stop processing with no warning (#9897)

* MULE-19089: add exeption to DefaultOutboundEndpoint when transacted with request-response

* only xa

* test default method in interface

* test with interface

* testing and comments

* remove imports

(cherry picked from commit 4d2f19cf970cf6f68db1639229b077ceb0785fd4)