### PR TITLE
W-10984029: After domain project's redployment the associated app's .…

### DIFF
--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultArtifactDeployer.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DefaultArtifactDeployer.java
@@ -16,7 +16,6 @@ import static org.mule.runtime.core.api.config.MuleDeploymentProperties.MULE_LAZ
 import static org.mule.runtime.core.internal.context.ArtifactStoppedPersistenceListener.ARTIFACT_STOPPED_LISTENER;
 import static org.mule.runtime.module.deployment.impl.internal.artifact.ArtifactFactoryUtils.withArtifactMuleContext;
 import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveArtifactStatusDeploymentProperties;
-import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -61,7 +60,7 @@ public class DefaultArtifactDeployer<T extends DeployableArtifact> implements Ar
       artifact.install();
       doInit(artifact);
       addFlowStoppedListeners(artifact);
-      if (startArtifact && shouldStartArtifact(artifact)) {
+      if (startArtifact && shouldStartArtifactAccordingToPersistedStatus(artifact)) {
         // The purpose of dispatching this to a separate thread is to have a clean call stack when starting the app.
         // This is needed in order to prevent an StackOverflowError when starting apps with really long flows.
         final Future<?> startTask = artifactStartExecutor.get().submit(() -> {
@@ -174,16 +173,21 @@ public class DefaultArtifactDeployer<T extends DeployableArtifact> implements Ar
     }
   }
 
-  private Boolean shouldStartArtifact(T artifact) {
-    Properties deploymentProperties = null;
+  /**
+   * Checks the persisted property START_ARTIFACT_ON_DEPLOYMENT_PROPERTY to know if the artifact should be started or not. If the
+   * artifact was purposely stopped and then the mule was restarted, the artifact should maintain its status and not start on
+   * deployment.
+   */
+  private Boolean shouldStartArtifactAccordingToPersistedStatus(T artifact) {
+    Properties artifactStatusProperties = null;
     try {
-      deploymentProperties = resolveArtifactStatusDeploymentProperties(artifact.getArtifactName(), empty());
+      artifactStatusProperties = resolveArtifactStatusDeploymentProperties(artifact.getArtifactName(), empty());
     } catch (IOException e) {
       logger.error("Failed to load deployment property for artifact "
           + artifact.getArtifactName(), e);
     }
-    return deploymentProperties != null
-        && parseBoolean(deploymentProperties.getProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, "true"));
+    return artifactStatusProperties != null
+        && parseBoolean(artifactStatusProperties.getProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, "true"));
   }
 
   @Override

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
@@ -12,15 +12,11 @@ import static org.mule.runtime.deployment.model.api.application.ApplicationStatu
 import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.STARTED;
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
 
-import static java.lang.String.valueOf;
-import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
-import static java.util.Optional.of;
 
 import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.application.ApplicationStatus;
 import org.mule.runtime.module.deployment.api.DeploymentService;
-import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.domain.Domain;
 import org.mule.runtime.module.artifact.api.Artifact;
 

--- a/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
+++ b/modules/deployment/src/main/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTemplate.java
@@ -11,6 +11,13 @@ import static java.util.Optional.of;
 import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.DEPLOYMENT_FAILED;
 import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.STARTED;
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
+
+import static java.lang.String.valueOf;
+import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import org.mule.runtime.deployment.model.api.application.Application;
 import org.mule.runtime.deployment.model.api.application.ApplicationStatus;
 import org.mule.runtime.module.deployment.api.DeploymentService;
 import org.mule.runtime.deployment.model.api.application.Application;
@@ -69,8 +76,9 @@ public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplat
         applicationDeployer.preTrackArtifact(domainApplication);
         if (applicationDeployer.isUpdatedZombieArtifact(domainApplication.getArtifactName())) {
           try {
-            applicationDeployer.deployExplodedArtifact(domainApplication.getArtifactName(),
-                                                       getProperties(appStatusPreRedeployment.get(domainApplication)));
+            applicationDeployer.deployExplodedArtifact(domainApplication.getArtifactName(), empty(),
+                                                       getArtifactStatusProperties(appStatusPreRedeployment
+                                                           .get(domainApplication)));
             applicationDeploymentListener.onRedeploymentSuccess(domainApplication.getArtifactName());
           } catch (RuntimeException e) {
             applicationDeploymentListener.onRedeploymentFailure(domainApplication.getArtifactName(), e);
@@ -87,7 +95,7 @@ public final class DomainDeploymentTemplate implements ArtifactDeploymentTemplat
     domainApplications = Collections.emptyList();
   }
 
-  private Optional<Properties> getProperties(ApplicationStatus applicationStatus) {
+  private Optional<Properties> getArtifactStatusProperties(ApplicationStatus applicationStatus) {
     Properties properties = new Properties();
     boolean startArtifact = applicationStatus.equals(STARTED) || applicationStatus.equals(DEPLOYMENT_FAILED);
     properties.setProperty(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY, valueOf(startArtifact));

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/ApplicationDeploymentTestCase.java
@@ -49,6 +49,7 @@ import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorC
 import static org.mule.runtime.extension.api.loader.xml.XmlExtensionModelLoader.RESOURCE_XML;
 import static org.mule.runtime.module.deployment.impl.internal.policy.PropertiesBundleDescriptorLoader.PROPERTIES_BUNDLE_DESCRIPTOR_LOADER_ID;
 import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveArtifactStatusDeploymentProperties;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
 import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveFlowDeploymentProperties;
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
 import static org.mule.runtime.module.deployment.internal.DeploymentDirectoryWatcher.DEPLOYMENT_APPLICATION_PROPERTY;
@@ -92,6 +93,7 @@ import org.mule.runtime.module.deployment.impl.internal.domain.DefaultDomainMana
 import org.mule.tck.junit4.rule.SystemProperty;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -287,6 +289,49 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     redeployAndVerifyPropertyInRegistry(dummyAppDescriptorWithPropsFileBuilder.getId(), deploymentProperties,
                                         (registry) -> registry.lookupByName(FLOW_PROPERTY_NAME).get()
                                             .equals(FLOW_PROPERTY_NAME_VALUE_ON_REDEPLOY));
+  }
+
+  @Test
+  @Issue("W-10984029")
+  public void deployRedeployAndStopAppWithDeploymentProperties() throws Exception {
+    Properties deploymentProperties = new Properties();
+    deploymentProperties.put(FLOW_PROPERTY_NAME, FLOW_PROPERTY_NAME_VALUE);
+    startDeployment();
+    deployAndVerifyPropertyInRegistry(dummyAppDescriptorWithPropsFileBuilder.getArtifactFile().toURI(), deploymentProperties,
+                                      (registry) -> registry.lookupByName(FLOW_PROPERTY_NAME).get()
+                                          .equals(FLOW_PROPERTY_NAME_VALUE));
+
+    stopAppAndVerifyDeploymentAndAppStatusProperties(dummyAppDescriptorWithPropsFileBuilder.getId(), FLOW_PROPERTY_NAME_VALUE);
+
+    // Redeploys without deployment properties (remains the same, as it takes the deployment properties from the persisted file)
+    redeployAndVerifyPropertyInRegistry(dummyAppDescriptorWithPropsFileBuilder
+        .getId(), null, (registry) -> registry.lookupByName(FLOW_PROPERTY_NAME).get().equals(FLOW_PROPERTY_NAME_VALUE));
+
+    stopAppAndVerifyDeploymentAndAppStatusProperties(dummyAppDescriptorWithPropsFileBuilder.getId(), FLOW_PROPERTY_NAME_VALUE);
+
+    // Redeploy with new deployment properties
+    deploymentProperties.clear();
+    deploymentProperties.put(FLOW_PROPERTY_NAME, FLOW_PROPERTY_NAME_VALUE_ON_REDEPLOY);
+    redeployAndVerifyPropertyInRegistry(dummyAppDescriptorWithPropsFileBuilder.getId(), deploymentProperties,
+                                        (registry) -> registry.lookupByName(FLOW_PROPERTY_NAME).get()
+                                            .equals(FLOW_PROPERTY_NAME_VALUE_ON_REDEPLOY));
+
+    stopAppAndVerifyDeploymentAndAppStatusProperties(dummyAppDescriptorWithPropsFileBuilder.getId(),
+                                                     FLOW_PROPERTY_NAME_VALUE_ON_REDEPLOY);
+  }
+
+  private void stopAppAndVerifyDeploymentAndAppStatusProperties(String artifactName, String deploymentPropertyValue)
+      throws IOException {
+    Application app = findApp(dummyAppDescriptorWithPropsFileBuilder.getId(), 1);
+    app.stop();
+
+    Properties artifactStatusDeploymentProperties =
+        resolveArtifactStatusDeploymentProperties(dummyAppDescriptorWithPropsFileBuilder.getId(), empty());
+    assertThat(artifactStatusDeploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is("false"));
+
+    Properties updatedDeploymentProperties = resolveDeploymentProperties(dummyAppDescriptorWithPropsFileBuilder.getId(), empty());
+    assertThat(updatedDeploymentProperties.get(FLOW_PROPERTY_NAME), is(deploymentPropertyValue));
+    assertThat(updatedDeploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
   }
 
   @Issue("MULE-16688")

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
@@ -7,6 +7,26 @@
 
 package org.mule.runtime.module.deployment.internal;
 
+import static org.mule.runtime.container.api.MuleFoldersUtil.getAppDataFolder;
+import static org.mule.runtime.container.internal.ClasspathModuleDiscoverer.EXPORTED_CLASS_PACKAGES_PROPERTY;
+import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
+import static org.mule.runtime.core.internal.context.ArtifactStoppedPersistenceListener.ARTIFACT_STOPPED_LISTENER;
+import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.CREATED;
+import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.DESTROYED;
+import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.STARTED;
+import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.STOPPED;
+import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.EXPORTED_PACKAGES;
+import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.EXPORTED_RESOURCES;
+import static org.mule.runtime.deployment.model.api.builder.DeployableArtifactClassLoaderFactoryProvider.domainClassLoaderFactory;
+import static org.mule.runtime.module.artifact.api.descriptor.DeployableArtifactDescriptor.PROPERTY_CONFIG_RESOURCES;
+import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
+import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveArtifactStatusDeploymentProperties;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
+import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
+import static org.mule.runtime.module.deployment.internal.TestDomainFactory.createDomainFactory;
+import static org.mule.test.allure.AllureConstants.ArtifactDeploymentFeature.DOMAIN_DEPLOYMENT;
+
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -675,6 +695,7 @@ public class DomainDeploymentTestCase extends AbstractDeploymentTestCase {
   }
 
   @Test
+  @Issue("MULE-19890")
   public void redeploysDomainZipRefreshesAppsAndStartsThemAndNoStatusPersistenceWasSaved() throws Exception {
     addPackedDomainFromBuilder(dummyDomainFileBuilder);
     File dummyDomainFile = new File(domainsDir, dummyDomainFileBuilder.getZipPath());
@@ -687,7 +708,37 @@ public class DomainDeploymentTestCase extends AbstractDeploymentTestCase {
     assertDeploymentSuccess(domainDeploymentListener, dummyDomainFileBuilder.getId());
     assertApplicationDeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
 
-    final Application app = findApp(dummyDomainApp1FileBuilder.getId(), 1);
+    reset(domainDeploymentListener);
+    reset(applicationDeploymentListener);
+
+    addPackedDomainFromBuilder(dummyDomainFileBuilder);
+    alterTimestampIfNeeded(dummyDomainFile, firstFileTimestamp);
+
+    assertUndeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
+    assertUndeploymentSuccess(domainDeploymentListener, dummyDomainFileBuilder.getId());
+    assertDeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
+    assertStatus(dummyDomainApp1FileBuilder.getId(), STARTED);
+    // no deberia ser dummyDomainFileBuilder?
+    Properties artifactStatusDeploymentProperties =
+        resolveArtifactStatusDeploymentProperties(emptyDomainFileBuilder.getId(), empty());
+    assertThat(artifactStatusDeploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
+  }
+
+  @Test
+  @Issue("W-10984029")
+  public void redeploysDomainZipRefreshesAppsAndStartsThemAndDeploymentPropertiesAreNotErased() throws Exception {
+    addPackedDomainFromBuilder(dummyDomainFileBuilder);
+    File dummyDomainFile = new File(domainsDir, dummyDomainFileBuilder.getZipPath());
+    long firstFileTimestamp = dummyDomainFile.lastModified();
+
+    startDeployment();
+
+    Properties initialDeploymentProperties = new Properties();
+    initialDeploymentProperties.put(COMPONENT_NAME, COMPONENT_CLASS);
+    deploymentService.deploy(dummyDomainApp1FileBuilder.getArtifactFile().getAbsoluteFile().toURI(), initialDeploymentProperties);
+
+    assertDeploymentSuccess(domainDeploymentListener, dummyDomainFileBuilder.getId());
+    assertApplicationDeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
 
     reset(domainDeploymentListener);
     reset(applicationDeploymentListener);
@@ -699,8 +750,9 @@ public class DomainDeploymentTestCase extends AbstractDeploymentTestCase {
     assertUndeploymentSuccess(domainDeploymentListener, dummyDomainFileBuilder.getId());
     assertDeploymentSuccess(applicationDeploymentListener, dummyDomainApp1FileBuilder.getId());
     assertStatus(dummyDomainApp1FileBuilder.getId(), STARTED);
-    Properties deploymentProperties = resolveArtifactStatusDeploymentProperties(emptyDomainFileBuilder.getId(), empty());
-    assertThat(deploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
+    Properties finalDeploymentProperties = resolveDeploymentProperties(dummyDomainApp1FileBuilder.getId(), empty());
+    assertThat(finalDeploymentProperties.get(START_ARTIFACT_ON_DEPLOYMENT_PROPERTY), is(nullValue()));
+    assertThat(finalDeploymentProperties.get(COMPONENT_NAME), is(COMPONENT_CLASS));
   }
 
   @Test

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
@@ -7,26 +7,6 @@
 
 package org.mule.runtime.module.deployment.internal;
 
-import static org.mule.runtime.container.api.MuleFoldersUtil.getAppDataFolder;
-import static org.mule.runtime.container.internal.ClasspathModuleDiscoverer.EXPORTED_CLASS_PACKAGES_PROPERTY;
-import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
-import static org.mule.runtime.core.internal.context.ArtifactStoppedPersistenceListener.ARTIFACT_STOPPED_LISTENER;
-import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.CREATED;
-import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.DESTROYED;
-import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.STARTED;
-import static org.mule.runtime.deployment.model.api.application.ApplicationStatus.STOPPED;
-import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.EXPORTED_PACKAGES;
-import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorConstants.EXPORTED_RESOURCES;
-import static org.mule.runtime.deployment.model.api.builder.DeployableArtifactClassLoaderFactoryProvider.domainClassLoaderFactory;
-import static org.mule.runtime.module.artifact.api.descriptor.DeployableArtifactDescriptor.PROPERTY_CONFIG_RESOURCES;
-import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
-import static org.mule.runtime.module.artifact.api.descriptor.DomainDescriptor.DEFAULT_DOMAIN_NAME;
-import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveArtifactStatusDeploymentProperties;
-import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
-import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
-import static org.mule.runtime.module.deployment.internal.TestDomainFactory.createDomainFactory;
-import static org.mule.test.allure.AllureConstants.ArtifactDeploymentFeature.DOMAIN_DEPLOYMENT;
-
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/DomainDeploymentTestCase.java
@@ -50,6 +50,7 @@ import static org.mule.runtime.deployment.model.api.artifact.ArtifactDescriptorC
 import static org.mule.runtime.deployment.model.api.domain.DomainDescriptor.DEFAULT_CONFIGURATION_RESOURCE;
 import static org.mule.runtime.deployment.model.api.domain.DomainDescriptor.DEFAULT_DOMAIN_NAME;
 import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveArtifactStatusDeploymentProperties;
+import static org.mule.runtime.module.deployment.impl.internal.util.DeploymentPropertiesUtils.resolveDeploymentProperties;
 import static org.mule.runtime.module.deployment.internal.DefaultArchiveDeployer.START_ARTIFACT_ON_DEPLOYMENT_PROPERTY;
 import static org.mule.test.allure.AllureConstants.ArtifactDeploymentFeature.DOMAIN_DEPLOYMENT;
 
@@ -88,7 +89,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 


### PR DESCRIPTION
…… (#11430)

* W-10984029: After domain project's redployment the associated app's .mule deployment.properties file gets overwritten, i.e., the properties are wiped out

* Reformatting

* Adding doc

(cherry picked from commit 78ba826ac18df7749409daff0f7d6dec9e35f60b)