### PR TITLE
MULE-19220: Request tracking fields should be set in the same thread …

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -37,6 +37,7 @@ import static org.mule.runtime.core.internal.processor.strategy.AbstractProcessi
 import static org.mule.runtime.core.internal.util.rx.ImmediateScheduler.IMMEDIATE_SCHEDULER;
 import static org.mule.runtime.core.internal.util.rx.RxUtils.createRoundRobinFluxSupplier;
 import static org.mule.runtime.core.internal.util.rx.RxUtils.propagateCompletion;
+import static org.mule.runtime.core.privileged.event.PrivilegedEvent.setCurrentEvent;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.WITHIN_PROCESS_TO_APPLY;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.createDefaultProcessingStrategyFactory;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.getProcessingStrategy;
@@ -104,6 +105,7 @@ import org.mule.runtime.core.internal.processor.strategy.OperationInnerProcessor
 import org.mule.runtime.core.internal.rx.FluxSinkRecorder;
 import org.mule.runtime.core.internal.util.rx.FluxSinkSupplier;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
+import org.mule.runtime.core.privileged.event.PrivilegedEvent;
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.core.privileged.exception.EventProcessingException;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationInstance;
@@ -161,6 +163,7 @@ import javax.inject.Inject;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 
+import org.slf4j.MDC;
 import reactor.core.publisher.Flux;
 import reactor.util.context.Context;
 
@@ -195,6 +198,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
   static final String INVALID_TARGET_MESSAGE =
       "Root component '%s' defines an invalid usage of operation '%s' which uses %s as %s";
+  public static final String PROCESSOR_PATH_MDC_KEY = "processorPath";
 
   private final ReflectionCache reflectionCache;
   private final ResultTransformer resultTransformer;
@@ -254,6 +258,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
    */
   private ReturnDelegate valueReturnDelegate;
   protected PolicyManager policyManager;
+  private String processorPath = null;
 
   public ComponentMessageProcessor(ExtensionModel extensionModel,
                                    T componentModel,
@@ -599,6 +604,12 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
       resolvedProcessorRepresentation = getRepresentation();
 
       initProcessingStrategy();
+
+      ComponentLocation componentLocation = getLocation();
+      if (componentLocation != null) {
+        processorPath = componentLocation.getLocation();
+      }
+
       initialised = true;
     }
   }
@@ -775,8 +786,33 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
     ExecutionContextAdapter<T> operationContext = oep.getExecutionContextAdapter();
 
-    executeOperation(operationContext, mapped(callbackSupplier.get(), operationContext,
-                                              isTargetWithPolicies(event) ? valueReturnDelegate : returnDelegate));
+    setCurrentEvent((PrivilegedEvent) event);
+    boolean wasProcessorPathSet = setCurrentLocation();
+    try {
+      executeOperation(operationContext, mapped(callbackSupplier.get(), operationContext,
+                                                isTargetWithPolicies(event) ? valueReturnDelegate : returnDelegate));
+    } finally {
+      unsetCurrentLocation(wasProcessorPathSet);
+    }
+  }
+
+  private boolean setCurrentLocation() {
+    if (MDC.get(PROCESSOR_PATH_MDC_KEY) != null) {
+      return false;
+    }
+
+    if (processorPath == null) {
+      return false;
+    }
+
+    MDC.put(PROCESSOR_PATH_MDC_KEY, processorPath);
+    return true;
+  }
+
+  private void unsetCurrentLocation(boolean wasProcessorPathSet) {
+    if (wasProcessorPathSet) {
+      MDC.remove(PROCESSOR_PATH_MDC_KEY);
+    }
   }
 
   private void initRetryPolicyResolver() {


### PR DESCRIPTION
…as the operation execution (#10240)

(cherry picked from commit 110b7c402a1f211bbe3ba290e75234b5ee5d270d)