### PR TITLE
MULE-19869: set template field to null after phase execution to avoid…

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/source/ExtensionsFlowProcessingTemplate.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/source/ExtensionsFlowProcessingTemplate.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 final class ExtensionsFlowProcessingTemplate extends FlowProcessingTemplate {
 
-  private final SourceResultAdapter sourceMessage;
+  private SourceResultAdapter sourceMessage;
   private final SourceCompletionHandler completionHandler;
 
   ExtensionsFlowProcessingTemplate(SourceResultAdapter sourceMessage,
@@ -67,6 +67,8 @@ final class ExtensionsFlowProcessingTemplate extends FlowProcessingTemplate {
       completionHandler.onTerminate(either);
     } catch (Exception e) {
       throw propagateWrappingFatal(e);
+    } finally {
+      sourceMessage = null;
     }
   }
 

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/source/ModuleFlowProcessingTemplateTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/source/ModuleFlowProcessingTemplateTestCase.java
@@ -7,32 +7,72 @@
 package org.mule.runtime.module.extension.internal.runtime.source;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.mule.runtime.api.component.location.Location.builder;
+import static org.mule.runtime.api.functional.Either.right;
+import static org.mule.runtime.api.metadata.MediaType.ANY;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.internal.execution.SourcePolicyTestUtils.onCallback;
+import static org.mule.runtime.core.internal.policy.SourcePolicyContext.from;
 import static reactor.core.publisher.Mono.just;
 
+import io.qameta.allure.Description;
+import io.qameta.allure.Issue;
+import org.mockito.ArgumentCaptor;
+import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.execution.CompletableCallback;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.functional.Either;
 import org.mule.runtime.api.util.Reference;
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.exception.FlowExceptionHandler;
+import org.mule.runtime.core.api.management.stats.CursorComponentDecoratorFactory;
 import org.mule.runtime.core.api.processor.Processor;
+import org.mule.runtime.core.api.source.MessageSource;
+import org.mule.runtime.core.internal.construct.AbstractPipeline;
+import org.mule.runtime.core.internal.exception.ExceptionRouter;
 import org.mule.runtime.core.internal.exception.MessagingException;
+import org.mule.runtime.core.internal.execution.FlowProcessMediator;
+import org.mule.runtime.core.internal.execution.MessageProcessContext;
+import org.mule.runtime.core.internal.execution.PhaseResultNotifier;
 import org.mule.runtime.core.internal.execution.SourceResultAdapter;
 import org.mule.runtime.core.internal.execution.SourcePolicyTestUtils;
-import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.runtime.core.internal.message.InternalEvent;
+import org.mule.runtime.core.internal.policy.PolicyManager;
+import org.mule.runtime.core.internal.policy.SourcePolicy;
+import org.mule.runtime.core.internal.policy.SourcePolicyContext;
+import org.mule.runtime.core.internal.policy.SourcePolicyFailureResult;
+import org.mule.runtime.core.internal.policy.SourcePolicySuccessResult;
+import org.mule.runtime.core.internal.util.MessagingExceptionResolver;
+import org.mule.runtime.dsl.api.component.config.DefaultComponentLocation;
+import org.mule.runtime.policy.api.PolicyPointcutParameters;
+import org.mule.sdk.api.runtime.operation.Result;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +83,7 @@ import org.reactivestreams.Publisher;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
-public class ModuleFlowProcessingTemplateTestCase extends AbstractMuleTestCase {
+public class ModuleFlowProcessingTemplateTestCase extends AbstractMuleContextTestCase {
 
   @Mock
   private SourceResultAdapter message;
@@ -66,6 +106,12 @@ public class ModuleFlowProcessingTemplateTestCase extends AbstractMuleTestCase {
   private final RuntimeException runtimeException = new RuntimeException();
 
   private ExtensionsFlowProcessingTemplate template;
+
+  private final AtomicReference<CoreEvent> atomicEvent = new AtomicReference<>();
+
+  private FlowProcessMediator flowProcessMediator;
+
+  private MessageProcessContext context;
 
   @Before
   public void before() throws Exception {
@@ -181,5 +227,93 @@ public class ModuleFlowProcessingTemplateTestCase extends AbstractMuleTestCase {
     }
 
     assertThat(exceptionReference.get(), equalTo(runtimeException));
+  }
+
+  @Test
+  @Issue("MULE-19869")
+  @Description("Set template field to null after phase execution to avoid a leak when creating reactor chains")
+  public void templateSetToNullAfterPhaseExecution() throws Exception {
+    initFlowProcessMediator();
+    flowProcessMediator.process(template, context);
+    assertThat(template.getSourceMessage(), is(nullValue()));
+  }
+
+  private void initFlowProcessMediator() throws Exception {
+    PolicyManager policyManager = mock(PolicyManager.class);
+    SourcePolicy sourcePolicy = mock(SourcePolicy.class);
+    when(policyManager.createSourcePolicyInstance(any(), any(), any(), any())).thenReturn(sourcePolicy);
+    when(policyManager.addSourcePointcutParametersIntoEvent(any(), any(), any())).thenAnswer(inv -> {
+      final PolicyPointcutParameters pointcutParams = mock(PolicyPointcutParameters.class);
+      final SourcePolicyContext sourcePolicyCtx = new SourcePolicyContext(pointcutParams);
+
+      final InternalEvent invEvent = inv.getArgument(2, InternalEvent.class);
+      invEvent.setSourcePolicyContext(sourcePolicyCtx);
+      atomicEvent.set(inv.getArgument(2, InternalEvent.class));
+      return pointcutParams;
+    });
+    SourcePolicySuccessResult successResult = mock(SourcePolicySuccessResult.class);
+    when(successResult.getResult()).then(invocation -> atomicEvent.get());
+    when(successResult.getResponseParameters()).thenReturn(Collections::emptyMap);
+    when(successResult.createErrorResponseParameters()).thenReturn(event -> emptyMap());
+    SourcePolicyFailureResult failureResult = mock(SourcePolicyFailureResult.class);
+    when(failureResult.getMessagingException()).then(invocation -> messagingException);
+    when(failureResult.getResult()).then(invocation -> messagingException.getEvent());
+    when(failureResult.getErrorResponseParameters()).thenReturn(Collections::emptyMap);
+    doAnswer(inv -> {
+      CoreEvent event = inv.getArgument(0);
+      CompletableCallback<Either<SourcePolicyFailureResult, SourcePolicySuccessResult>> callback = inv.getArgument(2);
+
+      from(event).configure(inv.getArgument(1), callback);
+
+      callback.complete(right(successResult));
+
+      return null;
+    }).when(sourcePolicy).process(any(), any(), any());
+
+    PhaseResultNotifier notifier = mock(PhaseResultNotifier.class);
+    flowProcessMediator = new FlowProcessMediator(policyManager, notifier);
+    initialiseIfNeeded(flowProcessMediator, muleContext);
+    startIfNeeded(flowProcessMediator);
+
+    AbstractPipeline flow = mock(AbstractPipeline.class, withSettings().extraInterfaces(Component.class));
+    when(flow.getLocation()).thenReturn(DefaultComponentLocation.from("flow"));
+    FlowExceptionHandler exceptionHandler = mock(FlowExceptionHandler.class);
+
+    // Call routeError failure callback for success response sending error test cases
+    final ArgumentCaptor<Consumer> propagateConsumerCaptor = forClass(Consumer.class);
+    ExceptionRouter flowErrorHandlerRouter = mock(ExceptionRouter.class);
+    doAnswer(inv -> {
+      propagateConsumerCaptor.getValue().accept(inv.getArgument(0));
+      return null;
+    })
+        .when(flowErrorHandlerRouter).accept(any(Exception.class));
+    when(exceptionHandler.router(any(Function.class), any(Consumer.class), propagateConsumerCaptor.capture()))
+        .thenReturn(flowErrorHandlerRouter);
+
+    final MessageSource source = mock(MessageSource.class);
+    when(source.getRootContainerLocation()).thenReturn(builder().globalName("root").build());
+    when(source.getLocation()).thenReturn(mock(ComponentLocation.class));
+
+    when(flow.errorRouterForSourceResponseError(any())).thenAnswer(inv -> exceptionHandler
+        .router(Function.identity(),
+                event -> ((Consumer<Exception>) inv.getArgument(0, Function.class).apply(flow))
+                    .accept((Exception) event.getError().get().getCause()),
+                error -> ((Consumer<Exception>) inv.getArgument(0, Function.class).apply(flow)).accept((Exception) error)));
+    when(flow.getExceptionListener()).thenReturn(exceptionHandler);
+    when(flow.getSource()).thenReturn(source);
+    when(flow.getMuleContext()).thenReturn(muleContext);
+
+    context = mock(MessageProcessContext.class);
+    when(context.getMessageSource()).thenReturn(source);
+    when(context.getMessagingExceptionResolver()).thenReturn(new MessagingExceptionResolver(source));
+    when(context.getTransactionConfig()).thenReturn(empty());
+    when(context.getFlowConstruct()).thenReturn(flow);
+    when(context.getComponentDecoratorFactory()).thenReturn(mock(CursorComponentDecoratorFactory.class));
+
+    SourceResultAdapter resultAdapter = mock(SourceResultAdapter.class);
+    when(resultAdapter.getResult()).thenReturn(Result.builder().build());
+    when(resultAdapter.getMediaType()).thenReturn(ANY);
+
+    template = new ExtensionsFlowProcessingTemplate(resultAdapter, messageProcessor, emptyList(), completionHandler);
   }
 }


### PR DESCRIPTION
… a leak (#10899)

* MULE-19869: set template null after phase execution

(cherry picked from commit 04aaf24c7d4aa1f0b00ed15f83107ea8190f10b3)