### PR TITLE
MULE-19355: Munit Runtime Validations (#10287)

### DIFF
--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/ArtifactClassLoaderModelBuilder.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/maven/ArtifactClassLoaderModelBuilder.java
@@ -142,14 +142,14 @@ public abstract class ArtifactClassLoaderModelBuilder extends ClassLoaderModel.C
     }
 
     // Sort them so the processing is consistent with how Maven calculates the plugin configuration for the effective pom.
-    final List<String> activeProfiles = getMavenConfig().getActiveProfiles().orElse(emptyList())
+    final List<String> activeProfiles = getActiveProfiles()
         .stream()
         .sorted((o1, o2) -> o1.compareTo(o2))
         .collect(toList());
 
     final Stream<Plugin> packagerConfigsForActivePluginsStream = model.getProfiles().stream()
         .filter(profile -> activeProfiles.contains(profile.getId()))
-        .map(profile -> findArtifactPackagerPlugin(profile.getBuild().getPlugins()))
+        .map(profile -> findArtifactPackagerPlugin(profile.getBuild() != null ? profile.getBuild().getPlugins() : null))
         .filter(plugin -> !plugin.equals(empty()))
         .map(Optional::get);
 
@@ -160,6 +160,11 @@ public abstract class ArtifactClassLoaderModelBuilder extends ClassLoaderModel.C
 
           return p1;
         });
+  }
+
+  // For testability pourposes
+  protected List<String> getActiveProfiles() {
+    return getMavenConfig().getActiveProfiles().orElse(emptyList());
   }
 
   private Optional<Plugin> findArtifactPackagerPlugin(List<Plugin> plugins) {

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/maven/ArtifactClassLoaderModelBuilderTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/maven/ArtifactClassLoaderModelBuilderTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.deployment.impl.internal.maven;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.qameta.allure.Issue;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.junit.Test;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDependency;
+import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
+
+public class ArtifactClassLoaderModelBuilderTestCase {
+
+  private List<Profile> profiles;
+
+  @Test
+  @Issue("MULE-19355")
+  public void testFindArtifactPackagerPluginDoesNotThrowException_IfProfileBuildIsNull() {
+    // Given
+    Model model = mock(Model.class);
+    Profile profile = mock(Profile.class);
+    String profileId = "profileId";
+    when(profile.getId()).thenReturn(profileId);
+    profiles = singletonList(profile);
+    when(model.getProfiles()).thenReturn(profiles);
+
+    File artifactFolder = mock(File.class);
+    BundleDescriptor artifactBundleDescriptor = new BundleDescriptor.Builder()
+        .setGroupId("some.group.id")
+        .setArtifactId("some-artifact-id")
+        .setVersion("1.2.3")
+        .build();
+
+    ArtifactClassLoaderModelBuilder artifactClassLoaderModelBuilder =
+        new ArtifactClassLoaderModelBuilder(artifactFolder, artifactBundleDescriptor) {
+
+          @Override
+          protected List<URI> processPluginAdditionalDependenciesURIs(BundleDependency bundleDependency) {
+            return null;
+          }
+
+          @Override
+          protected List<String> getActiveProfiles() {
+            return singletonList(profileId);
+          }
+        };
+
+    // When
+    artifactClassLoaderModelBuilder.findArtifactPackagerPlugin(model);
+
+    // Then
+    // No NPE is thrown
+
+  }
+
+}


### PR DESCRIPTION
When propagating maven profiles configurations to embedded runtimes, if the build section of the profile does not exists it will no longer throw an NPE.

(cherry picked from commit 9df7208b2662c8b7c489dd5ecf8362812e241bde)