### PR TITLE
W-10634129: Fix XML SDK implicit config creation and system property

### DIFF
--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/ast/XmlSdkImplicitConfigParameter.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/ast/XmlSdkImplicitConfigParameter.java
@@ -8,6 +8,7 @@
 package org.mule.runtime.extension.internal.ast;
 
 import static java.util.Optional.empty;
+import static org.mule.runtime.api.functional.Either.left;
 import static org.mule.runtime.api.functional.Either.right;
 import static org.mule.runtime.ast.api.ComponentGenerationInformation.EMPTY_GENERATION_INFO;
 
@@ -58,12 +59,12 @@ public class XmlSdkImplicitConfigParameter implements ComponentParameterAst {
 
   @Override
   public String getRawValue() {
-    return null;
+    return value != null ? value.toString() : null;
   }
 
   @Override
   public String getResolvedRawValue() {
-    return null;
+    return value != null ? value.toString() : null;
   }
 
   @Override

--- a/modules/extensions-xml-support/src/test/java/org/mule/test/functional/ModuleWithImplicitConfigurationCreatedTestCase.java
+++ b/modules/extensions-xml-support/src/test/java/org/mule/test/functional/ModuleWithImplicitConfigurationCreatedTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.functional;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ModuleWithImplicitConfigurationCreatedTestCase extends AbstractCeXmlExtensionMuleArtifactFunctionalTestCase {
+
+  @Override
+  protected String getModulePath() {
+    return "modules/module-global-element-default-params-with-no-use.xml";
+  }
+
+  @Override
+  protected String getConfigFile() {
+    return "flows/flows-using-module-global-element-default-params-with-no-use.xml";
+  }
+
+  @Test
+  public void testXmlPropertyWithoutImplicitConfiguration() throws Exception {
+    String payload = (String) flowRunner("testSetXmlProperty").run().getMessage().getPayload().getValue();
+    assertEquals(payload, "aniceproperty");
+  }
+}


### PR DESCRIPTION
This commit add the XML SDK properties to the implicit configuration even when there is no global element