### PR TITLE
W-10657384: Mule unit tests aren't properly disposing test flows and `MessageProcessorChain`s (#11303)

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/context/FlowTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/context/FlowTestCase.java
@@ -6,10 +6,14 @@
  */
 package org.mule.runtime.core.internal.el.context;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mule.runtime.api.message.Message.of;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.tck.MuleTestUtils.createFlow;
+import static org.slf4j.LoggerFactory.getLogger;
 
+import org.junit.After;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.message.InternalEvent;
 
@@ -26,10 +30,15 @@ public class FlowTestCase extends AbstractELTestCase {
     flowConstruct = createFlow(muleContext, "flowName");
   }
 
+  @After
+  public void after() {
+    disposeIfNeeded(flowConstruct, getLogger(getClass()));
+  }
+
   @Test
   public void flowName() {
     CoreEvent event = InternalEvent.builder(context).message(of("")).build();
-    assertEquals("flowName", evaluate("flow.name", event));
+    assertThat(evaluate("flow.name", event), equalTo("flowName"));
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/event/DefaultEventContextTestCase.java
@@ -21,7 +21,6 @@ import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentT
 import static org.mule.runtime.core.api.event.EventContextFactory.create;
 import static org.mule.runtime.core.internal.event.DefaultEventContext.child;
 import static org.mule.runtime.internal.dsl.DslConstants.CORE_PREFIX;
-import static org.mule.tck.MuleTestUtils.getTestFlow;
 import static org.mule.tck.probe.PollingProber.DEFAULT_POLLING_INTERVAL;
 import static org.mule.tck.probe.PollingProber.probe;
 import static org.mule.test.allure.AllureConstants.EventContextFeature.EVENT_CONTEXT;

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/exception/AbstractErrorHandlerTestCase.java
@@ -57,16 +57,10 @@ public abstract class AbstractErrorHandlerTestCase extends AbstractMuleContextTe
   @Before
   public void before() throws Exception {
     flow = getTestFlow(muleContext);
-    flow.initialise();
 
     context = create(flow, TEST_CONNECTOR_LOCATION);
     muleEvent = InternalEvent.builder(context).message(of("")).build();
 
     when(mockException.getExceptionInfo()).thenReturn(new MuleExceptionInfo());
-  }
-
-  @After
-  public void after() {
-    flow.dispose();
   }
 }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandlerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandlerTestCase.java
@@ -25,13 +25,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.mule.functional.junit4.matchers.ThrowableRootCauseMatcher.hasRootCause;
 import static org.mule.runtime.api.message.Message.of;
-import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
-import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.*;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.buildNewChainWithListOfProcessors;
 import static org.mule.tck.util.MuleContextUtils.getNotificationDispatcher;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
 import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ErrorHandlingStory.ON_ERROR_PROPAGATE;
+import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Mono.just;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
@@ -286,12 +286,14 @@ public class OnErrorPropagateHandlerTestCase extends AbstractErrorHandlerTestCas
     MessageProcessorChain chain =
         buildNewChainWithListOfProcessors(empty(), singletonList(createFailingEventMessageProcessor(mockException)),
                                           onErrorPropagateHandler);
+    initialiseIfNeeded(chain, muleContext);
     expectedException.expect(hasRootCause(sameInstance(mockException)));
     try {
       just(testEvent()).transform(chain).block();
       fail("Expected exception");
     } finally {
       onErrorPropagateHandler.assertAllRoutersWereDisposed();
+      disposeIfNeeded(chain, getLogger(getClass()));
     }
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AbstractAsyncDelegateMessageProcessorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AbstractAsyncDelegateMessageProcessorTestCase.java
@@ -19,7 +19,9 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.util.concurrent.Latch;
@@ -67,7 +69,7 @@ public abstract class AbstractAsyncDelegateMessageProcessorTestCase extends Abst
     async.stop();
     async.dispose();
 
-    flow.dispose();
+    disposeIfNeeded(flow, getLogger(getClass()));
     super.doTearDown();
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorBackPressureTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/AsyncDelegateMessageProcessorBackPressureTestCase.java
@@ -28,6 +28,7 @@ import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.api.processor.Sink;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
 import org.mule.runtime.core.internal.construct.FromFlowRejectedExecutionException;
+import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.runtime.core.internal.processor.strategy.StreamPerEventSink;
 import org.mule.runtime.core.privileged.event.BaseEventContext;
 import org.mule.tck.SimpleUnitTestSupportSchedulerService;
@@ -57,10 +58,10 @@ public class AsyncDelegateMessageProcessorBackPressureTestCase extends AbstractA
     super.doSetUp();
     BackPressureGeneratorProcessingStrategy strategy = new BackPressureGeneratorProcessingStrategy();
     flow = createAndRegisterFlow(muleContext, APPLE_FLOW, componentLocator, (ctx, n) -> strategy);
-    async = createAsyncDelegateMessageProcessor(target, flow);
     service = new FixingBackPressureSchedulerService(strategy);
-    async.setSchedulerService(service);
-    async.initialise();
+    muleContext.getCustomizationService().registerCustomServiceImpl(muleContext.getSchedulerService().getName(), service);
+    ((MuleContextWithRegistry) muleContext).getRegistry().registerObject(muleContext.getSchedulerService().getName(), service);
+    async = createAsyncDelegateMessageProcessor(target, flow);
     async.start();
   }
 

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyTestCase.java
@@ -32,16 +32,17 @@ import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.TIMEOUT;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.rx.Exceptions.rxExceptionToMuleException;
 import static org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair.of;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.newChain;
 import static org.mule.test.allure.AllureConstants.ForkJoinStrategiesFeature.FORK_JOIN_STRATEGIES;
+import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Flux.fromIterable;
 import static reactor.core.publisher.Mono.from;
 import static reactor.core.scheduler.Schedulers.fromExecutorService;
 
-import org.hamcrest.Matchers;
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
@@ -66,6 +67,7 @@ import org.mule.runtime.core.privileged.routing.RoutingResult;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.testmodels.fruit.Apple;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -81,6 +83,7 @@ import org.junit.rules.ExpectedException;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
+import reactor.core.Disposable;
 
 @Feature(FORK_JOIN_STRATEGIES)
 public abstract class AbstractForkJoinStrategyTestCase extends AbstractMuleContextTestCase {
@@ -93,6 +96,7 @@ public abstract class AbstractForkJoinStrategyTestCase extends AbstractMuleConte
   protected Scheduler actualScheduler;
   protected Scheduler scheduler;
   protected ErrorType timeoutErrorType;
+  private final List<MessageProcessorChain> chains = new ArrayList<>();
 
   @Before
   public void setup() {
@@ -109,6 +113,10 @@ public abstract class AbstractForkJoinStrategyTestCase extends AbstractMuleConte
   @After
   public void tearDown() {
     actualScheduler.stop();
+    if (!chains.isEmpty()) {
+      disposeIfNeeded(chains, getLogger(getClass()));
+      chains.clear();
+    }
   }
 
   protected abstract ForkJoinStrategy createStrategy(ProcessingStrategy processingStrategy, int concurrency, boolean delayErrors,
@@ -457,6 +465,7 @@ public abstract class AbstractForkJoinStrategyTestCase extends AbstractMuleConte
 
   protected MessageProcessorChain createChain(Processor processor) throws MuleException {
     MessageProcessorChain chain = newChain(Optional.empty(), processor);
+    chains.add(chain);
     initialiseIfNeeded(chain, muleContext);
     return chain;
   }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/source/polling/DefaultSchedulerMessageSourceTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/source/polling/DefaultSchedulerMessageSourceTestCase.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonMap;
 import static java.util.Optional.of;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -126,7 +127,7 @@ public class DefaultSchedulerMessageSourceTestCase extends AbstractMuleContextTe
     }).when(schedulerService).cpuLightScheduler();
 
     DefaultSchedulerMessageSource schedulerMessageSource = createMessageSource();
-    verify(schedulerService).cpuLightScheduler();
+    verify(schedulerService, atLeastOnce()).cpuLightScheduler();
 
     schedulerMessageSource.start();
 

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/IdempotentRedeliveryPolicyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/IdempotentRedeliveryPolicyTestCase.java
@@ -13,7 +13,6 @@ import static java.util.Optional.of;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,11 +27,14 @@ import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.metadata.DataType.OBJECT;
 import static org.mule.runtime.api.metadata.DataType.STRING;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.rx.Exceptions.checkedConsumer;
 import static org.mule.runtime.core.privileged.processor.IdempotentRedeliveryPolicy.SECURE_HASH_EXPR_FORMAT;
+import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Mono.error;
 import static reactor.core.publisher.Mono.from;
 
+import org.junit.After;
 import org.mule.runtime.api.el.CompiledExpression;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -133,6 +135,11 @@ public class IdempotentRedeliveryPolicyTestCase extends AbstractMuleContextTestC
 
     irp.setLockFactory(muleLockFactory);
     irp.setObjectStoreManager(mockObjectStoreManager);
+  }
+
+  @After
+  public void after() {
+    disposeIfNeeded(irp, getLogger(getClass()));
   }
 
   @Test(expected = ExpressionRuntimeException.class)

--- a/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/privileged/processor/chain/DefaultMessageProcessorChainTestCase.java
@@ -17,15 +17,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.ExpectedException.none;
 import static org.mockito.Mockito.mock;
@@ -128,6 +123,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
   private final ProcessingStrategyFactory processingStrategyFactory;
   private final RuntimeException illegalStateException = new IllegalStateException();
 
+  private Processor messageProcessor;
+
   @Rule
   public ExpectedException expectedException = none();
 
@@ -192,13 +189,21 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
   public void after() throws MuleException {
     flow.stop();
     flow.dispose();
+
+    if (messageProcessor != null) {
+      stopIfNeeded(messageProcessor);
+      disposeIfNeeded(messageProcessor, LOGGER);
+
+      messageProcessor = null;
+    }
   }
 
   @Test
   public void testMPChain() throws Exception {
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(getAppendingMP("1"), getAppendingMP("2"), getAppendingMP("3"));
-    assertEquals("0123", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(), equalTo("0123"));
   }
 
   /*
@@ -215,24 +220,25 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     builder.chain(mp1, mp2, nullmp, mp3);
 
     CoreEvent requestEvent = getTestEventUsingFlow("0");
-    assertNull(process(builder.build(), requestEvent));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, requestEvent), is(nullValue()));
 
     // mp1
-    assertSame(requestEvent.getMessage(), mp1.event.getMessage());
-    assertNotSame(mp1.event, mp1.resultEvent);
-    assertEquals("01", mp1.resultEvent.getMessage().getPayload().getValue());
+    assertThat(requestEvent.getMessage(), sameInstance(mp1.event.getMessage()));
+    assertThat(mp1.event, not(sameInstance(mp1.resultEvent)));
+    assertThat(mp1.resultEvent.getMessage().getPayload().getValue(), equalTo("01"));
 
     // mp2
-    assertSame(mp1.resultEvent.getMessage(), mp2.event.getMessage());
-    assertNotSame(mp2.event, mp2.resultEvent);
-    assertEquals("012", mp2.resultEvent.getMessage().getPayload().getValue());
+    assertThat(mp1.resultEvent.getMessage(), sameInstance(mp2.event.getMessage()));
+    assertThat(mp2.event, not(sameInstance(mp2.resultEvent)));
+    assertThat(mp2.resultEvent.getMessage().getPayload().getValue(), equalTo("012"));
 
     // nullmp
-    assertSame(mp2.resultEvent.getMessage(), nullmp.event.getMessage());
-    assertEquals("012", nullmp.event.getMessage().getPayload().getValue());
+    assertThat(mp2.resultEvent.getMessage(), sameInstance(nullmp.event.getMessage()));
+    assertThat(nullmp.event.getMessage().getPayload().getValue(), equalTo("012"));
 
     // mp3
-    assertNull(mp3.event);
+    assertThat(mp3.event, is(nullValue()));
   }
 
   /*
@@ -249,36 +255,39 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     builder.chain(mp1, mp2, voidmp, mp3);
 
     CoreEvent requestEvent = getTestEventUsingFlow("0");
-    assertEquals("0123", process(builder.build(), requestEvent).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, requestEvent).getMessage().getPayload().getValue(), equalTo("0123"));
 
     // mp1
     // assertSame(requestEvent, mp1.event);
-    assertNotSame(mp1.event, mp1.resultEvent);
+    assertThat(mp1.event, not(sameInstance(mp1.resultEvent)));
 
     // mp2
     // assertSame(mp1.resultEvent, mp2.event);
-    assertNotSame(mp2.event, mp2.resultEvent);
+    assertThat(mp2.event, not(sameInstance(mp2.resultEvent)));
 
     // void mp
-    assertEquals(mp2.resultEvent.getMessage(), voidmp.event.getMessage());
+    assertThat(mp2.resultEvent.getMessage(), equalTo(voidmp.event.getMessage()));
 
     // mp3
     assertThat(mp3.event.getMessage().getPayload().getValue(), equalTo(mp2.resultEvent.getMessage().getPayload().getValue()));
-    assertEquals(mp3.event.getMessage().getPayload().getValue(), "012");
+    assertThat(mp3.event.getMessage().getPayload().getValue(), equalTo("012"));
   }
 
   @Test
   public void testMPChainWithNullReturnAtEnd() throws Exception {
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(getAppendingMP("1"), getAppendingMP("2"), getAppendingMP("3"), new ReturnNullMP());
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
   public void testMPChainWithVoidReturnAtEnd() throws Exception {
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(getAppendingMP("1"), getAppendingMP("2"), getAppendingMP("3"), new ReturnVoidMP());
-    assertEquals("0123", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(), equalTo("0123"));
   }
 
   @Test
@@ -287,15 +296,17 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     builder.chain(getAppendingMP("1"));
     builder.chain((MessageProcessorBuilder) () -> getAppendingMP("2"));
     builder.chain(getAppendingMP("3"));
-    assertEquals("0123", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(), equalTo("0123"));
   }
 
   @Test
   public void testInterceptingMPChain() throws Exception {
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), new AppendingInterceptingMP("2"), new AppendingInterceptingMP("3"));
-    assertEquals("0before1before2before3after3after2after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before1before2before3after3after2after1"));
   }
 
   @Test
@@ -305,8 +316,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     AppendingInterceptingMP lastMP = new AppendingInterceptingMP("3");
 
     builder.chain(new AppendingInterceptingMP("1"), new AppendingInterceptingMP("2"), new ReturnNullInterceptongMP(), lastMP);
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
-    assertFalse(lastMP.invoked);
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
+    assertThat(lastMP.invoked, is(false));
   }
 
   @Test
@@ -316,8 +328,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     AppendingInterceptingMP lastMP = new AppendingInterceptingMP("3");
 
     builder.chain(new AppendingInterceptingMP("1"), new AppendingInterceptingMP("2"), new ReturnNullInterceptongMP(), lastMP);
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
-    assertFalse(lastMP.invoked);
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
+    assertThat(lastMP.invoked, is(false));
   }
 
   @Test
@@ -325,8 +338,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), getAppendingMP("3"), new AppendingInterceptingMP("4"),
                   getAppendingMP("5"));
-    assertEquals("0before123before45after4after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before123before45after4after1"));
   }
 
   @Test
@@ -335,7 +349,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), new ReturnNullInterceptongMP(), getAppendingMP("2"), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -344,7 +359,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), new ReturnVoidMPInterceptongMP(), getAppendingMP("2"), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertThat(process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
                equalTo("0before1after1"));
   }
 
@@ -354,7 +370,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), new ReturnNullInterceptongMP(), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -363,7 +380,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), new ReturnVoidMPInterceptongMP(), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertEquals("0before12after1", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before12after1"));
   }
 
   @Test
@@ -373,7 +392,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), new ReturnNullMP(), getAppendingMP("2"), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -383,8 +403,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), new ReturnVoidMP(), getAppendingMP("2"), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertEquals("0before123before45after4after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before123before45after4after1"));
   }
 
   @Test
@@ -394,7 +415,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), new ReturnNullMP(), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -404,8 +426,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), new ReturnVoidMP(), getAppendingMP("3"),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertEquals("0before123before45after4after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before123before45after4after1"));
   }
 
   @Test
@@ -415,7 +438,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), getAppendingMP("3"), new ReturnNullMP(),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -425,8 +449,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), getAppendingMP("3"), new ReturnVoidMP(),
                   new AppendingInterceptingMP("4"), getAppendingMP("5"));
-    assertEquals("0before123before45after4after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before123before45after4after1"));
   }
 
   @Test
@@ -435,7 +460,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), getAppendingMP("3"), new AppendingInterceptingMP("4"),
                   getAppendingMP("5"), new ReturnNullMP());
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -444,8 +470,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), getAppendingMP("2"), getAppendingMP("3"), new AppendingInterceptingMP("4"),
                   getAppendingMP("5"), new ReturnVoidMP());
-    assertEquals("0before123before45after4after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before123before45after4after1"));
   }
 
   @Test
@@ -454,7 +481,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     builder.chain(getAppendingMP("1"),
                   new DefaultMessageProcessorChainBuilder().chain(getAppendingMP("a"), getAppendingMP("b")).build(),
                   getAppendingMP("2"));
-    assertEquals("01ab2", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(), equalTo("01ab2"));
   }
 
   @Test
@@ -464,7 +492,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
                   getAppendingMP("1"), new DefaultMessageProcessorChainBuilder()
                       .chain(getAppendingMP("a"), new ReturnNullMP(), getAppendingMP("b")).build(),
                   new ReturnNullMP(), getAppendingMP("2"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -474,7 +503,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
                   getAppendingMP("1"), new DefaultMessageProcessorChainBuilder()
                       .chain(getAppendingMP("a"), new ReturnVoidMP(), getAppendingMP("b")).build(),
                   new ReturnVoidMP(), getAppendingMP("2"));
-    assertEquals("01ab2", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(), equalTo("01ab2"));
   }
 
   @Test
@@ -482,7 +512,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(getAppendingMP("1"), new DefaultMessageProcessorChainBuilder()
         .chain(getAppendingMP("a"), getAppendingMP("b"), new ReturnNullMP()).build(), getAppendingMP("2"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -490,7 +521,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(getAppendingMP("1"), new DefaultMessageProcessorChainBuilder()
         .chain(getAppendingMP("a"), getAppendingMP("b"), new ReturnVoidMP()).build(), getAppendingMP("2"));
-    assertEquals("01ab2", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(), equalTo("01ab2"));
   }
 
   @Test
@@ -501,7 +533,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
             .build();
     nested.setMuleContext(muleContext);
     builder.chain(getAppendingMP("1"), event -> nested.process(event), getAppendingMP("2"));
-    assertNull("012", process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat("012", process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -513,7 +546,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     nested.setMuleContext(muleContext);
     builder.chain(getAppendingMP("1"), event -> nested.process(InternalEvent.builder(event)
         .message(event.getMessage()).build()), getAppendingMP("2"));
-    assertEquals("01ab2", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(), equalTo("01ab2"));
   }
 
   @Test
@@ -523,8 +557,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
                   new DefaultMessageProcessorChainBuilder()
                       .chain(new AppendingInterceptingMP("a"), new AppendingInterceptingMP("b")).build(),
                   new AppendingInterceptingMP("2"));
-    assertEquals("0before1beforeabeforebafterbafterabefore2after2after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before1beforeabeforebafterbafterabefore2after2after1"));
   }
 
   @Test
@@ -535,7 +570,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
                       .chain(new AppendingInterceptingMP("a"), new ReturnNullInterceptongMP(), new AppendingInterceptingMP("b"))
                       .build(),
                   new AppendingInterceptingMP("2"));
-    assertNull(process(builder.build(), getTestEventUsingFlow("0")));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")), is(nullValue()));
   }
 
   @Test
@@ -546,7 +582,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
                       .chain(new AppendingInterceptingMP("a"), new ReturnVoidMPInterceptongMP(), new AppendingInterceptingMP("b"))
                       .build(),
                   new AppendingInterceptingMP("2"));
-    assertThat(process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
                equalTo("0before1beforeaafterabefore2after2after1"));
   }
 
@@ -557,15 +594,18 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
                   new DefaultMessageProcessorChainBuilder()
                       .chain(new AppendingInterceptingMP("a"), getAppendingMP("b")).build(),
                   new AppendingInterceptingMP("2"));
-    assertEquals("01beforeabafterabefore2after2",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("01beforeabafterabefore2after2"));
   }
 
   @Test
   public void testInterceptingMPChainStopFlow() throws Exception {
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new AppendingInterceptingMP("1"), new AppendingInterceptingMP("2", true), new AppendingInterceptingMP("3"));
-    assertEquals("0before1after1", process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before1after1"));
   }
 
   /**
@@ -579,8 +619,9 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
                   new DefaultMessageProcessorChainBuilder()
                       .chain(new AppendingInterceptingMP("a", true), new AppendingInterceptingMP("b")).build(),
                   new AppendingInterceptingMP("3"));
-    assertEquals("0before1before3after3after1",
-                 process(builder.build(), getTestEventUsingFlow("0")).getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, getTestEventUsingFlow("0")).getMessage().getPayload().getValue(),
+               equalTo("0before1before3after3after1"));
   }
 
   @Test
@@ -620,17 +661,19 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
   public void testNoneIntercepting() throws Exception {
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new TestNonIntercepting(), new TestNonIntercepting(), new TestNonIntercepting());
-    CoreEvent result = process(builder.build(), getTestEventUsingFlow(""));
-    assertEquals("MessageProcessorMessageProcessorMessageProcessor", result.getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    CoreEvent result = process(messageProcessor, getTestEventUsingFlow(""));
+    assertThat(result.getMessage().getPayload().getValue(), equalTo("MessageProcessorMessageProcessorMessageProcessor"));
   }
 
   @Test
   public void testAllIntercepting() throws Exception {
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new TestIntercepting(), new TestIntercepting(), new TestIntercepting());
-    CoreEvent result = process(builder.build(), getTestEventUsingFlow(""));
-    assertEquals("InterceptingMessageProcessorInterceptingMessageProcessorInterceptingMessageProcessor",
-                 result.getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    CoreEvent result = process(messageProcessor, getTestEventUsingFlow(""));
+    assertThat(result.getMessage().getPayload().getValue(),
+               equalTo("InterceptingMessageProcessorInterceptingMessageProcessorInterceptingMessageProcessor"));
   }
 
   @Test
@@ -638,9 +681,10 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new TestIntercepting(), new TestNonIntercepting(), new TestNonIntercepting(), new TestIntercepting(),
                   new TestNonIntercepting(), new TestNonIntercepting());
-    CoreEvent result = process(builder.build(), getTestEventUsingFlow(""));
-    assertEquals("InterceptingMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessor",
-                 result.getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    CoreEvent result = process(messageProcessor, getTestEventUsingFlow(""));
+    assertThat(result.getMessage().getPayload().getValue(),
+               equalTo("InterceptingMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessor"));
   }
 
   @Test
@@ -651,7 +695,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new TestIntercepting(), new TestNonIntercepting())
         .setMessagingExceptionHandler(errorHandler);
-    final InterceptingMessageProcessorChain chain = (InterceptingMessageProcessorChain) builder.build();
+    messageProcessor = builder.build();
+    final InterceptingMessageProcessorChain chain = (InterceptingMessageProcessorChain) messageProcessor;
 
     final DefaultMessageProcessorChain intercepting =
         (DefaultMessageProcessorChain) chain.getMessageProcessorsForLifecycle().get(0);
@@ -665,13 +710,13 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
 
   @Test
   public void testMixStaticFactory() throws Exception {
-    MessageProcessorChain chain =
+    messageProcessor =
         newChain(empty(), new TestIntercepting(), new TestNonIntercepting(),
                  new TestNonIntercepting(), new TestIntercepting(), new TestNonIntercepting(),
                  new TestNonIntercepting());
-    CoreEvent result = process(chain, getTestEventUsingFlow(""));
-    assertEquals("InterceptingMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessor",
-                 result.getMessage().getPayload().getValue());
+    CoreEvent result = process(messageProcessor, getTestEventUsingFlow(""));
+    assertThat(result.getMessage().getPayload().getValue(),
+               equalTo("InterceptingMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessor"));
   }
 
   @Test
@@ -679,19 +724,20 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new TestNonIntercepting(), new TestIntercepting(), new TestNonIntercepting(), new TestNonIntercepting(),
                   new TestNonIntercepting(), new TestIntercepting());
-    CoreEvent result = process(builder.build(), getTestEventUsingFlow(""));
-    assertEquals("MessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessor",
-                 result.getMessage().getPayload().getValue());
+    messageProcessor = builder.build();
+    CoreEvent result = process(messageProcessor, getTestEventUsingFlow(""));
+    assertThat(result.getMessage().getPayload().getValue(),
+               equalTo("MessageProcessorInterceptingMessageProcessorMessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessor"));
   }
 
   @Test
   public void testMix2StaticFactory() throws Exception {
-    MessageProcessorChain chain =
+    messageProcessor =
         newChain(empty(), new TestNonIntercepting(), new TestNonIntercepting(), new TestNonIntercepting(),
                  new TestIntercepting());
-    CoreEvent result = process(chain, getTestEventUsingFlow(""));
-    assertEquals("MessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessor",
-                 result.getMessage().getPayload().getValue());
+    CoreEvent result = process(messageProcessor, getTestEventUsingFlow(""));
+    assertThat(result.getMessage().getPayload().getValue(),
+               equalTo("MessageProcessorMessageProcessorMessageProcessorInterceptingMessageProcessor"));
   }
 
   @Test
@@ -738,7 +784,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(getAppendingMP("1"), new ExceptionThrowingMessageProcessor(illegalStateException));
     expectedException.expect(is(illegalStateException));
-    process(builder.build(), getTestEventUsingFlow("0"));
+    messageProcessor = builder.build();
+    process(messageProcessor, getTestEventUsingFlow("0"));
   }
 
   @Test
@@ -746,7 +793,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(new ExceptionThrowingMessageProcessor(illegalStateException), getAppendingMP("1"));
     expectedException.expect(is(illegalStateException));
-    process(builder.build(), getTestEventUsingFlow("0"));
+    messageProcessor = builder.build();
+    process(messageProcessor, getTestEventUsingFlow("0"));
   }
 
   @Test
@@ -754,7 +802,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     DefaultMessageProcessorChainBuilder builder = new DefaultMessageProcessorChainBuilder();
     builder.chain(getAppendingMP("1"), new ExceptionThrowingMessageProcessor(illegalStateException), getAppendingMP("2"));
     expectedException.expect(is(illegalStateException));
-    process(builder.build(), getTestEventUsingFlow("0"));
+    messageProcessor = builder.build();
+    process(messageProcessor, getTestEventUsingFlow("0"));
   }
 
   @Test
@@ -765,7 +814,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     builder.chain(getAppendingMP("1"));
     final CoreEvent inEvent = getTestEventUsingFlow("0");
     final String resultPayload = "01";
-    assertThat(process(builder.build(), inEvent).getMessage().getPayload().getValue(), equalTo(resultPayload));
+    messageProcessor = builder.build();
+    assertThat(process(messageProcessor, inEvent).getMessage().getPayload().getValue(), equalTo(resultPayload));
     assertThat(notificationList, hasSize(2));
     MessageProcessorNotification preNotification = notificationList.get(0);
     MessageProcessorNotification postNotification = notificationList.get(1);
@@ -785,7 +835,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     builder.chain(new ExceptionThrowingMessageProcessor(illegalStateException));
     final CoreEvent inEvent = getTestEventUsingFlow("0");
     try {
-      process(builder.build(), inEvent);
+      messageProcessor = builder.build();
+      process(messageProcessor, inEvent);
     } catch (Throwable t) {
       assertThat(t, is(illegalStateException));
       assertThat(notificationList, hasSize(2));
@@ -808,7 +859,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
     builder.chain(new ExceptionThrowingMessageProcessor(messagingException));
     final CoreEvent inEvent = getTestEventUsingFlow("0");
     try {
-      process(builder.build(), inEvent);
+      messageProcessor = builder.build();
+      process(messageProcessor, inEvent);
     } catch (Throwable t) {
       assertThat(t, instanceOf(IllegalStateException.class));
       assertThat(notificationList, hasSize(2));
@@ -964,7 +1016,8 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
 
     final CoreEvent inEvent = getTestEventUsingFlow("0");
     try {
-      process(builder.build(), inEvent);
+      messageProcessor = builder.build();
+      process(messageProcessor, inEvent);
       fail("Should have thrown");
     } catch (Throwable t) {
       // This is the most important assertion here, that the error was notified which means the chain was not
@@ -1014,11 +1067,11 @@ public class DefaultMessageProcessorChainTestCase extends AbstractReactiveProces
   }
 
   private void assertLifecycle(AppendingInterceptingMP mp) {
-    assertTrue(mp.muleContextInjected);
-    assertTrue(mp.initialised);
-    assertTrue(mp.started);
-    assertTrue(mp.stopped);
-    assertTrue(mp.disposed);
+    assertThat(mp.muleContextInjected, is(true));
+    assertThat(mp.initialised, is(true));
+    assertThat(mp.started, is(true));
+    assertThat(mp.stopped, is(true));
+    assertThat(mp.disposed, is(true));
   }
 
   class NonBlockingAppendingMP extends AppendingMP {

--- a/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyNextActionMessageProcessor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/policy/PolicyNextActionMessageProcessor.java
@@ -11,9 +11,11 @@ import static java.util.Optional.empty;
 import static org.mule.runtime.api.component.location.Location.builderFromStringRepresentation;
 import static org.mule.runtime.api.notification.PolicyNotification.AFTER_NEXT;
 import static org.mule.runtime.api.notification.PolicyNotification.BEFORE_NEXT;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.buildNewChainWithListOfProcessors;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processToApply;
+import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Flux.from;
 import static reactor.core.publisher.Mono.subscriberContext;
 
@@ -21,6 +23,7 @@ import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.lifecycle.Disposable;
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.util.Pair;
@@ -53,7 +56,7 @@ import org.reactivestreams.Publisher;
  *
  * @since 4.0
  */
-public class PolicyNextActionMessageProcessor extends AbstractComponent implements Processor, Initialisable {
+public class PolicyNextActionMessageProcessor extends AbstractComponent implements Processor, Initialisable, Disposable {
 
   static final String SOURCE_POLICY_PART_IDENTIFIER = "source";
   static final String SUBFLOW_POLICY_PART_IDENTIFIER = "sub-flow";
@@ -211,4 +214,8 @@ public class PolicyNextActionMessageProcessor extends AbstractComponent implemen
     return muleContext.getConfiguration().getId();
   }
 
+  @Override
+  public void dispose() {
+    disposeIfNeeded(nextDispatchAsChain, getLogger(getClass()));
+  }
 }

--- a/tests/component-plugin/src/test/java/org/mule/functional/api/component/OnErrorCheckLogHandlerTestCase.java
+++ b/tests/component-plugin/src/test/java/org/mule/functional/api/component/OnErrorCheckLogHandlerTestCase.java
@@ -12,13 +12,16 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mule.runtime.api.component.AbstractComponent.ROOT_CONTAINER_NAME_KEY;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Flux.just;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -48,6 +51,11 @@ public class OnErrorCheckLogHandlerTestCase extends AbstractMuleContextTestCase 
     checkLogHandler.setAnnotations(ImmutableMap.of(ROOT_CONTAINER_NAME_KEY, "someContainerName"));
     initialiseIfNeeded(checkLogHandler, muleContext);
     checkLogHandler.start();
+  }
+
+  @After
+  public void disposeLogHandler() {
+    disposeIfNeeded(checkLogHandler, getLogger(getClass()));
   }
 
   @Test

--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
@@ -400,6 +400,7 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase {
   @AfterClass
   public static void disposeContext() throws MuleException {
     try {
+      clearTestFlows();
       if (muleContext != null && !(muleContext.isDisposed() || muleContext.isDisposing())) {
         disposeOnlyMuleContext();
 

--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleTestCase.java
@@ -19,6 +19,7 @@ import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.util.MuleSystemProperties.MULE_ENABLE_STREAMING_STATISTICS;
 import static org.mule.runtime.api.util.MuleSystemProperties.TESTING_MODE_PROPERTY_NAME;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.util.StringMessageUtils.getBoilerPlate;
 import static org.mule.runtime.core.api.util.StringUtils.isBlank;
 import static org.mule.runtime.core.api.util.SystemUtils.parsePropertyDefinitions;
@@ -29,10 +30,13 @@ import static org.slf4j.LoggerFactory.getLogger;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.FeatureFlaggingService;
+import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.util.StringUtils;
 import org.mule.runtime.core.api.util.SystemUtils;
+import org.mule.tck.MuleTestUtils;
 import org.mule.tck.junit4.rule.WarningTimeout;
 import org.mule.tck.report.ThreadDumpOnTimeOut;
 
@@ -270,6 +274,22 @@ public abstract class AbstractMuleTestCase {
   public void takeTestCaseName() {
     if (testCaseName == null) {
       testCaseName = this.getClass().getName();
+    }
+  }
+
+  private static final List<Flow> testFlows = new ArrayList<>();
+
+  protected static Flow getTestFlow(MuleContext context) throws MuleException {
+    Flow flow = MuleTestUtils.getTestFlow(context);
+    testFlows.add(flow);
+    return flow;
+  }
+
+  @AfterClass
+  public static void clearTestFlows() {
+    if (!testFlows.isEmpty()) {
+      disposeIfNeeded(testFlows, LOGGER);
+      testFlows.clear();
     }
   }
 

--- a/tests/unit/src/main/java/org/mule/tck/util/MuleContextUtils.java
+++ b/tests/unit/src/main/java/org/mule/tck/util/MuleContextUtils.java
@@ -298,6 +298,7 @@ public class MuleContextUtils {
    */
   public static <B extends CoreEvent.Builder> B eventBuilder(MuleContext muleContext) throws MuleException {
     FlowConstruct flowConstruct = getTestFlow(muleContext);
+    ((MuleContextWithRegistry) muleContext).getRegistry().registerFlowConstruct(flowConstruct);
     return (B) InternalEvent.builder(create(flowConstruct, TEST_CONNECTOR_LOCATION));
   }
 


### PR DESCRIPTION
(cherry picked from commit 1109cc25db6a7bebe3534bdbcd582f73a0aa389c)