### PR TITLE
MULE-19140: Adding support for definedInApp in MediaType (#9985)

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/processor/simple/SetPayloadMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/simple/SetPayloadMessageProcessor.java
@@ -8,6 +8,8 @@
 package org.mule.runtime.core.internal.processor.simple;
 
 import static org.mule.runtime.api.metadata.DataType.OBJECT;
+import static org.mule.runtime.api.metadata.MediaType.parseDefinedInApp;
+
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.message.Message;
@@ -65,7 +67,7 @@ public class SetPayloadMessageProcessor extends SimpleMessageProcessor {
   }
 
   public void setMimeType(String mimeType) {
-    setDataType(DataType.builder(dataType == null ? OBJECT : dataType).mediaType(mimeType).build());
+    setDataType(DataType.builder(dataType == null ? OBJECT : dataType).mediaType(parseDefinedInApp(mimeType)).build());
   }
 
   public void setEncoding(String encoding) {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/AbstractReturnDelegate.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/AbstractReturnDelegate.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.module.extension.internal.runtime.operation;
 
 import static java.util.Optional.ofNullable;
+import static org.mule.runtime.api.metadata.MediaType.parseDefinedInApp;
 import static org.mule.runtime.api.metadata.MediaTypeUtils.parseCharset;
 import static org.mule.runtime.core.api.util.StreamingUtils.supportsStreaming;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
@@ -155,7 +156,7 @@ abstract class AbstractReturnDelegate implements ReturnDelegate {
   }
 
   private Optional<MediaType> getContextMimeType(Map<String, Object> params) {
-    return ofNullable((String) params.get(MIME_TYPE_PARAMETER_NAME)).map(mimeType -> MediaType.parse(mimeType));
+    return ofNullable((String) params.get(MIME_TYPE_PARAMETER_NAME)).map(mimeType -> MediaType.parseDefinedInApp(mimeType));
   }
 
   private Optional<Charset> getContextEncoding(Map<String, Object> params) {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/source/DefaultSourceCallback.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/source/DefaultSourceCallback.java
@@ -190,7 +190,7 @@ class DefaultSourceCallback<T, A> implements SourceCallbackAdapter<T, A> {
     encodingParam = ofNullable((String) initialisationParameters.get(ENCODING_PARAMETER_NAME))
         .map(encoding -> parseCharset(encoding));
     mimeTypeInitParam = ofNullable((String) initialisationParameters.get(MIME_TYPE_PARAMETER_NAME))
-        .map(mimeType -> MediaType.parse(mimeType));
+        .map(mimeType -> MediaType.parseDefinedInApp(mimeType));
   });
 
   /**

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/privileged/dsl/processor/AddVariablePropertyConfigurator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/privileged/dsl/processor/AddVariablePropertyConfigurator.java
@@ -7,9 +7,11 @@
 package org.mule.runtime.config.privileged.dsl.processor;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.mule.runtime.api.metadata.MediaType.parseDefinedInApp;
 
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.DataTypeParamsBuilder;
+import org.mule.runtime.api.metadata.MediaType;
 import org.mule.runtime.config.api.dsl.ObjectFactoryCommonConfigurator;
 import org.mule.runtime.core.privileged.processor.simple.AbstractAddVariablePropertyProcessor;
 
@@ -40,7 +42,7 @@ public final class AddVariablePropertyConfigurator
     if (mimeType != null) {
       DataTypeParamsBuilder builder = DataType.builder();
       if (isNotEmpty(mimeType)) {
-        builder.mediaType(mimeType);
+        builder.mediaType(parseDefinedInApp(mimeType));
       }
       propVarSetterInstance.setReturnDataType(builder.charset(encoding).build());
     }


### PR DESCRIPTION
* ParseTemplateProcessor did not allow configuring the outputMimeType in
this version