### PR TITLE
MULE-19900: TemplateParser#unbalacedCharactersMuleStyle is not parsin…

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/privileged/util/TemplateParser.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/util/TemplateParser.java
@@ -318,7 +318,7 @@ public final class TemplateParser {
           break;
       }
       lastStartedExpression = !lastIsBackSlash && c == START_EXPRESSION;
-      lastIsBackSlash = c == '\\';
+      lastIsBackSlash = (c == '\\' && !lastIsBackSlash);
       column++;
     }
     return stack;


### PR DESCRIPTION
…… (#10935)

* MULE-19900: TemplateParser#unbalacedCharactersMuleStyle is not parsing correctly a String that ends with '\'

* MULE-19900: refator to fix a test

(cherry picked from commit 6acf816349667c6ef1223d51c39f3e5e64e784d9)