### PR TITLE
MULE-19333: Ignore flaky ApplicationDependingOnDomainDeploymentTestCase.stoppedApplicationsAreNotStartedWhenDomainIsRedeployed (#10261)

### DIFF
--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDependingOnDomainDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDependingOnDomainDeploymentTestCase.java
@@ -25,8 +25,10 @@ import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.module.deployment.impl.internal.builder.ApplicationFileBuilder;
 import org.mule.runtime.module.deployment.impl.internal.builder.DomainFileBuilder;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
+import io.qameta.allure.Flaky;
 import io.qameta.allure.Feature;
 
 @Feature(DOMAIN_DEPLOYMENT)
@@ -231,6 +233,8 @@ public class ApplicationDependingOnDomainDeploymentTestCase extends AbstractDepl
   }
 
   @Test
+  @Flaky
+  @Ignore("MULE-19333")
   public void stoppedApplicationsAreNotStartedWhenDomainIsRedeployed() throws Exception {
     DeploymentListener mockDeploymentListener = spy(new DeploymentStatusTracker());
     deploymentService.addDeploymentListener(mockDeploymentListener);


### PR DESCRIPTION
(cherry-picked from 266f7b38a0fa25cbfb4db83b795282c88f36f344)