### PR TITLE
EE-8118: Avoiding unnecessary parsing and validation of the same Mule Version string.

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/ConfigurationInstanceFactory.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/ConfigurationInstanceFactory.java
@@ -8,6 +8,7 @@ package org.mule.runtime.module.extension.internal.runtime.config;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
+import static org.mule.runtime.core.api.extension.MuleExtensionModelProvider.getMuleVersion;
 import static org.mule.runtime.extension.api.util.ExtensionModelUtils.supportsConnectivity;
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.CONFIGURATION_MODEL_PROPERTY_NAME;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.injectFields;
@@ -184,7 +185,7 @@ public final class ConfigurationInstanceFactory<T> {
   private Pair<T, ResolverSetResult> createConfigurationInstance(String name, ResolverSetResult resolverSetResult)
       throws MuleException {
     Pair<T, ResolverSetResult> config = configurationObjectBuilder.build(resolverSetResult);
-    MuleVersion muleVersion = new MuleVersion(MuleExtensionModelProvider.MULE_VERSION);
+    MuleVersion muleVersion = getMuleVersion();
     injectFields(configurationModel, config.getFirst(), name, muleContext.getConfiguration().getDefaultEncoding(), muleVersion);
 
 
@@ -194,8 +195,7 @@ public final class ConfigurationInstanceFactory<T> {
   private Pair<T, ResolverSetResult> createConfigurationInstance(String name, CoreEvent event) throws MuleException {
     try (ValueResolvingContext context = ValueResolvingContext.builder(event).withExpressionManager(expressionManager).build()) {
       Pair<T, ResolverSetResult> config = configurationObjectBuilder.build(context);
-      String muleversion = MuleExtensionModelProvider.MULE_VERSION;
-      MuleVersion muleVersion = new MuleVersion(muleversion);
+      MuleVersion muleVersion = getMuleVersion();
       injectFields(configurationModel, config.getFirst(), name, muleContext.getConfiguration().getDefaultEncoding(), muleVersion);
       return config;
     }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/DefaultConnectionProviderObjectBuilder.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/DefaultConnectionProviderObjectBuilder.java
@@ -8,8 +8,8 @@ package org.mule.runtime.module.extension.internal.runtime.config;
 
 import static java.lang.Thread.currentThread;
 import static org.mule.runtime.api.meta.model.connection.ConnectionManagementType.POOLING;
-import static org.mule.runtime.core.api.extension.MuleExtensionModelProvider.MULE_VERSION;
 import static org.mule.runtime.core.internal.connection.ConnectionUtils.getInjectionTarget;
+import static org.mule.runtime.core.api.extension.MuleExtensionModelProvider.getMuleVersion;
 import static org.mule.runtime.core.internal.util.CompositeClassLoader.from;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.injectFields;
 
@@ -80,7 +80,7 @@ public class DefaultConnectionProviderObjectBuilder<C> extends ConnectionProvide
 
   protected ConnectionProvider<C> doBuild(ResolverSetResult result) throws MuleException {
     ConnectionProvider<C> provider = super.build(result).getFirst();
-    MuleVersion muleVersion = new MuleVersion(MULE_VERSION);
+    MuleVersion muleVersion = getMuleVersion();
     injectFields(providerModel, getInjectionTarget(provider), ownerConfigName,
                  muleContext.getConfiguration().getDefaultEncoding(), muleVersion);
     return provider;

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/objectbuilder/DefaultObjectBuilder.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/objectbuilder/DefaultObjectBuilder.java
@@ -12,7 +12,7 @@ import static java.util.function.UnaryOperator.identity;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.api.util.Preconditions.checkState;
-import static org.mule.runtime.core.api.extension.MuleExtensionModelProvider.MULE_VERSION;
+import static org.mule.runtime.core.api.extension.MuleExtensionModelProvider.getMuleVersion;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.internal.util.message.MessageUtils.decorateInput;
 import static org.mule.runtime.module.extension.api.util.MuleExtensionUtils.getInitialiserEvent;
@@ -145,7 +145,7 @@ public class DefaultObjectBuilder<T> implements ObjectBuilder<T>, Initialisable,
                                  : resolvedValue);
     }
 
-    injectFields(object, name, encoding, new MuleVersion(MULE_VERSION), reflectionCache);
+    injectFields(object, name, encoding, getMuleVersion(), reflectionCache);
 
     return object;
   }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/source/SourceConfigurer.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/source/SourceConfigurer.java
@@ -7,7 +7,7 @@
 package org.mule.runtime.module.extension.internal.runtime.source;
 
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
-import static org.mule.runtime.core.api.extension.MuleExtensionModelProvider.MULE_VERSION;
+import static org.mule.runtime.core.api.extension.MuleExtensionModelProvider.getMuleVersion;
 import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
 import static org.mule.runtime.extension.api.ExtensionConstants.POLLING_SOURCE_LIMIT_PARAMETER_NAME;
 import static org.mule.runtime.extension.api.ExtensionConstants.SCHEDULING_STRATEGY_PARAMETER_NAME;
@@ -22,7 +22,6 @@ import static java.lang.String.format;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
-import org.mule.runtime.api.meta.MuleVersion;
 import org.mule.runtime.api.meta.model.source.SourceModel;
 import org.mule.runtime.api.scheduler.SchedulingStrategy;
 import org.mule.runtime.core.api.MuleContext;
@@ -118,9 +117,8 @@ public final class SourceConfigurer {
           @Override
           public Object build(ValueResolvingContext context) throws MuleException {
             Object builtSource = build(buildResolverSetResult(source, context));
-            MuleVersion muleVersion = new MuleVersion(MULE_VERSION);
             injectDefaultEncoding(model, builtSource, muleContext.getConfiguration().getDefaultEncoding());
-            injectRuntimeVersion(model, builtSource, muleVersion);
+            injectRuntimeVersion(model, builtSource, getMuleVersion());
             injectComponentLocation(builtSource, componentLocation);
             config.ifPresent(c -> injectRefName(builtSource, c.getName(), getReflectionCache()));
             return builtSource;

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelProvider.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelProvider.java
@@ -20,6 +20,7 @@ import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.builder.BaseTypeBuilder;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.meta.MuleVersion;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.store.ObjectStore;
 import org.mule.runtime.api.util.LazyValue;
@@ -38,6 +39,8 @@ import java.util.Properties;
  * @since 4.0
  */
 public final class MuleExtensionModelProvider {
+
+  private static final MuleVersion PARSED_MULE_VERSION;
 
   public static final String MULE_NAME = CORE_PREFIX;
   public static final String MULE_VERSION;
@@ -66,6 +69,8 @@ public final class MuleExtensionModelProvider {
     } catch (IOException e) {
       throw new MuleRuntimeException(e);
     }
+
+    PARSED_MULE_VERSION = new MuleVersion(MULE_VERSION);
   }
 
   private static MetadataType loadPrimitive(String id) {
@@ -95,5 +100,12 @@ public final class MuleExtensionModelProvider {
    */
   public static ExtensionModel getTlsExtensionModel() {
     return TLS_EXTENSION_MODEL.get();
+  }
+
+  /**
+   * @return the parsed {@link MuleVersion} from the build properties.
+   */
+  public static MuleVersion getMuleVersion() {
+    return PARSED_MULE_VERSION;
   }
 }


### PR DESCRIPTION
After 70a5882,  the same Mule Version string is being parsed over and over with every new event, for example when building the response parameters. This is done regardless of whether any parameter was annotated with `@RuntimeVersion` or not.

This seems to be adding unnecessary, and not entirely marginal, processing time to the `DefaultObjectBuilder#build` method.

I'm not entirely sure if this should be refactored in order to avoid having to inject the Mule Version for all parameters, but for the meantime, I can contribute with this mitigation which involves having the parsed `MuleVersion` instance also available as a constant from the `MuleExtensionModelProvider` so we don't have to re-parse it every time.

Screenshots taken from a CPU tracing profile from the performance platform for the `http-default-proxy` scenario with a `4.4.0-20211129`:

![MuleVersion BackTraces](https://user-images.githubusercontent.com/6237096/151171810-a0024373-96c2-4fcc-aa86-83a49192c67c.png)
![MuleVersion contribution in callees](https://user-images.githubusercontent.com/6237096/151171833-647536ed-5159-4c42-93f5-d03d408b95ee.png)

