### PR TITLE
W-10668793: Fix duplicated response when using Async Scope when Response streaming mode is set to Auto

### DIFF
--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -213,15 +213,6 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
                         }
                         if (isStream) {
                             try {
-
-                                System.out.println("Payload:-orig" + payload.toString());
-                        /*    byte[] source = payload.toString().getBytes();
-                                System.out.println("Payload:-source" + new String(source));
-                                byte[] destn = new byte[source.length];
-                                System.arraycopy(source, 0, destn, 0, source.length);
-                                InputStream copiedPayLoad = new ByteArrayInputStream(destn);
-                                System.out.println("Payload:-copy" + new String(destn));
-                         */
                                 httpEntity = new InputStreamHttpEntity(IOUtils.toInputStream(payload.toString()));
                             } catch (Exception e) {
                                 throw new MessagingException(event, new Throwable("Error preparing message for streaming"));
@@ -231,7 +222,6 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
                         {
                             httpEntity = new OutputHandlerHttpEntity((OutputHandler) payload);
                         }
-                        //System.out.println("Payload:" + payload);
                     }
                     else
                     {

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -22,7 +22,6 @@ import static org.mule.module.http.api.requester.HttpStreamingType.ALWAYS;
 import static org.mule.module.http.api.requester.HttpStreamingType.AUTO;
 import static org.mule.module.http.internal.domain.HttpProtocol.HTTP_0_9;
 import static org.mule.module.http.internal.domain.HttpProtocol.HTTP_1_0;
-
 import org.apache.commons.io.IOUtils;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleContext;
@@ -210,10 +209,16 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
                             setupChunkedEncoding(httpResponseHeaderBuilder);
                         }
                         if (isStream) {
-                            try {
-                                httpEntity = new InputStreamHttpEntity(IOUtils.toInputStream(payload.toString()));
-                            } catch (Exception e) {
-                                throw new MessagingException(event, new Throwable("Error preparing message for streaming"));
+                            if(payload.getClass().getSimpleName().equals("ByteArraySeekableStream")) {
+                                try {
+                                    System.out.println("Its a ByteArraySeekableStream");
+                                    InputStream clonedInputStream = IOUtils.toBufferedInputStream((InputStream) payload);
+                                    httpEntity = new InputStreamHttpEntity(clonedInputStream);
+                                } catch (Exception e) {
+                                    throw new MessagingException(event, new Throwable("Error preparing message for streaming"));
+                                }
+                            } else {
+                                httpEntity = new InputStreamHttpEntity((InputStream) payload);
                             }
                         }
                         else

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -209,11 +209,9 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
                             setupChunkedEncoding(httpResponseHeaderBuilder);
                         }
                         if (isStream) {
-                            if(payload.getClass().getSimpleName().equals("ByteArraySeekableStream")) {
+                            if (payload.getClass().getSimpleName().equals("ByteArraySeekableStream")) {
                                 try {
-                                    System.out.println("Its a ByteArraySeekableStream");
-                                    InputStream clonedInputStream = IOUtils.toBufferedInputStream((InputStream) payload);
-                                    httpEntity = new InputStreamHttpEntity(clonedInputStream);
+                                    httpEntity = new InputStreamHttpEntity(IOUtils.toInputStream(payload.toString()));
                                 } catch (Exception e) {
                                     throw new MessagingException(event, new Throwable("Error preparing message for streaming"));
                                 }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -56,7 +56,6 @@ import org.mule.util.DataTypeUtils;
 import org.mule.util.NumberUtils;
 import org.mule.util.UUID;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -23,6 +23,7 @@ import static org.mule.module.http.api.requester.HttpStreamingType.AUTO;
 import static org.mule.module.http.internal.domain.HttpProtocol.HTTP_0_9;
 import static org.mule.module.http.internal.domain.HttpProtocol.HTTP_1_0;
 
+import org.apache.commons.io.IOUtils;
 import org.mule.api.MessagingException;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -55,6 +56,7 @@ import org.mule.util.DataTypeUtils;
 import org.mule.util.NumberUtils;
 import org.mule.util.UUID;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
@@ -164,6 +166,7 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
         else
         {
             final Object payload = event.getMessage().getPayload();
+
             if (payload == NullPayload.getInstance())
             {
                 setupContentLengthEncoding(httpResponseHeaderBuilder, 0);
@@ -209,12 +212,28 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
                             setupChunkedEncoding(httpResponseHeaderBuilder);
                         }
                         if (isStream) {
-                            httpEntity = new InputStreamHttpEntity((InputStream) payload);
+                            try {
+
+
+                                System.out.println("Payload:-orig" + payload.toString());
+
+/*                                byte[] source = payload.toString().getBytes();
+                                System.out.println("Payload:-source" + new String(source));
+                                byte[] destn = new byte[source.length];
+                                System.arraycopy(source, 0, destn, 0, source.length);
+                                InputStream copiedPayLoad = new ByteArrayInputStream(destn);
+                                System.out.println("Payload:-copy" + new String(destn));
+                         */
+                                httpEntity = new InputStreamHttpEntity(IOUtils.toInputStream(payload.toString()));
+                            } catch (Exception e) {
+                                throw new MessagingException(event, new Throwable("Error preparing message for streaming"));
+                            }
                         }
                         else
                         {
                             httpEntity = new OutputHandlerHttpEntity((OutputHandler) payload);
                         }
+                        //System.out.println("Payload:" + payload);
                     }
                     else
                     {

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -166,7 +166,6 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
         else
         {
             final Object payload = event.getMessage().getPayload();
-
             if (payload == NullPayload.getInstance())
             {
                 setupContentLengthEncoding(httpResponseHeaderBuilder, 0);

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/HttpResponseBuilder.java
@@ -214,10 +214,8 @@ public class HttpResponseBuilder extends HttpMessageBuilder implements Initialis
                         if (isStream) {
                             try {
 
-
                                 System.out.println("Payload:-orig" + payload.toString());
-
-/*                                byte[] source = payload.toString().getBytes();
+                        /*    byte[] source = payload.toString().getBytes();
                                 System.out.println("Payload:-source" + new String(source));
                                 byte[] destn = new byte[source.length];
                                 System.arraycopy(source, 0, destn, 0, source.length);

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -34,7 +34,8 @@ import org.glassfish.grizzly.memory.MemoryManager;
  * when the response body is an input stream.
  */
 public class ResponseStreamingCompletionHandler
-        extends BaseResponseCompletionHandler {
+        extends BaseResponseCompletionHandler
+{
 
     private final HttpContent EMPTY_CONTENT;
     private final MemoryManager memoryManager;
@@ -47,7 +48,8 @@ public class ResponseStreamingCompletionHandler
     public static final String MULE_CLASSLOADER = "MULE_CLASSLOADER";
 
     public ResponseStreamingCompletionHandler(final FilterChainContext ctx,
-                                              final HttpRequestPacket request, final HttpResponse httpResponse, ResponseStatusCallback responseStatusCallback) {
+                                              final HttpRequestPacket request, final HttpResponse httpResponse, ResponseStatusCallback responseStatusCallback)
+    {
 
         super(ctx);
         Preconditions.checkArgument((httpResponse.getEntity() instanceof InputStreamHttpEntity), "http response must have an input stream entity");
@@ -60,35 +62,32 @@ public class ResponseStreamingCompletionHandler
     }
 
     @Override
-    protected void doStart() throws IOException {
+    protected void doStart() throws IOException
+    {
         sendInputStreamChunk();
     }
 
-    public void sendInputStreamChunk() throws IOException {
+    public void sendInputStreamChunk() throws IOException
+    {
         final Buffer buffer = memoryManager.allocate(DEFAULT_BUFFER_SIZE);
 
         final int offset = buffer.arrayOffset();
         final int length = buffer.remaining();
 
-        System.out.println(Thread.currentThread().getName());
         isDone = readStreamManually(buffer, offset, length);
-
         ctx.getConnection().getAttributes().setAttribute(MULE_CLASSLOADER, loggerClassLoader);
 
         HttpContent content = httpResponsePacket.httpContentBuilder().content(buffer).build();
         ctx.write(content, this);
-        System.out.println("Wrote a content block:" + isDone);
 
         if (isDone) {
             content = httpResponsePacket.httpContentBuilder().build();
             ctx.write(content, this);
-            System.out.println("Wrote:EMPTY_CONTENT");
         }
-        System.out.println("Exiting:sendInputStreamChunk");
     }
 
-    private boolean readStreamManually(final Buffer buffer, int offset, int length) throws IOException {
-        System.out.println("In:readStream");
+    private boolean readStreamManually(final Buffer buffer, int offset, int length) throws IOException
+    {
         boolean isDone = false;
         byte[] bufferByteArray = buffer.array();
         int bytesRead = -1;
@@ -113,7 +112,6 @@ public class ResponseStreamingCompletionHandler
      */
     @Override
     public void completed(WriteResult result) {
-        System.out.println("completed:" + isDone);
         try {
             if (!isDone) {
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -86,17 +86,14 @@ public class ResponseStreamingCompletionHandler
         boolean isDone = false;
         byte[] bufferByteArray = buffer.array();
         int bytesRead = -1;
-        try {
-            int c;
-            while ((c = inputStream.read()) != -1 && offset < length) {
-                bufferByteArray[offset++] = (byte) c;
-            }
-            if (c == -1)
-                isDone = true;
-            else buffer.limit(bytesRead);
-        } catch (IOException e) {
-
+        int c;
+        while ((c = inputStream.read()) != -1 && offset < length) {
+            bufferByteArray[offset++] = (byte) c;
         }
+        if (c == -1)
+            isDone = true;
+        else buffer.limit(bytesRead);
+
         return isDone;
     }
 

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -8,7 +8,6 @@ package org.mule.module.http.internal.listener.grizzly;
 
 import static org.glassfish.grizzly.http.HttpServerFilter.RESPONSE_COMPLETE_EVENT;
 import static org.mule.config.i18n.MessageFactory.createStaticMessage;
-
 import org.mule.api.DefaultMuleException;
 import org.mule.module.http.internal.domain.InputStreamHttpEntity;
 import org.mule.module.http.internal.domain.response.HttpResponse;
@@ -16,10 +15,8 @@ import org.mule.module.http.internal.listener.async.ResponseStatusCallback;
 
 import com.google.common.base.Preconditions;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.WriteResult;
@@ -36,6 +33,7 @@ import org.glassfish.grizzly.memory.MemoryManager;
 public class ResponseStreamingCompletionHandler
         extends BaseResponseCompletionHandler
 {
+
     private final MemoryManager memoryManager;
     private final HttpResponsePacket httpResponsePacket;
     private final InputStream inputStream;
@@ -108,27 +106,34 @@ public class ResponseStreamingCompletionHandler
      * @param result the result
      */
     @Override
-    public void completed(WriteResult result) {
-        try {
-            if (!isDone) {
-
+    public void completed(WriteResult result)
+    {
+        try
+        {
+            if (!isDone)
+            {
                 sendInputStreamChunk();
-
                 // In HTTP 1.0 (no chunk supported) there is no more data sent to the client after the input stream is completed.
                 // As there is no more data to be sent (in HTTP 1.1 a last chunk with '0' is sent) the #completed method is not called
                 // So, we have to call it manually here
-                if (isDone && !httpResponsePacket.isChunked()) {
+                if (isDone && !httpResponsePacket.isChunked())
+                {
                     doComplete();
                 }
-            } else {
+            }
+            else
+            {
                 doComplete();
             }
-        } catch (Exception e) {
+        }
+        catch (IOException e)
+        {
             failed(e);
         }
     }
 
-    private void doComplete() {
+    private void doComplete()
+    {
         close();
         responseStatusCallback.responseSendSuccessfully();
         ctx.getConnection().getAttributes().removeAttribute(MULE_CLASSLOADER);
@@ -140,7 +145,8 @@ public class ResponseStreamingCompletionHandler
      * The method will be called, when file transferring was canceled
      */
     @Override
-    public void cancelled() {
+    public void cancelled()
+    {
         super.cancelled();
         ctx.getConnection().getAttributes().removeAttribute(MULE_CLASSLOADER);
         close();
@@ -154,7 +160,8 @@ public class ResponseStreamingCompletionHandler
      * @param throwable the cause
      */
     @Override
-    public void failed(Throwable throwable) {
+    public void failed(Throwable throwable)
+    {
         super.failed(throwable);
         ctx.getConnection().getAttributes().removeAttribute(MULE_CLASSLOADER);
         close();
@@ -164,10 +171,14 @@ public class ResponseStreamingCompletionHandler
     /**
      * Close the local file input stream.
      */
-    private void close() {
-        try {
+    private void close()
+    {
+        try
+        {
             inputStream.close();
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
 
         }
     }
@@ -175,7 +186,8 @@ public class ResponseStreamingCompletionHandler
     /**
      * Resume the HttpRequestPacket processing
      */
-    private void resume() {
+    private void resume()
+    {
         ctx.resume(ctx.getStopAction());
     }
 }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -36,8 +36,6 @@ import org.glassfish.grizzly.memory.MemoryManager;
 public class ResponseStreamingCompletionHandler
         extends BaseResponseCompletionHandler
 {
-
-    private final HttpContent EMPTY_CONTENT;
     private final MemoryManager memoryManager;
     private final HttpResponsePacket httpResponsePacket;
     private final InputStream inputStream;
@@ -58,7 +56,6 @@ public class ResponseStreamingCompletionHandler
         memoryManager = ctx.getConnection().getTransport().getMemoryManager();
         this.responseStatusCallback = responseStatusCallback;
         loggerClassLoader = Thread.currentThread().getContextClassLoader();
-        EMPTY_CONTENT = httpResponsePacket.httpTrailerBuilder().content(memoryManager.allocate(0)).build();
     }
 
     @Override

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -93,7 +93,7 @@ public class ResponseStreamingCompletionHandler
         }
         if (c == -1)
             isDone = true;
-        else buffer.limit(bytesRead);
+        buffer.limit(bytesRead);
 
         return isDone;
     }

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -104,16 +104,12 @@ public class ResponseStreamingCompletionHandler
         buffer.clear();*/
         boolean isDone = false;
         byte[] bufferByteArray = buffer.array();
-        System.out.println(String.format(" Input stream position before with invoctaion counter $ - %s",  inputStream.getPosition(), invocatioCter));
+        //System.out.println(String.format(" Input stream position before with invoctaion counter $ - %s",  inputStream.getPosition(), invocatioCter));
         //StringBuffer readDataBuf = new StringBuffer();
         int c;
         //int bytesRead = 0;
         int offset = buffer.arrayOffset();
         int length = buffer.remaining();
-        System.out.println("Array len:" + bufferByteArray.length);
-        System.out.println("ArrayOffset:" + buffer.arrayOffset());
-        System.out.println("Position:" + buffer.position());
-        System.out.println("Length:" + length);
 
         int current = 0;
 
@@ -123,11 +119,6 @@ public class ResponseStreamingCompletionHandler
             //readDataBuf.append((char)c);
             current++;
         }
-
-        System.out.println("Buffer arrayOffet after write:" + buffer.arrayOffset() );
-        System.out.println(" Input stream position After" + inputStream.getPosition());
-        //System.out.println("Data inn String buffer" + readDataBuf.toString());
-        System.out.println("Ending value of current" + current);
 
         if (c == -1)
             isDone = true;

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -85,10 +85,11 @@ public class ResponseStreamingCompletionHandler
     {
         boolean isDone = false;
         byte[] bufferByteArray = buffer.array();
-        int bytesRead = -1;
+        int bytesRead = 0;
         int c;
         while ((c = inputStream.read()) != -1 && offset < length) {
             bufferByteArray[offset++] = (byte) c;
+            bytesRead++;
         }
         if (c == -1)
             isDone = true;

--- a/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
+++ b/modules/http/src/main/java/org/mule/module/http/internal/listener/grizzly/ResponseStreamingCompletionHandler.java
@@ -79,6 +79,7 @@ public class ResponseStreamingCompletionHandler
 
         if (isDone) {
             System.out.println("Writig out closing chunk");
+            //content = httpResponsePacket.httpContentBuilder().build();
             ctx.write(EMPTY_CONTENT, this);
         }
     }
@@ -96,6 +97,7 @@ public class ResponseStreamingCompletionHandler
         if (c == -1)
             isDone = true;
         buffer.limit(bytesRead);
+        System.out.println("read" + (new String(bufferByteArray)).trim());
         return isDone;
     }
 


### PR DESCRIPTION
It was noticed that response messages were getting duplicated for Async scope after every X requests.

For example  we would see responses like 
```
{
  "applicationName": "Test Machine",
  "id": "7a8bd660-b05b-11ec-97e7-acde48001122",
  "responseCode": 404,
  "serverResponseCode": null,
  "responseDateTime": "2022-03-30T11:59:09.717-07:00",
  "responseMessage": [
    "INVALID_CROSS_REFERENCE_KEY"
  ],
  "responseDescription": [
    "invalid cross reference id"
  ]
}
{
  "applicationName": "Test Machine",
  "id": "7a8bd660-b05b-11ec-97e7-acde48001122",
  "responseCode": 404,
  "serverResponseCode": null,
  "responseDateTime": "2022-03-30T11:59:09.717-07:00",
  "responseMessage": [
    "INVALID_CROSS_REFERENCE_KEY"
  ],
  "responseDescription": [
    "invalid cross reference id"
  ]
}
```

Upon checking further I noticed that InputStream.read(buffer) was getting reread even after first read had detected a EOF and read the data completely. It did not appear as if there was more than one instance of ResponseStreamingCompletionHandler was created per request or thread sync issue with inputStream.

Noticed the following pattern during  local debug ( Hash code of input stream printed)

```
Broken request with duplication of response message


Creating ResponseStreamingCompletionHandler
sendInputStreamChunk[test_async_arc].HTTP_Listener_Configuration.worker.01
inputStream id45407803
sendInputStreamChunk[test_async_arc].http.listener(15) SelectorRunner
inputStream id45407803
sendInputStreamChunk[test_async_arc].http.listener(15) SelectorRunner
inputStream id45407803

Working

Creating ResponseStreamingCompletionHandler
sendInputStreamChunk[test_async_arc].HTTP_Listener_Configuration.worker.01
inputStream id2117880603
sendInputStreamChunk[test_async_arc].http.listener(12) SelectorRunner
inputStream id2117880603

```
To fix this I have done some custom implementation of read() here.