### PR TITLE
W-11861058: Allow obtaining the failing component from a PipelineMessageNotification (#11861)

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/processor/PipelineMessageNotificationTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/strategy/processor/PipelineMessageNotificationTestCase.java
@@ -285,13 +285,19 @@ public class PipelineMessageNotificationTestCase extends AbstractReactiveProcess
       EnrichedServerNotification notification = (EnrichedServerNotification) argument;
       Exception exception = notification.getException();
 
-      boolean result =
+      boolean result = true;
+      if (notification instanceof PipelineMessageNotification && exception != null) {
+        result = ((MessagingException) exception).getFailingComponent()
+            .equals(((PipelineMessageNotification) notification).getFailingComponent().get());
+      }
+
+      result = result &&
           expectedAction == notification.getAction().getActionId()
-              && (notification.getEvent() == null) == (this.event == null)
-              && (this.event == null ||
-                  (this.event.getMessage().getPayload().equals(notification.getEvent().getMessage().getPayload()) &&
-                      this.event.getMessage().getAttributes().equals(notification.getEvent().getMessage().getAttributes())))
-              && exceptionExpected == (exception != null);
+          && (notification.getEvent() == null) == (this.event == null)
+          && (this.event == null ||
+              (this.event.getMessage().getPayload().equals(notification.getEvent().getMessage().getPayload()) &&
+                  this.event.getMessage().getAttributes().equals(notification.getEvent().getMessage().getAttributes())))
+          && exceptionExpected == (exception != null);
 
       return result;
     }


### PR DESCRIPTION
(cherry picked from commit 83dc14eae83fa95d0fab346cee85566372c545cd)