### PR TITLE
W-11603893 Fix broken tests DynamicEvaluateProcessorFunctionalTestCase -  add null checks

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -475,7 +475,7 @@ class ComponentConfigurationBuilder<T> {
         value = componentAst.getMetadata().getSourceCode();
       }
 
-      if (value.isPresent() && value.get().startsWith(GLOBAL_FUNCTIONS_START_TAG)) {
+      if (value != null && value.isPresent() && value.get().startsWith(GLOBAL_FUNCTIONS_START_TAG)) {
         Optional<String> data =
             value.map(val -> val.substring(GLOBAL_FUNCTIONS_START_TAG.length(), val.indexOf(GLOBAL_FUNCTIONS_END_TAG)));
         this.value = data.orElse("");

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ComponentConfigurationBuilder.java
@@ -469,7 +469,12 @@ class ComponentConfigurationBuilder<T> {
 
     @Override
     public void onValueFromTextContent() {
-      Optional<String> value = createBeanDefinitionRequest.getComponent().getMetadata().getSourceCode();
+      ComponentAst componentAst = createBeanDefinitionRequest.getComponent();
+      Optional<String> value = Optional.empty();
+      if (componentAst != null && componentAst.getMetadata() != null) {
+        value = componentAst.getMetadata().getSourceCode();
+      }
+
       if (value.isPresent() && value.get().startsWith(GLOBAL_FUNCTIONS_START_TAG)) {
         Optional<String> data =
             value.map(val -> val.substring(GLOBAL_FUNCTIONS_START_TAG.length(), val.indexOf(GLOBAL_FUNCTIONS_END_TAG)));


### PR DESCRIPTION
Previous fix we made (https://github.com/mulesoft/mule-integration-tests/pull/1824)  broke DynamicEvaluateProcessorFunctionalTestCase as createBeanDefinitionRequest.getComponent() can be null