### PR TITLE
MULE-11009: Decouple extensions-support classes to a common jar to be used from `extensions-xml-support`

### DIFF
--- a/modules/extensions-xml-support/pom.xml
+++ b/modules/extensions-xml-support/pom.xml
@@ -37,18 +37,6 @@
             <artifactId>mule-extensions-api</artifactId>
         </dependency>
         <dependency>
-            <!-- TODO(fernandezlautaro): MULE-11009 needed dependency as we heavily rely  org.mule.runtime.module.extension.internal.introspection.DefaultExtensionFactory to generate an ExtensionModel from a Describer -->
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-extensions-support</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <!-- TODO(fernandezlautaro): MULE-9646 + MULE-9637 needed dependency as we heavily rely on org.mule.runtime.config.api.dsl.model.ComponentModel and org.mule.runtime.config.api.dsl.processor.xml.XmlApplicationParser to make templating work -->
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-spring-config</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>
             <version>${project.version}</version>

--- a/modules/extensions-xml-support/pom.xml
+++ b/modules/extensions-xml-support/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-extensions-spring-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -165,11 +170,6 @@
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-servlet_3.0_spec</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-extensions-spring-support</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <!--TODO: MULE-10837-->
         <dependency>

--- a/modules/spring-config/pom.xml
+++ b/modules/spring-config/pom.xml
@@ -59,6 +59,7 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>

--- a/modules/spring-config/pom.xml
+++ b/modules/spring-config/pom.xml
@@ -59,7 +59,6 @@
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>


### PR DESCRIPTION
This was already done when refactoring to use the mule-artifact-ast module. This PR just removes the stale dependencies.