### PR TITLE
MULE-19512: Avoiding ErrorCallbackNotImplemented on AbstractSinkRouter

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
@@ -25,6 +25,7 @@ import static org.mule.tck.processor.ContextPropagationChecker.assertContextProp
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import org.mule.runtime.api.el.ExpressionExecutionException;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -130,8 +131,9 @@ public class ChoiceRouterTestCase extends AbstractReactiveProcessorTestCase {
     choiceRouter.addRoute("wat", mp);
     initialise();
 
-    thrown.expectCause(instanceOf(ExpressionRuntimeException.class));
-    thrown.expectCause(hasMessage(containsString("evaluating expression: \"wat\"")));
+    thrown.expect(instanceOf(ExpressionRuntimeException.class));
+    thrown.expect(hasMessage(containsString("evaluating expression: \"wat\"")));
+    thrown.expectCause(instanceOf(ExpressionExecutionException.class));
     process(choiceRouter, zapEvent());
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/ChoiceRouterTestCase.java
@@ -25,6 +25,7 @@ import static org.mule.tck.processor.ContextPropagationChecker.assertContextProp
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import io.qameta.allure.Issue;
 import org.mule.runtime.api.el.ExpressionExecutionException;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
@@ -126,6 +127,7 @@ public class ChoiceRouterTestCase extends AbstractReactiveProcessorTestCase {
   }
 
   @Test
+  @Issue("MULE-19512")
   public void failingExpression() throws Exception {
     MessageProcessorChain mp = newChain(empty(), new TestMessageProcessor("bar"));
     choiceRouter.addRoute("wat", mp);

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/AbstractSinkRouter.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/AbstractSinkRouter.java
@@ -42,7 +42,7 @@ abstract class AbstractSinkRouter {
         .doOnComplete(() -> {
           this.routes.stream().forEach(ExecutableRoute::complete);
           phantomRoute.complete();
-        });
+        }).doOnError(this.phantomRoute::error);
   }
 
   /**

--- a/core/src/main/java/org/mule/runtime/core/internal/routing/ExecutableRoute.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/routing/ExecutableRoute.java
@@ -51,6 +51,15 @@ class ExecutableRoute {
   }
 
   /**
+   * Signals the given throwable on the route's sink.
+   *
+   * @param throwable The {@link Throwable} to signal.
+   */
+  void error(Throwable throwable) {
+    sinkRecorder.error(throwable);
+  }
+
+  /**
    * Triggers the underlying {@link Flux} completion signal.
    */
   public void complete() {


### PR DESCRIPTION
- Propagating the error thrown on `doOnNext` to the `phantomRoute`'s sink.
- Fixed a test which was overlooking the type of exception thrown.