### PR TITLE
MULE-20054: Optimize decoration of input streams

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/api/loader/java/type/ExtensionParameter.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/api/loader/java/type/ExtensionParameter.java
@@ -21,6 +21,7 @@ import org.mule.runtime.api.tls.TlsContextFactory;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyTemplate;
 import org.mule.runtime.extension.api.annotation.param.Config;
 import org.mule.runtime.extension.api.annotation.param.Connection;
+import org.mule.runtime.extension.api.annotation.param.Content;
 import org.mule.runtime.extension.api.annotation.param.DefaultEncoding;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.client.ExtensionsClient;
@@ -132,6 +133,14 @@ public interface ExtensionParameter extends WithType, WithAnnotations, NamedObje
       return getDefaultValue(annotation.get());
     }
     return java.util.Optional.empty();
+  }
+
+  /**
+   * @return Whether this parameter is considered content.
+   */
+  default boolean isContent() {
+    return isAnnotatedWith(Content.class)
+        || isAnnotatedWith(org.mule.sdk.api.annotation.param.Content.class);
   }
 
   /**

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/FieldWrapper.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/FieldWrapper.java
@@ -36,10 +36,14 @@ public class FieldWrapper implements FieldElement {
   private final FieldSetter fieldSetter;
   private final ClassTypeLoader typeLoader;
 
+  /** Cached value for whether this field is considered content (added for performance). */
+  private final boolean isContent;
+
   public FieldWrapper(Field field, ClassTypeLoader typeLoader) {
     this.field = field;
     this.fieldSetter = new FieldSetter<>(field);
     this.typeLoader = typeLoader;
+    this.isContent = FieldElement.super.isContent();
   }
 
   /**
@@ -102,6 +106,12 @@ public class FieldWrapper implements FieldElement {
     return isAnnotatedWith(annotationClass)
         ? Optional.of(new ClassBasedAnnotationValueFetcher<>(annotationClass, field, typeLoader))
         : empty();
+  }
+
+  @Override
+  public boolean isContent() {
+    // Return a cached value for performance reasons.
+    return isContent;
   }
 
   @Override

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/objectbuilder/ParameterGroupObjectBuilder.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/objectbuilder/ParameterGroupObjectBuilder.java
@@ -19,9 +19,7 @@ import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.management.stats.CursorComponentDecoratorFactory;
-import org.mule.runtime.core.internal.util.message.MessageUtils;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
-import org.mule.runtime.extension.api.annotation.param.Content;
 import org.mule.runtime.extension.api.annotation.param.ParameterGroup;
 import org.mule.runtime.module.extension.api.loader.java.type.FieldElement;
 import org.mule.runtime.module.extension.api.runtime.privileged.EventedExecutionContext;
@@ -32,9 +30,6 @@ import org.mule.runtime.module.extension.internal.runtime.resolver.StaticValueRe
 import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolvingContext;
 import org.mule.runtime.module.extension.internal.util.ReflectionCache;
 
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -109,13 +104,12 @@ public class ParameterGroupObjectBuilder<T> {
     for (FieldElement field : groupDescriptorFields) {
       String name = field.getName();
       if (hasParameter.test(name)) {
-        final boolean isContent = field.isAnnotatedWith(Content.class)
-            || field.isAnnotatedWith(org.mule.sdk.api.annotation.param.Content.class);
         Object resolvedValue = resolveValue(new StaticValueResolver<>(parameters
             .apply(name)), context);
         Object value = context == null || context.resolveCursors()
             ? resolveCursor(resolvedValue,
-                            isContent ? v -> decorateInput(v, context.getEvent().getCorrelationId(), componentDecoratorFactory)
+                            field.isContent()
+                                ? v -> decorateInput(v, context.getEvent().getCorrelationId(), componentDecoratorFactory)
                                 : identity())
             : resolvedValue;
         field.set(object, value);


### PR DESCRIPTION
It has been observed that change #9347 introduced a performance regression of about 3~4%.
Upon closer inspection, it seems most of the regression came from the fact that we are now decorating with `ObjectArgumentResolverDecorator` a lot of arguments that we were not decorating before (for example, arguments of type `List`). This change was done so that these arguments were also decorated by the new `CursorComponentDecoratorFactory`.

However, the `ObjectArgumentResolverDecorator` was added on #8528 because some arguments of `Object` type required cursor resolution.

For many of the new arguments that we now want to decorate because of the `CursorComponentDecoratorFactory` (like `List`), we don't really seem to be needing the cursor resolution. I'm proposing to use a different `ArgumentResolverDecorator` that decorates with `CursorComponentDecoratorFactory` but does not perform cursor resolution.

Moreover, it doesn't seem that we need to decorate all arguments with this, only those that are annotated as `Content`, because we were using `NO_OP_INSTANCE` as `CursorComponentDecoratorFactory` for everything else anyway.

[Here](https://stats.perf.anypoint.mulesoft.com/goto/8c61069eaa233dcb026d9c9eded18157) you can see the result of the performance executions of these same changes applied on a 4.4.0-20211129 (that one was selected for stability). The version labeled **MULE-20054b** would be containing only the first commit of this PR (0e175ce) and not the second one (b022efb).

Version | TPS | % to baseline
-- | -- | --
4.4.0-20211129 | 10492 | 0.00%
4.4.0-20211129 MULE-20054b | 10754 | 2.50%
4.4.0-20211129 MULE-20054 | 10816 | 3.09%

