### PR TITLE
MULE-19097: The non blocking completion callbacks should be executed …

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/NonBlockingCompletableMethodOperationExecutor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/NonBlockingCompletableMethodOperationExecutor.java
@@ -32,8 +32,10 @@ public class NonBlockingCompletableMethodOperationExecutor<M extends ComponentMo
   @Override
   protected void doExecute(ExecutionContext<M> executionContext, ExecutorCallback callback) {
     final ExecutionContextAdapter<M> context = (ExecutionContextAdapter<M>) executionContext;
-    context.setVariable(COMPLETION_CALLBACK_CONTEXT_PARAM, new ExecutorCompletionCallbackAdapter(callback));
+    context.setVariable(COMPLETION_CALLBACK_CONTEXT_PARAM,
+                        new ExecutorCompletionCallbackAdapter(new PreservingThreadContextExecutorCallback(callback)));
 
     executor.execute(executionContext);
   }
+
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextExecutorCallback.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextExecutorCallback.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.execution;
+
+import static java.lang.Thread.currentThread;
+import static org.mule.runtime.core.api.util.ClassUtils.setContextClassLoader;
+import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
+
+import java.util.Map;
+
+import org.slf4j.MDC;
+
+public class PreservingThreadContextExecutorCallback implements ExecutorCallback {
+
+  private final ExecutorCallback delegate;
+  private final ClassLoader classLoader;
+  private final Map<String, String> mdc;
+
+  public PreservingThreadContextExecutorCallback(ExecutorCallback delegate) {
+    this.delegate = delegate;
+    this.classLoader = currentThread().getContextClassLoader();
+    this.mdc = MDC.getCopyOfContextMap();
+  }
+
+  @Override
+  public void complete(Object value) {
+    try (ThreadContext ignored = new ThreadContext(classLoader, mdc)) {
+      delegate.complete(value);
+    }
+  }
+
+  @Override
+  public void error(Throwable e) {
+    try (ThreadContext ignored = new ThreadContext(classLoader, mdc)) {
+      delegate.error(e);
+    }
+  }
+
+  private static class ThreadContext implements AutoCloseable {
+
+    private final Thread currentThread;
+
+    private final ClassLoader innerClassLoader;
+    private final Map<String, String> innerMDC;
+
+    private final ClassLoader outerClassLoader;
+    private final Map<String, String> outerMDC;
+
+    ThreadContext(ClassLoader classLoader, Map<String, String> mdc) {
+      currentThread = currentThread();
+
+      innerClassLoader = classLoader;
+      innerMDC = mdc;
+
+      outerClassLoader = currentThread.getContextClassLoader();
+      outerMDC = MDC.getCopyOfContextMap();
+
+      MDC.setContextMap(innerMDC);
+      setContextClassLoader(currentThread, outerClassLoader, innerClassLoader);
+    }
+
+    @Override
+    public void close() {
+      try {
+        setContextClassLoader(currentThread, innerClassLoader, outerClassLoader);
+      } finally {
+        MDC.setContextMap(outerMDC);
+      }
+    }
+  }
+}

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/AbstractCompletableMethodOperationExecutorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/AbstractCompletableMethodOperationExecutorTestCase.java
@@ -46,7 +46,8 @@ public class AbstractCompletableMethodOperationExecutorTestCase extends Abstract
           @Override
           protected void doExecute(ExecutionContext<ComponentModel> executionContext, ExecutorCallback callback) {
             final ExecutionContextAdapter context = (ExecutionContextAdapter) executionContext;
-            context.setVariable(COMPLETION_CALLBACK_CONTEXT_PARAM, new ExecutorCompletionCallbackAdapter(callback));
+            context.setVariable(COMPLETION_CALLBACK_CONTEXT_PARAM,
+                                new ExecutorCompletionCallbackAdapter(new PreservingThreadContextExecutorCallback(callback)));
 
             throw expected;
           }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/CompletableOperationExecutorFactoryTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/CompletableOperationExecutorFactoryTestCase.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.execution;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextProperties.COMPLETION_CALLBACK_CONTEXT_PARAM;
+import org.mule.runtime.api.meta.model.ComponentModel;
+import org.mule.runtime.api.meta.model.operation.OperationModel;
+import org.mule.runtime.api.util.Reference;
+import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor;
+import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
+import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextAdapter;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.Map;
+
+import io.qameta.allure.Issue;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+@Issue("MULE-19097")
+public class CompletableOperationExecutorFactoryTestCase extends AbstractMuleTestCase {
+
+  private CompletableComponentExecutor<ComponentModel> executor;
+  private ExecutionContextAdapter<ComponentModel> executionContext;
+  private CompletableComponentExecutor.ExecutorCallback callback;
+  private Reference<CompletionCallback<Object, Object>> completionCallbackRef;
+  private Reference<ClassLoader> onErrorClassLoaderRef;
+  private Reference<ClassLoader> onCompleteClassLoaderRef;
+  private Reference<Map<String, String>> onErrorMDC;
+  private Reference<Map<String, String>> onCompleteMDC;
+
+  @Before
+  public void setup() {
+    CompletableOperationExecutorFactory<String, ComponentModel> factory =
+        new CompletableOperationExecutorFactory<>(String.class, String.class.getMethods()[0]);
+    executor = factory.createExecutor(mock(OperationModel.class), emptyMap());
+
+    executionContext = mock(ExecutionContextAdapter.class);
+    callback = mock(CompletableComponentExecutor.ExecutorCallback.class);
+
+    completionCallbackRef = new Reference<>();
+    when(executionContext.setVariable(eq(COMPLETION_CALLBACK_CONTEXT_PARAM), any(CompletionCallback.class)))
+        .thenAnswer(invocation -> {
+          completionCallbackRef.set(invocation.getArgument(1));
+          return null;
+        });
+
+    onErrorClassLoaderRef = new Reference<>();
+    onErrorMDC = new Reference<>();
+    doAnswer(ignored -> {
+      onErrorClassLoaderRef.set(currentThread().getContextClassLoader());
+      onErrorMDC.set(MDC.getCopyOfContextMap());
+      return null;
+    }).when(callback).error(any());
+
+    onCompleteClassLoaderRef = new Reference<>();
+    onCompleteMDC = new Reference<>();
+    doAnswer(ignored -> {
+      onCompleteClassLoaderRef.set(currentThread().getContextClassLoader());
+      onCompleteMDC.set(MDC.getCopyOfContextMap());
+      return null;
+    }).when(callback).complete(any());
+  }
+
+  @Test
+  public void preserveClassLoaderOnError() {
+    // Given a non-blocking operation executed with certain classloader.
+    ClassLoader executionClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(executionClassLoader, () -> executor.execute(executionContext, callback));
+
+    // When the completion callback is completed with error using another classloader.
+    ClassLoader anotherClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(anotherClassLoader, () -> completionCallbackRef.get().error(new NullPointerException()));
+
+    // Then the real on error method is called using the execution classloader.
+    assertThat(onErrorClassLoaderRef.get(), is(executionClassLoader));
+  }
+
+  @Test
+  public void preserveClassLoaderOnComplete() {
+    // Given a non-blocking operation executed with certain classloader.
+    ClassLoader executionClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(executionClassLoader, () -> executor.execute(executionContext, callback));
+
+    // When the completion callback is completed using another classloader.
+    ClassLoader anotherClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(anotherClassLoader, () -> completionCallbackRef.get().success(null));
+
+    // Then the real complete method is called using the execution classloader.
+    assertThat(onCompleteClassLoaderRef.get(), is(executionClassLoader));
+  }
+
+  @Test
+  public void preserveMDCOnError() {
+    // Given a non-blocking operation executed with certain MDC.
+    Map<String, String> executionMap = singletonMap("on", "execution");
+    withMDC(executionMap, () -> executor.execute(executionContext, callback));
+
+    // When the completion callback is completed with error using another MDC.
+    Map<String, String> anotherMap = singletonMap("on", "another");
+    withMDC(anotherMap, () -> completionCallbackRef.get().error(new NullPointerException()));
+
+    // Then the real on error method is called using the execution MDC.
+    assertThat(onErrorMDC.get().get("on"), is("execution"));
+  }
+
+  @Test
+  public void preserveMDCOnCompletion() {
+    // Given a non-blocking operation executed with certain MDC.
+    Map<String, String> executionMap = singletonMap("on", "execution");
+    withMDC(executionMap, () -> executor.execute(executionContext, callback));
+
+    // When the completion callback is completed using another MDC.
+    Map<String, String> anotherMap = singletonMap("on", "another");
+    withMDC(anotherMap, () -> completionCallbackRef.get().success(null));
+
+    // Then the real on complete method is called using the execution MDC.
+    assertThat(onCompleteMDC.get().get("on"), is("execution"));
+  }
+
+  private void withMDC(Map<String, String> mdc, Runnable callback) {
+    Map<String, String> oldMDC = MDC.getCopyOfContextMap();
+    MDC.setContextMap(mdc);
+    try {
+      callback.run();
+    } finally {
+      MDC.setContextMap(oldMDC);
+    }
+  }
+}

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextExecutorCallbackTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextExecutorCallbackTestCase.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.execution;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import org.mule.runtime.api.util.Reference;
+import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.Map;
+
+import io.qameta.allure.Issue;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.slf4j.MDC;
+
+@Issue("MULE-19097")
+public class PreservingThreadContextExecutorCallbackTestCase extends AbstractMuleTestCase {
+
+  @Mock
+  private CompletableComponentExecutor.ExecutorCallback executorCallback =
+      mock(CompletableComponentExecutor.ExecutorCallback.class);
+
+  @Test
+  public void preserveClassLoaderOnError() {
+    Reference<PreservingThreadContextExecutorCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    ClassLoader onCreationClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(onCreationClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextExecutorCallback(executorCallback));
+    });
+
+    Reference<ClassLoader> onErrorClassLoaderRef = new Reference<>();
+    doAnswer(ignored -> {
+      onErrorClassLoaderRef.set(currentThread().getContextClassLoader());
+      return null;
+    }).when(executorCallback).error(any());
+
+    ClassLoader anotherClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(anotherClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.get().error(new NullPointerException());
+    });
+
+    assertThat(onErrorClassLoaderRef.get(), is(onCreationClassLoader));
+  }
+
+  @Test
+  public void preserveClassLoaderOnComplete() {
+    Reference<PreservingThreadContextExecutorCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    ClassLoader onCreationClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(onCreationClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextExecutorCallback(executorCallback));
+    });
+
+    Reference<ClassLoader> onCompleteClassLoaderRef = new Reference<>();
+    doAnswer(ignored -> {
+      onCompleteClassLoaderRef.set(currentThread().getContextClassLoader());
+      return null;
+    }).when(executorCallback).complete(any());
+
+    ClassLoader anotherClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(anotherClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.get().complete(null);
+    });
+
+    assertThat(onCompleteClassLoaderRef.get(), is(onCreationClassLoader));
+  }
+
+  @Test
+  public void preserveMDCOnError() {
+    Reference<PreservingThreadContextExecutorCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    Map<String, String> onCreationMap = singletonMap("on", "creation");
+    withMDC(onCreationMap, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextExecutorCallback(executorCallback));
+    });
+
+    Reference<Map<String, String>> onErrorMDCRef = new Reference<>();
+    doAnswer(ignored -> {
+      onErrorMDCRef.set(MDC.getCopyOfContextMap());
+      return null;
+    }).when(executorCallback).error(any());
+
+    Map<String, String> anotherMap = singletonMap("on", "another");
+    withMDC(anotherMap, () -> {
+      preservingCtxExecutorCallbackRef.get().error(new NullPointerException());
+    });
+
+    assertThat(onErrorMDCRef.get().get("on"), is("creation"));
+  }
+
+  @Test
+  public void preserveMDCOnComplete() {
+    Reference<PreservingThreadContextExecutorCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    Map<String, String> onCreationMap = singletonMap("on", "creation");
+    withMDC(onCreationMap, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextExecutorCallback(executorCallback));
+    });
+
+    Reference<Map<String, String>> onCompleteMDCRef = new Reference<>();
+    doAnswer(ignored -> {
+      onCompleteMDCRef.set(MDC.getCopyOfContextMap());
+      return null;
+    }).when(executorCallback).complete(any());
+
+    Map<String, String> anotherMap = singletonMap("on", "another");
+    withMDC(anotherMap, () -> {
+      preservingCtxExecutorCallbackRef.get().complete(null);
+    });
+
+    assertThat(onCompleteMDCRef.get().get("on"), is("creation"));
+  }
+
+  private void withMDC(Map<String, String> mdc, Runnable callback) {
+    Map<String, String> oldMDC = MDC.getCopyOfContextMap();
+    MDC.setContextMap(mdc);
+    try {
+      callback.run();
+    } finally {
+      MDC.setContextMap(oldMDC);
+    }
+  }
+}


### PR DESCRIPTION
…with the same class loader and MDC as the corresponding operation (#9899)

(cherry picked from commit 647b2e40b4e7f7cbce04687641cca27ab0455feb)