### PR TITLE
W-11410770 Ensue that ObjectStore is always created to fix - oauth dance authorize getting stuck when using custom Redis object   store 

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
@@ -127,10 +127,7 @@ public abstract class OAuthHandler<Dancer> implements Lifecycle {
       String storeName = storeConfig
           .map(OAuthObjectStoreConfig::getObjectStoreName)
           .orElse(BASE_PERSISTENT_OBJECT_STORE_KEY);
-      ObjectStore os =
-          objectStoreManager.getOrCreateObjectStore(storeName, ObjectStoreSettings.builder().persistent(true).build());
-
-      return os;
+      return objectStoreManager.getOrCreateObjectStore(storeName, ObjectStoreSettings.builder().persistent(true).build());
     };
   }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
@@ -129,12 +129,8 @@ public abstract class OAuthHandler<Dancer> implements Lifecycle {
       String storeName = storeConfig
           .map(OAuthObjectStoreConfig::getObjectStoreName)
           .orElse(BASE_PERSISTENT_OBJECT_STORE_KEY);
-      ObjectStore os = objectStoreManager.getOrCreateObjectStore(storeName, ObjectStoreSettings
-          .builder()
-          .entryTtl(0L)
-          .expirationInterval(0L)
-          .persistent(DEFAULT_PERSISTENCE_SETTING)
-          .build());
+      ObjectStore os =
+          objectStoreManager.getOrCreateObjectStore(storeName, ObjectStoreSettings.builder().persistent(true).build());
 
       return os;
     };

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
@@ -147,4 +147,8 @@ public abstract class OAuthHandler<Dancer> implements Lifecycle {
     }
   }
 
+  public Function<OAuthConfig, ObjectStore> getObjectStoreLocator() {
+    return objectStoreLocator;
+  }
+
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
@@ -21,6 +21,7 @@ import org.mule.runtime.api.lifecycle.Lifecycle;
 import org.mule.runtime.api.lock.LockFactory;
 import org.mule.runtime.api.store.ObjectStore;
 import org.mule.runtime.api.store.ObjectStoreManager;
+import org.mule.runtime.api.store.ObjectStoreSettings;
 import org.mule.runtime.api.util.LazyValue;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.internal.util.LazyLookup;
@@ -47,6 +48,8 @@ import org.slf4j.Logger;
  */
 public abstract class OAuthHandler<Dancer> implements Lifecycle {
 
+  public static final ThreadLocal<MuleContext> currentMuleContext = new ThreadLocal<>();
+  private static final boolean DEFAULT_PERSISTENCE_SETTING = true;
   private static final Logger LOGGER = getLogger(OAuthHandler.class);
 
   @Inject
@@ -122,8 +125,15 @@ public abstract class OAuthHandler<Dancer> implements Lifecycle {
       String storeName = storeConfig
           .map(OAuthObjectStoreConfig::getObjectStoreName)
           .orElse(BASE_PERSISTENT_OBJECT_STORE_KEY);
-
-      return objectStoreManager.getObjectStore(storeName);
+      System.out.println("storeName" + storeName);
+      ObjectStore os = objectStoreManager.getOrCreateObjectStore(storeName, ObjectStoreSettings
+          .builder()
+          .entryTtl(0L)
+          .expirationInterval(0L)
+          .persistent(DEFAULT_PERSISTENCE_SETTING)
+          .build());
+      System.out.println("objectStore" + os);
+      return os;
     };
   }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
@@ -52,8 +52,6 @@ import org.slf4j.Logger;
  */
 public abstract class OAuthHandler<Dancer> implements Lifecycle {
 
-  public static final ThreadLocal<MuleContext> currentMuleContext = new ThreadLocal<>();
-  private static final boolean DEFAULT_PERSISTENCE_SETTING = true;
   private static final Logger LOGGER = getLogger(OAuthHandler.class);
 
   @Inject

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.connectivity.oauth;
 
-
 import static org.mule.runtime.api.store.ObjectStoreManager.BASE_PERSISTENT_OBJECT_STORE_KEY;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STORE_MANAGER;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandler.java
@@ -6,14 +6,18 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.connectivity.oauth;
 
-import static java.util.stream.Collectors.toMap;
+
 import static org.mule.runtime.api.store.ObjectStoreManager.BASE_PERSISTENT_OBJECT_STORE_KEY;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STORE_MANAGER;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
+
+import static java.util.stream.Collectors.toMap;
+
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.el.MuleExpressionLanguage;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -125,14 +129,13 @@ public abstract class OAuthHandler<Dancer> implements Lifecycle {
       String storeName = storeConfig
           .map(OAuthObjectStoreConfig::getObjectStoreName)
           .orElse(BASE_PERSISTENT_OBJECT_STORE_KEY);
-      System.out.println("storeName" + storeName);
       ObjectStore os = objectStoreManager.getOrCreateObjectStore(storeName, ObjectStoreSettings
           .builder()
           .entryTtl(0L)
           .expirationInterval(0L)
           .persistent(DEFAULT_PERSISTENCE_SETTING)
           .build());
-      System.out.println("objectStore" + os);
+
       return os;
     };
   }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
@@ -36,7 +36,6 @@ import org.mule.runtime.api.store.ObjectStoreManager;
 import org.mule.runtime.api.store.ObjectStoreSettings;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.authcode.AuthorizationCodeOAuthHandler;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.ocs.PlatformManagedOAuthConfig;
-import org.mule.tck.SimpleUnitTestSupportSchedulerService;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -73,7 +72,6 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
   @Mock
   private ObjectStore<MetadataCache> objectStore;
 
-  private SimpleUnitTestSupportSchedulerService schedulerService;
   private ConfigurationProperties configurationProperties;
   private static final String CLIENT_ID = "client_id";
   private static final String SECRET_ID = "secret_id";

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
@@ -6,13 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.connectivity.oauth;
 
-import static org.mule.runtime.api.scheduler.SchedulerConfig.config;
-import static org.mule.runtime.api.store.ObjectStoreManager.BASE_IN_MEMORY_OBJECT_STORE_KEY;
-import static org.mule.runtime.api.store.ObjectStoreManager.BASE_PERSISTENT_OBJECT_STORE_KEY;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CLASSLOADER_REPOSITORY;
-import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STORE_MANAGER;
-import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
-import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.internal.context.DefaultMuleContext.currentMuleContext;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_API_VERSION;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_CLIENT_ID;
@@ -21,23 +15,21 @@ import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_ORG_ID;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_PLATFORM_AUTH_URL;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_SERVICE_URL;
 
-import static java.lang.Thread.currentThread;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.component.ConfigurationProperties;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -45,45 +37,27 @@ import org.mule.runtime.api.metadata.MetadataCache;
 import org.mule.runtime.api.store.ObjectStore;
 import org.mule.runtime.api.store.ObjectStoreException;
 import org.mule.runtime.api.store.ObjectStoreManager;
-import org.mule.runtime.api.store.PartitionableObjectStore;
-import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.config.ConfigurationBuilder;
-import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
-import org.mule.runtime.core.api.config.MuleConfiguration;
-import org.mule.runtime.core.api.context.DefaultMuleContextFactory;
-import org.mule.runtime.core.api.context.MuleContextBuilder;
-import org.mule.runtime.core.api.context.MuleContextFactory;
-import org.mule.runtime.core.internal.config.builders.ServiceCustomizationsConfigurationBuilder;
+import org.mule.runtime.api.store.ObjectStoreSettings;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
-import org.mule.runtime.core.internal.registry.MuleRegistry;
-import org.mule.runtime.core.internal.store.PartitionedInMemoryObjectStore;
-import org.mule.runtime.core.internal.store.PartitionedPersistentObjectStore;
-import org.mule.runtime.core.internal.util.store.MuleObjectStoreManager;
-import org.mule.runtime.core.internal.util.store.MuleObjectStoreManagerTestCase;
 import org.mule.runtime.module.artifact.api.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.authcode.AuthorizationCodeOAuthHandler;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.ocs.PlatformManagedOAuthConfig;
 import org.mule.tck.SimpleUnitTestSupportSchedulerService;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
-import org.mule.tck.junit4.AbstractMuleTestCase;
-import org.mule.tck.junit4.MockExtensionManagerConfigurationBuilder;
 import org.mule.tck.size.SmallTest;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.inject.Named;
-
+import io.qameta.allure.Description;
+import io.qameta.allure.Issue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -93,10 +67,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
 
+  private static final String SOME_KEY = "1874947571-1840879217-380895431-1745289126";
+  private static final String OTHER_KEY = "1874947571-1840879217-123123123-1745289126";
 
-  // private MuleContext muleContext;
-
+  private static final List<String> OBJECT_STORE_ENTRIES = Arrays.asList(SOME_KEY, OTHER_KEY);
   private MuleContextWithRegistry muleContext;
+
   @InjectMocks
   AuthorizationCodeOAuthHandler oauthHandler = new AuthorizationCodeOAuthHandler();
 
@@ -107,53 +83,38 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
   private ObjectStore<MetadataCache> objectStore;
 
   private SimpleUnitTestSupportSchedulerService schedulerService;
-  private volatile CountDownLatch expireDelayLatch = new CountDownLatch(0);
-  private AtomicInteger expires = new AtomicInteger();
   private ConfigurationProperties configurationProperties;
   private static final String CLIENT_ID = "client_id";
   private static final String SECRET_ID = "secret_id";
   private static final String ORG_ID = "org_id";
   private static final String SERVICE_URL = "service_url";
   private static final String PLATFORM_AUTH_URL = "http://localhost/accounts";
-  private static final String PLATFORM_AUTH_PATH = "/token";
-  private static final String CUSTOM_OCS_API_VERSION = "v80";
 
   @Test
-  public void initialise() throws InitialisationException {
+  @Issue("W-11410770")
+  @Description("Verify that ObjectStore is always created, if none exists a new one is created")
+  public void verifyThatObjectStoreisAlwaysCreated() throws InitialisationException, ObjectStoreException {
     PlatformManagedOAuthConfig config = PlatformManagedOAuthConfig.from("", "", null, null, null, null, configurationProperties);
 
-    // oauthHandler = new AuthorizationCodeOAuthHandler();
     oauthHandler.initialise();
 
-    ObjectStore os = oauthHandler.getObjectStoreLocator().apply(config);
-    assertThat(os, is(notNullValue()));
-    // assertThat(os.isPersistent(), is(notNullValue()));
+    ObjectStore objectStore = oauthHandler.getObjectStoreLocator().apply(config);
+    assertThat(objectStore, is(notNullValue()));
+    assertThat(objectStore.allKeys(), is(OBJECT_STORE_ENTRIES));
+    verify(storeManager, times(1)).getOrCreateObjectStore(anyString(), any(ObjectStoreSettings.class));
   }
 
   @Rule
   public TemporaryFolder tempWorkDir = new TemporaryFolder();
 
   @Before
-  public void setup() {
+  public void setup() throws ObjectStoreException {
     schedulerService = new SimpleUnitTestSupportSchedulerService();
     muleContext = mock(MuleContextWithRegistry.class);
-    MuleConfiguration muleConfiguration = mock(MuleConfiguration.class);
-    when(muleConfiguration.getWorkingDirectory()).thenReturn(tempWorkDir.getRoot().getAbsolutePath());
-    when(muleContext.getConfiguration()).thenReturn(muleConfiguration);
-
-    Registry registry = mock(Registry.class);
-
-    createRegistryAndBaseStore(muleContext, registry);
-    when(muleContext.getSchedulerBaseConfig())
-        .thenReturn(config().withPrefix(OAuthHandlerTestCase.class.getName() + "#" + name.getMethodName()));
-
-    /*
-     * storeManager = new MuleObjectStoreManager(); storeManager.setSchedulerService(schedulerService);
-     * storeManager.setRegistry(registry); storeManager.setMuleContext(muleContext);
-     */
 
     when(storeManager.getOrCreateObjectStore(anyString(), any()))
         .thenReturn(objectStore);
+    when(objectStore.allKeys()).thenReturn(Arrays.asList(SOME_KEY, OTHER_KEY));
 
     configurationProperties = mock(ConfigurationProperties.class);
     when(configurationProperties.resolveStringProperty(OCS_CLIENT_SECRET)).thenReturn(of(SECRET_ID));
@@ -165,52 +126,9 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
     when(configurationProperties.resolveStringProperty(OCS_API_VERSION)).thenReturn(empty());
   }
 
-  private void createRegistryAndBaseStore(MuleContextWithRegistry muleContext, Registry registry) {
-    when(registry.lookupByName(BASE_PERSISTENT_OBJECT_STORE_KEY))
-        .thenReturn(of(createPersistentPartitionableObjectStore(muleContext)));
-    when(registry.lookupByName(BASE_IN_MEMORY_OBJECT_STORE_KEY)).thenReturn(of(createTransientPartitionableObjectStore()));
-  }
 
-  private PartitionableObjectStore<?> createPersistentPartitionableObjectStore(MuleContext muleContext) {
-    return new PartitionedPersistentObjectStore(muleContext) {
-
-      @Override
-      public void expire(long entryTTL, int maxEntries, String partitionName) throws ObjectStoreException {
-        expires.incrementAndGet();
-        super.expire(entryTTL, maxEntries, partitionName);
-        expireDelay();
-      }
-    };
-  }
-
-  private PartitionableObjectStore<?> createTransientPartitionableObjectStore() {
-    return new PartitionedInMemoryObjectStore() {
-
-      @Override
-      public void expire(long entryTTL, int maxEntries, String partitionName) throws ObjectStoreException {
-        expires.incrementAndGet();
-        super.expire(entryTTL, maxEntries, partitionName);
-        expireDelay();
-      }
-    };
-  }
-
-  private void expireDelay() {
-    try {
-      expireDelayLatch.await();
-    } catch (InterruptedException e) {
-      currentThread().interrupt();
-      return;
-    }
-  }
-
-  /*
-   * @After public void tearDown() { currentMuleContext.set(null); }
-   */
   @Override
   protected void doTearDown() throws Exception {
-
-    // template method
     oauthHandler.stop();
     currentMuleContext.set(null);
   }
@@ -220,10 +138,6 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
   public void after() throws MuleException {
     schedulerService.stop();
   }
-  /*
-   * @Before public void doSetUp() throws Exception { super.doSetUp(); muleContext = createMuleContext();
-   * currentMuleContext.set(muleContext); // initialiseIfNeeded(serializationProtocol, true, muleContext); }
-   */
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
@@ -83,7 +83,7 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
 
   @Test
   @Issue("W-11410770")
-  @Description("Verify that ObjectStore is always created, if none exists a new one is created")
+  @Description("Verify that ObjectStore is created, if none exists by calling getOrCreateObjectStore")
   public void verifyThatObjectStoreisAlwaysCreated() throws InitialisationException, ObjectStoreException {
     PlatformManagedOAuthConfig config = PlatformManagedOAuthConfig.from("", "", null, null, null, null, configurationProperties);
 

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.connectivity.oauth;
+
+import static org.mule.runtime.api.scheduler.SchedulerConfig.config;
+import static org.mule.runtime.api.store.ObjectStoreManager.BASE_IN_MEMORY_OBJECT_STORE_KEY;
+import static org.mule.runtime.api.store.ObjectStoreManager.BASE_PERSISTENT_OBJECT_STORE_KEY;
+import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CLASSLOADER_REPOSITORY;
+import static org.mule.runtime.core.api.config.bootstrap.ArtifactType.APP;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.internal.context.DefaultMuleContext.currentMuleContext;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.singletonMap;
+import static java.util.Optional.of;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.mule.runtime.api.artifact.Registry;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.api.store.ObjectStoreException;
+import org.mule.runtime.api.store.PartitionableObjectStore;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.config.ConfigurationBuilder;
+import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
+import org.mule.runtime.core.api.config.MuleConfiguration;
+import org.mule.runtime.core.api.context.DefaultMuleContextFactory;
+import org.mule.runtime.core.api.context.MuleContextBuilder;
+import org.mule.runtime.core.api.context.MuleContextFactory;
+import org.mule.runtime.core.internal.config.builders.ServiceCustomizationsConfigurationBuilder;
+import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
+import org.mule.runtime.core.internal.store.PartitionedInMemoryObjectStore;
+import org.mule.runtime.core.internal.store.PartitionedPersistentObjectStore;
+import org.mule.runtime.core.internal.util.store.MuleObjectStoreManager;
+import org.mule.runtime.core.internal.util.store.MuleObjectStoreManagerTestCase;
+import org.mule.runtime.module.artifact.api.classloader.ClassLoaderRepository;
+import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.authcode.AuthorizationCodeOAuthHandler;
+import org.mule.tck.SimpleUnitTestSupportSchedulerService;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+import org.mule.tck.junit4.MockExtensionManagerConfigurationBuilder;
+import org.mule.tck.size.SmallTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@SmallTest
+@RunWith(MockitoJUnitRunner.class)
+public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
+
+  // private MuleContext muleContext;
+  AuthorizationCodeOAuthHandler oauthHandler;
+
+  @Test
+  public void initialise() throws InitialisationException {
+    oauthHandler = new AuthorizationCodeOAuthHandler();
+    oauthHandler.initialise();
+  }
+
+  private MuleContextWithRegistry muleContext;
+  private MuleObjectStoreManager storeManager;
+
+  private SimpleUnitTestSupportSchedulerService schedulerService;
+  private volatile CountDownLatch expireDelayLatch = new CountDownLatch(0);
+  private AtomicInteger expires = new AtomicInteger();
+
+  @Rule
+  public TemporaryFolder tempWorkDir = new TemporaryFolder();
+
+  @Before
+  public void setup() {
+    schedulerService = new SimpleUnitTestSupportSchedulerService();
+    muleContext = mock(MuleContextWithRegistry.class);
+    MuleConfiguration muleConfiguration = mock(MuleConfiguration.class);
+    when(muleConfiguration.getWorkingDirectory()).thenReturn(tempWorkDir.getRoot().getAbsolutePath());
+    when(muleContext.getConfiguration()).thenReturn(muleConfiguration);
+
+    Registry registry = mock(Registry.class);
+    createRegistryAndBaseStore(muleContext, registry);
+    when(muleContext.getSchedulerBaseConfig())
+        .thenReturn(config().withPrefix(MuleObjectStoreManagerTestCase.class.getName() + "#" + name.getMethodName()));
+
+    storeManager = new MuleObjectStoreManager();
+    storeManager.setSchedulerService(schedulerService);
+    storeManager.setRegistry(registry);
+    storeManager.setMuleContext(muleContext);
+  }
+
+  private void createRegistryAndBaseStore(MuleContextWithRegistry muleContext, Registry registry) {
+    when(registry.lookupByName(BASE_PERSISTENT_OBJECT_STORE_KEY))
+        .thenReturn(of(createPersistentPartitionableObjectStore(muleContext)));
+    when(registry.lookupByName(BASE_IN_MEMORY_OBJECT_STORE_KEY)).thenReturn(of(createTransientPartitionableObjectStore()));
+  }
+
+  private PartitionableObjectStore<?> createPersistentPartitionableObjectStore(MuleContext muleContext) {
+    return new PartitionedPersistentObjectStore(muleContext) {
+
+      @Override
+      public void expire(long entryTTL, int maxEntries, String partitionName) throws ObjectStoreException {
+        expires.incrementAndGet();
+        super.expire(entryTTL, maxEntries, partitionName);
+        expireDelay();
+      }
+    };
+  }
+
+  private PartitionableObjectStore<?> createTransientPartitionableObjectStore() {
+    return new PartitionedInMemoryObjectStore() {
+
+      @Override
+      public void expire(long entryTTL, int maxEntries, String partitionName) throws ObjectStoreException {
+        expires.incrementAndGet();
+        super.expire(entryTTL, maxEntries, partitionName);
+        expireDelay();
+      }
+    };
+  }
+
+
+  private void expireDelay() {
+    try {
+      expireDelayLatch.await();
+    } catch (InterruptedException e) {
+      currentThread().interrupt();
+      return;
+    }
+  }
+
+  /*
+   * @After public void tearDown() { currentMuleContext.set(null); }
+   */
+  @Override
+  protected void doTearDown() throws Exception {
+
+    // template method
+    oauthHandler.stop();
+    currentMuleContext.set(null);
+  }
+
+
+  @After
+  public void after() throws MuleException {
+    schedulerService.stop();
+  }
+  /*
+   * @Before public void doSetUp() throws Exception { super.doSetUp(); muleContext = createMuleContext();
+   * currentMuleContext.set(muleContext); // initialiseIfNeeded(serializationProtocol, true, muleContext); }
+   */
+
+  @Override
+  protected Map<String, Object> getStartUpRegistryObjects() {
+    return singletonMap(OBJECT_CLASSLOADER_REPOSITORY, new ClassLoaderRepository() {
+
+      @Override
+      public Optional<String> getId(ClassLoader classLoader) {
+        return null;
+      }
+
+      @Override
+      public Optional<ClassLoader> find(String classLoaderId) {
+        return null;
+      }
+    });
+  }
+}

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.connectivity.oauth;
 
-import static org.mule.runtime.core.internal.context.DefaultMuleContext.currentMuleContext;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_API_VERSION;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_CLIENT_ID;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_CLIENT_SECRET;
@@ -119,7 +118,6 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
   @Override
   protected void doTearDown() throws Exception {
     oauthHandler.stop();
-    currentMuleContext.set(null);
   }
 
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
@@ -69,19 +69,18 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
 
   // private MuleContext muleContext;
   AuthorizationCodeOAuthHandler oauthHandler;
-
-  @Test
-  public void initialise() throws InitialisationException {
-    oauthHandler = new AuthorizationCodeOAuthHandler();
-    oauthHandler.initialise();
-  }
-
   private MuleContextWithRegistry muleContext;
   private MuleObjectStoreManager storeManager;
 
   private SimpleUnitTestSupportSchedulerService schedulerService;
   private volatile CountDownLatch expireDelayLatch = new CountDownLatch(0);
   private AtomicInteger expires = new AtomicInteger();
+
+  @Test
+  public void initialise() throws InitialisationException {
+    oauthHandler = new AuthorizationCodeOAuthHandler();
+    oauthHandler.initialise();
+  }
 
   @Rule
   public TemporaryFolder tempWorkDir = new TemporaryFolder();
@@ -134,7 +133,6 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
       }
     };
   }
-
 
   private void expireDelay() {
     try {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/OAuthHandlerTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.connectivity.oauth;
 
-import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_CLASSLOADER_REPOSITORY;
 import static org.mule.runtime.core.internal.context.DefaultMuleContext.currentMuleContext;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_API_VERSION;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_CLIENT_ID;
@@ -15,7 +14,6 @@ import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_ORG_ID;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_PLATFORM_AUTH_URL;
 import static org.mule.runtime.extension.internal.ocs.OCSConstants.OCS_SERVICE_URL;
 
-import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
@@ -31,15 +29,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.mule.runtime.api.component.ConfigurationProperties;
-import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.metadata.MetadataCache;
 import org.mule.runtime.api.store.ObjectStore;
 import org.mule.runtime.api.store.ObjectStoreException;
 import org.mule.runtime.api.store.ObjectStoreManager;
 import org.mule.runtime.api.store.ObjectStoreSettings;
-import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
-import org.mule.runtime.module.artifact.api.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.authcode.AuthorizationCodeOAuthHandler;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.ocs.PlatformManagedOAuthConfig;
 import org.mule.tck.SimpleUnitTestSupportSchedulerService;
@@ -48,8 +43,6 @@ import org.mule.tck.size.SmallTest;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
@@ -71,7 +64,6 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
   private static final String OTHER_KEY = "1874947571-1840879217-123123123-1745289126";
 
   private static final List<String> OBJECT_STORE_ENTRIES = Arrays.asList(SOME_KEY, OTHER_KEY);
-  private MuleContextWithRegistry muleContext;
 
   @InjectMocks
   AuthorizationCodeOAuthHandler oauthHandler = new AuthorizationCodeOAuthHandler();
@@ -109,8 +101,6 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
 
   @Before
   public void setup() throws ObjectStoreException {
-    schedulerService = new SimpleUnitTestSupportSchedulerService();
-    muleContext = mock(MuleContextWithRegistry.class);
 
     when(storeManager.getOrCreateObjectStore(anyString(), any()))
         .thenReturn(objectStore);
@@ -126,33 +116,10 @@ public class OAuthHandlerTestCase extends AbstractMuleContextTestCase {
     when(configurationProperties.resolveStringProperty(OCS_API_VERSION)).thenReturn(empty());
   }
 
-
   @Override
   protected void doTearDown() throws Exception {
     oauthHandler.stop();
     currentMuleContext.set(null);
-  }
-
-
-  @After
-  public void after() throws MuleException {
-    schedulerService.stop();
-  }
-
-  @Override
-  protected Map<String, Object> getStartUpRegistryObjects() {
-    return singletonMap(OBJECT_CLASSLOADER_REPOSITORY, new ClassLoaderRepository() {
-
-      @Override
-      public Optional<String> getId(ClassLoader classLoader) {
-        return null;
-      }
-
-      @Override
-      public Optional<ClassLoader> find(String classLoaderId) {
-        return null;
-      }
-    });
   }
 
 }


### PR DESCRIPTION
Oauth dance authorize is stuck when using custom object store which uses Redis Cache

CCE noticed the following upon debug

Debuging the app I notice that when trying to obtain the object store in order to store the token I am getting a "ObjectStore 'object_store' is not defined".
protected Function<OAuthConfig, ObjectStore> buildObjectStoreLocator() {

  return config -> {

   Optional<OAuthObjectStoreConfig> storeConfig = config.getStoreConfig();

   String storeName = storeConfig

     .map(OAuthObjectStoreConfig::getObjectStoreName)

     .orElse(BASE_PERSISTENT_OBJECT_STORE_KEY);



   **return objectStoreManager.getObjectStore(storeName);**   Changed to-----> getOrCreateObjectStore

  };

 }

I deployed the provided manually and also created the Slack WS with Carlos, after the fix the app is starting and token is retrieved successfully upon accessing https //localhost/8081/activate.