### PR TITLE
MULE-19144: refactor to reference the right constants

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/validation/InvalidExtensionConfigTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/validation/InvalidExtensionConfigTestCase.java
@@ -54,7 +54,7 @@ public class InvalidExtensionConfigTestCase extends AbstractConfigurationFailure
   public void heisenbergDefaultConfigNegative() throws Exception {
     expectedException.expect(ConfigurationException.class);
     expectedException
-        .expectMessage("[validation/heisenberg-default-illegal-config.xml:21]: "
+        .expectMessage("[validation/heisenberg-default-illegal-config.xml:10]: "
             + "Element <heisenberg:config> is missing required parameter 'knownAddresses'.");
     loadConfiguration("validation/heisenberg-default-illegal-config.xml");
   }
@@ -72,7 +72,7 @@ public class InvalidExtensionConfigTestCase extends AbstractConfigurationFailure
   public void operationWithExpressionConfigReference() throws Exception {
     expectedException.expect(ConfigurationException.class);
     expectedException
-        .expectMessage("[validation/operation-with-expression-config-ref.xml:19]: "
+        .expectMessage("[validation/operation-with-expression-config-ref.xml:8]: "
             + "Element <heisenberg:config> is missing required parameter 'knownAddresses'.");
     loadConfiguration("validation/operation-with-expression-config-ref.xml");
   }
@@ -81,7 +81,7 @@ public class InvalidExtensionConfigTestCase extends AbstractConfigurationFailure
   public void sourceWithExpressionConfigReference() throws Exception {
     expectedException.expect(ConfigurationException.class);
     expectedException
-        .expectMessage("[validation/source-with-expression-config-ref.xml:20]: "
+        .expectMessage("[validation/source-with-expression-config-ref.xml:8]: "
             + "Element <heisenberg:config> is missing required parameter 'knownAddresses'.");
     loadConfiguration("validation/source-with-expression-config-ref.xml");
   }

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/declaration/AstXmlArtifactDeclarationLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/declaration/AstXmlArtifactDeclarationLoader.java
@@ -25,9 +25,9 @@ import static org.mule.runtime.app.declaration.api.fluent.SimpleValueType.DATETI
 import static org.mule.runtime.app.declaration.api.fluent.SimpleValueType.NUMBER;
 import static org.mule.runtime.app.declaration.api.fluent.SimpleValueType.STRING;
 import static org.mule.runtime.app.declaration.api.fluent.SimpleValueType.TIME;
+import static org.mule.runtime.ast.api.xml.AstXmlParserAttribute.IS_CDATA;
 import static org.mule.runtime.config.internal.dsl.XmlConstants.buildRawParamKeyForDocAttribute;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_MULE_CONFIGURATION;
-import static org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.IS_CDATA;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.getId;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.isMap;
 import static org.mule.runtime.extension.api.util.LayoutOrderComparator.OBJECTS_FIELDS_BY_LAYOUT_ORDER;
@@ -836,7 +836,7 @@ public class AstXmlArtifactDeclarationLoader implements XmlArtifactDeclarationLo
         .filter(e -> !e.getKey().equals(CONFIG_ATTRIBUTE_NAME))
         .forEach(e -> builder
             .withParameter(e.getKey(),
-                           (boolean) e.getValue().getMetadata().map(m -> m.getParserAttributes().getOrDefault(IS_CDATA, false))
+                           e.getValue().getMetadata().map(m -> IS_CDATA.get(m).orElse(false))
                                .orElse(false)
                                    ? createParameterSimpleCdataValue(e.getValue().getRawValue(),
                                                                      getGroupParameterType(group, e.getKey()))

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/declaration/DefaultXmlArtifactDeclarationLoader.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/declaration/DefaultXmlArtifactDeclarationLoader.java
@@ -26,8 +26,8 @@ import static org.mule.runtime.app.declaration.api.fluent.SimpleValueType.NUMBER
 import static org.mule.runtime.app.declaration.api.fluent.SimpleValueType.STRING;
 import static org.mule.runtime.app.declaration.api.fluent.SimpleValueType.TIME;
 import static org.mule.runtime.deployment.model.internal.application.MuleApplicationClassLoader.resolveContextArtifactPluginClassLoaders;
+import static org.mule.runtime.dsl.api.xml.parser.XmlApplicationParser.IS_CDATA;
 import static org.mule.runtime.dsl.api.xml.parser.XmlConfigurationDocumentLoader.noValidationDocumentLoader;
-import static org.mule.runtime.dsl.internal.xml.parser.XmlApplicationParser.IS_CDATA;
 import static org.mule.runtime.extension.api.ExtensionConstants.EXPIRATION_POLICY_PARAMETER_NAME;
 import static org.mule.runtime.extension.api.ExtensionConstants.POOLING_PROFILE_PARAMETER_NAME;
 import static org.mule.runtime.extension.api.ExtensionConstants.RECONNECTION_CONFIG_PARAMETER_NAME;


### PR DESCRIPTION
- New constants have been added on the AST for DSL-specific attributes. We should be referencing those now from `AstXmlArtifactDeclarationLoader`.
- Also, on `DefaultXmlArtifactDeclarationLoader` (which uses dsl-api directly without the AST), we still need to use the constant from dsl-api, however, we need not use the internally defined constant, since there is one defined at the API level.