### PR TITLE
MULE-19097: The non blocking completion callbacks should be executed …

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextCompletionCallback.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextCompletionCallback.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.execution;
+
+import static java.lang.Thread.currentThread;
+import org.mule.runtime.extension.api.runtime.operation.Result;
+import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
+
+import java.util.Map;
+
+import org.slf4j.MDC;
+
+public class PreservingThreadContextCompletionCallback<T, A> implements CompletionCallback<T, A> {
+
+  private final CompletionCallback<T, A> delegate;
+  private final ClassLoader classLoader;
+  private final Map<String, String> mdc;
+
+  public PreservingThreadContextCompletionCallback(CompletionCallback<T, A> delegate) {
+    this.delegate = delegate;
+    this.classLoader = currentThread().getContextClassLoader();
+    this.mdc = MDC.getCopyOfContextMap();
+  }
+
+  @Override
+  public void success(Result<T, A> result) {
+    try (ThreadContext ignored = new ThreadContext(classLoader, mdc)) {
+      delegate.success(result);
+    }
+  }
+
+  @Override
+  public void error(Throwable e) {
+    try (ThreadContext ignored = new ThreadContext(classLoader, mdc)) {
+      delegate.error(e);
+    }
+  }
+
+  private static class ThreadContext implements AutoCloseable {
+
+    private final Thread currentThread;
+
+    private final ClassLoader innerClassLoader;
+    private final Map<String, String> innerMDC;
+
+    private final ClassLoader outerClassLoader;
+    private final Map<String, String> outerMDC;
+
+    ThreadContext(ClassLoader classLoader, Map<String, String> mdc) {
+      currentThread = currentThread();
+
+      innerClassLoader = classLoader;
+      innerMDC = mdc;
+
+      outerClassLoader = currentThread.getContextClassLoader();
+      outerMDC = MDC.getCopyOfContextMap();
+
+      MDC.setContextMap(innerMDC);
+      setContextClassLoader(currentThread, outerClassLoader, innerClassLoader);
+    }
+
+    @Override
+    public void close() {
+      try {
+        setContextClassLoader(currentThread, innerClassLoader, outerClassLoader);
+      } finally {
+        MDC.setContextMap(outerMDC);
+      }
+    }
+
+    private static void setContextClassLoader(Thread thread, ClassLoader currentClassLoader, ClassLoader newClassLoader) {
+      if (currentClassLoader != newClassLoader) {
+        thread.setContextClassLoader(newClassLoader);
+      }
+    }
+  }
+}

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/ReactiveOperationExecutionWrapper.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/ReactiveOperationExecutionWrapper.java
@@ -59,7 +59,7 @@ public final class ReactiveOperationExecutionWrapper<M extends ComponentModel>
     ExecutionContextAdapter<M> context = (ExecutionContextAdapter<M>) executionContext;
     return Mono.create(sink -> {
       ReactorCompletionCallback callback = new ReactorCompletionCallback(sink);
-      context.setVariable(COMPLETION_CALLBACK_CONTEXT_PARAM, callback);
+      context.setVariable(COMPLETION_CALLBACK_CONTEXT_PARAM, new PreservingThreadContextCompletionCallback<>(callback));
 
       try {
         delegate.execute(executionContext);

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/OperationExecutorFactoryWrapperTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/OperationExecutorFactoryWrapperTestCase.java
@@ -9,6 +9,8 @@ package org.mule.runtime.module.extension.internal.runtime.execution;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Optional.empty;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,7 +23,6 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.internal.util.rx.ImmediateScheduler.IMMEDIATE_SCHEDULER;
 import static org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextProperties.COMPLETION_CALLBACK_CONTEXT_PARAM;
 import static reactor.core.publisher.Mono.from;
-
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.meta.model.ExtensionModel;
@@ -43,6 +44,7 @@ import org.mule.runtime.module.extension.internal.runtime.operation.ReflectiveMe
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
+import io.qameta.allure.Issue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,7 +53,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 import org.reactivestreams.Publisher;
-
 import reactor.core.publisher.Mono;
 
 @SmallTest
@@ -119,6 +120,23 @@ public class OperationExecutorFactoryWrapperTestCase extends AbstractMuleTestCas
     when(constructModel.getModelProperty(ImplementingMethodModelProperty.class)).thenReturn(empty());
     wrapper.createExecutor(constructModel, emptyMap()).execute(ctx);
     verify(ctx, never()).setVariable(eq(COMPLETION_CALLBACK_CONTEXT_PARAM), any());
+  }
+
+  @Test
+  @Issue("MULE-19097")
+  public void javaNonBlockingUsesPreservingThreadContextCompletionCallback() {
+    setupJava();
+    when(executor.execute(any())).thenAnswer((Answer<Publisher<Object>>) invocationOnMock -> {
+      ExecutionContextAdapter ctx = invocationOnMock.getArgument(0);
+      CompletionCallback completionCallback = ((CompletionCallback) ctx.getVariable(COMPLETION_CALLBACK_CONTEXT_PARAM));
+      completionCallback.success(mock(Result.class));
+      assertThat(completionCallback, instanceOf(PreservingThreadContextCompletionCallback.class));
+      return Mono.empty();
+    });
+
+    from(wrapper.createExecutor(mockOperation(false), emptyMap()).execute(ctx)).block();
+    verify(executor).execute(ctx);
+    verify(ctx, times(1)).setVariable(eq(COMPLETION_CALLBACK_CONTEXT_PARAM), any());
   }
 
   private void assertOperation(boolean java, boolean blocking) {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextCompletionCallbackTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/PreservingThreadContextCompletionCallbackTestCase.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.execution;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import org.mule.runtime.api.util.Reference;
+import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.util.Map;
+
+import io.qameta.allure.Issue;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.slf4j.MDC;
+
+@Issue("MULE-19097")
+public class PreservingThreadContextCompletionCallbackTestCase extends AbstractMuleTestCase {
+
+  @Mock
+  private CompletionCallback<Object, Object> completionCallback = mock(CompletionCallback.class);
+
+  @Test
+  public void preserveClassLoaderOnError() {
+    Reference<PreservingThreadContextCompletionCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    ClassLoader onCreationClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(onCreationClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextCompletionCallback<>(completionCallback));
+    });
+
+    Reference<ClassLoader> onErrorClassLoaderRef = new Reference<>();
+    doAnswer(ignored -> {
+      onErrorClassLoaderRef.set(currentThread().getContextClassLoader());
+      return null;
+    }).when(completionCallback).error(any());
+
+    ClassLoader anotherClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(anotherClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.get().error(new NullPointerException());
+    });
+
+    assertThat(onErrorClassLoaderRef.get(), is(onCreationClassLoader));
+  }
+
+  @Test
+  public void preserveClassLoaderOnComplete() {
+    Reference<PreservingThreadContextCompletionCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    ClassLoader onCreationClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(onCreationClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextCompletionCallback<>(completionCallback));
+    });
+
+    Reference<ClassLoader> onCompleteClassLoaderRef = new Reference<>();
+    doAnswer(ignored -> {
+      onCompleteClassLoaderRef.set(currentThread().getContextClassLoader());
+      return null;
+    }).when(completionCallback).success(any());
+
+    ClassLoader anotherClassLoader = mock(ClassLoader.class);
+    withContextClassLoader(anotherClassLoader, () -> {
+      preservingCtxExecutorCallbackRef.get().success(null);
+    });
+
+    assertThat(onCompleteClassLoaderRef.get(), is(onCreationClassLoader));
+  }
+
+  @Test
+  public void preserveMDCOnError() {
+    Reference<PreservingThreadContextCompletionCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    Map<String, String> onCreationMap = singletonMap("on", "creation");
+    withMDC(onCreationMap, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextCompletionCallback<>(completionCallback));
+    });
+
+    Reference<Map<String, String>> onErrorMDCRef = new Reference<>();
+    doAnswer(ignored -> {
+      onErrorMDCRef.set(MDC.getCopyOfContextMap());
+      return null;
+    }).when(completionCallback).error(any());
+
+    Map<String, String> anotherMap = singletonMap("on", "another");
+    withMDC(anotherMap, () -> {
+      preservingCtxExecutorCallbackRef.get().error(new NullPointerException());
+    });
+
+    assertThat(onErrorMDCRef.get().get("on"), is("creation"));
+  }
+
+  @Test
+  public void preserveMDCOnComplete() {
+    Reference<PreservingThreadContextCompletionCallback> preservingCtxExecutorCallbackRef = new Reference<>();
+
+    Map<String, String> onCreationMap = singletonMap("on", "creation");
+    withMDC(onCreationMap, () -> {
+      preservingCtxExecutorCallbackRef.set(new PreservingThreadContextCompletionCallback<>(completionCallback));
+    });
+
+    Reference<Map<String, String>> onCompleteMDCRef = new Reference<>();
+    doAnswer(ignored -> {
+      onCompleteMDCRef.set(MDC.getCopyOfContextMap());
+      return null;
+    }).when(completionCallback).success(any());
+
+    Map<String, String> anotherMap = singletonMap("on", "another");
+    withMDC(anotherMap, () -> {
+      preservingCtxExecutorCallbackRef.get().success(null);
+    });
+
+    assertThat(onCompleteMDCRef.get().get("on"), is("creation"));
+  }
+
+  private void withMDC(Map<String, String> mdc, Runnable callback) {
+    Map<String, String> oldMDC = MDC.getCopyOfContextMap();
+    MDC.setContextMap(mdc);
+    try {
+      callback.run();
+    } finally {
+      MDC.setContextMap(oldMDC);
+    }
+  }
+}


### PR DESCRIPTION
…with the same class loader and MDC as the corresponding operation (#9921)

(cherry picked from commit 69c3dad350034d9e6038cf476b05de5eadefdbe3)