### PR TITLE
fireNotification to be called directly as it is not called by parent …

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/exception/OnCriticalErrorHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/OnCriticalErrorHandler.java
@@ -52,6 +52,7 @@ public class OnCriticalErrorHandler extends AbstractExceptionListener implements
   @Override
   public CoreEvent handleException(Exception exception, CoreEvent event) {
     logException(exception);
+    fireNotification(exception, event);
     return event;
   }
 


### PR DESCRIPTION
…because critical error does not use handleException.
fireNotification enables Mule-Runtimes to log more details about e.g. a StackOverflowError
similar to other exceptions which happens

via org.mule.runtime.api.notification.ExceptionNotificationListener
(currently ExceptionNotificationListener is not called by OnCriticalErrorHandler)