### PR TITLE
MULE-17309: Fixing description for Until Successful construct.

### DIFF
--- a/modules/extensions-support/src/test/resources/mule-extension-model.json
+++ b/modules/extensions-support/src/test/resources/mule-extension-model.json
@@ -2704,7 +2704,7 @@
         }
       ],
       "name": "untilSuccessful",
-      "description": "Attempts to route a message to the message processor it contains in a synchronous manner. Routing is considered successful if no exception has been raised and, optionally, if the response matches an expression",
+      "description": "Attempts to route a message to its inner chain in a synchronous manner. Routing is considered successful if no exception has been raised and, optionally, if the response matches an expression",
       "modelProperties": {},
       "kind": "construct"
     }

--- a/modules/extensions-support/src/test/resources/mule-extension-model.json
+++ b/modules/extensions-support/src/test/resources/mule-extension-model.json
@@ -2704,7 +2704,7 @@
         }
       ],
       "name": "untilSuccessful",
-      "description": "Attempts to route a message to the message processor it contains in an asynchronous manner. Routing is considered successful if no exception has been raised and, optionally, if the response matches an expression",
+      "description": "Attempts to route a message to the message processor it contains in a synchronous manner. Routing is considered successful if no exception has been raised and, optionally, if the response matches an expression",
       "modelProperties": {},
       "kind": "construct"
     }

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarer.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarer.java
@@ -559,7 +559,7 @@ class MuleExtensionModelDeclarer {
 
   private void declareUntilSuccessful(ExtensionDeclarer extensionDeclarer, ClassTypeLoader typeLoader) {
     ConstructDeclarer untilSuccessful = extensionDeclarer.withConstruct("untilSuccessful")
-        .describedAs("Attempts to route a message to the message processor it contains in a synchronous manner. " +
+        .describedAs("Attempts to route a message to its inner chain in a synchronous manner. " +
             "Routing is considered successful if no error has been raised and, optionally, if the response matches an expression.");
 
     untilSuccessful.withChain();

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarer.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarer.java
@@ -559,7 +559,7 @@ class MuleExtensionModelDeclarer {
 
   private void declareUntilSuccessful(ExtensionDeclarer extensionDeclarer, ClassTypeLoader typeLoader) {
     ConstructDeclarer untilSuccessful = extensionDeclarer.withConstruct("untilSuccessful")
-        .describedAs("Attempts to route a message to the message processor it contains in an asynchronous manner. " +
+        .describedAs("Attempts to route a message to the message processor it contains in a synchronous manner. " +
             "Routing is considered successful if no error has been raised and, optionally, if the response matches an expression.");
 
     untilSuccessful.withChain();

--- a/runtime-extension-model/src/main/resources/META-INF/mule-core-common.xsd
+++ b/runtime-extension-model/src/main/resources/META-INF/mule-core-common.xsd
@@ -2533,7 +2533,7 @@
     <xsd:element name="until-successful" substitutionGroup="abstract-routing-message-processor">
         <xsd:annotation>
             <xsd:documentation>
-                Attempts to route a message to the message processor it contains in a synchronous manner.
+                Attempts to route a message to its inner chain in a synchronous manner.
                 Routing is considered successful if no error has been raised and, optionally, if the response matches an expression
             </xsd:documentation>
         </xsd:annotation>

--- a/runtime-extension-model/src/main/resources/META-INF/mule-core-common.xsd
+++ b/runtime-extension-model/src/main/resources/META-INF/mule-core-common.xsd
@@ -2533,7 +2533,7 @@
     <xsd:element name="until-successful" substitutionGroup="abstract-routing-message-processor">
         <xsd:annotation>
             <xsd:documentation>
-                Attempts to route a message to the message processor it contains in an asynchronous manner.
+                Attempts to route a message to the message processor it contains in a synchronous manner.
                 Routing is considered successful if no error has been raised and, optionally, if the response matches an expression
             </xsd:documentation>
         </xsd:annotation>


### PR DESCRIPTION
Where it previously said "asynchronous" now it says "synchronous".

As can be seen in the commits, the same string appeared in different places. One of them seems to be a candidate for removal. I'm proposing this change in [MULE-19462](https://www.mulesoft.org/jira/browse/MULE-19462).