### PR TITLE
W-11070209:  Enable FIPS support for JDK11 and beyond

### DIFF
--- a/modules/launcher/pom.xml
+++ b/modules/launcher/pom.xml
@@ -53,6 +53,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.mulesoft.mule.runtime.modules</groupId>
+            <artifactId>mule-module-cluster-ee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
         </dependency>


### PR DESCRIPTION
Adding FIPs support for JDK 11 and hopefully for 17. This is still a work in progress. 
Tested JDK 11 locally but need to test on docker containers in cloud hub.

I would raise a separate PR for wrapper.conf changes