### PR TITLE
Log more details about open sinks

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/StreamPerThreadSink.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/strategy/StreamPerThreadSink.java
@@ -135,18 +135,24 @@ public class StreamPerThreadSink implements Sink, Disposable {
         LOGGER.warn("TX Subscribers of ProcessingStrategy for flow '{}' not completed before thread interruption",
                     flowConstruct.getName());
       }
+      LOGGER.warn("invalidate all shinks: {}",sinks);
       sinks.invalidateAll();
+      LOGGER.warn("invalidate all sinksNestedTx: {}",sinksNestedTx);
       sinksNestedTx.invalidateAll();
     } else if (disposableSinks.get() != 0) {
+      long remainingDisposableSinks = disposableSinks.get();
       if (getProperty(MULE_LIFECYCLE_FAIL_ON_FIRST_DISPOSE_ERROR) != null) {
-        throw new IllegalStateException(format("TX Subscribers of ProcessingStrategy for flow '%s' not completed in %d ms",
+        throw new IllegalStateException(format("TX Subscribers %d of ProcessingStrategy for flow '%s' not completed in %d ms",
+                                               remainingDisposableSinks,
                                                flowConstruct.getName(),
                                                shutdownTimeout));
       } else {
-        LOGGER.warn("TX Subscribers of ProcessingStrategy for flow '{}' not completed in {} ms", flowConstruct.getName(),
+        LOGGER.warn("TX Subscribers {} of ProcessingStrategy for flow '{}' not completed in {} ms", remainingDisposableSinks, flowConstruct.getName(),
                     shutdownTimeout);
       }
+      LOGGER.warn("invalidate all shinks: {}",sinks);
       sinks.invalidateAll();
+      LOGGER.warn("invalidate all sinksNestedTx: {}",sinksNestedTx);
       sinksNestedTx.invalidateAll();
     }
   }


### PR DESCRIPTION
Stopping one of our workers shows 
```
WARN    org.mule.runtime.core.internal.processor.strategy.StreamPerThreadSink TX Subscribers of ProcessingStrategy for flow 'upsert-customer' not completed in 60000 ms
WARN    org.mule.runtime.core.internal.processor.strategy.StreamPerThreadSink TX Subscribers of ProcessingStrategy for flow 'verify-if-customer-update-needed' not completed in 60000 ms
```

but just the flow-name without count of sinks and/or cache content makes it impossible to find the root cause of pending sinks.

So I added more logging information in case of disposableSinks still filled.