### PR TITLE
W-11032583: Refactor - Make it easy to add new characteristics to be discovered by traversing the inner operations of a reusable operation

### DIFF
--- a/modules/extensions-mule-support/src/main/java/org/mule/runtime/module/extension/mule/internal/loader/parser/MuleSdkOperationModelParserSdk.java
+++ b/modules/extensions-mule-support/src/main/java/org/mule/runtime/module/extension/mule/internal/loader/parser/MuleSdkOperationModelParserSdk.java
@@ -9,6 +9,7 @@ package org.mule.runtime.module.extension.mule.internal.loader.parser;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.mule.runtime.api.component.TypedComponentIdentifier.ComponentType.UNKNOWN;
@@ -48,6 +49,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -65,10 +68,12 @@ class MuleSdkOperationModelParserSdk extends BaseMuleSdkExtensionModelParser imp
   private static final String TYPE_PARAMETER = "type";
   private static final String VISIBILITY_PARAMETER = "visibility";
   private static final String DEPRECATED_CONSTRUCT_NAME = "deprecated";
+  private static final String CHARACTERISTICS_NOT_COMPUTED_MSG = "Characteristics have not been computed yet.";
 
   private final ComponentAst operation;
   private final TypeLoader typeLoader;
-  private Boolean isBlocking;
+
+  private final Characteristic<Boolean> isBlocking = new AnyMatchCharacteristic(OperationModel::isBlocking);
 
   private String name;
 
@@ -159,8 +164,7 @@ class MuleSdkOperationModelParserSdk extends BaseMuleSdkExtensionModelParser imp
 
   @Override
   public boolean isBlocking() {
-    checkState(isBlocking != null, "Characteristics have not been computed yet.");
-    return isBlocking;
+    return isBlocking.getValue();
   }
 
   @Override
@@ -323,11 +327,80 @@ class MuleSdkOperationModelParserSdk extends BaseMuleSdkExtensionModelParser imp
         });
   }
 
-  private void computeIsBlocking(Map<String, MuleSdkOperationModelParserSdk> operationModelParsersByName) {
-    isBlocking = getOperationModelsRecursiveStream(operationModelParsersByName).anyMatch(OperationModel::isBlocking);
+  public void computeCharacteristics(Map<String, MuleSdkOperationModelParserSdk> operationModelParsersByName) {
+    computeCharacteristics(singletonList(isBlocking), operationModelParsersByName);
   }
 
-  public void computeCharacteristics(Map<String, MuleSdkOperationModelParserSdk> operationModelParsersByName) {
-    computeIsBlocking(operationModelParsersByName);
+  private void computeCharacteristics(List<Characteristic<?>> characteristics,
+                                      Map<String, MuleSdkOperationModelParserSdk> operationModelParsersByName) {
+    getOperationModelsRecursiveStream(operationModelParsersByName).anyMatch(operationModel -> {
+      for (Characteristic<?> characteristic : characteristics) {
+        characteristic.computeFrom(operationModel);
+      }
+
+      return areAllCharacteristicsWithDefinitiveValue(characteristics);
+    });
+
+    for (Characteristic<?> characteristic : characteristics) {
+      if (!characteristic.hasValue()) {
+        characteristic.setWithDefault();
+      }
+    }
+  }
+
+  private boolean areAllCharacteristicsWithDefinitiveValue(List<Characteristic<?>> characteristics) {
+    return characteristics.stream().allMatch(Characteristic::hasDefinitiveValue);
+  }
+
+  private static class Characteristic<T> {
+
+    private final BiFunction<OperationModel, T, T> mapper;
+    private final T defaultValue;
+    private final T stopValue;
+
+    private T value;
+
+    private Characteristic(BiFunction<OperationModel, T, T> mapper, T defaultValue, T stopValue) {
+      this.mapper = mapper;
+      this.defaultValue = defaultValue;
+      this.stopValue = stopValue;
+    }
+
+    public void computeFrom(OperationModel operationModel) {
+      value = mapper.apply(operationModel, value);
+    }
+
+    public void setWithDefault() {
+      value = defaultValue;
+    }
+
+    public boolean hasDefinitiveValue() {
+      return stopValue.equals(value);
+    }
+
+    public boolean hasValue() {
+      return value != null;
+    }
+
+    public T getValue() {
+      checkState(hasValue(), CHARACTERISTICS_NOT_COMPUTED_MSG);
+      return value;
+    }
+  }
+
+  private static class BooleanCharacteristic extends Characteristic<Boolean> {
+
+    private BooleanCharacteristic(Predicate<OperationModel> predicate, Boolean defaultValue, Boolean stopValue) {
+      super(((operationModel,
+              curValue) -> (curValue != null && curValue == stopValue) ? curValue : predicate.test(operationModel)),
+            defaultValue, stopValue);
+    }
+  }
+
+  private static class AnyMatchCharacteristic extends BooleanCharacteristic {
+
+    private AnyMatchCharacteristic(Predicate<OperationModel> predicate) {
+      super(predicate, false, true);
+    }
   }
 }

--- a/modules/extensions-mule-support/src/main/java/org/mule/runtime/module/extension/mule/internal/loader/parser/MuleSdkOperationModelParserSdk.java
+++ b/modules/extensions-mule-support/src/main/java/org/mule/runtime/module/extension/mule/internal/loader/parser/MuleSdkOperationModelParserSdk.java
@@ -297,8 +297,7 @@ class MuleSdkOperationModelParserSdk extends BaseMuleSdkExtensionModelParser imp
     if (operationParser != null) {
       return operationParser.getOperationModelsRecursiveStream(operationModelParsersByName, visitedOperations);
     } else {
-      // Null here represents an empty stream, but it is more efficient because we avoid constructing one.
-      return null;
+      return Stream.empty();
     }
   }
 
@@ -321,8 +320,7 @@ class MuleSdkOperationModelParserSdk extends BaseMuleSdkExtensionModelParser imp
           } else if (componentAst.getComponentType().equals(UNKNOWN)) {
             return expandOperationWithoutModel(operationModelParsersByName, visitedOperations, componentAst);
           } else {
-            // Null here represents an empty stream, but it is more efficient because we avoid constructing one.
-            return null;
+            return Stream.empty();
           }
         });
   }


### PR DESCRIPTION
Refactor to generate a single stream expanding processors from operation calls.

This should scale better to other characteristics that may depend on the order of the processors.

Also adding some helpers to compute multiple characteristics on a single pass.

Note for the reviewer. This PR contains basically the same as #11440 but without adding the `isConnected` implementation. We decided to separate this because it will probably be more complex than originally anticipated and will require more analysis and discussion. Meanwhile, the refactor alone could be useful for some other characteristics that we have already discussed.