### PR TITLE
W-11090837: Migrate HttpListenerBindTestCase to unit test

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
@@ -28,11 +28,13 @@ public class DefaultLifecycleManagerTestCase extends AbstractMuleTestCase {
     Lifecycle configurationProviderToolingAdapter = mock(Lifecycle.class);
     LifecycleCallback lifecycleCallback = mock(LifecycleCallback.class);
     doThrow(new DefaultMuleException("Test exception")).when(lifecycleCallback).onTransition(any(), any());
-    
-    DefaultLifecycleManager defaultLifecycleManager = new DefaultLifecycleManager("org.mule.runtime.module.extension.internal.runtime.config.ConfigurationProviderToolingAdapter-lisConfig", configurationProviderToolingAdapter);
+
+    DefaultLifecycleManager defaultLifecycleManager =
+        new DefaultLifecycleManager("org.mule.runtime.module.extension.internal.runtime.config.ConfigurationProviderToolingAdapter-lisConfig",
+                                    configurationProviderToolingAdapter);
     DefaultLifecycleManager defaultLifecycleManagerSpy = spy(defaultLifecycleManager);
     doNothing().when(defaultLifecycleManagerSpy).checkPhase(any());
-    
+
     defaultLifecycleManagerSpy.fireStartPhase(lifecycleCallback);
   }
 }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.runtime.core.internal.lifecycle;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
@@ -1,0 +1,32 @@
+package org.mule.runtime.core.internal.lifecycle;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import org.mule.runtime.api.exception.DefaultMuleException;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.lifecycle.Lifecycle;
+import org.mule.runtime.api.lifecycle.LifecycleException;
+import org.mule.runtime.core.api.lifecycle.LifecycleCallback;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import org.junit.Test;
+
+public class DefaultLifecycleManagerTestCase extends AbstractMuleTestCase {
+
+  @Test(expected = LifecycleException.class)
+  public void testDefaultLifecycleManagerTestCaseWrapsDefaultMuleExceptionIntoLifecycleException() throws MuleException {
+    Lifecycle configurationProviderToolingAdapter = mock(Lifecycle.class);
+    LifecycleCallback lifecycleCallback = mock(LifecycleCallback.class);
+    doThrow(new DefaultMuleException("Test exception")).when(lifecycleCallback).onTransition(any(), any());
+    
+    DefaultLifecycleManager defaultLifecycleManager = new DefaultLifecycleManager("org.mule.runtime.module.extension.internal.runtime.config.ConfigurationProviderToolingAdapter-lisConfig", configurationProviderToolingAdapter);
+    DefaultLifecycleManager defaultLifecycleManagerSpy = spy(defaultLifecycleManager);
+    doNothing().when(defaultLifecycleManagerSpy).checkPhase(any());
+    
+    defaultLifecycleManagerSpy.fireStartPhase(lifecycleCallback);
+  }
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/DefaultLifecycleManagerTestCase.java
@@ -6,6 +6,8 @@
  */
 package org.mule.runtime.core.internal.lifecycle;
 
+import static org.mule.test.allure.AllureConstants.ErrorHandlingFeature.ERROR_HANDLING;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -19,11 +21,20 @@ import org.mule.runtime.api.lifecycle.LifecycleException;
 import org.mule.runtime.core.api.lifecycle.LifecycleCallback;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+@Feature(ERROR_HANDLING)
+@Issue("W-11090837")
 public class DefaultLifecycleManagerTestCase extends AbstractMuleTestCase {
 
-  @Test(expected = LifecycleException.class)
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
   public void testDefaultLifecycleManagerTestCaseWrapsDefaultMuleExceptionIntoLifecycleException() throws MuleException {
     Lifecycle configurationProviderToolingAdapter = mock(Lifecycle.class);
     LifecycleCallback lifecycleCallback = mock(LifecycleCallback.class);
@@ -35,6 +46,7 @@ public class DefaultLifecycleManagerTestCase extends AbstractMuleTestCase {
     DefaultLifecycleManager defaultLifecycleManagerSpy = spy(defaultLifecycleManager);
     doNothing().when(defaultLifecycleManagerSpy).checkPhase(any());
 
+    expectedException.expect(LifecycleException.class);
     defaultLifecycleManagerSpy.fireStartPhase(lifecycleCallback);
   }
 }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
@@ -491,9 +491,7 @@ public abstract class AbstractDeploymentTestCase extends AbstractMuleTestCase {
           .containingClass(echoTestClassFile, "org/foo/EchoTest.class");
   protected final ApplicationFileBuilder dummyErrorAppOnStartDescriptorFileBuilder =
       new ApplicationFileBuilder("dummy-error-app-start")
-          .definedBy("dummy-error-app-start.xml").configuredWith("myCustomProp", "someValue")
-          .dependingOn(callbackExtensionPlugin)
-          .containingClass(echoTestClassFile, "org/foo/EchoTest.class");
+          .definedBy("dummy-error-app-start.xml").configuredWith("myCustomProp", "someValue");
 
   // Domain file builders
   protected DomainFileBuilder dummyDomainFileBuilder =

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/AbstractDeploymentTestCase.java
@@ -489,6 +489,11 @@ public abstract class AbstractDeploymentTestCase extends AbstractMuleTestCase {
           .definedBy("dummy-app-several-flows.xml").configuredWith("myCustomProp", "someValue")
           .dependingOn(callbackExtensionPlugin)
           .containingClass(echoTestClassFile, "org/foo/EchoTest.class");
+  protected final ApplicationFileBuilder dummyErrorAppOnStartDescriptorFileBuilder =
+      new ApplicationFileBuilder("dummy-error-app-start")
+          .definedBy("dummy-error-app-start.xml").configuredWith("myCustomProp", "someValue")
+          .dependingOn(callbackExtensionPlugin)
+          .containingClass(echoTestClassFile, "org/foo/EchoTest.class");
 
   // Domain file builders
   protected DomainFileBuilder dummyDomainFileBuilder =

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/logging/LoggingAppStartErrorTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/logging/LoggingAppStartErrorTestCase.java
@@ -101,12 +101,12 @@ public class LoggingAppStartErrorTestCase extends AbstractApplicationDeploymentT
     when(applicationDescriptorMock.getClassLoaderModel())
         .thenReturn(new ClassLoaderModel.ClassLoaderModelBuilder().containing(new URL("file:/target/classes")).build());
     application = new DefaultMuleApplication(applicationDescriptorMock, parentArtifactClassLoader, emptyList(),
-        null, mock(ServiceRepository.class),
-        mock(ExtensionModelLoaderRepository.class),
-        appLocation, null, null,
-        getRuntimeLockFactory(),
-        mock(MemoryManagementService.class),
-        mock(ArtifactConfigurationProcessor.class));
+                                             null, mock(ServiceRepository.class),
+                                             mock(ExtensionModelLoaderRepository.class),
+                                             appLocation, null, null,
+                                             getRuntimeLockFactory(),
+                                             mock(MemoryManagementService.class),
+                                             mock(ArtifactConfigurationProcessor.class));
 
     Method setArtifactContext = application.getClass().getDeclaredMethod("setArtifactContext", ArtifactContext.class);
     setArtifactContext.setAccessible(true);
@@ -129,7 +129,7 @@ public class LoggingAppStartErrorTestCase extends AbstractApplicationDeploymentT
       assertStatus(DEPLOYMENT_FAILED);
       assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().size(), is(1));
       assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().get(0).getMessage(),
-          containsString(expectedLogMessage));
+                 containsString(expectedLogMessage));
     }
   }
 
@@ -146,7 +146,7 @@ public class LoggingAppStartErrorTestCase extends AbstractApplicationDeploymentT
       @Override
       public String describeFailure() {
         return format("Application remained at status %s instead of moving to %s", application.getStatus().name(),
-            status.name());
+                      status.name());
       }
     });
 
@@ -164,13 +164,13 @@ public class LoggingAppStartErrorTestCase extends AbstractApplicationDeploymentT
 
     assertThat(loggerDefaultArtifactDeployer.getAllLoggingEvents().size(), is(1));
     assertThat(loggerDefaultArtifactDeployer.getAllLoggingEvents().get(0).getMessage(),
-        containsString(expectedLogMessageDefaultArtifactDeployer));
+               containsString(expectedLogMessageDefaultArtifactDeployer));
 
     assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().size(), is(1));
     assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().get(0).getMessage(),
-        containsString(expectedLogMessageDefaultMuleApplication));
+               containsString(expectedLogMessageDefaultMuleApplication));
     assertThat(((MuleArtifactClassLoader) loggerDefaultMuleApplication.getAllLoggingEvents().get(0).getThreadContextClassLoader())
-            .getArtifactId(),
-        containsString("dummy-error-app-start"));
+        .getArtifactId(),
+               containsString("dummy-error-app-start"));
   }
 }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/logging/LoggingAppStartErrorTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/logging/LoggingAppStartErrorTestCase.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.deployment.logging;
+
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.core.internal.config.RuntimeLockFactoryUtil.getRuntimeLockFactory;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+import static com.github.valfirst.slf4jtest.TestLoggerFactory.getTestLogger;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import org.mule.runtime.api.lifecycle.LifecycleException;
+import org.mule.runtime.api.lifecycle.Startable;
+import org.mule.runtime.api.lifecycle.Stoppable;
+import org.mule.runtime.api.memory.management.MemoryManagementService;
+import org.mule.runtime.api.notification.NotificationListenerRegistry;
+import org.mule.runtime.api.service.ServiceRepository;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.source.MessageSource;
+import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
+import org.mule.runtime.core.internal.registry.DefaultRegistry;
+import org.mule.runtime.deployment.model.api.application.ApplicationDescriptor;
+import org.mule.runtime.deployment.model.api.application.ApplicationStatus;
+import org.mule.runtime.deployment.model.api.artifact.ArtifactConfigurationProcessor;
+import org.mule.runtime.deployment.model.api.artifact.ArtifactContext;
+import org.mule.runtime.deployment.model.api.artifact.extension.ExtensionModelLoaderRepository;
+import org.mule.runtime.module.artifact.activation.internal.classloader.MuleApplicationClassLoader;
+import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderModel;
+import org.mule.runtime.module.deployment.impl.internal.application.DefaultMuleApplication;
+import org.mule.runtime.module.deployment.internal.AbstractApplicationDeploymentTestCase;
+import org.mule.runtime.module.deployment.internal.DefaultArtifactDeployer;
+import org.mule.tck.probe.JUnitProbe;
+import org.mule.tck.probe.PollingProber;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.valfirst.slf4jtest.TestLogger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+public class LoggingAppStartErrorTestCase extends AbstractApplicationDeploymentTestCase {
+
+  private static final int PROBER_TIMEOUT = 1000;
+  private static final int PROBER_INTERVAL = 100;
+
+  private DefaultMuleApplication application;
+  private ArtifactContext mockArtifactContext;
+
+  private final File appLocation = new File("fakeLocation");
+
+  TestLogger loggerDefaultMuleApplication = getTestLogger(DefaultMuleApplication.class);
+  TestLogger loggerDefaultArtifactDeployer = getTestLogger(DefaultArtifactDeployer.class);
+
+  @Parameterized.Parameters(name = "Parallel: {0}")
+  public static List<Boolean> params() {
+    return asList(false);
+  }
+
+  public LoggingAppStartErrorTestCase(boolean parallelDeployment) {
+    super(parallelDeployment);
+  }
+
+  @Before
+  public void doSetUp() throws Exception {
+    MuleApplicationClassLoader parentArtifactClassLoader = mock(MuleApplicationClassLoader.class);
+    mockArtifactContext = mock(ArtifactContext.class);
+    MuleContextWithRegistry muleContext = mock(MuleContextWithRegistry.class);
+    when(mockArtifactContext.getMuleContext()).thenReturn(muleContext);
+
+    DefaultRegistry defaultRegistryMock = mock(DefaultRegistry.class);
+    when(mockArtifactContext.getRegistry()).thenReturn(defaultRegistryMock);
+
+    NotificationListenerRegistry notificationListenerRegistryMock = mock(NotificationListenerRegistry.class);
+    when(defaultRegistryMock.lookupByType(any())).thenReturn(Optional.of(notificationListenerRegistryMock));
+
+    ApplicationDescriptor applicationDescriptorMock = mock(ApplicationDescriptor.class, RETURNS_DEEP_STUBS.get());
+    when(applicationDescriptorMock.getClassLoaderModel())
+        .thenReturn(new ClassLoaderModel.ClassLoaderModelBuilder().containing(new URL("file:/target/classes")).build());
+    application = new DefaultMuleApplication(applicationDescriptorMock, parentArtifactClassLoader, emptyList(),
+                                             null, mock(ServiceRepository.class),
+                                             mock(ExtensionModelLoaderRepository.class),
+                                             appLocation, null, null,
+                                             getRuntimeLockFactory(),
+                                             mock(MemoryManagementService.class),
+                                             mock(ArtifactConfigurationProcessor.class));
+
+    Method setArtifactContext = application.getClass().getDeclaredMethod("setArtifactContext", ArtifactContext.class);
+    setArtifactContext.setAccessible(true);
+    setArtifactContext.invoke(application, mockArtifactContext);
+  }
+
+  @Test
+  public void whenAppThrowsLifecycleExceptionWhileStartingTheErrorShouldBeLogged() throws Exception {
+    MuleContext mockedMuleContext = mock(MuleContext.class);
+    when(mockArtifactContext.getMuleContext()).thenReturn(mockedMuleContext);
+    String expectedLogMessage = "Could not start HTTP server for 'lisConfig' on port 27664: Address already in use";
+
+    MessageSource mockMessageSource = mock(MessageSource.class, withSettings().extraInterfaces(Startable.class, Stoppable.class));
+    doThrow(new LifecycleException(createStaticMessage(expectedLogMessage), mockMessageSource)).when(mockedMuleContext).start();
+
+    try {
+      application.start();
+      fail("Was expecting start to fail");
+    } catch (Exception e) {
+      assertStatus(ApplicationStatus.DEPLOYMENT_FAILED);
+      Assert.assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().size(), is(1));
+      Assert.assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().get(0).getMessage(),
+                        containsString(expectedLogMessage));
+    }
+  }
+
+  private void assertStatus(final ApplicationStatus status) {
+    PollingProber prober = new PollingProber(PROBER_TIMEOUT, PROBER_INTERVAL);
+    prober.check(new JUnitProbe() {
+
+      @Override
+      protected boolean test() throws Exception {
+        Assert.assertThat(application.getStatus(), is(status));
+        return true;
+      }
+
+      @Override
+      public String describeFailure() {
+        return String.format("Application remained at status %s instead of moving to %s", application.getStatus().name(),
+                             status.name());
+      }
+    });
+
+  }
+
+  @Test
+  public void whenAppFailsWhileStartingTheErrorLogShouldBeCreatedWithTheAppClassloader() throws Exception {
+    String expectedLogMessageDefaultMuleApplication = "Failing processor error";
+    String expectedLogMessageDefaultArtifactDeployer = "Failed to deploy artifact";
+    addPackedAppFromBuilder(dummyErrorAppOnStartDescriptorFileBuilder);
+
+    startDeployment();
+
+    assertDeploymentFailure(applicationDeploymentListener, dummyErrorAppOnStartDescriptorFileBuilder.getId());
+
+    assertThat(loggerDefaultArtifactDeployer.getAllLoggingEvents().size(), is(1));
+    Assert.assertThat(loggerDefaultArtifactDeployer.getAllLoggingEvents().get(0).getMessage(),
+                      containsString(expectedLogMessageDefaultArtifactDeployer));
+
+    assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().size(), is(1));
+    Assert.assertThat(loggerDefaultMuleApplication.getAllLoggingEvents().get(0).getMessage(),
+                      containsString(expectedLogMessageDefaultMuleApplication));
+    assertThat(((MuleArtifactClassLoader) loggerDefaultMuleApplication.getAllLoggingEvents().get(0).getThreadContextClassLoader())
+        .getArtifactId(),
+               containsString("dummy-error-app-start"));
+  }
+}

--- a/modules/deployment/src/test/resources/dummy-error-app-start.xml
+++ b/modules/deployment/src/test/resources/dummy-error-app-start.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:callback="http://www.mulesoft.org/schema/mule/callback"
+      xsi:schemaLocation="
+            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+            http://www.mulesoft.org/schema/mule/callback http://www.mulesoft.org/schema/mule/callback/current/mule-callback.xsd">
+
+    <description>Failing Mule Application</description>
+
+    <object class="org.mule.runtime.module.deployment.internal.ApplicationDeploymentTestCase.FailingProcessorTest" name="FailingProcessor">
+    </object>
+
+    <flow name="test2" >
+        <scheduler>
+            <scheduling-strategy >
+                <fixed-frequency timeUnit="DAYS" frequency="1"/>
+            </scheduling-strategy>
+        </scheduler>
+        <flow-ref name="FailingProcessor"/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
The HttpListenerBindTestCase system test was split up into two unit tests:
- This one which tests that the exception thrown is logged with the correct classloader
- One in [http-connector](https://github.com/mulesoft/mule-http-connector/pull/621) which tests that the exception is correctly wrapped as a MuleException

A test in http-service which checks that an exception is thrown if the port is already being used already [exists](https://github.com/mulesoft/mule-http-service/blob/master/src/test/java/org/mule/service/http/impl/functional/server/HttpServerBindTestCase.java) 