### PR TITLE
W-11603893: Read Global function value from getComponent().getMetadata()

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -59,6 +59,8 @@ import org.springframework.beans.factory.support.ManagedMap;
 class ComponentConfigurationBuilder<T> {
 
   private static final Logger LOGGER = getLogger(ComponentConfigurationBuilder.class);
+  private static final String GLOBAL_FUNCTIONS_START_TAG = "<global-functions><![CDATA[";
+  private static final String GLOBAL_FUNCTIONS_END_TAG = "]]></global-functions>";
 
   private final BeanDefinitionBuilderHelper beanDefinitionBuilderHelper;
   private final ObjectReferencePopulator objectReferencePopulator = new ObjectReferencePopulator();
@@ -467,8 +469,15 @@ class ComponentConfigurationBuilder<T> {
 
     @Override
     public void onValueFromTextContent() {
-      getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
-          .ifPresent(v -> this.value = v);
+      Optional<String> value = createBeanDefinitionRequest.getComponent().getMetadata().getSourceCode();
+      if (value.isPresent() && value.get().startsWith(GLOBAL_FUNCTIONS_START_TAG)) {
+        Optional<String> data =
+            value.map(val -> val.substring(GLOBAL_FUNCTIONS_START_TAG.length(), val.indexOf(GLOBAL_FUNCTIONS_END_TAG)));
+        this.value = data.orElse("");
+      } else {
+        getParameterValue(((CreateParamBeanDefinitionRequest) createBeanDefinitionRequest).getParam().getModel().getName(), null)
+            .ifPresent(v -> this.value = v);
+      }
     }
 
     @Override


### PR DESCRIPTION
Due to recent changes ComponentConfigurationBuilder$ValueExtractorAttributeDefinitionVisitor.onValueFromTextContent() throws ClassCastException reading value of GlobalFunction.

org.mule.runtime.config.internal.dsl.spring.CreateComponentBeanDefinitionRequest cannot be cast to org.mule.runtime.config.internal.dsl.spring.CreateParamBeanDefinitionRequest

This prevents the customer app deploy when global function is there. This is since 4.4.0-20210906 and is reproduceable in 4.5.
I'm trying to handle this specific case, but don't know full history of these changes
