### PR TITLE
MULE-19241: Error type from mapping in XML SDK connector is added to the errorType repository

### DIFF
--- a/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
+++ b/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
@@ -100,6 +100,11 @@ public interface AllureConstants {
 
   }
 
+  interface LazyInitializationFeature {
+
+    String LAZY_INITIALIZATION = "Lazy Initialization";
+  }
+
   interface DeploymentConfiguration {
 
     String DEPLOYMENT_CONFIGURATION = "Deployment Configuration";


### PR DESCRIPTION
* Add missing Allure annotations