### PR TITLE
hooks needs to be synchronized to avoid sometimes errors during shutdown

### DIFF
--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLog4jContextFactory.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLog4jContextFactory.java
@@ -122,12 +122,16 @@ public class MuleLog4jContextFactory extends Log4jContextFactory implements Disp
 
     @Override
     public Cancellable addShutdownCallback(Runnable callback) {
-      hooks.add(callback);
+      synchronized (hooks) {
+    	  hooks.add(callback);
+      }
       return new Cancellable() {
 
         @Override
         public void cancel() {
-          hooks.remove(callback);
+            synchronized (hooks) {
+            	hooks.remove(callback);
+            }
         }
 
         @Override


### PR DESCRIPTION
Sometimes during MUnit run the shutdown fails with

```
Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@647ce40c rejected from java.util.concurrent.ThreadPoolExecutor@65802086[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
  	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
  	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
  	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
  	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112)
  	at org.mule.runtime.module.launcher.log4j2.MuleLog4jContextFactory$MuleShutdownCallbackRegistry.dispose(MuleLog4jContextFactory.java:143)
  	at org.mule.runtime.module.launcher.log4j2.MuleLog4jContextFactory.dispose(MuleLog4jContextFactory.java:113)
  	at org.mule.runtime.module.launcher.MuleContainer.stop(MuleContainer.java:357)
  	at org.mule.runtime.module.embedded.impl.EmbeddedController.lambda$stop$2(EmbeddedController.java:140)
  	at org.mule.runtime.module.embedded.impl.EmbeddedController.executeWithinContainerClassLoader(EmbeddedController.java:127)
```

probably due to not removing all 3 hooks

[Shutdown callback for LoggerContext[name=sun.misc.Launcher$AppClassLoader@18b4aac2], Shutdown callback for LoggerContext[name=/domain/default], Shutdown callback for LoggerContext[name=domain/default/app/YOUR_MULE_APP-xp]]

