### PR TITLE
MULE-19435 Wrap exception with MuleRuntimeException.

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBean.java
@@ -512,7 +512,7 @@ public class FlowRefFactoryBean extends AbstractComponentFactory<Processor> impl
         try {
           resolvedTarget = resolveTargetFlowOrSubflow(event);
         } catch (MuleException e) {
-          return error(e);
+          throw new MuleRuntimeException(e);
         }
 
         Optional<Flow> targetAsFlow = resolvedTarget instanceof Flow ? of((Flow) resolvedTarget) : empty();

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/factories/FlowRefFactoryBeanTestCase.java
@@ -82,7 +82,6 @@ import org.mule.runtime.core.api.util.ClassUtils;
 import org.mule.runtime.core.internal.processor.chain.SubflowMessageProcessorChainBuilder;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.runtime.core.privileged.processor.chain.MessageProcessorChain;
-import org.mule.runtime.core.privileged.routing.RoutePathNotFoundException;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -344,8 +343,9 @@ public class FlowRefFactoryBeanTestCase extends AbstractMuleTestCase {
                                                                                  eq(NULL_BINDING_CONTEXT), any(CoreEvent.class),
                                                                                  any(ComponentLocation.class), eq(true));
 
-    expectedException.expect(instanceOf(RoutePathNotFoundException.class));
-    getFlowRefProcessor(createFlowRefFactoryBean(DYNAMIC_NON_EXISTANT, "flow", applicationContext)).process(testEvent());
+    expectedException.expect(instanceOf(MuleRuntimeException.class));
+    getFlowRefProcessor(createFlowRefFactoryBean(DYNAMIC_NON_EXISTANT, "flow", applicationContext))
+        .process(testEvent());
   }
 
   @Test()


### PR DESCRIPTION
When a dynamic flow does not exist, throw a MuleRuntimeException instead of calling Flux.error so flux does not get blocked.