### PR TITLE
MULE-19716: Moving DefaultExecutionMediator's CompositeClassLoader instantiation to initialization phase.

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -1142,6 +1142,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
                                         componentModel,
                                         createInterceptorChain(),
                                         errorTypeRepository,
+                                        muleContext.getExecutionClassLoader(),
                                         resultTransformer);
   }
 

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/DefaultExecutionMediatorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/DefaultExecutionMediatorTestCase.java
@@ -217,7 +217,8 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     mediator = new DefaultExecutionMediator(extensionModel,
                                             operationModel,
                                             interceptorChain,
-                                            muleContext.getErrorTypeRepository());
+                                            muleContext.getErrorTypeRepository(),
+                                            muleContext.getExecutionClassLoader());
 
     final ReconnectableConnectionProviderWrapper<Object> connectionProviderWrapper =
         new ReconnectableConnectionProviderWrapper<>(null,
@@ -317,7 +318,8 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     mediator = new DefaultExecutionMediator(extensionModel,
                                             operationModel,
                                             interceptorChain,
-                                            muleContext.getErrorTypeRepository());
+                                            muleContext.getErrorTypeRepository(),
+                                            muleContext.getExecutionClassLoader());
     execute();
   }
 
@@ -330,7 +332,8 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     mediator = new DefaultExecutionMediator(extensionModel,
                                             operationModel,
                                             interceptorChain,
-                                            muleContext.getErrorTypeRepository());
+                                            muleContext.getErrorTypeRepository(),
+                                            muleContext.getExecutionClassLoader());
     execute();
   }
 
@@ -347,7 +350,9 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     mediator = new DefaultExecutionMediator(extensionModel,
                                             operationModel,
                                             interceptorChain,
-                                            muleContext.getErrorTypeRepository(), failingTransformer);
+                                            muleContext.getErrorTypeRepository(),
+                                            muleContext.getExecutionClassLoader(),
+                                            failingTransformer);
     execute();
   }
 
@@ -364,7 +369,9 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     mediator = new DefaultExecutionMediator(extensionModel,
                                             operationModel,
                                             interceptorChain,
-                                            errorTypeRepository, failingTransformer);
+                                            errorTypeRepository,
+                                            muleContext.getExecutionClassLoader(),
+                                            failingTransformer);
     execute();
   }
 
@@ -380,7 +387,9 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     mediator = new DefaultExecutionMediator(extensionModel,
                                             operationModel,
                                             interceptorChain,
-                                            muleContext.getErrorTypeRepository(), failingTransformer);
+                                            muleContext.getErrorTypeRepository(),
+                                            muleContext.getExecutionClassLoader(),
+                                            failingTransformer);
 
     execute();
   }
@@ -399,7 +408,9 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     mediator = new DefaultExecutionMediator(extensionModel,
                                             operationModel,
                                             interceptorChain,
-                                            errorTypeRepository, failingTransformer);
+                                            errorTypeRepository,
+                                            muleContext.getExecutionClassLoader(),
+                                            failingTransformer);
     execute();
   }
 
@@ -435,6 +446,7 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
                                             operationModel,
                                             interceptorChain,
                                             mockErrorModel(),
+                                            muleContext.getExecutionClassLoader(),
                                             failingTransformer);
 
     try {


### PR DESCRIPTION
- Reverting the revert c14268839ab1563ab857ddb3437a956ad6c849bc.
- Fixing the issue with lookup policies not being honoured by using the `RegionClassLoader` instead of the `MuleApplicationClassLoader`.
- Just to be safe we are replicating the same logic that the `AbstractMessageProcessorChain` uses for doing this.