### PR TITLE
MULE-19040: Allow apps to be redeployed without being started (#9905)

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/context/ArtifactStoppedPersistenceListener.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/context/ArtifactStoppedPersistenceListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.context;
+
+/**
+ * Defines a listener to persist stop events of Mule artifacts.
+ */
+public interface ArtifactStoppedPersistenceListener {
+
+  String ARTIFACT_STOPPED_LISTENER = "artifactStoppedPersistenceListener";
+
+  /**
+   * Notifies an artifact has been started.
+   */
+  void onStart();
+
+  /**
+   * Notifies an artifact has been stopped.
+   */
+  void onStop();
+
+  /**
+   * Turns off persistence.
+   * <p>
+   * The artifact stopped state should only be persisted if it was stopped by external users.
+   * Since external users usually call the artifact stop() method directly from their own methods, a workaround is
+   * to prevent persistence when the artifact is stopped for other reasons.
+   */
+  void doNotPersist();
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
@@ -42,6 +42,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.util.UUID.getClusterUUID;
+import static org.mule.runtime.core.internal.context.ArtifactStoppedPersistenceListener.ARTIFACT_STOPPED_LISTENER;
 import static org.mule.runtime.core.internal.logging.LogUtil.log;
 import static org.mule.runtime.core.internal.util.FunctionalUtils.safely;
 import static org.mule.runtime.core.internal.util.JdkVersionUtils.getSupportedJdks;
@@ -357,6 +358,11 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
       fireNotification(new MuleContextNotification(this, CONTEXT_STARTED));
       final org.mule.runtime.api.artifact.Registry apiRegistry = getApiRegistry();
       listeners.forEach(l -> l.onStart(this, apiRegistry));
+      ArtifactStoppedPersistenceListener artifactStoppedPersistenceListener =
+          getRegistry().lookupObject(ARTIFACT_STOPPED_LISTENER);
+      if (artifactStoppedPersistenceListener != null) {
+        artifactStoppedPersistenceListener.onStart();
+      }
 
       startLatch.release();
 
@@ -414,6 +420,11 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
 
       final org.mule.runtime.api.artifact.Registry apiRegistry = getApiRegistry();
       listeners.forEach(l -> l.onStop(this, apiRegistry));
+      ArtifactStoppedPersistenceListener artifactStoppedPersistenceListener =
+          getRegistry().lookupObject(ARTIFACT_STOPPED_LISTENER);
+      if (artifactStoppedPersistenceListener != null) {
+        artifactStoppedPersistenceListener.onStop();
+      }
     }
   }
 

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultMuleApplication.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/DefaultMuleApplication.java
@@ -433,5 +433,4 @@ public class DefaultMuleApplication extends AbstractDeployableArtifact<Applicati
 
     return domainRepository.getCompatibleDomain(domainBundleDescriptor.get());
   }
-
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ArtifactFactoryUtils.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/artifact/ArtifactFactoryUtils.java
@@ -96,7 +96,7 @@ public class ArtifactFactoryUtils {
    * @since 4.2
    */
   public static Optional<MuleContext> getMuleContext(DeployableArtifact artifact) {
-    return artifact != null ? artifact.getRegistry().lookupByType(MuleContext.class) : empty();
+    return artifact != null && artifact.getRegistry() != null ? artifact.getRegistry().lookupByType(MuleContext.class) : empty();
   }
 
   /**

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/domain/DefaultMuleDomain.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/domain/DefaultMuleDomain.java
@@ -288,5 +288,4 @@ public class DefaultMuleDomain extends AbstractDeployableArtifact<DomainDescript
   protected File getArtifactInstallationDirectory() {
     return descriptor.getArtifactLocation();
   }
-
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArchiveDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArchiveDeployer.java
@@ -53,4 +53,6 @@ public interface ArchiveDeployer<T extends Artifact> {
   void deployArtifact(T artifact, Optional<Properties> deploymentProperties) throws DeploymentException;
 
   T deployExplodedArtifact(String artifactDir, Optional<Properties> deploymentProperties);
+
+  void doNotPersistArtifactStop(T artifact);
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArtifactDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArtifactDeployer.java
@@ -17,7 +17,7 @@ public interface ArtifactDeployer<T extends DeployableArtifact> {
 
   /**
    * Deploys an artifact.
-   *
+   *<p>
    * The deployer executes the artifact installation phases until the artifact is deployed After this method call the Artifact
    * will be installed in the container and started.
    *  @param artifact artifact to be deployed
@@ -27,7 +27,7 @@ public interface ArtifactDeployer<T extends DeployableArtifact> {
 
   /**
    * Deploys an artifact.
-   *
+   *<p>
    * The deployer executes the artifact installation phases until the artifact is deployed After this method call the Artifact
    * will be installed in the container and started.
    *  @param artifact artifact to be deployed
@@ -38,7 +38,7 @@ public interface ArtifactDeployer<T extends DeployableArtifact> {
 
   /**
    * Undeploys an artifact.
-   *
+   *<p>
    * The deployer executes the artifact desinstallation phases until de artifact is undeployed. After this method call the
    * Artifact will not longer be running inside the container.
    *
@@ -46,4 +46,12 @@ public interface ArtifactDeployer<T extends DeployableArtifact> {
    */
   void undeploy(final T artifact);
 
+  /**
+   * Cancels the persistence of a stop of an artifact.
+   *<p>
+   * A stop of a certain artifact must only be persisted when it was stopped by the Agent. In case of undeployment, it should not be persisted.
+   *
+   * @param artifact artifact to be undeployed
+   */
+  void doNotPersistArtifactStop(T artifact);
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArtifactStoppedDeploymentPersistenceListener.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArtifactStoppedDeploymentPersistenceListener.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.deployment.internal;
+
+import static java.lang.String.valueOf;
+import static java.util.Optional.of;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
+import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
+
+import org.mule.runtime.core.internal.context.ArtifactStoppedPersistenceListener;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class ArtifactStoppedDeploymentPersistenceListener implements ArtifactStoppedPersistenceListener {
+
+  private static transient final Logger logger = LoggerFactory.getLogger(ArtifactStoppedDeploymentPersistenceListener.class);
+  /**
+   * A possible race condition could happen if a stop request and a shutdown request
+   * are concurrently sent to mule, in order to prevent it this property is defined as an AtomicBoolean.
+   */
+  private AtomicBoolean shouldPersist;
+  private String artifactName;
+
+  public ArtifactStoppedDeploymentPersistenceListener(String artifactName) {
+    this.artifactName = artifactName;
+    shouldPersist = new AtomicBoolean(true);
+  }
+
+  @Override
+  public void onStart() {
+    Properties properties = new Properties();
+    properties.setProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, valueOf(true));
+    try {
+      resolveDeploymentProperties(artifactName, of(properties));
+    } catch (IOException e) {
+      logger.error("ArtifactStoppedDeploymentPersistenceListener failed to process notification onStart for artifact "
+          + artifactName, e);
+    }
+  }
+
+  @Override
+  public void onStop() {
+    if (!shouldPersist.get()) {
+      return;
+    }
+    Properties properties = new Properties();
+    properties.setProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, valueOf(false));
+    try {
+      resolveDeploymentProperties(artifactName, of(properties));
+    } catch (IOException e) {
+      logger.error("ArtifactStoppedDeploymentPersistenceListener failed to process notification onStop for artifact "
+          + artifactName, e);
+    }
+  }
+
+  @Override
+  public void doNotPersist() {
+    shouldPersist.set(false);
+  }
+}

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultArchiveDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultArchiveDeployer.java
@@ -579,4 +579,8 @@ public class DefaultArchiveDeployer<T extends DeployableArtifact> implements Arc
 
     return deployExplodedApp(artifactDir, deploymentProperties);
   }
+
+  public void doNotPersistArtifactStop(T artifact) {
+    deployer.doNotPersistArtifactStop(artifact);
+  }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DeploymentDirectoryWatcher.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DeploymentDirectoryWatcher.java
@@ -197,6 +197,7 @@ public class DeploymentDirectoryWatcher implements Runnable {
 
     deploymentLock.lock();
     try {
+      notifyStopListeners();
       stopArtifacts(applications);
       stopArtifacts(domains);
     } finally {
@@ -555,6 +556,14 @@ public class DeploymentDirectoryWatcher implements Runnable {
       });
     }
   }
-}
 
+  private void notifyStopListeners() {
+    for (Application application : applications) {
+      applicationArchiveDeployer.doNotPersistArtifactStop(application);
+    }
+    for (Domain domain : domains) {
+      domainArchiveDeployer.doNotPersistArtifactStop(domain);
+    }
+  }
+}
 

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainArchiveDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainArchiveDeployer.java
@@ -133,4 +133,9 @@ public class DomainArchiveDeployer implements ArchiveDeployer<Domain> {
   public Domain deployExplodedArtifact(String artifactDir, Optional<Properties> deploymentProperties) {
     return domainDeployer.deployExplodedArtifact(artifactDir, deploymentProperties);
   }
+
+  @Override
+  public void doNotPersistArtifactStop(Domain artifact) {
+    domainDeployer.doNotPersistArtifactStop(artifact);
+  }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplate {
 
   private Collection<Application> domainApplications = Collections.emptyList();
+  //TODO MULE-19166: Remove this property since it's no longer necessary
   private Map<Application, ApplicationStatus> appStatusPreRedeployment;
   private final DefaultArchiveDeployer<Application> applicationDeployer;
   private final DeploymentService deploymentservice;

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
@@ -1736,7 +1736,7 @@ public abstract class AbstractDeploymentTestCase extends AbstractMuleTestCase {
     }
   }
 
-  private static class TestMuleDeploymentService extends MuleDeploymentService {
+  protected static class TestMuleDeploymentService extends MuleDeploymentService {
 
     public TestMuleDeploymentService(DefaultDomainFactory domainFactory, DefaultApplicationFactory applicationFactory,
                                      Supplier<SchedulerService> schedulerServiceSupplier) {

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -35,12 +36,17 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mule.runtime.container.internal.ClasspathModuleDiscoverer.EXPORTED_CLASS_PACKAGES_PROPERTY;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.core.internal.context.ArtifactStoppedPersistenceListener.ARTIFACT_STOPPED_LISTENER;
 import static org.mule.runtime.deployment.model.api.DeployableArtifactDescriptor.PROPERTY_CONFIG_RESOURCES;
+import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.CREATED;
 import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.DESTROYED;
 import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.EXPORTED_PACKAGES;
 import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.EXPORTED_RESOURCES;
 import static org.mule.runtime.deployment.model.api.domain.DomainDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
 import static org.mule.runtime.deployment.model.api.domain.DomainDescriptor.DEFAULT_DOMAIN_NAME;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
+import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
+
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.exception.MuleFatalException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
@@ -73,6 +79,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 
@@ -624,6 +631,36 @@ public class DomainDeploymentTestCase extends AbstractDeploymentTestCase {
   }
 
   @Test
+  @Issue("MULE-19040")
+  @Description("When a domain was stopped and the server is restarted, the domain should not start")
+  public void redeploysDomainZipRefreshesAppsButIfTheyWereStoppedTheyDoNotStart() throws Exception {
+    addPackedDomainFromBuilder(dummyDomainFileBuilder);
+    File dummyDomainFile = new File(domainsDir, dummyDomainFileBuilder.getZipPath());
+    long firstFileTimestamp = dummyDomainFile.lastModified();
+
+    addPackedAppFromBuilder(dummyDomainApp1FileBuilder);
+
+    startDeployment();
+
+    assertDeploymentSuccess(domainDeploymentListener, dummyDomainFileBuilder.getId());
+    assertApplicationDeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
+
+    final Application app = findApp(dummyDomainApp1FileBuilder.getId(), 1);
+    app.stop();
+
+    reset(domainDeploymentListener);
+    reset(applicationDeploymentListener);
+
+    addPackedDomainFromBuilder(dummyDomainFileBuilder);
+    alterTimestampIfNeeded(dummyDomainFile, firstFileTimestamp);
+
+    assertUndeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
+    assertDomainRedeploymentSuccess(dummyDomainFileBuilder.getId());
+    assertDeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
+    assertStatus(dummyDomainApp1FileBuilder.getId(), CREATED);
+  }
+
+  @Test
   public void redeploysDomainZipDeployedAfterStartup() throws Exception {
     addPackedDomainFromBuilder(dummyDomainFileBuilder);
     File dummyDomainFile = new File(domainsDir, dummyDomainFileBuilder.getZipPath());
@@ -1068,6 +1105,43 @@ public class DomainDeploymentTestCase extends AbstractDeploymentTestCase {
   }
 
   @Test
+  @Issue("MULE-19040")
+  @Description("When a domain was stopped, this state should be persisted as a deployment property")
+  public void whenDomainIsStoppedStateIsPersistedAsDeploymentProperty() throws Exception {
+    addPackedDomainFromBuilder(emptyDomainFileBuilder);
+
+    startDeployment();
+
+    assertDeploymentSuccess(domainDeploymentListener, emptyDomainFileBuilder.getId());
+    final Domain domain = findADomain(emptyDomainFileBuilder.getId());
+    domain.stop();
+
+    assertThat(domain.getRegistry().lookupByName(ARTIFACT_STOPPED_LISTENER), is(notNullValue()));
+
+    Properties deploymentProperties = resolveDeploymentProperties(emptyDomainFileBuilder.getId(), Optional.empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(notNullValue()));
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
+  }
+
+  @Test
+  @Issue("MULE-19040")
+  @Description("When a domain was stopped by undeployment, this state should not be persisted as a deployment property")
+  public void whenDomainIsStoppedByUndeploymentStateIsNotPersistedAsDeploymentProperty() throws Exception {
+    addPackedDomainFromBuilder(emptyDomainFileBuilder);
+
+    startDeployment();
+
+    assertDeploymentSuccess(domainDeploymentListener, emptyDomainFileBuilder.getId());
+    final Domain domain = findADomain(emptyDomainFileBuilder.getId());
+
+    assertThat(domain.getRegistry().lookupByName(ARTIFACT_STOPPED_LISTENER), is(notNullValue()));
+    deploymentService.undeploy(domain);
+
+    Properties deploymentProperties = resolveDeploymentProperties(emptyDomainFileBuilder.getId(), Optional.empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
+  }
+
+  @Test
   public void undeploysDomainRemovingAnchorFile() throws Exception {
     addPackedDomainFromBuilder(emptyDomainFileBuilder);
 
@@ -1272,6 +1346,34 @@ public class DomainDeploymentTestCase extends AbstractDeploymentTestCase {
     redeployAndVerifyPropertyInRegistry(domainWithPropsFileBuilder.getId(), deploymentProperties,
                                         (registry) -> registry.lookupByName(COMPONENT_NAME_IN_APP)
                                             .get() instanceof TestComponentOnRedeploy);
+  }
+
+  @Test
+  @Issue("MULE-19040")
+  @Description("When a domain is restarted, if its apps were stopped before restart, they should not get started")
+  public void redeployDomainWithStoppedAppsShouldPersistStoppedStateAndDoNotStartApps() throws Exception {
+    addPackedDomainFromBuilder(dummyDomainFileBuilder);
+    File dummyDomainFile = new File(domainsDir, dummyDomainFileBuilder.getZipPath());
+
+    addPackedAppFromBuilder(dummyDomainApp1FileBuilder);
+
+    startDeployment();
+
+    assertDeploymentSuccess(domainDeploymentListener, dummyDomainFileBuilder.getId());
+    final Domain domain = findADomain(dummyDomainFileBuilder.getId());
+    assertThat(domain.getRegistry().lookupByName(ARTIFACT_STOPPED_LISTENER), is(notNullValue()));
+
+    assertApplicationDeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
+
+    final Application app = findApp(dummyDomainApp1FileBuilder.getId(), 1);
+    app.stop();
+
+    redeployId(dummyDomainFileBuilder.getId(), null);
+
+    Properties deploymentProperties = resolveDeploymentProperties(dummyDomainApp1FileBuilder.getId(), Optional.empty());
+    assertStatus(dummyDomainApp1FileBuilder.getId(), CREATED);
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(notNullValue()));
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
   }
 
   @Ignore("MULE-6926: flaky test")


### PR DESCRIPTION
* Created and set listener

* Added deployment property load procedure

* Adapting domain restart

* Changed approach to use Mule Context registry

* Added tests and fix

* Refactoring where to add listener

* Cleaning unused classes

* Reformatting

* Cleaning unused classes

* Reformatting

* Fixes according to PR comments

* Cleaning unused classes

* Reformatted

* Reformatting

* Another reformat

* Removing intellij formatter changes

* Log fix

* Refactor: moved doNotPersist method to DefaultArtifactDeployer

* Fixing PR comments

* Adding comments

* Adding TODO

(cherry picked from commit 887b71b617472914df85164373e93747ece8203d)