### PR TITLE
MULE-19525: adding test for ErrorCallbackNotImplemented thrown inside ReactiveInterceptorAdapter.

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/interceptor/ReactiveInterceptorAdapterTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/interceptor/ReactiveInterceptorAdapterTestCase.java
@@ -14,6 +14,7 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -23,6 +24,7 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,6 +54,7 @@ import static org.mule.tck.junit4.matcher.EventMatcher.hasErrorTypeThat;
 import static org.mule.tck.junit4.matcher.MessagingExceptionMatcher.withEventThat;
 import static org.mule.tck.junit4.matcher.MessagingExceptionMatcher.withFailingComponent;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
+import static reactor.core.Exceptions.errorCallbackNotImplemented;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.scheduler.Schedulers.fromExecutorService;
 
@@ -61,6 +64,7 @@ import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.TypedComponentIdentifier;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.interception.InterceptionAction;
 import org.mule.runtime.api.interception.InterceptionEvent;
 import org.mule.runtime.api.interception.ProcessorInterceptor;
@@ -792,7 +796,17 @@ public class ReactiveInterceptorAdapterTestCase extends AbstractMuleContextTestC
   @Test
   public void interceptedThrowsException() throws Exception {
     RuntimeException expectedException = new RuntimeException("Some Error");
-    ProcessorInterceptor interceptor = prepareInterceptor(new ProcessorInterceptor() {});
+    ProcessorInterceptor interceptor = prepareInterceptor(new ProcessorInterceptor() {
+
+      @Override
+      public void before(ComponentLocation location,
+                         Map<String, ProcessorParameterValue> parameters,
+                         InterceptionEvent event) {
+        // If we don't include either a before or after method override, then the interceptor is not applied and the
+        // test is not as useful
+        ProcessorInterceptor.super.before(location, parameters, event);
+      }
+    });
     startFlowWithInterceptors(interceptor);
 
     when(processor.process(any())).thenThrow(expectedException);
@@ -810,6 +824,48 @@ public class ReactiveInterceptorAdapterTestCase extends AbstractMuleContextTestC
         inOrder.verify(interceptor).around(any(), any(), any(), any());
         inOrder.verify(processor).process(any());
         inOrder.verify(interceptor).after(any(), any(), eq(of(expectedException)));
+
+        verifyParametersResolvedAndDisposed(times(1));
+      }
+    }
+  }
+
+  @Test
+  @Issue("MULE-19593")
+  public void interceptedThrowsErrorCallbackNotImplemented() throws Exception {
+    UnsupportedOperationException expectedException = errorCallbackNotImplemented(new RuntimeException("Some Error"));
+    ProcessorInterceptor interceptor = prepareInterceptor(new ProcessorInterceptor() {
+
+      @Override
+      public void before(ComponentLocation location,
+                         Map<String, ProcessorParameterValue> parameters,
+                         InterceptionEvent event) {
+        // If we don't include either a before or after method override, then the interceptor is not applied and the
+        // test is not as useful
+        ProcessorInterceptor.super.before(location, parameters, event);
+      }
+    });
+    startFlowWithInterceptors(interceptor);
+
+    when(processor.process(any())).thenThrow(expectedException);
+
+    expected.expect(MessagingException.class);
+    expected.expect(withEventThat(hasErrorType(UNKNOWN.getNamespace(), UNKNOWN.getName())));
+    expected.expectCause(instanceOf(MuleRuntimeException.class));
+    expected.expectCause(hasCause(sameInstance(expectedException)));
+    try {
+      process(flow, eventBuilder(muleContext).message(Message.of("")).build());
+    } finally {
+      if (useMockInterceptor) {
+        InOrder inOrder = inOrder(processor, interceptor);
+
+        inOrder.verify(interceptor).before(any(), any(), any());
+        inOrder.verify(interceptor).around(any(), any(), any(), any());
+        inOrder.verify(processor).process(any());
+        inOrder.verify(interceptor).after(any(),
+                                          any(),
+                                          argThat(optionalWithValue(allOf(instanceOf(RuntimeException.class),
+                                                                          hasCause(sameInstance(expectedException))))));
 
         verifyParametersResolvedAndDisposed(times(1));
       }
@@ -2118,5 +2174,36 @@ public class ReactiveInterceptorAdapterTestCase extends AbstractMuleContextTestC
       return "TestProcessorInterceptor: " + name;
     }
 
+  }
+
+  private static final class OptionalMatcher<T> extends TypeSafeMatcher<Optional<T>> {
+
+    private final Matcher<?> matcher;
+
+    public OptionalMatcher(Matcher<?> valueMatcher) {
+      this.matcher = valueMatcher;
+    }
+
+    public void describeTo(Description description) {
+      description.appendText("optional with value ");
+      description.appendDescriptionOf(this.matcher);
+    }
+
+    protected boolean matchesSafely(Optional<T> item) {
+      return item.isPresent() && this.matcher.matches(item.get());
+    }
+
+    protected void describeMismatchSafely(Optional<T> item, Description description) {
+      description.appendText("optional ");
+      if (!item.isPresent()) {
+        description.appendText("value is not present");
+      } else {
+        this.matcher.describeMismatch(item.get(), description);
+      }
+    }
+  }
+
+  private static <T> Matcher<Optional<T>> optionalWithValue(Matcher<?> matcher) {
+    return new OptionalMatcher<>(matcher);
   }
 }


### PR DESCRIPTION
(cherry picked from commit 70c029c56069eba01556c8eaad84fff4a78b0870)