### PR TITLE
dispose maybe called twice from MuleContainer.stop() and so avoid hooks

### DIFF
--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLog4jContextFactory.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/log4j2/MuleLog4jContextFactory.java
@@ -139,8 +139,15 @@ public class MuleLog4jContextFactory extends Log4jContextFactory implements Disp
 
     @Override
     public void dispose() {
-      for (Runnable hook : new ArrayList<>(hooks)) {
+      ArrayList<Runnable> hooksToSubmit;
+      synchronized (hooks) {
+        hooksToSubmit = new ArrayList<>(hooks);
+      }
+      for (Runnable hook : hooksToSubmit) {
         executorService.submit(hook);
+      }
+      synchronized (hooks) {
+        hooks.removeAll(hooksToSubmit);
       }
       try {
         executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
to be executed twice (as executorServie is shutDown)

Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@54ab0af8 rejected from java.util.concurrent.ThreadPoolExecutor@6b0d68df[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112)
	at org.mule.runtime.module.launcher.log4j2.MuleLog4jContextFactory$MuleShutdownCallbackRegistry.dispose(MuleLog4jContextFactory.java:143)