### PR TITLE
Change logger to private static final (avoid: was created with the message factory)

### DIFF
--- a/core/src/main/java/org/mule/construct/Validator.java
+++ b/core/src/main/java/org/mule/construct/Validator.java
@@ -9,6 +9,8 @@ package org.mule.construct;
 import java.util.Collections;
 
 import org.apache.commons.lang.Validate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.MessageExchangePattern;
 import org.mule.VoidMuleEvent;
 import org.mule.RequestContext;
@@ -36,6 +38,7 @@ import org.mule.expression.transformers.ExpressionArgument;
 import org.mule.expression.transformers.ExpressionTransformer;
 import org.mule.message.DefaultExceptionPayload;
 import org.mule.processor.AbstractInterceptingMessageProcessor;
+import org.mule.processor.AbstractInterceptingMessageProcessorBase;
 import org.mule.processor.ResponseMessageProcessorAdapter;
 import org.mule.routing.ChoiceRouter;
 import org.mule.util.StringUtils;
@@ -225,6 +228,7 @@ public class Validator extends AbstractConfigurationPattern
     private static class ErrorAwareEventReturningMessageProcessor extends
         AbstractInterceptingMessageProcessor
     {
+        private static final Log logger = LogFactory.getLog(ErrorAwareEventReturningMessageProcessor.class);
         /*
          * Returns the incoming event whatever the outcome of the rest of the chain maybe. Sets an exception payload on
          * the incoming event if an error occurred downstream.

--- a/core/src/main/java/org/mule/construct/Validator.java
+++ b/core/src/main/java/org/mule/construct/Validator.java
@@ -38,7 +38,6 @@ import org.mule.expression.transformers.ExpressionArgument;
 import org.mule.expression.transformers.ExpressionTransformer;
 import org.mule.message.DefaultExceptionPayload;
 import org.mule.processor.AbstractInterceptingMessageProcessor;
-import org.mule.processor.AbstractInterceptingMessageProcessorBase;
 import org.mule.processor.ResponseMessageProcessorAdapter;
 import org.mule.routing.ChoiceRouter;
 import org.mule.util.StringUtils;

--- a/core/src/main/java/org/mule/endpoint/outbound/OutboundTxRollbackMessageProcessor.java
+++ b/core/src/main/java/org/mule/endpoint/outbound/OutboundTxRollbackMessageProcessor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.endpoint.outbound;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
 import org.mule.api.transaction.Transaction;
@@ -19,6 +21,8 @@ import org.mule.transaction.TransactionCoordination;
  */
 public class OutboundTxRollbackMessageProcessor extends AbstractInterceptingMessageProcessor
 {
+    private static final Log logger = LogFactory.getLog(OutboundTxRollbackMessageProcessor.class);
+
     public MuleEvent process(MuleEvent event) throws MuleException
     {
         // No point continuing if the service has rolledback the transaction

--- a/core/src/main/java/org/mule/lifecycle/processor/ProcessIfStartedWaitIfPausedMessageProcessor.java
+++ b/core/src/main/java/org/mule/lifecycle/processor/ProcessIfStartedWaitIfPausedMessageProcessor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.lifecycle.processor;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -16,6 +18,7 @@ import org.mule.service.Pausable;
 
 public class ProcessIfStartedWaitIfPausedMessageProcessor extends ProcessIfStartedMessageProcessor
 {
+    private static final Log logger = LogFactory.getLog(ProcessIfStartedWaitIfPausedMessageProcessor.class);
 
     public ProcessIfStartedWaitIfPausedMessageProcessor(Startable startable, LifecycleState lifecycleState)
     {

--- a/core/src/main/java/org/mule/lifecycle/processor/ProcessIfStartedWaitIfSyncPausedMessageProcessor.java
+++ b/core/src/main/java/org/mule/lifecycle/processor/ProcessIfStartedWaitIfSyncPausedMessageProcessor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.lifecycle.processor;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
@@ -16,6 +18,7 @@ import org.mule.config.i18n.CoreMessages;
 public class ProcessIfStartedWaitIfSyncPausedMessageProcessor extends
     ProcessIfStartedWaitIfPausedMessageProcessor
 {
+    private static final Log logger = LogFactory.getLog(ProcessIfStartedWaitIfSyncPausedMessageProcessor.class);
 
     public ProcessIfStartedWaitIfSyncPausedMessageProcessor(Startable startable, LifecycleState lifecycleState)
     {

--- a/core/src/main/java/org/mule/processor/AbstractInterceptingMessageProcessorBase.java
+++ b/core/src/main/java/org/mule/processor/AbstractInterceptingMessageProcessorBase.java
@@ -40,7 +40,7 @@ public abstract class AbstractInterceptingMessageProcessorBase extends AbstractA
         implements MessageProcessor, MuleContextAware, MessageProcessorContainer
 {
 
-    protected Log logger = LogFactory.getLog(getClass());
+    private static final Log logger = LogFactory.getLog(AbstractInterceptingMessageProcessorBase.class);
 
     protected ServerNotificationHandler notificationHandler;
     private MessageProcessorExecutionTemplate messageProcessorExecutorWithoutNotifications = MessageProcessorExecutionTemplate.createExceptionTransformerExecutionTemplate();

--- a/core/src/main/java/org/mule/processor/AsyncInterceptingMessageProcessor.java
+++ b/core/src/main/java/org/mule/processor/AsyncInterceptingMessageProcessor.java
@@ -8,6 +8,8 @@ package org.mule.processor;
 
 import static org.mule.config.i18n.CoreMessages.errorSchedulingMessageProcessorForAsyncInvocation;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.VoidMuleEvent;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
@@ -45,6 +47,8 @@ public class AsyncInterceptingMessageProcessor extends AbstractInterceptingMessa
 {
 
     public static final String SYNCHRONOUS_NONBLOCKING_EVENT_ERROR_MESSAGE = "Unable to process a synchronous or non-blocking event asynchronously";
+
+    private static final Log logger = LogFactory.getLog(AsyncInterceptingMessageProcessor.class);
 
     protected WorkManagerSource workManagerSource;
     protected boolean doThreading = true;

--- a/core/src/main/java/org/mule/processor/SedaStageInterceptingMessageProcessor.java
+++ b/core/src/main/java/org/mule/processor/SedaStageInterceptingMessageProcessor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.processor;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.DefaultMuleEvent;
 import org.mule.OptimizedRequestContext;
 import org.mule.RequestContext;
@@ -51,6 +53,7 @@ public class SedaStageInterceptingMessageProcessor extends AsyncInterceptingMess
     implements Work, Lifecycle, Pausable, Resumable
 {
     protected static final String QUEUE_NAME_PREFIX = "seda.queue";
+    private static final Log logger = LogFactory.getLog(SedaStageInterceptingMessageProcessor.class);
     public static int DEFAULT_QUEUE_SIZE_MAX_THREADS_FACTOR = 4;
 
     protected QueueProfile queueProfile;

--- a/core/src/main/java/org/mule/routing/ExpressionSplitter.java
+++ b/core/src/main/java/org/mule/routing/ExpressionSplitter.java
@@ -6,6 +6,8 @@
  */
 package org.mule.routing;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.DefaultMuleMessage;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleMessage;
@@ -38,6 +40,8 @@ import org.w3c.dom.NodeList;
 public class ExpressionSplitter extends AbstractSplitter
     implements Initialisable
 {
+    private static final Log logger = LogFactory.getLog(ExpressionSplitter.class);
+
     protected ExpressionManager expressionManager;
     protected ExpressionConfig config = new ExpressionConfig();
 

--- a/core/src/main/java/org/mule/routing/IdempotentMessageFilter.java
+++ b/core/src/main/java/org/mule/routing/IdempotentMessageFilter.java
@@ -147,18 +147,18 @@ public class IdempotentMessageFilter extends AbstractFilteringMessageProcessor i
                 }
                 catch (ObjectStoreNotAvaliableException e)
                 {
-                    logger.error("ObjectStore not available: " + e.getMessage());
+                    LOGGER.error("ObjectStore not available: " + e.getMessage());
                     return false;
                 }
                 catch (ObjectStoreException e)
                 {
-                    logger.warn("ObjectStore exception: " + e.getMessage());
+                    LOGGER.warn("ObjectStore exception: " + e.getMessage());
                     return false;
                 }
             }
             catch (MessagingException e)
             {
-                logger.warn("Could not retrieve Id or Value for event: " + e.getMessage());
+                LOGGER.warn("Could not retrieve Id or Value for event: " + e.getMessage());
                 return false;
             }
         }
@@ -176,7 +176,7 @@ public class IdempotentMessageFilter extends AbstractFilteringMessageProcessor i
         }
         else
         {
-            logger.error("This IdempotentMessageFilter was configured on the service: "
+            LOGGER.error("This IdempotentMessageFilter was configured on the service: "
                          + storePrefix + " but has received an event for service: "
                          + flowConstruct.getName() + ". Please check your config to make sure each service"
                          + "has its own instance of IdempotentMessageFilter.");
@@ -200,7 +200,7 @@ public class IdempotentMessageFilter extends AbstractFilteringMessageProcessor i
         }
         catch (MuleException e)
         {
-            logger.error("Exception attempting to determine idempotency of incoming message for "
+            LOGGER.error("Exception attempting to determine idempotency of incoming message for "
                          + event.getFlowConstruct().getName() + " from the endpoint "
                          + event.getMessageSourceURI(), e);
             return false;

--- a/core/src/main/java/org/mule/routing/outbound/AbstractMessageSequenceSplitter.java
+++ b/core/src/main/java/org/mule/routing/outbound/AbstractMessageSequenceSplitter.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.collections.Transformer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.System.getProperty;
@@ -48,6 +50,8 @@ import static org.mule.api.config.MuleProperties.MULE_DISABLE_COMPOUND_CORRELATI
 public abstract class AbstractMessageSequenceSplitter extends AbstractInterceptingMessageProcessor
     implements MuleContextAware
 {
+    private static final Log logger = LogFactory.getLog(AbstractMessageSequenceSplitter.class);
+
     protected MuleContext muleContext;
     protected RouterResultsHandler resultsHandler = new DefaultRouterResultsHandler();
     protected CorrelationMode enableCorrelation = CorrelationMode.IF_NOT_SET;

--- a/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
+++ b/core/src/main/java/org/mule/routing/requestreply/AbstractAsyncRequestReplyRequester.java
@@ -45,6 +45,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.collections.buffer.BoundedFifoBuffer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterceptingMessageProcessorBase
     implements RequestReplyRequesterMessageProcessor, FlowConstructAware, Initialisable, Startable, Stoppable, Disposable
@@ -53,6 +55,7 @@ public abstract class AbstractAsyncRequestReplyRequester extends AbstractInterce
     public static final int UNCLAIMED_TIME_TO_LIVE = 60000;
     public static int UNCLAIMED_INTERVAL = 60000;
 
+    private static final Log logger = LogFactory.getLog(AbstractAsyncRequestReplyRequester.class);
 
     public static final String NAME_TEMPLATE = "%s.%s.%s.asyncReplies";
     protected String name;

--- a/core/src/main/java/org/mule/service/ForwardingConsumer.java
+++ b/core/src/main/java/org/mule/service/ForwardingConsumer.java
@@ -6,6 +6,8 @@
  */
 package org.mule.service;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.VoidMuleEvent;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleEvent;
@@ -23,6 +25,7 @@ import org.mule.routing.MessageFilter;
 @Deprecated
 public class ForwardingConsumer extends MessageFilter
 {
+    private static final Log logger = LogFactory.getLog(ForwardingConsumer.class);
     @Override
     public MuleEvent processNext(MuleEvent event) throws MessagingException
     {

--- a/core/src/main/java/org/mule/service/ServiceCompositeMessageSource.java
+++ b/core/src/main/java/org/mule/service/ServiceCompositeMessageSource.java
@@ -6,6 +6,8 @@
  */
 package org.mule.service;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.api.MuleEvent;
 import org.mule.api.MuleException;
 import org.mule.api.construct.FlowConstructAware;
@@ -39,6 +41,7 @@ import java.util.List;
 @Deprecated
 public class ServiceCompositeMessageSource extends StartableCompositeMessageSource implements Initialisable, RouterStatisticsRecorder
 {
+    private static final Log logger = LogFactory.getLog(ServiceCompositeMessageSource.class);
     protected List<MessageProcessor> processors = new LinkedList<MessageProcessor>();
     protected RouterStatistics statistics;
     protected List<InboundEndpoint> endpoints = new ArrayList<InboundEndpoint>();

--- a/core/src/main/java/org/mule/service/processor/ServiceOutboundMessageProcessor.java
+++ b/core/src/main/java/org/mule/service/processor/ServiceOutboundMessageProcessor.java
@@ -6,6 +6,8 @@
  */
 package org.mule.service.processor;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mule.DefaultMuleEvent;
 import org.mule.DefaultMuleMessage;
 import org.mule.VoidMuleEvent;
@@ -30,6 +32,7 @@ import org.mule.transport.NullPayload;
 @Deprecated
 public class ServiceOutboundMessageProcessor extends AbstractInterceptingMessageProcessor
 {
+    private static final Log logger = LogFactory.getLog(ServiceOutboundMessageProcessor.class);
 
     protected Service service;
 


### PR DESCRIPTION
On our onpremise server where multiple mule-apps are deployed we are facing more and more 

```
...-prod].HTTP_Listener_Configuration.worker.198 WARN
The Logger com.mulesoft.module.client.processors.APIPlatformValidateClientMessageProcessor
was created with the message factory org.apache.logging.log4j.message.ReusableMessageFactory@1076af91 and is now
requested with the message factory org.apache.logging.log4j.message.ReusableMessageFactory@c06cbb1,
which may create log events with unexpected formatting.
```

logger messages in our mule_ee.log files (see org.apache.logging.log4j.spi.AbstractLogger.checkMessageFactory(ExtendedLogger, MessageFactory)).

Checking the hierarchy APIPlatformValidateClientMessageProcessor in 
C:\swd\AnypointStudio\plugins\org.mule.tooling.server.3.9.5.ee_6.6.4.202112281952\mule\lib\mule\api-gateway-client-3.9.5-20211223.jar
which is: AbstractNonBlockingFilteringMessageProcessor:AbstractInterceptingMessageProcessor:AbstractInterceptingMessageProcessorBase:AbstractInterceptingMessageProcessorBase

and the AbstractInterceptingMessageProcessorBase has a 
```
protected Log logger = LogFactory.getLog(getClass());
```
which causes creating the APIPlatformValidateClientMessageProcessor on two different places (classloaders) and so having different message factories.

To avoid such WARN messages best is to set loggers "private static final " which I have done for AbstractInterceptingMessageProcessorBase.

In all sub-classes I added the 
```
    private static final Log logger = LogFactory.getLog(<className>.class);
```
to keep existing loggers as is.
