### PR TITLE
MULE-20012: Custom object serializer mishandled when lazy init is run multiple times (#11120)

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/BeanDefinitionFactory.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/BeanDefinitionFactory.java
@@ -647,7 +647,8 @@ public class BeanDefinitionFactory {
       ComponentParameterAst objectSerializerRefParam = component.getParameter(DEFAULT_GROUP_NAME, OBJECT_SERIALIZER_REF);
       if (objectSerializerRefParam != null) {
         String defaultObjectSerializer = objectSerializerRefParam.getResolvedRawValue();
-        if (defaultObjectSerializer != null && defaultObjectSerializer != DEFAULT_OBJECT_SERIALIZER_NAME) {
+        if (defaultObjectSerializer != null && !defaultObjectSerializer.equals(DEFAULT_OBJECT_SERIALIZER_NAME)
+            && !registry.isAlias(DEFAULT_OBJECT_SERIALIZER_NAME)) {
           registry.removeBeanDefinition(DEFAULT_OBJECT_SERIALIZER_NAME);
           registry.registerAlias(defaultObjectSerializer, DEFAULT_OBJECT_SERIALIZER_NAME);
         }

--- a/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
+++ b/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
@@ -889,4 +889,9 @@ public interface AllureConstants {
       String OBJECT_PROPERTIES = "Object properties";
     }
   }
+
+  interface ObjectSerializer {
+
+    String CUSTOM_OBJECT_SERIALIZER = "Custom object serializer";
+  }
 }


### PR DESCRIPTION
(cherry picked from commit 45c7afb6600807e81c5e0852ae0d2d799813b42e)