### PR TITLE
MULE-19096: Upgrade Guava version to 30.1

### DIFF
--- a/distributions/standalone/assembly-whitelist.txt
+++ b/distributions/standalone/assembly-whitelist.txt
@@ -273,7 +273,7 @@
 /mule-standalone-${productVersion}/lib/opt/grizzly-websockets-2.3.36-MULE-021.jar
 /mule-standalone-${productVersion}/lib/opt/connection-pool-2.3.36-MULE-021.jar
 /mule-standalone-${productVersion}/lib/opt/groovy-all-2.4.15-indy.jar
-/mule-standalone-${productVersion}/lib/opt/guava-26.0-android.jar
+/mule-standalone-${productVersion}/lib/opt/guava-30.1-android.jar
 /mule-standalone-${productVersion}/lib/opt/hamcrest-core-1.3.jar
 /mule-standalone-${productVersion}/lib/opt/hamcrest-library-1.3.jar
 /mule-standalone-${productVersion}/lib/opt/hk2-api-2.6.1.jar

--- a/modules/launcher/src/main/java/com/google/common/util/concurrent/AbstractFuture.java
+++ b/modules/launcher/src/main/java/com/google/common/util/concurrent/AbstractFuture.java
@@ -15,14 +15,16 @@
 package com.google.common.util.concurrent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static com.google.common.util.concurrent.Futures.getDone;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.lang.Integer.toHexString;
+import static java.lang.System.identityHashCode;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.GwtCompatible;
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.internal.InternalFutureFailureAccess;
+import com.google.common.util.concurrent.internal.InternalFutures;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.ForOverride;
 import com.google.j2objc.annotations.ReflectionSupport;
@@ -63,18 +65,37 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 @SuppressWarnings("ShortCircuitBoolean") // we use non-short circuiting comparisons intentionally
 @GwtCompatible(emulated = true)
 @ReflectionSupport(value = ReflectionSupport.Level.FULL)
-public abstract class AbstractFuture<V> extends FluentFuture<V> {
+public abstract class AbstractFuture<V> extends InternalFutureFailureAccess
+        implements ListenableFuture<V> {
     // NOTE: Whenever both tests are cheap and functional, it's faster to use &, | instead of &&, ||
 
-    private static final boolean GENERATE_CANCELLATION_CAUSES =
-            Boolean.parseBoolean(
-                    System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
+    private static final boolean GENERATE_CANCELLATION_CAUSES;
+
+    static {
+        // System.getProperty may throw if the security policy does not permit access.
+        boolean generateCancellationCauses;
+        try {
+            generateCancellationCauses =
+                    Boolean.parseBoolean(
+                            System.getProperty("guava.concurrent.generate_cancellation_cause", "false"));
+        } catch (SecurityException e) {
+            generateCancellationCauses = false;
+        }
+        GENERATE_CANCELLATION_CAUSES = generateCancellationCauses;
+    }
+
+    /**
+     * Tag interface marking trusted subclasses. This enables some optimizations. The implementation
+     * of this interface must also be an AbstractFuture and must not override or expose for overriding
+     * any of the public methods of ListenableFuture.
+     */
+    interface Trusted<V> extends ListenableFuture<V> {}
 
     /**
      * A less abstract subclass of AbstractFuture. This can be used to optimize setFuture by ensuring
      * that {@link #get} calls exactly the implementation of {@link AbstractFuture#get}.
      */
-    abstract static class TrustedFuture<V> extends AbstractFuture<V> {
+    abstract static class TrustedFuture<V> extends AbstractFuture<V> implements Trusted<V> {
         @CanIgnoreReturnValue
         @Override
         public final V get() throws InterruptedException, ExecutionException {
@@ -377,7 +398,8 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             throws InterruptedException, TimeoutException, ExecutionException {
         // NOTE: if timeout < 0, remainingNanos will be < 0 and we will fall into the while(true) loop
         // at the bottom and throw a timeoutexception.
-        long remainingNanos = unit.toNanos(timeout); // we rely on the implicit null check on unit.
+        final long timeoutNanos = unit.toNanos(timeout); // we rely on the implicit null check on unit.
+        long remainingNanos = timeoutNanos;
         if (Thread.interrupted()) {
             throw new InterruptedException();
         }
@@ -396,7 +418,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
                     node.setNext(oldHead);
                     if (ATOMIC_HELPER.casWaiters(this, oldHead, node)) {
                         while (true) {
-                            LockSupport.parkNanos(this, remainingNanos);
+                            OverflowAvoidingLockSupport.parkNanos(this, remainingNanos);
                             // Check interruption first, if we woke up due to interruption we need to honor that.
                             if (Thread.interrupted()) {
                                 removeWaiter(node);
@@ -440,24 +462,37 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
         }
 
         String futureToString = toString();
+        final String unitString = unit.toString().toLowerCase(Locale.ROOT);
+        String message = "Waited " + timeout + " " + unit.toString().toLowerCase(Locale.ROOT);
+        // Only report scheduling delay if larger than our spin threshold - otherwise it's just noise
+        if (remainingNanos + SPIN_THRESHOLD_NANOS < 0) {
+            // We over-waited for our timeout.
+            message += " (plus ";
+            long overWaitNanos = -remainingNanos;
+            long overWaitUnits = unit.convert(overWaitNanos, TimeUnit.NANOSECONDS);
+            long overWaitLeftoverNanos = overWaitNanos - unit.toNanos(overWaitUnits);
+            boolean shouldShowExtraNanos =
+                    overWaitUnits == 0 || overWaitLeftoverNanos > SPIN_THRESHOLD_NANOS;
+            if (overWaitUnits > 0) {
+                message += overWaitUnits + " " + unitString;
+                if (shouldShowExtraNanos) {
+                    message += ",";
+                }
+                message += " ";
+            }
+            if (shouldShowExtraNanos) {
+                message += overWaitLeftoverNanos + " nanoseconds ";
+            }
+
+            message += "delay)";
+        }
         // It's confusing to see a completed future in a timeout message; if isDone() returns false,
         // then we know it must have given a pending toString value earlier. If not, then the future
         // completed after the timeout expired, and the message might be success.
         if (isDone()) {
-            throw new TimeoutException(
-                    "Waited "
-                            + timeout
-                            + " "
-                            + unit.toString().toLowerCase(Locale.ROOT)
-                            + " but future completed as timeout expired");
+            throw new TimeoutException(message + " but future completed as timeout expired");
         }
-        throw new TimeoutException(
-                "Waited "
-                        + timeout
-                        + " "
-                        + unit.toString().toLowerCase(Locale.ROOT)
-                        + " for "
-                        + futureToString);
+        throw new TimeoutException(message + " for " + futureToString);
     }
 
     /**
@@ -520,7 +555,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             return null;
         } else {
             @SuppressWarnings("unchecked") // this is the only other option
-                    V asV = (V) obj;
+            V asV = (V) obj;
             return asV;
         }
     }
@@ -549,6 +584,9 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
      * #wasInterrupted} as necessary. This ensures that the work is done even if the future is
      * cancelled without a call to {@code cancel}, such as by calling {@code
      * setFuture(cancelledFuture)}.
+     *
+     * <p>Beware of completing a future while holding a lock. Its listeners may do slow work or
+     * acquire other locks, risking deadlocks.
      */
     @CanIgnoreReturnValue
     @Override
@@ -569,7 +607,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
             while (true) {
                 if (ATOMIC_HELPER.casValue(abstractFuture, localValue, valueToSet)) {
                     rValue = true;
-                    // We call interuptTask before calling complete(), which is consistent with
+                    // We call interruptTask before calling complete(), which is consistent with
                     // FutureTask
                     if (mayInterruptIfRunning) {
                         abstractFuture.interruptTask();
@@ -579,7 +617,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
                         // propagate cancellation to the future set in setfuture, this is racy, and we don't
                         // care if we are successful or not.
                         ListenableFuture<?> futureToPropagateTo = ((SetFuture) localValue).future;
-                        if (futureToPropagateTo instanceof TrustedFuture) {
+                        if (futureToPropagateTo instanceof Trusted) {
                             // If the future is a TrustedFuture then we specifically avoid calling cancel()
                             // this has 2 benefits
                             // 1. for long chains of futures strung together with setFuture we consume less stack
@@ -619,7 +657,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
      *
      * <p>The default implementation does nothing.
      *
-     * <p>This method is likely to be deprecated. Prefer to override {@link #afterDone}, consulting
+     * <p>This method is likely to be deprecated. Prefer to override {@link #afterDone}, checking
      * {@link #wasInterrupted} to decide whether to interrupt your task.
      *
      * @since 10.0
@@ -646,16 +684,27 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     public void addListener(Runnable listener, Executor executor) {
         checkNotNull(listener, "Runnable was null.");
         checkNotNull(executor, "Executor was null.");
-        Listener oldHead = listeners;
-        if (oldHead != Listener.TOMBSTONE) {
-            Listener newNode = new Listener(listener, executor);
-            do {
-                newNode.next = oldHead;
-                if (ATOMIC_HELPER.casListeners(this, oldHead, newNode)) {
-                    return;
-                }
-                oldHead = listeners; // re-read
-            } while (oldHead != Listener.TOMBSTONE);
+        // Checking isDone and listeners != TOMBSTONE may seem redundant, but our contract for
+        // addListener says that listeners execute 'immediate' if the future isDone(). However, our
+        // protocol for completing a future is to assign the value field (which sets isDone to true) and
+        // then to release waiters, followed by executing afterDone(), followed by releasing listeners.
+        // That means that it is possible to observe that the future isDone and that your listeners
+        // don't execute 'immediately'.  By checking isDone here we avoid that.
+        // A corollary to all that is that we don't need to check isDone inside the loop because if we
+        // get into the loop we know that we weren't done when we entered and therefore we aren't under
+        // an obligation to execute 'immediately'.
+        if (!isDone()) {
+            Listener oldHead = listeners;
+            if (oldHead != Listener.TOMBSTONE) {
+                Listener newNode = new Listener(listener, executor);
+                do {
+                    newNode.next = oldHead;
+                    if (ATOMIC_HELPER.casListeners(this, oldHead, newNode)) {
+                        return;
+                    }
+                    oldHead = listeners; // re-read
+                } while (oldHead != Listener.TOMBSTONE);
+            }
         }
         // If we get here then the Listener TOMBSTONE was set, which means the future is done, call
         // the listener.
@@ -670,6 +719,9 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
      * Future} may have previously been set asynchronously, in which case its result may not be known
      * yet. That result, though not yet known, cannot be overridden by a call to a {@code set*}
      * method, only by a call to {@link #cancel}.
+     *
+     * <p>Beware of completing a future while holding a lock. Its listeners may do slow work or
+     * acquire other locks, risking deadlocks.
      *
      * @param value the value to be used as the result
      * @return true if the attempt was accepted, completing the {@code Future}
@@ -692,6 +744,9 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
      * {@code Future} may have previously been set asynchronously, in which case its result may not be
      * known yet. That result, though not yet known, cannot be overridden by a call to a {@code set*}
      * method, only by a call to {@link #cancel}.
+     *
+     * <p>Beware of completing a future while holding a lock. Its listeners may do slow work or
+     * acquire other locks, risking deadlocks.
      *
      * @param throwable the exception to be used as the failed result
      * @return true if the attempt was accepted, completing the {@code Future}
@@ -727,12 +782,14 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
      * invoke the {@link #interruptTask} method, and the {@link #wasInterrupted} method will not
      * return {@code true}.
      *
+     * <p>Beware of completing a future while holding a lock. Its listeners may do slow work or
+     * acquire other locks, risking deadlocks.
+     *
      * @param future the future to delegate to
      * @return true if the attempt was accepted, indicating that the {@code Future} was not previously
      *     cancelled or set.
      * @since 19.0
      */
-    @Beta
     @CanIgnoreReturnValue
     protected boolean setFuture(ListenableFuture<? extends V> future) {
         checkNotNull(future);
@@ -751,7 +808,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
                 // the listener is responsible for calling completeWithFuture, directExecutor is appropriate
                 // since all we are doing is unpacking a completed future which should be fast.
                 try {
-                    future.addListener(valueToSet, directExecutor());
+                    future.addListener(valueToSet, DirectExecutor.INSTANCE);
                 } catch (Throwable t) {
                     // addListener has thrown an exception! SetFuture.run can't throw any exceptions so this
                     // must have been caused by addListener itself. The most likely explanation is a
@@ -785,8 +842,7 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
      * <p>This is approximately the inverse of {@link #getDoneValue(Object)}
      */
     private static Object getFutureValue(ListenableFuture<?> future) {
-        Object valueToSet;
-        if (future instanceof TrustedFuture) {
+        if (future instanceof Trusted) {
             // Break encapsulation for TrustedFuture instances since we know that subclasses cannot
             // override .get() (since it is final) and therefore this is equivalent to calling .get()
             // and unpacking the exceptions like we do below (just much faster because it is a single
@@ -805,20 +861,75 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
                 }
             }
             return v;
-        } else {
-            // Otherwise calculate valueToSet by calling .get()
-            try {
-                Object v = getDone(future);
-                valueToSet = v == null ? NULL : v;
-            } catch (ExecutionException exception) {
-                valueToSet = new Failure(exception.getCause());
-            } catch (CancellationException cancellation) {
-                valueToSet = new Cancellation(false, cancellation);
-            } catch (Throwable t) {
-                valueToSet = new Failure(t);
+        }
+        if (future instanceof InternalFutureFailureAccess) {
+            Throwable throwable =
+                    InternalFutures.tryInternalFastPathGetFailure((InternalFutureFailureAccess) future);
+            if (throwable != null) {
+                return new Failure(throwable);
             }
         }
-        return valueToSet;
+        boolean wasCancelled = future.isCancelled();
+        // Don't allocate a CancellationException if it's not necessary
+        if (!GENERATE_CANCELLATION_CAUSES & wasCancelled) {
+            return Cancellation.CAUSELESS_CANCELLED;
+        }
+        // Otherwise calculate the value by calling .get()
+        try {
+            Object v = getUninterruptibly(future);
+            if (wasCancelled) {
+                return new Cancellation(
+                        false,
+                        new IllegalArgumentException(
+                                "get() did not throw CancellationException, despite reporting "
+                                        + "isCancelled() == true: "
+                                        + future));
+            }
+            return v == null ? NULL : v;
+        } catch (ExecutionException exception) {
+            if (wasCancelled) {
+                return new Cancellation(
+                        false,
+                        new IllegalArgumentException(
+                                "get() did not throw CancellationException, despite reporting "
+                                        + "isCancelled() == true: "
+                                        + future,
+                                exception));
+            }
+            return new Failure(exception.getCause());
+        } catch (CancellationException cancellation) {
+            if (!wasCancelled) {
+                return new Failure(
+                        new IllegalArgumentException(
+                                "get() threw CancellationException, despite reporting isCancelled() == false: "
+                                        + future,
+                                cancellation));
+            }
+            return new Cancellation(false, cancellation);
+        } catch (Throwable t) {
+            return new Failure(t);
+        }
+    }
+
+    /**
+     * An inlined private copy of {@link Uninterruptibles#getUninterruptibly} used to break an
+     * internal dependency on other /util/concurrent classes.
+     */
+    private static <V> V getUninterruptibly(Future<V> future) throws ExecutionException {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    return future.get();
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     /** Unblocks all threads and runs all listeners. */
@@ -828,7 +939,8 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
         while (true) {
             future.releaseWaiters();
             // We call this before the listeners in order to avoid needing to manage a separate stack data
-            // structure for them.
+            // structure for them.  Also, some implementations rely on this running prior to listeners
+            // so that the cleanup work is visible to listeners.
             // afterDone() should be generally fast and only used for cleanup work... but in theory can
             // also be recursive and create StackOverflowErrors
             future.afterDone();
@@ -877,15 +989,36 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     @ForOverride
     protected void afterDone() {}
 
+    // TODO(b/114236866): Inherit doc from InternalFutureFailureAccess. Also, -link to its URL.
     /**
-     * Returns the exception that this {@code Future} completed with. This includes completion through
-     * a call to {@link #setException} or {@link #setFuture setFuture}{@code (failedFuture)} but not
-     * cancellation.
+     * Usually returns {@code null} but, if this {@code Future} has failed, may <i>optionally</i>
+     * return the cause of the failure. "Failure" means specifically "completed with an exception"; it
+     * does not include "was cancelled." To be explicit: If this method returns a non-null value,
+     * then:
      *
-     * @throws RuntimeException if the {@code Future} has not failed
+     * <ul>
+     *   <li>{@code isDone()} must return {@code true}
+     *   <li>{@code isCancelled()} must return {@code false}
+     *   <li>{@code get()} must not block, and it must throw an {@code ExecutionException} with the
+     *       return value of this method as its cause
+     * </ul>
+     *
+     * <p>This method is {@code protected} so that classes like {@code
+     * com.google.common.util.concurrent.SettableFuture} do not expose it to their users as an
+     * instance method. In the unlikely event that you need to call this method, call {@link
+     * InternalFutures#tryInternalFastPathGetFailure(InternalFutureFailureAccess)}.
+     *
+     * @since 27.0
      */
-    final Throwable trustedGetException() {
-        return ((Failure) value).exception;
+    @Override
+    protected final @NullableDecl Throwable tryInternalFastPathGetFailure() {
+        if (this instanceof Trusted) {
+            Object obj = value;
+            if (obj instanceof Failure) {
+                return ((Failure) obj).exception;
+            }
+        }
+        return null;
     }
 
     /**
@@ -934,32 +1067,23 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
         return reversedList;
     }
 
-    // TODO(user) move this up into FluentFuture, or parts as a default method on ListenableFuture?
+    // TODO(user): move parts into a default method on ListenableFuture?
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder().append(super.toString()).append("[status=");
+        // TODO(cpovirk): Presize to something plausible?
+        StringBuilder builder = new StringBuilder();
+        if (getClass().getName().startsWith("com.google.common.util.concurrent.")) {
+            builder.append(getClass().getSimpleName());
+        } else {
+            builder.append(getClass().getName());
+        }
+        builder.append('@').append(toHexString(identityHashCode(this))).append("[status=");
         if (isCancelled()) {
             builder.append("CANCELLED");
         } else if (isDone()) {
             addDoneString(builder);
         } else {
-            String pendingDescription;
-            try {
-                pendingDescription = pendingToString();
-            } catch (RuntimeException e) {
-                // Don't call getMessage or toString() on the exception, in case the exception thrown by the
-                // subclass is implemented with bugs similar to the subclass.
-                pendingDescription = "Exception thrown from implementation: " + e.getClass();
-            }
-            // The future may complete during or before the call to getPendingToString, so we use null
-            // as a signal that we should try checking if the future is done again.
-            if (!isNullOrEmpty(pendingDescription)) {
-                builder.append("PENDING, info=[").append(pendingDescription).append("]");
-            } else if (isDone()) {
-                addDoneString(builder);
-            } else {
-                builder.append("PENDING");
-            }
+            addPendingString(builder); // delegates to addDoneString if future completes mid-way
         }
         return builder.append("]").toString();
     }
@@ -967,15 +1091,12 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
     /**
      * Provide a human-readable explanation of why this future has not yet completed.
      *
-     * @return null if an explanation cannot be provided because the future is done.
+     * @return null if an explanation cannot be provided (e.g. because the future is done).
      * @since 23.0
      */
-    @NullableDecl
-    protected String pendingToString() {
-        Object localValue = value;
-        if (localValue instanceof SetFuture) {
-            return "setFuture=[" + userObjectToString(((SetFuture) localValue).future) + "]";
-        } else if (this instanceof ScheduledFuture) {
+    protected @NullableDecl String pendingToString() {
+        // TODO(diamondm) consider moving this into addPendingString so it's always in the output
+        if (this instanceof ScheduledFuture) {
             return "remaining delay=["
                     + ((ScheduledFuture) this).getDelay(TimeUnit.MILLISECONDS)
                     + " ms]";
@@ -983,10 +1104,47 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
         return null;
     }
 
+    private void addPendingString(StringBuilder builder) {
+        // Capture current builder length so it can be truncated if this future ends up completing while
+        // the toString is being calculated
+        int truncateLength = builder.length();
+
+        builder.append("PENDING");
+
+        Object localValue = value;
+        if (localValue instanceof SetFuture) {
+            builder.append(", setFuture=[");
+            appendUserObject(builder, ((SetFuture) localValue).future);
+            builder.append("]");
+        } else {
+            String pendingDescription;
+            try {
+                pendingDescription = Strings.emptyToNull(pendingToString());
+            } catch (RuntimeException | StackOverflowError e) {
+                // Don't call getMessage or toString() on the exception, in case the exception thrown by the
+                // subclass is implemented with bugs similar to the subclass.
+                pendingDescription = "Exception thrown from implementation: " + e.getClass();
+            }
+            if (pendingDescription != null) {
+                builder.append(", info=[").append(pendingDescription).append("]");
+            }
+        }
+
+        // The future may complete while calculating the toString, so we check once more to see if the
+        // future is done
+        if (isDone()) {
+            // Truncate anything that was appended before realizing this future is done
+            builder.delete(truncateLength, builder.length());
+            addDoneString(builder);
+        }
+    }
+
     private void addDoneString(StringBuilder builder) {
         try {
-            V value = getDone(this);
-            builder.append("SUCCESS, result=[").append(userObjectToString(value)).append("]");
+            V value = getUninterruptibly(this);
+            builder.append("SUCCESS, result=[");
+            appendResultObject(builder, value);
+            builder.append("]");
         } catch (ExecutionException e) {
             builder.append("FAILURE, cause=[").append(e.getCause()).append("]");
         } catch (CancellationException e) {
@@ -996,16 +1154,41 @@ public abstract class AbstractFuture<V> extends FluentFuture<V> {
         }
     }
 
-    /** Helper for printing user supplied objects into our toString method. */
-    private String userObjectToString(Object o) {
-        // This is some basic recursion detection for when people create cycles via set/setFuture
-        // This is however only partial protection though since it only detects self loops.  We could
-        // detect arbitrary cycles using a thread local or possibly by catching StackOverflowExceptions
-        // but this should be a good enough solution (it is also what jdk collections do in these cases)
-        if (o == this) {
-            return "this future";
+    /**
+     * Any object can be the result of a Future, and not every object has a reasonable toString()
+     * implementation. Using a reconstruction of the default Object.toString() prevents OOMs and stack
+     * overflows, and helps avoid sensitive data inadvertently ending up in exception messages.
+     */
+    private void appendResultObject(StringBuilder builder, Object o) {
+        if (o == null) {
+            builder.append("null");
+        } else if (o == this) {
+            builder.append("this future");
+        } else {
+            builder
+                    .append(o.getClass().getName())
+                    .append("@")
+                    .append(Integer.toHexString(System.identityHashCode(o)));
         }
-        return String.valueOf(o);
+    }
+
+    /** Helper for printing user supplied objects into our toString method. */
+    private void appendUserObject(StringBuilder builder, Object o) {
+        // This is some basic recursion detection for when people create cycles via set/setFuture or
+        // when deep chains of futures exist resulting in a StackOverflowException. We could detect
+        // arbitrary cycles using a thread local but this should be a good enough solution (it is also
+        // what jdk collections do in these cases)
+        try {
+            if (o == this) {
+                builder.append("this future");
+            } else {
+                builder.append(o);
+            }
+        } catch (RuntimeException | StackOverflowError e) {
+            // Don't call getMessage or toString() on the exception, in case the exception thrown by the
+            // user object is implemented with bugs similar to the user object.
+            builder.append("Exception thrown from implementation: ").append(e.getClass());
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <geronimoSpecsServletApiVersion>1.0</geronimoSpecsServletApiVersion>
         <servletApiVersion>3.1.0</servletApiVersion>
         <grizzlyVersion>2.3.36-MULE-021</grizzlyVersion>
-        <guavaVersion>26.0-android</guavaVersion>
+        <guavaVersion>30.1-android</guavaVersion>
         <hamcrestVersion>1.3</hamcrestVersion>
         <hk2Version>2.3.0-b05</hk2Version>
         <jacksonVersion>1.9.14-MULE-002</jacksonVersion>


### PR DESCRIPTION
It was needed to upgrade the class we are overriding. For future upgrades: that class is overriden due to logging issues (our logging system uses guava, which tries to log when we are still initializing the logging framework). So there are needed 2 changes: 
1. remove all logs from that class
2. change `@Nullable` annotations to `@NullableDecl`