### PR TITLE
MULE-18782: remove more deprecated code

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -14,9 +14,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Stream.concat;
 import static org.mule.runtime.api.util.MuleSystemProperties.DEFAULT_SCHEDULER_FIXED_FREQUENCY;
-import static org.mule.runtime.ast.api.ComponentAst.BODY_RAW_PARAM_NAME;
 import static org.mule.runtime.config.internal.dsl.spring.CommonComponentBeanDefinitionCreator.areMatchingTypes;
-import static org.mule.runtime.config.internal.dsl.spring.PropertyComponentUtils.getRawParameterValue;
 import static org.mule.runtime.config.internal.model.ApplicationModel.FIXED_FREQUENCY_STRATEGY_IDENTIFIER;
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_POSTFIX;
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_PREFIX;
@@ -60,6 +58,7 @@ import org.springframework.beans.factory.support.ManagedMap;
 class ComponentConfigurationBuilder<T> {
 
   private static final Logger LOGGER = getLogger(ComponentConfigurationBuilder.class);
+  private static final String SCRIPT_PARAMETER = "script";
 
   private final BeanDefinitionBuilderHelper beanDefinitionBuilderHelper;
   private final ObjectReferencePopulator objectReferencePopulator = new ObjectReferencePopulator();
@@ -499,9 +498,8 @@ class ComponentConfigurationBuilder<T> {
 
     @Override
     public void onValueFromTextContent() {
-      if (component != null) {
-        // TODO MULE-18782 migrate this
-        this.value = getRawParameterValue(component, BODY_RAW_PARAM_NAME).orElse(null);
+      if (component != null && component.getParameter(SCRIPT_PARAMETER) != null) {
+        this.value = component.getParameter(SCRIPT_PARAMETER).getResolvedRawValue();
       } else {
         getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
             .ifPresent(v -> this.value = v);

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -14,7 +14,9 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Stream.concat;
 import static org.mule.runtime.api.util.MuleSystemProperties.DEFAULT_SCHEDULER_FIXED_FREQUENCY;
+import static org.mule.runtime.ast.api.ComponentAst.BODY_RAW_PARAM_NAME;
 import static org.mule.runtime.config.internal.dsl.spring.CommonComponentBeanDefinitionCreator.areMatchingTypes;
+import static org.mule.runtime.config.internal.dsl.spring.PropertyComponentUtils.getRawParameterValue;
 import static org.mule.runtime.config.internal.model.ApplicationModel.FIXED_FREQUENCY_STRATEGY_IDENTIFIER;
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_POSTFIX;
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_PREFIX;
@@ -497,8 +499,13 @@ class ComponentConfigurationBuilder<T> {
 
     @Override
     public void onValueFromTextContent() {
-      getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
-          .ifPresent(v -> this.value = v);
+      if (component != null) {
+        // TODO MULE-18782 migrate this
+        this.value = getRawParameterValue(component, BODY_RAW_PARAM_NAME).orElse(null);
+      } else {
+        getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
+            .ifPresent(v -> this.value = v);
+      }
     }
 
     @Override

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -14,6 +14,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Stream.concat;
 import static org.mule.runtime.api.util.MuleSystemProperties.DEFAULT_SCHEDULER_FIXED_FREQUENCY;
+import static org.mule.runtime.ast.api.ComponentAst.BODY_RAW_PARAM_NAME;
 import static org.mule.runtime.config.internal.dsl.spring.CommonComponentBeanDefinitionCreator.areMatchingTypes;
 import static org.mule.runtime.config.internal.model.ApplicationModel.FIXED_FREQUENCY_STRATEGY_IDENTIFIER;
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_POSTFIX;
@@ -498,9 +499,13 @@ class ComponentConfigurationBuilder<T> {
 
     @Override
     public void onValueFromTextContent() {
-      if (component != null && component.getParameter(SCRIPT_PARAMETER) != null) {
-        // TODO (MULE-19618) review the necessity for this (ee-transform extension model) + this entire class
-        this.value = component.getParameter(SCRIPT_PARAMETER).getResolvedRawValue();
+      if (component != null) {
+        if (component.getParameter(SCRIPT_PARAMETER) != null) {
+          // TODO (MULE-19618) review the necessity for this (ee-transform extension model) + this entire class
+          this.value = component.getParameter(SCRIPT_PARAMETER).getResolvedRawValue();
+        } else {
+          this.value = component.getParameter(BODY_RAW_PARAM_NAME).getResolvedRawValue();
+        }
       } else {
         getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
             .ifPresent(v -> this.value = v);

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -14,9 +14,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Stream.concat;
 import static org.mule.runtime.api.util.MuleSystemProperties.DEFAULT_SCHEDULER_FIXED_FREQUENCY;
-import static org.mule.runtime.ast.api.ComponentAst.BODY_RAW_PARAM_NAME;
 import static org.mule.runtime.config.internal.dsl.spring.CommonComponentBeanDefinitionCreator.areMatchingTypes;
-import static org.mule.runtime.config.internal.dsl.spring.PropertyComponentUtils.getRawParameterValue;
 import static org.mule.runtime.config.internal.model.ApplicationModel.FIXED_FREQUENCY_STRATEGY_IDENTIFIER;
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_POSTFIX;
 import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_PREFIX;
@@ -499,13 +497,8 @@ class ComponentConfigurationBuilder<T> {
 
     @Override
     public void onValueFromTextContent() {
-      if (component != null) {
-        // TODO MULE-18782 migrate this
-        this.value = getRawParameterValue(component, BODY_RAW_PARAM_NAME).orElse(null);
-      } else {
-        getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
-            .ifPresent(v -> this.value = v);
-      }
+      getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
+          .ifPresent(v -> this.value = v);
     }
 
     @Override

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -499,6 +499,7 @@ class ComponentConfigurationBuilder<T> {
     @Override
     public void onValueFromTextContent() {
       if (component != null && component.getParameter(SCRIPT_PARAMETER) != null) {
+        // TODO (MULE-19618) review the necessity for this (ee-transform extension model) + this entire class
         this.value = component.getParameter(SCRIPT_PARAMETER).getResolvedRawValue();
       } else {
         getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -504,7 +504,8 @@ class ComponentConfigurationBuilder<T> {
           // TODO (MULE-19618) review the necessity for this (ee-transform extension model) + this entire class
           this.value = component.getParameter(SCRIPT_PARAMETER).getResolvedRawValue();
         } else {
-          this.value = component.getParameter(BODY_RAW_PARAM_NAME).getResolvedRawValue();
+          ComponentParameterAst bodyParameter = component.getParameter(BODY_RAW_PARAM_NAME);
+          this.value = bodyParameter != null ? bodyParameter.getResolvedRawValue() : null;
         }
       } else {
         getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)


### PR DESCRIPTION
We keep "global-functions" in the xsd definition for MEL compatibility, but DW does not have this