### PR TITLE
MULE-19263: validate CompletionCallback's generic types

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/TypeWrapper.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/TypeWrapper.java
@@ -59,14 +59,15 @@ public class TypeWrapper implements Type {
   private LazyValue<Boolean> instantiable;
 
   public TypeWrapper(Class<?> aClass, ClassTypeLoader typeLoader) {
-    this.aClass = aClass;
+    this.aClass = aClass != null ? aClass : Object.class;
     instantiable = new LazyValue<>(() -> IntrospectionUtils.isInstantiable(aClass, new ReflectionCache()));
     this.type = aClass;
     this.typeLoader = typeLoader;
   }
 
   public TypeWrapper(ResolvableType resolvableType, ClassTypeLoader typeLoader) {
-    this.aClass = resolvableType.resolve();
+    Class<?> resolvedTypeClass = resolvableType.resolve();
+    this.aClass = resolvedTypeClass != null ? resolvedTypeClass : Object.class;
     instantiable = new LazyValue<>(() -> IntrospectionUtils.isInstantiable(aClass, new ReflectionCache()));
     this.type = resolvableType.getType();
     this.generics = new ArrayList<>();
@@ -160,7 +161,7 @@ public class TypeWrapper implements Type {
 
   @Override
   public boolean isAssignableFrom(Class<?> clazz) {
-    return aClass != null && aClass.isAssignableFrom(clazz);
+    return aClass.isAssignableFrom(clazz);
   }
 
   @Override
@@ -174,7 +175,7 @@ public class TypeWrapper implements Type {
 
   @Override
   public boolean isAssignableTo(Class<?> clazz) {
-    return aClass != null && clazz.isAssignableFrom(aClass);
+    return clazz.isAssignableFrom(aClass);
   }
 
   @Override
@@ -193,7 +194,7 @@ public class TypeWrapper implements Type {
 
   @Override
   public boolean isSameType(Class<?> clazz) {
-    return aClass != null && aClass.equals(clazz);
+    return aClass.equals(clazz);
   }
 
   @Override

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/TypeWrapper.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/TypeWrapper.java
@@ -193,7 +193,7 @@ public class TypeWrapper implements Type {
 
   @Override
   public boolean isSameType(Class<?> clazz) {
-    return aClass.equals(clazz);
+    return aClass != null && aClass.equals(clazz);
   }
 
   @Override

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidator.java
@@ -10,7 +10,7 @@ import static java.lang.String.format;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.isCompileTime;
 
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.api.meta.model.ComponentModel;
+import org.mule.runtime.api.meta.NamedObject;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.operation.OperationModel;
 import org.mule.runtime.api.meta.model.util.IdempotentExtensionWalker;
@@ -92,20 +92,16 @@ public class OperationReturnTypeModelValidator implements ExtensionModelValidato
   private void validateNonBlockingCallback(MethodElement<? extends Type> operationMethod, ProblemsReporter problemsReporter,
                                            OperationModel operationModel, ExtensionModel extensionModel) {
     operationMethod.getParameters().stream()
-        .filter(p -> p.getType().isSameType(CompletionCallback.class))
-        .findFirst().ifPresent(p -> {
-          List<TypeGeneric> generics = p.getType().getGenerics();
+        .filter(extensionParameter -> extensionParameter.getType().isSameType(CompletionCallback.class))
+        .findFirst().ifPresent(extensionParameter -> {
+          List<TypeGeneric> generics = extensionParameter.getType().getGenerics();
           if (generics.isEmpty()) {
-            problemsReporter.addError(new Problem(p, format(MISSING_GENERICS_ERROR_MESSAGE, operationModel.getName(),
-                                                            extensionModel.getName(), CompletionCallback.class.getName())));
+            problemsReporter
+                .addError(new Problem(extensionParameter, format(MISSING_GENERICS_ERROR_MESSAGE, operationModel.getName(),
+                                                                 extensionModel.getName(), CompletionCallback.class.getName())));
           } else {
-            if (isCompileTime(extensionModel)) {
-              if (generics.get(0).getConcreteType().isSameType(Void.class) &&
-                  !generics.get(1).getConcreteType().isSameType(Void.class)) {
-                problemsReporter.addError(new Problem(p, format(INVALID_GENERICS_ERROR_MESSAGE, operationModel.getName(),
-                                                                extensionModel.getName(), CompletionCallback.class.getName())));
-              }
-            }
+            validateGenerics(extensionModel, extensionParameter, operationModel, generics, CompletionCallback.class,
+                             problemsReporter);
           }
         });
   }
@@ -118,14 +114,7 @@ public class OperationReturnTypeModelValidator implements ExtensionModelValidato
         problemsReporter.addError(new Problem(operationModel, format(MISSING_GENERICS_ERROR_MESSAGE, operationModel.getName(),
                                                                      extensionModel.getName(), Result.class)));
       } else {
-        if (isCompileTime(extensionModel)) {
-          if (generics.get(0).getConcreteType().isSameType(Void.class) &&
-              !generics.get(1).getConcreteType().isSameType(Void.class)) {
-            problemsReporter.addError(new Problem(operationModel, format(INVALID_GENERICS_ERROR_MESSAGE, operationModel.getName(),
-                                                                         extensionModel.getName(),
-                                                                         Result.class.getName())));
-          }
-        }
+        validateGenerics(extensionModel, operationModel, operationModel, generics, Result.class, problemsReporter);
       }
     }
   }
@@ -142,15 +131,7 @@ public class OperationReturnTypeModelValidator implements ExtensionModelValidato
             problemsReporter.addError(new Problem(operationModel, format(MISSING_GENERICS_ERROR_MESSAGE, operationModel.getName(),
                                                                          extensionModel.getName(), Result.class)));
           }
-          if (isCompileTime(extensionModel)) {
-            if (concreteTypeGenerics.get(0).getConcreteType().isSameType(Void.class) &&
-                !concreteTypeGenerics.get(1).getConcreteType().isSameType(Void.class)) {
-              problemsReporter.addError(new Problem(operationModel,
-                                                    format(INVALID_GENERICS_ERROR_MESSAGE, operationModel.getName(),
-                                                           extensionModel.getName(),
-                                                           Result.class.getName())));
-            }
-          }
+          validateGenerics(extensionModel, operationModel, operationModel, concreteTypeGenerics, Result.class, problemsReporter);
         }
       }
     }
@@ -161,4 +142,14 @@ public class OperationReturnTypeModelValidator implements ExtensionModelValidato
                                                               operationModel.getName(), model.getName()));
   }
 
+  private void validateGenerics(ExtensionModel extensionModel, NamedObject namedObject, OperationModel operationModel,
+                                List<TypeGeneric> generics, Class returnType, ProblemsReporter problemsReporter) {
+    if (isCompileTime(extensionModel)) {
+      if (generics.get(0).getConcreteType().isSameType(Void.class) &&
+          !generics.get(1).getConcreteType().isSameType(Void.class)) {
+        problemsReporter.addError(new Problem(namedObject, format(INVALID_GENERICS_ERROR_MESSAGE, operationModel.getName(),
+                                                                  extensionModel.getName(), returnType.getName())));
+      }
+    }
+  }
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidator.java
@@ -130,8 +130,10 @@ public class OperationReturnTypeModelValidator implements ExtensionModelValidato
           if (concreteTypeGenerics.isEmpty()) {
             problemsReporter.addError(new Problem(operationModel, format(MISSING_GENERICS_ERROR_MESSAGE, operationModel.getName(),
                                                                          extensionModel.getName(), Result.class)));
+          } else {
+            validateGenerics(extensionModel, operationModel, operationModel, concreteTypeGenerics, Result.class,
+                             problemsReporter);
           }
-          validateGenerics(extensionModel, operationModel, operationModel, concreteTypeGenerics, Result.class, problemsReporter);
         }
       }
     }
@@ -144,12 +146,10 @@ public class OperationReturnTypeModelValidator implements ExtensionModelValidato
 
   private void validateGenerics(ExtensionModel extensionModel, NamedObject namedObject, OperationModel operationModel,
                                 List<TypeGeneric> generics, Class returnType, ProblemsReporter problemsReporter) {
-    if (isCompileTime(extensionModel)) {
-      if (generics.get(0).getConcreteType().isSameType(Void.class) &&
-          !generics.get(1).getConcreteType().isSameType(Void.class)) {
-        problemsReporter.addError(new Problem(namedObject, format(INVALID_GENERICS_ERROR_MESSAGE, operationModel.getName(),
+    if (generics.get(0).getConcreteType().isSameType(Void.class) &&
+        !generics.get(1).getConcreteType().isSameType(Void.class)) {
+      problemsReporter.addWarning(new Problem(namedObject, format(INVALID_GENERICS_ERROR_MESSAGE, operationModel.getName(),
                                                                   extensionModel.getName(), returnType.getName())));
-      }
     }
   }
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidatorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidatorTestCase.java
@@ -112,7 +112,7 @@ public class OperationReturnTypeModelValidatorTestCase extends AbstractMuleTestC
   }
 
   @Test(expected = IllegalModelDefinitionException.class)
-  public void completionCallbackWithInvalidGenerics() {
+  public void completionCallbackWithInvalidGenericsCompileTime() {
     setCompileTime(true);
     when(operationElement.getReturnType()).thenReturn(new TypeWrapper(forType(new TypeToken<Void>() {}.getType()), typeLoader));
     ExtensionParameter completionCallbackParam = mock(ExtensionParameter.class);
@@ -123,7 +123,7 @@ public class OperationReturnTypeModelValidatorTestCase extends AbstractMuleTestC
   }
 
   @Test(expected = IllegalModelDefinitionException.class)
-  public void resultWithInvalidGenerics() {
+  public void resultWithInvalidGenericsCompileTime() {
     setCompileTime(true);
     when(operationElement.getReturnType())
         .thenReturn(new TypeWrapper(forType(new TypeToken<Result<Void, String>>() {}.getType()), typeLoader));
@@ -131,6 +131,32 @@ public class OperationReturnTypeModelValidatorTestCase extends AbstractMuleTestC
   }
 
   @Test(expected = IllegalModelDefinitionException.class)
+  public void resultCollectionWithInvalidGenericsCompileTime() {
+    setCompileTime(true);
+    when(operationElement.getReturnType())
+        .thenReturn(new TypeWrapper(forType(new TypeToken<List<Result<Void, String>>>() {}.getType()), typeLoader));
+    validate(extensionModel, validator);
+  }
+
+  @Test
+  public void completionCallbackWithInvalidGenerics() {
+    when(operationElement.getReturnType()).thenReturn(new TypeWrapper(forType(new TypeToken<Void>() {}.getType()), typeLoader));
+    ExtensionParameter completionCallbackParam = mock(ExtensionParameter.class);
+    when(completionCallbackParam.getType())
+        .thenReturn(new TypeWrapper(forType(new TypeToken<CompletionCallback<Void, String>>() {}.getType()), typeLoader));
+    when(operationElement.getParameters()).thenReturn(singletonList(completionCallbackParam));
+    validate(extensionModel, validator);
+  }
+
+  @Test
+  public void resultWithInvalidGenerics() {
+    setCompileTime(true);
+    when(operationElement.getReturnType())
+        .thenReturn(new TypeWrapper(forType(new TypeToken<Result<Void, String>>() {}.getType()), typeLoader));
+    validate(extensionModel, validator);
+  }
+
+  @Test
   public void resultCollectionWithInvalidGenerics() {
     setCompileTime(true);
     when(operationElement.getReturnType())

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidatorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidatorTestCase.java
@@ -9,6 +9,7 @@ package org.mule.runtime.module.extension.internal.loader.validation;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,7 @@ import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
 import org.mule.runtime.module.extension.api.loader.java.type.ExtensionParameter;
 import org.mule.runtime.module.extension.api.loader.java.type.OperationElement;
+import org.mule.runtime.module.extension.internal.loader.java.property.CompileTimeModelProperty;
 import org.mule.runtime.module.extension.internal.loader.java.type.property.ExtensionOperationDescriptorModelProperty;
 import org.mule.runtime.module.extension.internal.loader.java.type.runtime.TypeWrapper;
 import org.mule.tck.junit4.AbstractMuleTestCase;
@@ -111,11 +113,28 @@ public class OperationReturnTypeModelValidatorTestCase extends AbstractMuleTestC
 
   @Test(expected = IllegalModelDefinitionException.class)
   public void completionCallbackWithInvalidGenerics() {
+    setCompileTime(true);
     when(operationElement.getReturnType()).thenReturn(new TypeWrapper(forType(new TypeToken<Void>() {}.getType()), typeLoader));
     ExtensionParameter completionCallbackParam = mock(ExtensionParameter.class);
     when(completionCallbackParam.getType())
         .thenReturn(new TypeWrapper(forType(new TypeToken<CompletionCallback<Void, String>>() {}.getType()), typeLoader));
     when(operationElement.getParameters()).thenReturn(singletonList(completionCallbackParam));
+    validate(extensionModel, validator);
+  }
+
+  @Test(expected = IllegalModelDefinitionException.class)
+  public void resultWithInvalidGenerics() {
+    setCompileTime(true);
+    when(operationElement.getReturnType())
+        .thenReturn(new TypeWrapper(forType(new TypeToken<Result<Void, String>>() {}.getType()), typeLoader));
+    validate(extensionModel, validator);
+  }
+
+  @Test(expected = IllegalModelDefinitionException.class)
+  public void resultCollectionWithInvalidGenerics() {
+    setCompileTime(true);
+    when(operationElement.getReturnType())
+        .thenReturn(new TypeWrapper(forType(new TypeToken<List<Result<Void, String>>>() {}.getType()), typeLoader));
     validate(extensionModel, validator);
   }
 
@@ -131,5 +150,10 @@ public class OperationReturnTypeModelValidatorTestCase extends AbstractMuleTestC
     when(operationElement.getReturnType())
         .thenReturn(new TypeWrapper(forType(new TypeToken<Message>() {}.getType()), typeLoader));
     validate(extensionModel, validator);
+  }
+
+  private void setCompileTime(boolean compileTime) {
+    when(extensionModel.getModelProperty(CompileTimeModelProperty.class))
+        .thenReturn(ofNullable(compileTime ? new CompileTimeModelProperty() : null));
   }
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidatorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/OperationReturnTypeModelValidatorTestCase.java
@@ -100,11 +100,21 @@ public class OperationReturnTypeModelValidatorTestCase extends AbstractMuleTestC
   }
 
   @Test(expected = IllegalModelDefinitionException.class)
-  public void completitionCallbackWithoutGenerics() {
+  public void completionCallbackWithoutGenerics() {
     when(operationElement.getReturnType()).thenReturn(new TypeWrapper(forType(new TypeToken<Void>() {}.getType()), typeLoader));
     ExtensionParameter completionCallbackParam = mock(ExtensionParameter.class);
     when(completionCallbackParam.getType())
         .thenReturn(new TypeWrapper(forType(new TypeToken<CompletionCallback>() {}.getType()), typeLoader));
+    when(operationElement.getParameters()).thenReturn(singletonList(completionCallbackParam));
+    validate(extensionModel, validator);
+  }
+
+  @Test(expected = IllegalModelDefinitionException.class)
+  public void completionCallbackWithInvalidGenerics() {
+    when(operationElement.getReturnType()).thenReturn(new TypeWrapper(forType(new TypeToken<Void>() {}.getType()), typeLoader));
+    ExtensionParameter completionCallbackParam = mock(ExtensionParameter.class);
+    when(completionCallbackParam.getType())
+        .thenReturn(new TypeWrapper(forType(new TypeToken<CompletionCallback<Void, String>>() {}.getType()), typeLoader));
     when(operationElement.getParameters()).thenReturn(singletonList(completionCallbackParam));
     validate(extensionModel, validator);
   }


### PR DESCRIPTION
This commit modify the validation at compile time of operation's return type  to
forbide the existence of CompletionCallback with Void type for output and non Void type
for output attributes.