### PR TITLE
W-11086587: Add logging to offer method in AbstractQueueStoreDelegate…

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/util/queue/AbstractQueueStoreDelegate.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/queue/AbstractQueueStoreDelegate.java
@@ -54,7 +54,8 @@ public abstract class AbstractQueueStoreDelegate implements QueueStoreDelegate {
           } else {
             if (l2 <= 0L) {
               logger
-                  .warn(format("Timeout of %d milliseconds reached, object could not be queued. Queue capacity full.", timeout));
+                  .warn(format("Timeout of %d milliseconds reached, object could not be queued. Queue capacity of %d full.",
+                               timeout, capacity));
               return false;
             }
             this.wait(l2);

--- a/core/src/main/java/org/mule/runtime/core/internal/util/queue/AbstractQueueStoreDelegate.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/util/queue/AbstractQueueStoreDelegate.java
@@ -6,14 +6,22 @@
  */
 package org.mule.runtime.core.internal.util.queue;
 
+import static java.lang.String.format;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.io.Serializable;
 import java.util.Collection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract queue delegate implementation that forces common queue behaviour
  */
 public abstract class AbstractQueueStoreDelegate implements QueueStoreDelegate {
 
+  private final Logger logger = getLogger(AbstractQueueStoreDelegate.class);
   private final int capacity;
 
   public AbstractQueueStoreDelegate(int capacity) {
@@ -45,6 +53,8 @@ public abstract class AbstractQueueStoreDelegate implements QueueStoreDelegate {
             this.wait(0);
           } else {
             if (l2 <= 0L) {
+              logger
+                  .warn(format("Timeout of %d milliseconds reached, object could not be queued. Queue capacity full.", timeout));
               return false;
             }
             this.wait(l2);


### PR DESCRIPTION
… so that we know why a record was not successfully queued

A test for this use case already exists and it's located in https://github.com/mulesoft/mule/blob/f3c3da51aeebe9232d28a6a6e65f1411fafabcb9/tests/unit/src/main/java/org/mule/tck/core/util/queue/QueueStoreTestCase.java#L63