### PR TITLE
MULE-19924: Processors in subflows are not getting the processing strategy of the root flow

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/privileged/processor/MessageProcessors.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/processor/MessageProcessors.java
@@ -11,6 +11,7 @@ import static java.util.Arrays.asList;
 import static java.util.Optional.empty;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.FLOW;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.ROUTER;
+import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.SCOPE;
 import static org.mule.runtime.api.functional.Either.left;
 import static org.mule.runtime.api.functional.Either.right;
 import static org.mule.runtime.core.api.rx.Exceptions.rxExceptionToMuleException;
@@ -682,11 +683,15 @@ public class MessageProcessors {
       return empty();
     }
 
+    // TODO MULE-19930 - remove this logic and try to propagate the processing strategy down from the root container
+    // instead of doing the lookup.
     return component.getLocation().getParts().get(0).getPartIdentifier()
         // This filter is consistent with the types that implement ProcessingStrategySupplier
         .filter(id -> id.getType().equals(FLOW)
             // a top level router is a policy...
-            || id.getType().equals(ROUTER))
+            || id.getType().equals(ROUTER)
+            // a top level scope should only be a subflow
+            || id.getType().equals(SCOPE))
         .flatMap(id -> getProcessingStrategy(locator, component.getRootContainerLocation()));
   }
 


### PR DESCRIPTION
- Adding top level scopes (i.e.: subflows) to the getProcessingStrategy filter.
- This is a temporary fix. There is [MULE-19930](https://www.mulesoft.org/jira/browse/MULE-19930) to properly fix this.