### PR TITLE
MULE-19489: DslElementModel: Use ComponentAst parameters instead of children

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/DslElementModel.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/api/dsl/model/DslElementModel.java
@@ -411,7 +411,7 @@ public class DslElementModel<T> {
           builder.withNestedComponent(dslElementBuilder.build());
         });
       } else {
-        builder.withParameter(param.getModel().getName(), expr);
+        builder.withParameter(param.getModel().getName(), "#[" + expr + "]");
       }
     }
 

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/declaration/AstXmlArtifactDeclarationLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/declaration/AstXmlArtifactDeclarationLoader.java
@@ -369,7 +369,7 @@ public class AstXmlArtifactDeclarationLoader implements XmlArtifactDeclarationLo
                                                       pm -> component.getParameter(group.getName(), pm.getName()))));
     }
 
-    declareComposableModel(model, elementDsl, component.directChildrenStream(), declarer);
+    declareComposableModel(model, elementDsl, component, declarer);
   }
 
   private void declareParameterGroup(ComponentAst component, ComponentModel model, ComponentElementDeclarer declarer,
@@ -468,8 +468,8 @@ public class AstXmlArtifactDeclarationLoader implements XmlArtifactDeclarationLo
   }
 
   private void declareComposableModel(ComposableModel model, DslElementSyntax elementDsl,
-                                      Stream<ComponentAst> children, HasNestedComponentDeclarer declarer) {
-    children.forEach(child -> {
+                                      ComponentAst composableComponent, HasNestedComponentDeclarer declarer) {
+    composableComponent.directChildrenStream().forEach(child -> {
       ElementDeclarer extensionElementsDeclarer = forExtension(child.getExtension().getName());
 
       Reference<Boolean> componentFound = new Reference<>(false);
@@ -502,7 +502,7 @@ public class AstXmlArtifactDeclarationLoader implements XmlArtifactDeclarationLo
 
           declareParameterizedComponent((ParameterizedModel) nestedModel,
                                         routeDsl, routeDeclarer, attributes, child);
-          declareComposableModel((ComposableModel) nestedModel, elementDsl, child.directChildrenStream(), routeDeclarer);
+          declareComposableModel((ComposableModel) nestedModel, elementDsl, child, routeDeclarer);
           return routeDeclarer.getDeclaration();
         });
   }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/ComponentAstBasedElementModelFactory.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/ComponentAstBasedElementModelFactory.java
@@ -306,7 +306,6 @@ class ComponentAstBasedElementModelFactory {
                                              DslElementModel.Builder builder, ComponentAst configuration,
                                              Function<ParameterGroupModel, Function<ParameterModel, ComponentParameterAst>> paramFetcher) {
 
-    Multimap<ComponentIdentifier, ComponentAst> innerComponents = getNestedComponents(configuration);
     Map<String, String> parameters = configuration.getParameters()
         .stream()
         .filter(p -> p.getResolvedRawValue() != null)
@@ -314,17 +313,15 @@ class ComponentAstBasedElementModelFactory {
 
     model.getParameterGroupModels().stream()
         .filter(ParameterGroupModel::isShowInDsl)
-        .forEach(group -> addInlineGroup(configuration, innerComponents, parameters, builder, group,
+        .forEach(group -> addInlineGroup(configuration, parameters, builder, group,
                                          paramFetcher.apply(group)));
 
-
-    model.getParameterGroupModels()
+    model.getParameterGroupModels().stream()
+        .filter(g -> !g.isShowInDsl())
         .forEach(g -> {
           g.getParameterModels().forEach(p -> {
-            if (!g.isShowInDsl()) {
-              addElementParameter(configuration, innerComponents, parameters, elementDsl, builder, p,
-                                  paramModel -> configuration.getParameter(paramModel.getName()));
-            }
+            addElementParameter(configuration, parameters, elementDsl, builder, p,
+                                paramModel -> configuration.getParameter(paramModel.getName()));
           });
         });
   }
@@ -369,8 +366,7 @@ class ComponentAstBasedElementModelFactory {
         .forEach(nestedComponentConfig -> create(nestedComponentConfig).ifPresent(builder::containing));
   }
 
-  private void addInlineGroup(ComponentAst configuration, Multimap<ComponentIdentifier, ComponentAst> innerComponents,
-                              Map<String, String> parameters,
+  private void addInlineGroup(ComponentAst configuration, Map<String, String> parameters,
                               DslElementModel.Builder parent, ParameterGroupModel group,
                               Function<ParameterModel, ComponentParameterAst> paramFetcher) {
     final DslElementSyntax groupSyntax =
@@ -383,17 +379,14 @@ class ComponentAstBasedElementModelFactory {
         .withModel(group)
         .withDsl(groupSyntax);
 
-    ComponentAst groupComponent = getSingleComponentConfiguration(innerComponents, identifier);
-    if (groupComponent != null) {
-      groupElementBuilder.withConfig(groupComponent);
+    if (configuration.getParameters().stream().anyMatch(param -> param.getGroupModel().equals(group))) {
+      groupElementBuilder.withGroupConfig(configuration, group);
 
-      Multimap<ComponentIdentifier, ComponentAst> groupInnerComponents = getNestedComponents(groupComponent);
       group.getParameterModels()
-          .forEach(p -> addElementParameter(configuration, groupInnerComponents, parameters, groupSyntax, groupElementBuilder,
+          .forEach(p -> addElementParameter(configuration, parameters, groupSyntax, groupElementBuilder,
                                             p, paramFetcher));
 
       parent.containing(groupElementBuilder.build());
-
     } else if (shouldBuildDefaultGroup(group)) {
       buildDefaultInlineGroupElement(parent, groupElementBuilder.isExplicitInDsl(false), group, groupSyntax,
                                      identifier.get());
@@ -448,8 +441,7 @@ class ComponentAstBasedElementModelFactory {
     return !isRequired(group) && group.getParameterModels().stream().anyMatch(p -> getDefaultValue(p).isPresent());
   }
 
-  private void addElementParameter(ComponentAst configuration, Multimap<ComponentIdentifier, ComponentAst> innerComponents,
-                                   Map<String, String> parameters,
+  private void addElementParameter(ComponentAst configuration, Map<String, String> parameters,
                                    DslElementSyntax groupDsl, DslElementModel.Builder<ParameterGroupModel> groupElementBuilder,
                                    ParameterModel paramModel, Function<ParameterModel, ComponentParameterAst> paramFetcher) {
     final DslElementSyntax paramSyntax = groupDsl.getContainedElement(paramModel.getName())

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/ComponentAstBasedElementModelFactory.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/ComponentAstBasedElementModelFactory.java
@@ -305,7 +305,6 @@ class ComponentAstBasedElementModelFactory {
   private void populateParameterizedElements(ParameterizedModel model, DslElementSyntax elementDsl,
                                              DslElementModel.Builder builder, ComponentAst configuration,
                                              Function<ParameterGroupModel, Function<ParameterModel, ComponentParameterAst>> paramFetcher) {
-
     Map<String, String> parameters = configuration.getParameters()
         .stream()
         .filter(p -> p.getResolvedRawValue() != null)
@@ -315,6 +314,7 @@ class ComponentAstBasedElementModelFactory {
         .filter(ParameterGroupModel::isShowInDsl)
         .forEach(group -> addInlineGroup(configuration, parameters, builder, group,
                                          paramFetcher.apply(group)));
+
 
     model.getParameterGroupModels().stream()
         .filter(g -> !g.isShowInDsl())
@@ -379,7 +379,9 @@ class ComponentAstBasedElementModelFactory {
         .withModel(group)
         .withDsl(groupSyntax);
 
-    if (configuration.getParameters().stream().anyMatch(param -> param.getGroupModel().equals(group))) {
+    if (configuration.getParameters().stream()
+        .filter(param -> !param.isDefaultValue())
+        .anyMatch(param -> param.getGroupModel().equals(group))) {
       groupElementBuilder.withGroupConfig(configuration, group);
 
       group.getParameterModels()
@@ -387,6 +389,7 @@ class ComponentAstBasedElementModelFactory {
                                             p, paramFetcher));
 
       parent.containing(groupElementBuilder.build());
+
     } else if (shouldBuildDefaultGroup(group)) {
       buildDefaultInlineGroupElement(parent, groupElementBuilder.isExplicitInDsl(false), group, groupSyntax,
                                      identifier.get());


### PR DESCRIPTION
* Addendum for DSL param groups