### PR TITLE
W-11528601: setting the minMuleVersion when using lazy init in functional test cases.

### DIFF
--- a/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
+++ b/tests/functional/src/main/java/org/mule/functional/junit4/FunctionalTestCase.java
@@ -256,7 +256,9 @@ public abstract class FunctionalTestCase extends AbstractMuleContextTestCase {
   @Override
   protected DefaultMuleConfiguration createMuleConfiguration() {
     if (enableLazyInit()) {
-      return new ReconfigurableMuleConfiguration();
+      DefaultMuleConfiguration muleConfiguration = new ReconfigurableMuleConfiguration();
+      configureMuleConfiguration(muleConfiguration);
+      return muleConfiguration;
     } else {
       return super.createMuleConfiguration();
     }

--- a/tests/functional/src/test/java/org/mule/functional/junit4/FunctionalTestCaseWithLazyInitTestCase.java
+++ b/tests/functional/src/test/java/org/mule/functional/junit4/FunctionalTestCaseWithLazyInitTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.functional.junit4;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.qameta.allure.Description;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests for the {@link FunctionalTestCase} support class when used with and without lazy initialization.
+ */
+@RunWith(Parameterized.class)
+public class FunctionalTestCaseWithLazyInitTestCase extends FunctionalTestCase {
+
+  private final boolean enableLazyInit;
+
+  @Parameterized.Parameters(name = "enableLazyInit: {0} ")
+  public static Object[] data() {
+    return new Object[] {true, false};
+  }
+
+  public FunctionalTestCaseWithLazyInitTestCase(boolean enableLazyInit) {
+    this.enableLazyInit = enableLazyInit;
+  }
+
+  @Override
+  public boolean enableLazyInit() {
+    return enableLazyInit;
+  }
+
+  @Override
+  protected String getConfigFile() {
+    return "dummy-mule-app.xml";
+  }
+
+  @Test
+  @Description("Checks that the min Mule version is present in the MuleConfiguration")
+  public void minMuleVersionHasBeenSet() {
+    assertThat(muleContext.getConfiguration().getMinMuleVersion().isPresent(), is(true));
+  }
+}

--- a/tests/functional/src/test/resources/dummy-mule-app.xml
+++ b/tests/functional/src/test/resources/dummy-mule-app.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+      http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+</mule>

--- a/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/junit4/AbstractMuleContextTestCase.java
@@ -308,12 +308,21 @@ public abstract class AbstractMuleContextTestCase extends AbstractMuleTestCase {
   }
 
   protected DefaultMuleConfiguration createMuleConfiguration() {
-    if (getMavenProjectVersionProperty() == null) {
-      return new DefaultMuleConfiguration();
-    }
     DefaultMuleConfiguration muleConfiguration = new DefaultMuleConfiguration();
-    muleConfiguration.setMinMuleVersion(new MuleVersion(getMavenProjectVersionProperty()));
+    configureMuleConfiguration(muleConfiguration);
     return muleConfiguration;
+  }
+
+  /**
+   * Configures convenient default values for the Mule configuration of the testing environment.
+   * 
+   * @param muleConfiguration A {@link MuleConfiguration} to configure.
+   */
+  protected void configureMuleConfiguration(DefaultMuleConfiguration muleConfiguration) {
+    String mvnVersionProperty = getMavenProjectVersionProperty();
+    if (mvnVersionProperty != null) {
+      muleConfiguration.setMinMuleVersion(new MuleVersion(mvnVersionProperty));
+    }
   }
 
   /**


### PR DESCRIPTION
With #11350 we added the minMuleVersions by default to all `AbstractMuleContextTestCases`. However, for the case of `FunctionalTestCases` (a subclass of the former) it is not happening when enabling lazy initialization because there is an override.