### PR TITLE
MTS-514: ParameterExtractor generates invalid DW expression if value contains ' - fix test

### DIFF
--- a/modules/tooling-support/src/test/java/org/mule/runtime/module/tooling/internal/artifact/params/ParameterExtractorTestCase.java
+++ b/modules/tooling-support/src/test/java/org/mule/runtime/module/tooling/internal/artifact/params/ParameterExtractorTestCase.java
@@ -81,7 +81,7 @@ public class ParameterExtractorTestCase {
     ParameterValue level0 = ParameterObjectValue.builder().withParameter("field", plain("value")).build();
     ParameterValue parameterValue = ParameterObjectValue.builder().withParameter("level0", level0).build();
     TypedValue<?> extracted = asDataWeaveExpression(parameterValue, metadataType);
-    checkContains(extracted, "{'level0':{'field':'value'}}");
+    checkContains(extracted, "{\"level0\":{\"field\":\"value\"}}");
   }
 
   @Test


### PR DESCRIPTION
(chery picked from commit 18f02a34a571fbfabd88c32a10bea26bcc5b8903)