### PR TITLE
W-10998630: Remove warning: "An expression value was given for parame…

### DIFF
--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarer.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarer.java
@@ -7,6 +7,8 @@
 package org.mule.runtime.core.api.extension;
 
 import static com.google.common.collect.ImmutableSet.of;
+
+import static java.lang.Boolean.getBoolean;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.mule.metadata.api.model.MetadataFormat.JAVA;
@@ -21,6 +23,7 @@ import static org.mule.runtime.api.meta.model.parameter.ParameterGroupModel.OUTP
 import static org.mule.runtime.api.meta.model.parameter.ParameterRole.BEHAVIOUR;
 import static org.mule.runtime.api.meta.model.parameter.ParameterRole.PRIMARY_CONTENT;
 import static org.mule.runtime.api.meta.model.stereotype.StereotypeModelBuilder.newStereotype;
+import static org.mule.runtime.api.util.MuleSystemProperties.REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.ANY;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.CLIENT_SECURITY;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.COMPOSITE_ROUTING;
@@ -155,7 +158,6 @@ class MuleExtensionModelDeclarer {
   final ErrorModel duplicateMessageError = newError(DUPLICATE_MESSAGE).withParent(validationError).build();
 
   ExtensionDeclarer createExtensionModel() {
-
     ExtensionDeclarer extensionDeclarer = new ExtensionDeclarer()
         .named(MULE_NAME)
         .describedAs("Mule Runtime and Integration Platform: Core components")
@@ -474,11 +476,19 @@ class MuleExtensionModelDeclarer {
     setVariable.withOutput().ofType(VOID_TYPE);
     setVariable.withOutputAttributes().ofType(VOID_TYPE);
 
-    setVariable.onDefaultParameterGroup()
-        .withOptionalParameter("variableName")
-        .ofType(STRING_TYPE)
-        .withExpressionSupport(NOT_SUPPORTED)
-        .describedAs("The name of the variable.");
+    if (getBoolean(REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY)) {
+      setVariable.onDefaultParameterGroup()
+          .withOptionalParameter("variableName")
+          .ofType(STRING_TYPE)
+          .withExpressionSupport(NOT_SUPPORTED)
+          .describedAs("The name of the variable.");
+    } else {
+      setVariable.onDefaultParameterGroup()
+          .withOptionalParameter("variableName")
+          .ofType(STRING_TYPE)
+          .withExpressionSupport(SUPPORTED)
+          .describedAs("The name of the variable.");
+    }
 
     setVariable.onDefaultParameterGroup()
         .withRequiredParameter("value")

--- a/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/SetVariableVariableNameValidationTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/SetVariableVariableNameValidationTestCase.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Story;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 @Feature(MULE_DSL)
@@ -49,6 +48,6 @@ public class SetVariableVariableNameValidationTestCase extends AbstractCoreValid
         "   </flow>\n" +
         "</mule>");
 
-    assertThat(msg, Matchers.is(empty()));
+    assertThat(msg, is(empty()));
   }
 }

--- a/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/SetVariableVariableNameValidationTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/SetVariableVariableNameValidationTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.internal.validation;
+
+import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
+import static org.mule.test.allure.AllureConstants.MuleDsl.MULE_DSL;
+
+import static java.util.Optional.empty;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.mule.runtime.ast.api.validation.Validation;
+import org.mule.runtime.ast.api.validation.ValidationResultItem;
+
+import java.util.Optional;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+@Feature(MULE_DSL)
+@Story(DSL_VALIDATION_STORY)
+@Issue("W-10998630")
+public class SetVariableVariableNameValidationTestCase extends AbstractCoreValidationTestCase {
+
+  @Override
+  protected Validation getValidation() {
+    return new NoExpressionsInNoExpressionsSupportedParams();
+  }
+
+  @Test
+  public void variableNameSupportsExpressionsSoNoValidationShouldArise() {
+    final Optional<ValidationResultItem> msg = runValidation("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<mule xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n"
+        +
+        "   xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+        "   xsi:schemaLocation=\"http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\">\n"
+        +
+        "   <flow name=\"expression-for-variablenameFlow\">\n" +
+        "       <set-variable value=\"myVariable\" variableName=\"targetName\"/>" +
+        "       <set-variable value=\"specialValue\" variableName=\"#[vars.targetName]\"/>\n" +
+        "   </flow>\n" +
+        "</mule>");
+
+    assertThat(msg, Matchers.is(empty()));
+  }
+}

--- a/runtime-extension-model/src/test/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarerTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/core/api/extension/MuleExtensionModelDeclarerTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.api.extension;
+
+import static org.mule.runtime.api.util.MuleSystemProperties.REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY;
+import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
+import static org.mule.test.allure.AllureConstants.MuleDsl.MULE_DSL;
+
+import static java.util.Arrays.asList;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.mule.runtime.api.meta.ExpressionSupport;
+import org.mule.runtime.api.meta.model.declaration.fluent.ExtensionDeclarer;
+import org.mule.runtime.api.meta.model.declaration.fluent.OperationDeclaration;
+import org.mule.runtime.api.meta.model.declaration.fluent.ParameterDeclaration;
+
+import java.util.Collection;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@Feature(MULE_DSL)
+@Story(DSL_VALIDATION_STORY)
+@RunWith(Parameterized.class)
+public class MuleExtensionModelDeclarerTestCase {
+
+  private String systemPropertyName;
+  private String systemPropertyValue;
+  private String systemPropertyOldValue;
+  private String expectedResult;
+
+  public MuleExtensionModelDeclarerTestCase(String supportExtressionsInVariableNameInSetVariable, String expectedResult) {
+    systemPropertyName = REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY;
+    systemPropertyValue = supportExtressionsInVariableNameInSetVariable;
+    this.expectedResult = expectedResult;
+  }
+
+  @Parameterized.Parameters(name = "Do not support expressions in variableName in SetVariable: {0}")
+  public static Collection<Object[]> data() {
+    return asList(new Object[][] {
+        {"true", "NOT_SUPPORTED"},
+        {"false", "SUPPORTED"}
+    });
+  }
+
+  @Before
+  public void setUp() {
+    systemPropertyOldValue = System.setProperty(systemPropertyName, systemPropertyValue);
+  }
+
+  @After
+  public void tearDown() {
+    if (systemPropertyOldValue == null) {
+      System.clearProperty(systemPropertyName);
+    } else {
+      System.setProperty(systemPropertyName, systemPropertyOldValue);
+    }
+  }
+
+  @Test
+  @Issue("W-10998630")
+  public void whenCreatingExtensionModelVariableNameShouldSupportExpressionsAccordingToSystemProperty() {
+    MuleExtensionModelDeclarer muleExtensionModelDeclarer = new MuleExtensionModelDeclarer();
+    ExtensionDeclarer extensionDeclarer = muleExtensionModelDeclarer.createExtensionModel();
+    OperationDeclaration setVariableOperation = extensionDeclarer.getDeclaration().getOperations().stream()
+        .filter(operationDeclaration -> operationDeclaration.getName().equals("setVariable")).findFirst().get();
+    ParameterDeclaration setVariableParameter = setVariableOperation.getParameterGroup("General").getParameters().stream()
+        .filter(parameterDeclaration -> parameterDeclaration.getName().equals("variableName")).findFirst().get();
+    ExpressionSupport expressionSupport = setVariableParameter.getExpressionSupport();
+
+    assertThat(expressionSupport.name(), is(expectedResult));
+  }
+}

--- a/runtime-extension-model/src/test/java/org/mule/runtime/core/extension/CoreExtensionModelTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/core/extension/CoreExtensionModelTestCase.java
@@ -774,7 +774,7 @@ public class CoreExtensionModelTestCase {
     ParameterModel mimeType = setVariable.getAllParameterModels().get(3);
 
     assertThat(variableName.getName(), is("variableName"));
-    assertThat(variableName.getExpressionSupport(), is(NOT_SUPPORTED));
+    assertThat(variableName.getExpressionSupport(), is(SUPPORTED));
     assertThat(variableName.getType(), is(instanceOf(StringType.class)));
 
     assertThat(value.getName(), is("value"));


### PR DESCRIPTION
…ter 'variableName' but it doesn't support expressions" from logging (#11574)

* W-10998630: Remove warning: "An expression value was given for parameter 'variableName' but it doesn't support expressions" from logging

* Changed test name

* Adding license

* PR comments

* Removing unused imports

* Cleaning

* Adding license

* Renaming property and moving property initialization

* Refactor

(cherry picked from commit a9c496778a009aa5d27401736b74b96d37d32675)