### PR TITLE
MULE-19890: Remove app stopped persistence when undeploying app (#10952)

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/context/ArtifactStoppedPersistenceListener.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/context/ArtifactStoppedPersistenceListener.java
@@ -31,4 +31,9 @@ public interface ArtifactStoppedPersistenceListener {
    * stopped for other reasons.
    */
   void doNotPersist();
+
+  /**
+   * Deletes stopped persistence properties
+   */
+  void deletePersistenceProperties();
 }

--- a/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/util/DeploymentPropertiesUtils.java
+++ b/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/util/DeploymentPropertiesUtils.java
@@ -32,6 +32,8 @@ public class DeploymentPropertiesUtils {
 
   private static final String DEPLOYMENT_PROPERTIES_DIRECTORY = "deployment-properties";
 
+  private static final String ARTIFACT_STATUS_DEPLOYMENT_PROPERTIES_FILE_NAME = "artifact.status.deployment.properties";
+
   /**
    * This method resolves the deploymentProperties for a new deploy/redeploy considering the new deployment properties passed by
    * the user as parameter and the deployment properties persisted in a previous deploy. In case no new deployment properties are
@@ -147,5 +149,19 @@ public class DeploymentPropertiesUtils {
   public static Properties resolveFlowDeploymentProperties(String appName, Optional<Properties> deploymentProperties)
       throws IOException {
     return resolveDeploymentProperties(appName, deploymentProperties, FLOWS_DEPLOYMENT_PROPERTIES_FILE_NAME);
+  }
+
+  /**
+   * This method resolves the statusProperties for the status (started, stopped) of a certain artifact. There is one
+   * artifact.status.deployment.properties file for each artifact (domain/app).
+   *
+   * @param artifactName     name of the artifact.
+   * @param statusProperties status deployment properties set in the new deploy/redeploy as parameters.
+   * @return deployment properties
+   * @throws IOException
+   */
+  public static Properties resolveArtifactStatusDeploymentProperties(String artifactName, Optional<Properties> statusProperties)
+      throws IOException {
+    return resolveDeploymentProperties(artifactName, statusProperties, ARTIFACT_STATUS_DEPLOYMENT_PROPERTIES_FILE_NAME);
   }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArtifactStoppedDeploymentPersistenceListener.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/ArtifactStoppedDeploymentPersistenceListener.java
@@ -8,6 +8,7 @@ package org.mule.runtime.module.deployment.internal;
 
 import static java.lang.String.valueOf;
 import static java.util.Optional.of;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveArtifactStatusDeploymentProperties;
 import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
 
@@ -43,7 +44,7 @@ final class ArtifactStoppedDeploymentPersistenceListener implements ArtifactStop
     Properties properties = new Properties();
     properties.setProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, valueOf(true));
     try {
-      resolveDeploymentProperties(artifactName, of(properties));
+      resolveArtifactStatusDeploymentProperties(artifactName, of(properties));
     } catch (IOException e) {
       logger.error("ArtifactStoppedDeploymentPersistenceListener failed to process notification onStart for artifact "
           + artifactName, e);
@@ -58,7 +59,7 @@ final class ArtifactStoppedDeploymentPersistenceListener implements ArtifactStop
     Properties properties = new Properties();
     properties.setProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, valueOf(false));
     try {
-      resolveDeploymentProperties(artifactName, of(properties));
+      resolveArtifactStatusDeploymentProperties(artifactName, of(properties));
     } catch (IOException e) {
       logger.error("ArtifactStoppedDeploymentPersistenceListener failed to process notification onStop for artifact "
           + artifactName, e);
@@ -68,5 +69,15 @@ final class ArtifactStoppedDeploymentPersistenceListener implements ArtifactStop
   @Override
   public void doNotPersist() {
     shouldPersist.set(false);
+  }
+
+  @Override
+  public void deletePersistenceProperties() {
+    try {
+      resolveArtifactStatusDeploymentProperties(artifactName, of(new Properties()));
+    } catch (IOException e) {
+      logger.error("ArtifactStoppedDeploymentPersistenceListener failed to delete persistence for artifact {}",
+                   artifactName, e);
+    }
   }
 }

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultArchiveDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultArchiveDeployer.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.module.deployment.internal;
 
+import static java.lang.Boolean.valueOf;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
@@ -23,6 +24,7 @@ import org.mule.runtime.deployment.model.api.DeployableArtifact;
 import org.mule.runtime.deployment.model.api.DeployableArtifactDescriptor;
 import org.mule.runtime.deployment.model.api.DeploymentException;
 import org.mule.runtime.deployment.model.api.DeploymentStartException;
+import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.module.artifact.api.Artifact;
 import org.mule.runtime.module.deployment.api.DeploymentListener;
 import org.mule.runtime.module.deployment.impl.internal.artifact.AbstractDeployableArtifactFactory;
@@ -463,7 +465,7 @@ public class DefaultArchiveDeployer<T extends DeployableArtifact> implements Arc
       trackArtifact(artifact);
 
       deploymentListener.onDeploymentStart(artifact.getArtifactName());
-      deployer.deploy(artifact, true);
+      deployer.deploy(artifact, shouldStartArtifact(artifact, deploymentProperties.orElse(null)));
 
       artifactArchiveInstaller.createAnchorFile(artifact.getArtifactName());
       deploymentListener.onDeploymentSuccess(artifact.getArtifactName());
@@ -488,6 +490,14 @@ public class DefaultArchiveDeployer<T extends DeployableArtifact> implements Arc
         throw new DeploymentException(createStaticMessage("Failed to deploy artifact: " + artifact.getArtifactName()), t);
       }
     }
+  }
+
+  private boolean shouldStartArtifact(T artifact, Properties deploymentProperties) {
+    if (!(artifact instanceof Application) || deploymentProperties == null) {
+      return true;
+    }
+
+    return valueOf(deploymentProperties.getProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, "true"));
   }
 
   private T deployOrRedeployPackagedArtifact(final URI artifactUri, String artifactName,

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
@@ -7,7 +7,6 @@
 package org.mule.runtime.module.deployment.internal;
 
 import static java.lang.String.valueOf;
-import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.DEPLOYMENT_FAILED;
 import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.STARTED;
@@ -31,6 +30,7 @@ import java.util.Properties;
 public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplate {
 
   private Collection<Application> domainApplications = Collections.emptyList();
+  private Map<Application, ApplicationStatus> appStatusPreRedeployment;
   private final DefaultArchiveDeployer<Application> applicationDeployer;
   private final DeploymentService deploymentservice;
   private final CompositeDeploymentListener applicationDeploymentListener;
@@ -48,8 +48,10 @@ public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplat
   @Override
   public void preRedeploy(Artifact domain) {
     if (domain instanceof Domain) {
+      appStatusPreRedeployment = new HashMap<>();
       domainApplications = deploymentservice.findDomainApplications(domain.getArtifactName());
       for (Application domainApplication : domainApplications) {
+        appStatusPreRedeployment.put(domainApplication, domainApplication.getStatus());
         applicationDeploymentListener.onRedeploymentStart(domainApplication.getArtifactName());
         applicationDeployer.undeployArtifactWithoutUninstall(domainApplication);
       }
@@ -68,7 +70,7 @@ public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplat
         if (applicationDeployer.isUpdatedZombieArtifact(domainApplication.getArtifactName())) {
           try {
             applicationDeployer.deployExplodedArtifact(domainApplication.getArtifactName(),
-                                                       empty());
+                                                       getProperties(appStatusPreRedeployment.get(domainApplication)));
             applicationDeploymentListener.onRedeploymentSuccess(domainApplication.getArtifactName());
           } catch (RuntimeException e) {
             applicationDeploymentListener.onRedeploymentFailure(domainApplication.getArtifactName(), e);
@@ -83,5 +85,12 @@ public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplat
       }
     }
     domainApplications = Collections.emptyList();
+  }
+
+  private Optional<Properties> getProperties(ApplicationStatus applicationStatus) {
+    Properties properties = new Properties();
+    boolean startArtifact = applicationStatus.equals(STARTED) || applicationStatus.equals(DEPLOYMENT_FAILED);
+    properties.setProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, valueOf(startArtifact));
+    return of(properties);
   }
 }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDeploymentTestCase.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
-import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -50,7 +49,7 @@ import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorC
 import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.MULE_LOADER_ID;
 import static org.mule.runtime.extension.api.loader.xml.XmlExtensionModelLoader.RESOURCE_XML;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID;
-import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveArtifactStatusDeploymentProperties;
 import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveFlowDeploymentProperties;
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
 import static org.mule.runtime.module.deployment.internal.DeploymentDirectoryWatcher.DEPLOYMENT_APPLICATION_PROPERTY;
@@ -343,7 +342,7 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     app.stop();
 
     assertThat(app.getArtifactContext().getRegistry().lookupByName(ARTIFACT_STOPPED_LISTENER), is(notNullValue()));
-    Properties deploymentProperties = resolveDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
     assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(notNullValue()));
     assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
   }
@@ -357,7 +356,7 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     assertThat(app.getArtifactContext().getRegistry().lookupByName(ARTIFACT_STOPPED_LISTENER), is(notNullValue()));
     deploymentService.undeploy(app);
 
-    Properties deploymentProperties = resolveDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
     assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
   }
 
@@ -783,10 +782,26 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     deploymentService.undeploy(app);
   }
 
+  @Test
+  public void whenAppIsUndeployedStoppedPersistenceIsDeleted() throws Exception {
+    final Application app = deployApplication(emptyAppFileBuilder);
+    app.stop();
+    assertStatus(app, STOPPED);
+
+    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(notNullValue()));
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
+
+    deploymentService.undeploy(app);
+
+    deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
+  }
+
   @Issue("MULE-19040")
   @Test
   @Story(UNDEPLOYMENT)
-  public void undeploysStoppedAppAndDoesNotStartItOnDeploy() throws Exception {
+  public void runtimeWithStoppedAppRestartsAndDoesNotStartAppOnDeployBecauseOfStatusDeploymentProperties() throws Exception {
     final Application app = deployApplication(emptyAppFileBuilder);
     app.stop();
     assertStatus(app, STOPPED);
@@ -794,12 +809,15 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     restartServer();
 
     assertAppDeploymentAndStatus(emptyAppFileBuilder, CREATED);
+    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(notNullValue()));
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
   }
 
   @Issue("MULE-19040")
   @Test
   @Story(UNDEPLOYMENT)
-  public void undeploysStoppedAppDoesNotStartItOnDeployButCanBeStartedManually() throws Exception {
+  public void runtimeWithStoppedAppRestartsAndDoesNotStartAppOnDeployButItCanBeStartedManually() throws Exception {
     final Application app = deployApplication(emptyAppFileBuilder);
     app.stop();
     assertStatus(app, STOPPED);
@@ -809,6 +827,10 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     assertDeploymentSuccess(applicationDeploymentListener, emptyAppFileBuilder.getId());
     final Application app_2 = findApp(emptyAppFileBuilder.getId(), 1);
     assertStatus(app_2, CREATED);
+    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(notNullValue()));
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
+
     app_2.start();
     assertStatus(app_2, STARTED);
   }
@@ -816,13 +838,33 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
   @Issue("MULE-19040")
   @Test
   @Story(UNDEPLOYMENT)
-  public void undeploysNotStoppedAppAndStartsItOnDeploy() throws Exception {
+  public void runtimeWithStartedAppRestartsAndStartsAppOnDeploy() throws Exception {
     final Application app = deployApplication(emptyAppFileBuilder);
     assertStatus(app, STARTED);
 
     restartServer();
 
     assertAppDeploymentAndStatus(emptyAppFileBuilder, STARTED);
+    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
+  }
+
+  @Test
+  public void redeploysStoppedAppAndStartsItOnDeployBecauseStatusPersistenceGetsDeleted() throws Exception {
+    final Application app = deployApplication(emptyAppFileBuilder);
+    app.stop();
+    assertStatus(app, STOPPED);
+    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(notNullValue()));
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
+
+    reset(applicationDeploymentListener);
+
+    deploymentService.redeploy(emptyAppFileBuilder.getId());
+
+    assertAppDeploymentAndStatus(emptyAppFileBuilder, STARTED);
+    deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyAppFileBuilder.getId(), empty());
+    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
   }
 
   @Test


### PR DESCRIPTION
* Revert "MULE-19166: Remove appStatusPreRedeployment property in DomainDeploymentTemplate since it's no longer necessary (#10098)"

This reverts commit b7f38d836a8dd526596419978cc58205f16b7e11.

* Removing status persistence when undeploying app

* Fix

* Fix

(cherry picked from commit e2e31b7efcc8401b810ca092e06d1f341ad404dd)