### PR TITLE
MULE-19209: StreamPerThreadSink is holding a strong reference to thread

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamEmitterProcessingStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/TransactionAwareProactorStreamEmitterProcessingStrategyTestCase.java
@@ -56,9 +56,6 @@ public class TransactionAwareProactorStreamEmitterProcessingStrategyTestCase
     extends ProactorStreamEmitterProcessingStrategyTestCase
     implements TransactionAwareProcessingStrategyTestCase {
 
-  private static final int PROBER_POLIING_TIMEOUT = 5000;
-  private static final int PROBER_POLLING_INTERVAL = 100;
-
   public TransactionAwareProactorStreamEmitterProcessingStrategyTestCase(Mode mode) {
     super(mode);
   }
@@ -137,18 +134,18 @@ public class TransactionAwareProactorStreamEmitterProcessingStrategyTestCase
     // we cannot do a thread.join because we must not set a strong reference
     Latch latch = new Latch();
 
-    new Thread(() -> {
+    asyncExecutor.submit(() -> {
       try {
-        getInstance()
-            .bindTransaction(new TestTransaction("appName", getNotificationDispatcher(muleContext)));
+        getInstance().bindTransaction(new TestTransaction("appName", getNotificationDispatcher(muleContext)));
         processFlow(testEvent());
         threads.clear();
         latch.release();
       } catch (Exception e) {
       }
-    }).start();
+    });
 
     latch.await();
+    asyncExecutor.stop();
 
     assertThat(captor.reference, is(eventually(collectedByGc())));
   }


### PR DESCRIPTION
This: https://github.com/mulesoft/mule/pull/10079/files#diff-273bc92c5a998250608788f4ff817073f831a6d6c1cfdcc234850a18fcb63a85L47 + this: https://github.com/mulesoft/mule/pull/10079/files#diff-273bc92c5a998250608788f4ff817073f831a6d6c1cfdcc234850a18fcb63a85L77-L78

= this:
![image](https://user-images.githubusercontent.com/7670018/107270014-29a7d380-6a29-11eb-96df-b51d7021dbc9.png)
