### PR TITLE
W-10617943: Fix namespace read while picking up connector error type as seen for SAP S4hana Odata connector

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ExceptionHandlerManager.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/exception/ExceptionHandlerManager.java
@@ -51,9 +51,11 @@ public final class ExceptionHandlerManager {
 
   private ErrorType resolveConnectionErrorType(ExtensionModel extensionModel, ErrorTypeRepository errorTypeRepository) {
     String extensionNamespace = (extensionModel.getName() != null ? extensionModel.getName().toUpperCase() : null);
+    String namespaceFromXmlDsl = extensionModel.getXmlDslModel().getPrefix().toUpperCase();
     Predicate<ErrorModel> connectivityErrorCondition = errorModel -> errorModel.getType().equals(CONNECTIVITY_ERROR_IDENTIFIER);
     Predicate<ErrorModel> extensionConnectivityErrorCondition =
-        connectivityErrorCondition.and(errorModel -> errorModel.getNamespace().equals(extensionNamespace));
+        connectivityErrorCondition.and(errorModel -> errorModel.getNamespace().equals(extensionNamespace)
+            || errorModel.getNamespace().equals(namespaceFromXmlDsl));
 
     return extensionModel.getErrorModels().stream()
         .filter(extensionConnectivityErrorCondition).findFirst().map(Optional::of)

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/exception/ExceptionHandlerManagerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/exception/ExceptionHandlerManagerTestCase.java
@@ -15,6 +15,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.mockExceptionEnricher;
 
+import io.qameta.allure.Description;
+import io.qameta.allure.Issue;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
@@ -51,10 +53,7 @@ public class ExceptionHandlerManagerTestCase {
   private static final String MULE_NAMESPACE = "MULE";
   private static final String CONNECTIVITY_ERROR_TYPE = "CONNECTIVITY";
   private static final String ERROR_MESSAGE = "ERROR MESSAGE";
-
-  private static final String CUST_EXTENSION_NAME = "SAP 4 HANA";
-  private static final String CUST_EXTENSION_NAMESPACE = "S4HANA";
-  private static final String CUST_EXTENSION_PREFIX = "S4HANA";
+  private static final String EXTENSION_NAME_WITH_SPACES = "extension With Spaces";
 
   @Mock(lenient = true)
   private ExtensionModel extensionModel;
@@ -160,14 +159,16 @@ public class ExceptionHandlerManagerTestCase {
   }
 
   @Test
+  @Issue("W-10617943")
+  @Description("This test checks for extension names with spaces and verifies that correct error type is picked based on namespace")
   public void handleConnectionExceptionExtensionWithSpacesAndCustomConnectivityError() {
     Set<ErrorModel> errorModels = new HashSet<>();
-    errorModels.add(ErrorModelBuilder.newError(CONNECTIVITY_ERROR_TYPE, CUST_EXTENSION_NAMESPACE).build());
+    errorModels.add(ErrorModelBuilder.newError(CONNECTIVITY_ERROR_TYPE, EXTENSION_NAMESPACE).build());
     errorModels.add(ErrorModelBuilder.newError(CONNECTIVITY_ERROR_TYPE, MULE_NAMESPACE).build());
 
-    when(extensionModel.getName()).thenReturn(CUST_EXTENSION_NAME);
+    when(extensionModel.getName()).thenReturn(EXTENSION_NAME_WITH_SPACES);
     when(extensionModel.getErrorModels()).thenReturn(errorModels);
-    when(extensionModel.getXmlDslModel()).thenReturn(XmlDslModel.builder().setPrefix(CUST_EXTENSION_PREFIX).build());
+    when(extensionModel.getXmlDslModel()).thenReturn(XmlDslModel.builder().setPrefix(EXTENSION_NAMESPACE).build());
 
     ExceptionHandlerManager exceptionHandlerManager =
         new ExceptionHandlerManager(extensionModel, sourceModel, errorTypeRepository);
@@ -178,7 +179,7 @@ public class ExceptionHandlerManagerTestCase {
     assertThat(throwable.getMessage(), is(ERROR_MESSAGE));
     assertThat(((ConnectionException) throwable).getErrorType().isPresent(), is(true));
     assertThat(((ConnectionException) throwable).getErrorType().get().getIdentifier(), is(CONNECTIVITY_ERROR_TYPE));
-    assertThat(((ConnectionException) throwable).getErrorType().get().getNamespace(), is(CUST_EXTENSION_PREFIX));
+    assertThat(((ConnectionException) throwable).getErrorType().get().getNamespace(), is(EXTENSION_NAMESPACE));
   }
 
   @Test
@@ -202,17 +203,11 @@ public class ExceptionHandlerManagerTestCase {
   private void mockErrorTypesRepository() {
     ErrorType extensionConnectivityErrorType = createErrorType(CONNECTIVITY_ERROR_TYPE, EXTENSION_NAMESPACE);
     ErrorType muleConnectivityErrorType = createErrorType(CONNECTIVITY_ERROR_TYPE, MULE_NAMESPACE);
-    ErrorType extensionWithSpacesConnectivityErrorType = createErrorType(CONNECTIVITY_ERROR_TYPE, CUST_EXTENSION_NAMESPACE);
 
     when(errorTypeRepository.getErrorType(ComponentIdentifier.builder()
         .namespace(EXTENSION_NAMESPACE)
         .name(CONNECTIVITY_ERROR_TYPE)
         .build())).thenReturn(Optional.of(extensionConnectivityErrorType));
-
-    when(errorTypeRepository.getErrorType(ComponentIdentifier.builder()
-        .namespace(CUST_EXTENSION_NAMESPACE)
-        .name(CONNECTIVITY_ERROR_TYPE)
-        .build())).thenReturn(Optional.of(extensionWithSpacesConnectivityErrorType));
 
     when(errorTypeRepository.getErrorType(ComponentIdentifier.builder()
         .namespace(MULE_NAMESPACE)

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/exception/ExceptionHandlerManagerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/exception/ExceptionHandlerManagerTestCase.java
@@ -55,6 +55,7 @@ public class ExceptionHandlerManagerTestCase {
   private static final String CUST_EXTENSION_NAME = "SAP 4 HANA";
   private static final String CUST_EXTENSION_NAMESPACE = "S4HANA";
   private static final String CUST_EXTENSION_PREFIX = "S4HANA";
+
   @Mock(lenient = true)
   private ExtensionModel extensionModel;
 


### PR DESCRIPTION
We notice some test failures in  Sap - S4hana Odata Mule 4. 
```
+ Running test: config-null-base-url-test - Cause a CONNECTIVITY Error. Thrown +
+ when the base url is null.                                                   +
java.lang.AssertionError: The error ID thrown does not match the expected one.  expected:<[S4HANA]:CONNECTIVITY> but was:<[MULE]:CONNECTIVITY>
```
This is due to recent changes to `ExceptionHandlerManager -> resolveConnectionErrorType()` 11/2/21, where a namespace name S4 HANA does not match expected type S4HANA

` "S4HANA:CONNECTIVITY"`
