### PR TITLE
LogManager.getFactory() and log4jContextFactory maybe same instance and dispose() should be called once only.

### DIFF
--- a/modules/launcher/src/main/java/org/mule/runtime/module/launcher/MuleContainer.java
+++ b/modules/launcher/src/main/java/org/mule/runtime/module/launcher/MuleContainer.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -349,11 +350,12 @@ public class MuleContainer {
       toolingService.stop();
     }
 
-    if (LogManager.getFactory() instanceof MuleLog4jContextFactory) {
-      ((MuleLog4jContextFactory) LogManager.getFactory()).dispose();
+    LoggerContextFactory defaultLogManagerFactory = LogManager.getFactory();
+    if (defaultLogManagerFactory instanceof MuleLog4jContextFactory) {
+      ((MuleLog4jContextFactory) defaultLogManagerFactory).dispose();
     }
 
-    if (log4jContextFactory != null) {
+    if (log4jContextFactory != null && log4jContextFactory != defaultLogManagerFactory) {
       log4jContextFactory.dispose();
     }
   }


### PR DESCRIPTION
Due to static part in MuleContainer in line 107 and 108 the
log4jContextFactory and LogManager.getFactory() may be identical.

Calling dispose twice may have several impacts. One is a RejectedExecutionException in case
there were some leftover hooks.
As some other dispose activities may rely on single call this PR should be done additional to
https://github.com/mulesoft/mule/pull/10815