### PR TITLE
MULE-19992: Private object stores should be able to be expired in secondary node (#11060)

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/store/MonitoredObjectStoreWrapperTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/store/MonitoredObjectStoreWrapperTestCase.java
@@ -10,20 +10,30 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.junit.MockitoJUnit.rule;
+import static org.mule.runtime.api.scheduler.SchedulerConfig.config;
 import static org.mule.tck.probe.PollingProber.DEFAULT_POLLING_INTERVAL;
 import static org.mule.tck.probe.PollingProber.check;
 
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.store.ObjectDoesNotExistException;
 import org.mule.runtime.api.store.ObjectStore;
 import org.mule.runtime.api.store.ObjectStoreException;
 import org.mule.runtime.api.store.ObjectStoreSettings;
+import org.mule.runtime.core.api.config.MuleConfiguration;
+import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.runtime.core.internal.util.store.MonitoredObjectStoreWrapper.StoredObject;
+import org.mule.tck.SimpleUnitTestSupportSchedulerService;
 import org.mule.tck.core.util.store.InMemoryObjectStore;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.probe.JUnitLambdaProbe;
@@ -33,6 +43,7 @@ import org.mule.tck.size.SmallTest;
 import java.io.Serializable;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Rule;
@@ -40,6 +51,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoRule;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
 
 @SmallTest
@@ -219,5 +231,46 @@ public class MonitoredObjectStoreWrapperTestCase extends AbstractMuleTestCase {
 
     wrapper = new MonitoredObjectStoreWrapper(objectStore, settings);
     wrapper.expire();
+  }
+
+  @Test
+  @Issue("MULE-19992")
+  @Description("Tests that private store entries are also expired in secondary nodes in a cluster.")
+  public void expirePrivateObjectStoreInSecondaryNode()
+      throws MuleException {
+    when(settings.getMaxEntries()).thenReturn(empty());
+    when(settings.getEntryTTL()).thenReturn(of(1L));
+    when(settings.getExpirationInterval()).thenReturn(1L);
+    when(settings.isAlwaysExpire()).thenReturn(true);
+
+    objectStore = new InMemoryObjectStore() {
+
+      @Override
+      public List<String> allKeys() {
+        return (List<String>) store.values().stream().map(e -> ((InMemoryObjectStore.StoredObject) e).getId()).collect(toList());
+      }
+    };
+
+    objectStore.store(KEY, new StoredObject<>("", 0L, KEY));
+    assertEquals(Collections.singletonList(KEY), objectStore.allKeys());
+
+    MuleContextWithRegistry muleContext = mock(MuleContextWithRegistry.class);
+    SimpleUnitTestSupportSchedulerService schedulerService = new SimpleUnitTestSupportSchedulerService();
+    when(muleContext.getSchedulerService()).thenReturn(schedulerService);
+    when(muleContext.getSchedulerBaseConfig())
+        .thenReturn(config().withPrefix(MonitoredObjectStoreWrapperTestCase.class.getName() + "#" + name.getMethodName()));
+
+    when(muleContext.isPrimaryPollingInstance()).thenReturn(false);
+
+    wrapper = new MonitoredObjectStoreWrapper(objectStore, settings);
+    wrapper.setMuleContext(muleContext);
+    wrapper.initialise();
+
+    new PollingProber(5000, 1000).check(new JUnitLambdaProbe(() -> {
+      assertFalse(objectStore.contains(KEY));
+      return true;
+    }, "Expiration is not being performed for secondary node."));
+
+    schedulerService.stop();
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/util/store/MonitoredObjectStoreWrapper.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/store/MonitoredObjectStoreWrapper.java
@@ -76,11 +76,17 @@ public class MonitoredObjectStoreWrapper<T extends Serializable> extends Templat
    */
   protected String name = null;
 
+  /**
+   * Whether old entries should be expired every time the expiration thread runs.
+   */
+  private boolean shouldAlwaysExpire;
+
   public MonitoredObjectStoreWrapper(ObjectStore<StoredObject<T>> baseStore, ObjectStoreSettings settings) {
     this.baseStore = baseStore;
     maxEntries = settings.getMaxEntries().orElse(null);
     entryTtl = settings.getEntryTTL().orElse(null);
     expirationInterval = settings.getExpirationInterval();
+    shouldAlwaysExpire = settings.isAlwaysExpire();
   }
 
   @Override
@@ -150,7 +156,7 @@ public class MonitoredObjectStoreWrapper<T extends Serializable> extends Templat
 
   @Override
   public void run() {
-    if (context.isPrimaryPollingInstance()) {
+    if (context.isPrimaryPollingInstance() || shouldAlwaysExpire) {
       expire();
     }
   }


### PR DESCRIPTION
(cherry picked from commit e73d805b7d5e39f82a24c1d7cf9d2fbce426be99)