### PR TITLE
MULE-19107: fix null pointer exception when a header is null (#9923)

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseHeaderBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseHeaderBuilder.java
@@ -62,6 +62,12 @@ public class HttpResponseHeaderBuilder
         }
         else
         {
+            if (headerValue == null)
+            {
+                LOGGER.warn("The header " + headerName + " is null. Ignoring it from the response.");
+                return;
+            }
+
             addSimpleValue(headerName, headerValue.toString());
         }
     }

--- a/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpResponseHeaderBuilderTestCase.java
+++ b/modules/http/src/test/java/org/mule/module/http/internal/listener/HttpResponseHeaderBuilderTestCase.java
@@ -1,0 +1,16 @@
+package org.mule.module.http.internal.listener;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class HttpResponseHeaderBuilderTestCase {
+
+    @Test
+    public void testNullHeaderValueIsIgnored()
+    {
+        HttpResponseHeaderBuilder httpResponseHeaderBuilder = new HttpResponseHeaderBuilder();
+        httpResponseHeaderBuilder.addHeader("header", null);
+        assertTrue(httpResponseHeaderBuilder.getHeaderNames().isEmpty());
+    }
+}


### PR DESCRIPTION
* MULE-19107: fix null pointer exception when a header is null

* test

* format

* change warn

(cherry picked from commit 205168d0eea00830c2700e34eb8ab5dcef19c3ca)