### PR TITLE
MULE-20019: In-memory OAuth Authorization Code Grant type credentials…

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/authcode/UpdatingAuthorizationCodeState.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/authcode/UpdatingAuthorizationCodeState.java
@@ -31,7 +31,7 @@ public class UpdatingAuthorizationCodeState implements AuthorizationCodeState {
                                         ResourceOwnerOAuthContext initialContext,
                                         Consumer<ResourceOwnerOAuthContext> onUpdate) {
     delegate = toAuthorizationCodeState(config, initialContext);
-    dancer.addListener(new AuthorizationCodeListener() {
+    dancer.addListener(initialContext.getResourceOwnerId(), new AuthorizationCodeListener() {
 
       @Override
       public void onAuthorizationCompleted(ResourceOwnerOAuthContext context) {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/UpdatingAuthorizationCodeStateTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/UpdatingAuthorizationCodeStateTestCase.java
@@ -15,6 +15,7 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,6 +48,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
   private static final String REFRESH_TOKEN = "myRefreshToken";
   private static final String NEW_TOKEN = "newToken";
   private static final String NEW_REFRESH_TOKEN = "newRefresh";
+  private static final String RESOURCE_OWNER_ID = "id";
 
   private AuthorizationCodeConfig oAuthConfig;
 
@@ -68,13 +70,15 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                               emptyMap(),
                                               new AuthorizationCodeGrantType("url", "url", "#[s]", "reg", "#[x]", "sd"),
                                               mock(OAuthCallbackConfig.class),
-                                              "key", "secret", "url", "url", "scope", "id", null, null);
+                                              "key", "secret", "url", "url", "scope", RESOURCE_OWNER_ID, null, null);
 
     when(initialContext.getAccessToken()).thenReturn(ACCESS_TOKEN);
     when(initialContext.getRefreshToken()).thenReturn(REFRESH_TOKEN);
+    when(initialContext.getResourceOwnerId()).thenReturn(RESOURCE_OWNER_ID);
 
     when(refreshedContext.getAccessToken()).thenReturn(NEW_TOKEN);
     when(refreshedContext.getRefreshToken()).thenReturn(NEW_REFRESH_TOKEN);
+    when(refreshedContext.getResourceOwnerId()).thenReturn(RESOURCE_OWNER_ID);
   }
 
   @Test
@@ -87,7 +91,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));
@@ -106,7 +110,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));
@@ -134,7 +138,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));
@@ -163,7 +167,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));


### PR DESCRIPTION
… are overwritten (#11159)

(cherry picked from commit b95e4a1c3a2c1d52660a9e969d272cb3e92a193d)