### PR TITLE
Extract variables to see which one is null during shutdown.

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/config/DefaultComponentInitialStateManager.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/config/DefaultComponentInitialStateManager.java
@@ -9,7 +9,10 @@ package org.mule.runtime.config.internal.dsl.model.config;
 import static org.mule.runtime.api.source.SchedulerMessageSource.SCHEDULER_MESSAGE_SOURCE_IDENTIFIER;
 
 import org.mule.runtime.api.component.Component;
+import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.ConfigurationProperties;
+import org.mule.runtime.api.component.TypedComponentIdentifier;
+import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.deployment.management.ComponentInitialStateManager;
 import org.mule.runtime.api.util.MuleSystemProperties;
 
@@ -26,7 +29,10 @@ public class DefaultComponentInitialStateManager implements ComponentInitialStat
   @Override
   public boolean mustStartMessageSource(Component component) {
     if (configurationProperties.resolveProperty(MuleSystemProperties.DISABLE_SCHEDULER_SOURCES_PROPERTY).isPresent()) {
-      if (component.getLocation().getComponentIdentifier().getIdentifier().equals(SCHEDULER_MESSAGE_SOURCE_IDENTIFIER)) {
+      ComponentLocation tempLocation = component.getLocation();
+      TypedComponentIdentifier tempComponentIdentifier = tempLocation.getComponentIdentifier();
+      ComponentIdentifier tempIdentifier = tempComponentIdentifier.getIdentifier();
+      if (tempIdentifier.equals(SCHEDULER_MESSAGE_SOURCE_IDENTIFIER)) {
         return !configurationProperties.resolveBooleanProperty(MuleSystemProperties.DISABLE_SCHEDULER_SOURCES_PROPERTY)
             .orElse(false);
       }


### PR DESCRIPTION
During shutdown of our mule applications (cloud - so not able to perform breakpoints) 
we are facing NullPointerExceptions in line 29 (see full stacktrace below)

To get a better indication which of 
`component.getLocation().getComponentIdentifier().getIdentifier().`
is null I extracted the code to local variables.

(currently no change made, just NullPointerException will show line which field is null)

```08:17:19.921     05/05/2021     Worker-0     qtp437659588-36     INFO
Stopping flow: post:\validate:application\json:api-config
08:17:19.921     05/05/2021     Worker-0     qtp437659588-36     WARN
Stopping pipeline 'post:\validate:application\json:api-config' due to error on starting, but another exception was also found while shutting down: null
java.lang.NullPointerException
	at org.mule.runtime.config.internal.dsl.model.config.DefaultComponentInitialStateManager.mustStartMessageSource(DefaultComponentInitialStateManager.java:29)
	at org.mule.runtime.core.internal.construct.AbstractPipeline.lambda$doStop$26(AbstractPipeline.java:553)
	at org.mule.runtime.core.api.util.func.CheckedRunnable.run(CheckedRunnable.java:22)
	at org.mule.runtime.core.internal.construct.AbstractPipeline.stopSafely(AbstractPipeline.java:526)
	at org.mule.runtime.core.internal.construct.AbstractPipeline.doStop(AbstractPipeline.java:552)
	at org.mule.runtime.core.internal.construct.AbstractFlowConstruct.lambda$stop$4(AbstractFlowConstruct.java:136)
	at org.mule.runtime.core.privileged.lifecycle.AbstractLifecycleManager.invokePhase(AbstractLifecycleManager.java:132)
	at org.mule.runtime.core.internal.construct.FlowConstructLifecycleManager.fireStopPhase(FlowConstructLifecycleManager.java:76)
	at org.mule.runtime.core.internal.construct.AbstractFlowConstruct.stop(AbstractFlowConstruct.java:135)
	at org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded(LifecycleUtils.java:222)
	at org.mule.runtime.core.api.util.func.CheckedConsumer.accept(CheckedConsumer.java:19)
	at org.mule.runtime.core.internal.lifecycle.phases.DefaultLifecyclePhase.applyLifecycle(DefaultLifecyclePhase.java:115)
	at org.mule.runtime.core.internal.lifecycle.RegistryLifecycleCallback.applyLifecycle(RegistryLifecycleCallback.java:93)
	at org.mule.runtime.core.internal.lifecycle.RegistryLifecycleCallback.doApplyLifecycle(RegistryLifecycleCallback.java:86)
	at org.mule.runtime.core.internal.lifecycle.RegistryLifecycleCallback.doOnTransition(RegistryLifecycleCallback.java:71)
	at org.mule.runtime.core.internal.lifecycle.RegistryLifecycleCallback.lambda$onTransition$0(RegistryLifecycleCallback.java:54)
	at org.mule.runtime.core.api.util.func.CheckedRunnable.run(CheckedRunnable.java:22)
	at org.mule.runtime.core.internal.context.DefaultMuleContext.withLifecycleLock(DefaultMuleContext.java:532)
	at org.mule.runtime.core.internal.lifecycle.RegistryLifecycleCallback.onTransition(RegistryLifecycleCallback.java:54)
	at org.mule.runtime.core.privileged.lifecycle.AbstractLifecycleManager.invokePhase(AbstractLifecycleManager.java:132)
	at org.mule.runtime.core.internal.lifecycle.RegistryLifecycleManager.fireLifecycle(RegistryLifecycleManager.java:104)
	at org.mule.runtime.core.internal.registry.AbstractRegistry.fireLifecycle(AbstractRegistry.java:131)
	at org.mule.runtime.core.internal.registry.MuleRegistryHelper.fireLifecycle(MuleRegistryHelper.java:115)
	at org.mule.runtime.core.internal.lifecycle.MuleContextLifecycleManager$MuleContextLifecycleCallback.onTransition(MuleContextLifecycleManager.java:73)
	at org.mule.runtime.core.internal.lifecycle.MuleContextLifecycleManager$MuleContextLifecycleCallback.onTransition(MuleContextLifecycleManager.java:69)
	at org.mule.runtime.core.privileged.lifecycle.AbstractLifecycleManager.invokePhase(AbstractLifecycleManager.java:132)
	at org.mule.runtime.core.internal.lifecycle.MuleContextLifecycleManager.fireLifecycle(MuleContextLifecycleManager.java:61)
	at org.mule.runtime.core.internal.context.DefaultMuleContext.stop(DefaultMuleContext.java:410)
	at org.mule.runtime.module.deployment.impl.internal.artifact.AbstractDeployableArtifact.lambda$stop$1(AbstractDeployableArtifact.java:81)
	at org.mule.runtime.core.api.util.ExceptionUtils.tryExpecting(ExceptionUtils.java:224)
	at org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader(ClassUtils.java:966)
	at org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader(ClassUtils.java:884)
	at org.mule.runtime.module.deployment.impl.internal.artifact.AbstractDeployableArtifact.stop(AbstractDeployableArtifact.java:80)
	at org.mule.runtime.core.api.util.ExceptionUtils.tryExpecting(ExceptionUtils.java:265)
	at org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader(ClassUtils.java:923)
	at org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader(ClassUtils.java:861)
	at org.mule.runtime.module.deployment.impl.internal.artifact.DeployableArtifactWrapper.executeWithinArtifactClassLoader(DeployableArtifactWrapper.java:140)
	at org.mule.runtime.module.deployment.impl.internal.artifact.DeployableArtifactWrapper.stop(DeployableArtifactWrapper.java:133)
	at org.mule.runtime.module.deployment.internal.DefaultArtifactDeployer.tryToStopArtifact(DefaultArtifactDeployer.java:144)
	at org.mule.runtime.module.deployment.internal.DefaultArtifactDeployer.undeploy(DefaultArtifactDeployer.java:119)
	at org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.undeploy(DefaultArchiveDeployer.java:300)
	at org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.undeployArtifact(DefaultArchiveDeployer.java:125)
	at org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.undeployArtifact(DefaultArchiveDeployer.java:110)
	at org.mule.runtime.module.deployment.internal.MuleDeploymentService.lambda$undeploy$1(MuleDeploymentService.java:214)
	at org.mule.runtime.module.deployment.internal.MuleDeploymentService.executeSynchronized(MuleDeploymentService.java:372)
	at org.mule.runtime.module.deployment.internal.MuleDeploymentService.undeploy(MuleDeploymentService.java:214)
	at com.mulesoft.agent.services.application.AgentApplicationService.undeploy(AgentApplicationService.java:368)
	at com.mulesoft.agent.external.handlers.deployment.ApplicationsRequestHandler.undeploy(ApplicationsRequestHandler.java:265)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:151)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:171)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:152)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:104)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:387)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:331)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:103)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:271)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:297)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:254)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:1028)
	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:372)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:381)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:344)
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:221)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:876)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1623)
	at com.mulesoft.agent.rest.RequestLoggingFilter.doFilter(RequestLoggingFilter.java:95)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
	at com.mulesoft.agent.rest.AuthorizationFilter.doFilter(AuthorizationFilter.java:49)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:540)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:146)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:548)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:257)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1711)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1347)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:480)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1678)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1249)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:505)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:370)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:427)
	at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:321)
	at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:159)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:781)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:917)
	at java.lang.Thread.run(Thread.java:748)
```