### PR TITLE
DEL-3860: Fix enforcer plugin error in extensions-spring-support with…

### DIFF
--- a/modules/extensions-spring-support/pom.xml
+++ b/modules/extensions-spring-support/pom.xml
@@ -135,6 +135,14 @@
             <version>${muleTestComponentsVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- Excluding as it will be resolved with SNAPSHOT version because test-components
+                    is SNAPSHOT to avoid a circular dep within mule and mule-test-artifacts repos -->
+                    <groupId>org.mule.sdk</groupId>
+                    <artifactId>mule-sdk-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>xmlunit</groupId>


### PR DESCRIPTION
… mule-sdk-api due to the test-components and mule repo circular dependency issue

(cherry picked from commit 87cc4065bd51a9580119318cf4b040a25ee5e56c)