### PR TITLE
W-10742153: handle statistics not initialized error in `DefaultExecutionMediator` and add logging to `LifecycleAwareConfigurationInstance`. (#11358)

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/LifecycleAwareConfigurationInstance.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/config/LifecycleAwareConfigurationInstance.java
@@ -137,6 +137,10 @@ public final class LifecycleAwareConfigurationInstance implements ConfigurationI
 
   @Override
   public synchronized void initialise() throws InitialisationException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(format("Initializing LifecycleAwareConfigurationInstance '%s'", getName()));
+    }
+
     if (!initialized) {
       initialized = true;
       testConnectivityLock = lockFactory.createLock(this.getClass().getName() + "-testConnectivity-" + getName());
@@ -144,6 +148,8 @@ public final class LifecycleAwareConfigurationInstance implements ConfigurationI
         initStats();
         doInitialise();
       } catch (Exception e) {
+        LOGGER.error(format("Error initializing LifecycleAwareConfigurationInstance '%s'", getName()), e);
+
         if (e instanceof InitialisationException) {
           throw (InitialisationException) e;
         } else {
@@ -155,6 +161,10 @@ public final class LifecycleAwareConfigurationInstance implements ConfigurationI
 
   @Override
   public synchronized void start() throws MuleException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(format("Starting LifecycleAwareConfigurationInstance '%s'", getName()));
+    }
+
     if (!started) {
       started = true;
       if (connectionProvider.isPresent()) {
@@ -259,6 +269,10 @@ public final class LifecycleAwareConfigurationInstance implements ConfigurationI
    */
   @Override
   public synchronized void stop() throws MuleException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(format("Stopping LifecycleAwareConfigurationInstance '%s'", getName()));
+    }
+
     if (started) {
       started = false;
       try {
@@ -283,6 +297,10 @@ public final class LifecycleAwareConfigurationInstance implements ConfigurationI
    */
   @Override
   public synchronized void dispose() {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(format("Disposing LifecycleAwareConfigurationInstance '%s'", getName()));
+    }
+
     if (initialized) {
       initialized = false;
       disposeIfNeeded(value, LOGGER);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/DefaultExecutionMediator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/DefaultExecutionMediator.java
@@ -119,15 +119,8 @@ public final class DefaultExecutionMediator<M extends ComponentModel> implements
   public void execute(CompletableComponentExecutor<M> executor,
                       ExecutionContextAdapter<M> context,
                       ExecutorCallback callback) {
-
-    final MutableConfigurationStats stats = getMutableConfigurationStats(context);
-    if (stats != null) {
-      stats.addActiveComponent();
-      stats.addInflightOperation();
-    }
-
     try (DeferredExecutorCallback deferredCallback =
-        new DeferredExecutorCallback(getDelegateExecutorCallback(stats, callback, context))) {
+        new DeferredExecutorCallback(getDelegateExecutorCallback(getStats(context), callback, context))) {
       withExecutionTemplate((ExecutionContextAdapter<ComponentModel>) context, () -> {
         executeWithInterceptors(executor, context, deferredCallback);
         return null;
@@ -137,6 +130,16 @@ public final class DefaultExecutionMediator<M extends ComponentModel> implements
     } catch (Throwable t) {
       callback.error(wrapFatal(t));
     }
+  }
+
+  private MutableConfigurationStats getStats(ExecutionContextAdapter<M> context) {
+    final MutableConfigurationStats stats = getMutableConfigurationStats(context);
+    if (stats != null) {
+      stats.addActiveComponent();
+      stats.addInflightOperation();
+    }
+
+    return stats;
   }
 
   private ExecutorCallback getDelegateExecutorCallback(final MutableConfigurationStats stats,

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/DefaultExecutionMediatorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/DefaultExecutionMediatorTestCase.java
@@ -42,6 +42,7 @@ import static org.mule.test.heisenberg.extension.HeisenbergErrors.HEALTH;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.mockExceptionEnricher;
 import static reactor.core.Exceptions.unwrap;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.connection.ConnectionProvider;
@@ -68,10 +69,12 @@ import org.mule.runtime.extension.api.exception.ModuleException;
 import org.mule.runtime.extension.api.property.ClassLoaderModelProperty;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationInstance;
 import org.mule.runtime.extension.api.runtime.exception.ExceptionHandler;
+import org.mule.runtime.extension.api.runtime.config.ConfigurationState;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
 import org.mule.runtime.extension.api.runtime.operation.Interceptor;
 import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextAdapter;
+import org.mule.runtime.module.extension.internal.runtime.config.LifecycleAwareConfigurationInstance;
 import org.mule.runtime.module.extension.internal.runtime.config.MutableConfigurationStats;
 import org.mule.runtime.module.extension.internal.runtime.execution.interceptor.InterceptorChain;
 import org.mule.runtime.module.extension.internal.runtime.operation.DefaultExecutionMediator;
@@ -496,6 +499,19 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
     });
   }
 
+  @Test
+  @Description("Tests the exception raised when trying to get the statistics from a configuration instance before " +
+      "initializing it is correctly propagated through the executor's error callback")
+  @Issue("W-10742153")
+  public void getStatisticsFromNotInitializedConfigurationInstance() throws Throwable {
+    expectedException.expect(IllegalStateException.class);
+    ConfigurationInstance configurationInstance =
+        new LifecycleAwareConfigurationInstance("name", mock(ConfigurationModel.class), null, mock(ConfigurationState.class),
+                                                of(mock(ConnectionProvider.class)));
+    when(operationContext.getConfiguration()).thenReturn(of(configurationInstance));
+    execute();
+  }
+
   private void assertException(Consumer<Throwable> assertion) throws Throwable {
     try {
       execute();
@@ -586,14 +602,17 @@ public class DefaultExecutionMediatorTestCase extends AbstractMuleContextTestCas
       return null;
     }).when(executorCallback).error(any());
 
-    mediator.execute(operationExecutor, operationContext, executorCallback);
+    try {
+      mediator.execute(operationExecutor, operationContext, executorCallback);
+    } catch (Throwable e) {
+      fail("Uncaught throwable in execution mediator");
+    }
 
     latch.await(5, SECONDS);
 
     if (exception.get() != null) {
       throw exception.get();
     }
-
 
     return result.get();
   }


### PR DESCRIPTION
(cherry picked from commit c5d4b214ea9574d1e641edf07949b616fce80e6f)