### PR TITLE
MULE-19146: Revert creation of configResources from URL instead of InputStream.

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/SpringXmlConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/SpringXmlConfigurationBuilder.java
@@ -68,7 +68,6 @@ import org.mule.runtime.deployment.model.api.artifact.ArtifactContext;
 import org.mule.runtime.dsl.api.ConfigResource;
 
 import java.io.InputStream;
-import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -252,7 +251,9 @@ public class SpringXmlConfigurationBuilder extends AbstractResourceConfiguration
           final AstXmlParser parser = createMuleXmlParser(extensions, artifactProperties, disableXmlValidations);
 
           artifactAst = parser.parse(stream(artifactConfigResources)
-              .map((CheckedFunction<ConfigResource, URL>) (ConfigResource::getUrl)).toArray(URL[]::new));
+              .map((CheckedFunction<ConfigResource, Pair<String, InputStream>>) (configFile -> new Pair<>(configFile
+                  .getResourceName(), configFile.getInputStream())))
+              .collect(toList()));
         }
       } else {
         artifactAst = toArtifactast(artifactDeclaration, extensions);


### PR DESCRIPTION
This reverts commit 36270e9050450f38c5ca1a6cefa65931f14f2b7d.