### PR TITLE
MULE-20019: In-memory OAuth Authorization Code Grant type credentials are overwritten (#11166)

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/authcode/UpdatingAuthorizationCodeState.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/authcode/UpdatingAuthorizationCodeState.java
@@ -31,7 +31,7 @@ public class UpdatingAuthorizationCodeState implements AuthorizationCodeState {
                                         ResourceOwnerOAuthContext initialContext,
                                         Consumer<ResourceOwnerOAuthContext> onUpdate) {
     delegate = toAuthorizationCodeState(config, initialContext);
-    dancer.addListener(new AuthorizationCodeListener() {
+    dancer.addListener(initialContext.getResourceOwnerId(), new AuthorizationCodeListener() {
 
       @Override
       public void onAuthorizationCompleted(ResourceOwnerOAuthContext context) {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/UpdatingAuthorizationCodeStateTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/UpdatingAuthorizationCodeStateTestCase.java
@@ -15,6 +15,7 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,6 +48,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
   private static final String REFRESH_TOKEN = "myRefreshToken";
   private static final String NEW_TOKEN = "newToken";
   private static final String NEW_REFRESH_TOKEN = "newRefresh";
+  private static final String RESOURCE_OWNER_ID = "id";
 
   private AuthorizationCodeConfig oAuthConfig;
 
@@ -68,13 +70,15 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                               emptyMap(),
                                               new AuthorizationCodeGrantType("url", "url", "#[s]", "reg", "#[x]", "sd"),
                                               mock(OAuthCallbackConfig.class),
-                                              "key", "secret", "url", "url", "scope", "id", null, null);
+                                              "key", "secret", "url", "url", "scope", RESOURCE_OWNER_ID, null, null);
 
     when(initialContext.getAccessToken()).thenReturn(ACCESS_TOKEN);
     when(initialContext.getRefreshToken()).thenReturn(REFRESH_TOKEN);
+    when(initialContext.getResourceOwnerId()).thenReturn(RESOURCE_OWNER_ID);
 
     when(refreshedContext.getAccessToken()).thenReturn(NEW_TOKEN);
     when(refreshedContext.getRefreshToken()).thenReturn(NEW_REFRESH_TOKEN);
+    when(refreshedContext.getResourceOwnerId()).thenReturn(RESOURCE_OWNER_ID);
   }
 
   @Test
@@ -87,7 +91,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));
@@ -106,7 +110,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));
@@ -134,7 +138,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));
@@ -163,7 +167,7 @@ public class UpdatingAuthorizationCodeStateTestCase extends AbstractMuleTestCase
                                                                               initialContext,
                                                                               newContext::set);
 
-    verify(dancer).addListener(listenerCaptor.capture());
+    verify(dancer).addListener(anyString(), listenerCaptor.capture());
 
     assertThat(state.getAccessToken(), equalTo(ACCESS_TOKEN));
     assertThat(state.getRefreshToken().get(), equalTo(REFRESH_TOKEN));

--- a/modules/oauth-api/api-changes.json
+++ b/modules/oauth-api/api-changes.json
@@ -1,4 +1,28 @@
 {
+  "4.3.1": {
+    "revapi": {
+      "ignore": [
+        {
+          "code": "java.method.defaultMethodAddedToInterface",
+          "new": "method void org.mule.runtime.oauth.api.AuthorizationCodeOAuthDancer::addListener(java.lang.String, org.mule.runtime.oauth.api.listener.AuthorizationCodeListener)",
+          "package": "org.mule.runtime.oauth.api",
+          "classSimpleName": "AuthorizationCodeOAuthDancer",
+          "methodName": "addListener",
+          "elementKind": "method",
+          "justification": "MULE-20019: In-memory OAuth Authorization Code Grant type credentials are overwritten"
+        },
+        {
+          "code": "java.method.defaultMethodAddedToInterface",
+          "new": "method void org.mule.runtime.oauth.api.AuthorizationCodeOAuthDancer::removeListener(java.lang.String, org.mule.runtime.oauth.api.listener.AuthorizationCodeListener)",
+          "package": "org.mule.runtime.oauth.api",
+          "classSimpleName": "AuthorizationCodeOAuthDancer",
+          "methodName": "removeListener",
+          "elementKind": "method",
+          "justification": "MULE-20019: In-memory OAuth Authorization Code Grant type credentials are overwritten"
+        }
+      ]
+    }
+  },
   "4.3.0": {
     "revapi": {
       "ignore": [

--- a/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/AuthorizationCodeOAuthDancer.java
+++ b/modules/oauth-api/src/main/java/org/mule/runtime/oauth/api/AuthorizationCodeOAuthDancer.java
@@ -85,7 +85,9 @@ public interface AuthorizationCodeOAuthDancer {
    * @param listener the {@link AuthorizationCodeListener} to be added
    * @throws IllegalArgumentException if the {@code listener} is {@code null}
    * @since 4.2.0
+   * @deprecated since 4.3.1
    */
+  @Deprecated
   void addListener(AuthorizationCodeListener listener);
 
   /**
@@ -94,7 +96,35 @@ public interface AuthorizationCodeOAuthDancer {
    * @param listener the {@link AuthorizationCodeListener} to be removed
    * @throws IllegalArgumentException if the {@code listener} is {@code null}
    * @since 4.2.0
+   * @deprecated since 4.3.1
    */
+  @Deprecated
   void removeListener(AuthorizationCodeListener listener);
+
+  /**
+   * Adds the {@code listener}. Listeners will be invoked in the same order as they were added
+   *
+   * @param resourceOwnerId id of the user who the listener corresponds to
+   * @param listener        the {@link AuthorizationCodeListener} to be added
+   * @throws IllegalArgumentException if the {@code listener} is {@code null}
+   *
+   * @since 4.3.1
+   */
+  default void addListener(String resourceOwnerId, AuthorizationCodeListener listener) {
+    addListener(listener);
+  }
+
+  /**
+   * Removes the {@code listener}. Nothing happens if it wasn't part of {@code this} dancer.
+   *
+   * @param resourceOwnerId id of the user who the listener corresponds to
+   * @param listener        the {@link AuthorizationCodeListener} to be removed
+   * @throws IllegalArgumentException if the {@code listener} is {@code null}
+   *
+   * @since 4.3.1
+   */
+  default void removeListener(String resourceOwnerId, AuthorizationCodeListener listener) {
+    removeListener(listener);
+  }
 
 }


### PR DESCRIPTION
(cherry picked from commit 3832e82f841cf31b4305139dcc4607fcc94515c5)