### PR TITLE
W-11985583: Redelivery policy should only handle its object store lifecycle if it has the ownership (#11922)

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/processor/IdempotentRedeliveryPolicyTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/processor/IdempotentRedeliveryPolicyTestCase.java
@@ -6,6 +6,15 @@
  */
 package org.mule.runtime.core.internal.processor;
 
+import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
+import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.api.metadata.DataType.OBJECT;
+import static org.mule.runtime.api.metadata.DataType.STRING;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
+import static org.mule.runtime.core.api.rx.Exceptions.checkedConsumer;
+import static org.mule.runtime.core.internal.processor.IdempotentRedeliveryPolicy.SECURE_HASH_EXPR_FORMAT;
+
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -20,23 +29,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
-import static org.mule.runtime.api.component.location.ConfigurationComponentLocator.REGISTRY_KEY;
-import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
-import static org.mule.runtime.api.metadata.DataType.OBJECT;
-import static org.mule.runtime.api.metadata.DataType.STRING;
-import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
-import static org.mule.runtime.core.api.rx.Exceptions.checkedConsumer;
-import static org.mule.runtime.core.internal.processor.IdempotentRedeliveryPolicy.SECURE_HASH_EXPR_FORMAT;
 import static org.slf4j.LoggerFactory.getLogger;
 import static reactor.core.publisher.Mono.error;
 import static reactor.core.publisher.Mono.from;
 
-import org.junit.After;
 import org.mule.runtime.api.el.CompiledExpression;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
@@ -69,12 +70,13 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.qameta.allure.Issue;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.reactivestreams.Publisher;
-
 import reactor.core.publisher.Mono;
 
 public class IdempotentRedeliveryPolicyTestCase extends AbstractMuleContextTestCase {
@@ -91,7 +93,8 @@ public class IdempotentRedeliveryPolicyTestCase extends AbstractMuleContextTestC
   private final CountDownLatch waitingMessageProcessorExecutionLatch = new CountDownLatch(2);
   private final IdempotentRedeliveryPolicy irp = new IdempotentRedeliveryPolicy();
   private final AtomicInteger count = new AtomicInteger();
-  private final ObjectStore mockObjectStore = mock(ObjectStore.class);
+  private final ObjectStore<RedeliveryCounter> mockObjectStore = mock(ObjectStore.class);
+  private final InMemoryObjectStore inMemoryObjectStore = spy(new InMemoryObjectStore());
   private CoreEvent event;
   private ExpressionManager expressionManager;
 
@@ -127,7 +130,6 @@ public class IdempotentRedeliveryPolicyTestCase extends AbstractMuleContextTestC
     MuleLockFactory muleLockFactory = new MuleLockFactory();
     muleLockFactory.setLockProvider(new SingleServerLockProvider());
     muleLockFactory.initialise();
-    final InMemoryObjectStore inMemoryObjectStore = new InMemoryObjectStore();
     when(mockObjectStoreManager.getObjectStore(anyString())).thenReturn(inMemoryObjectStore);
     when(mockObjectStoreManager.createObjectStore(any(), any())).thenReturn(inMemoryObjectStore);
     when(event.getMessage()).thenReturn(message);
@@ -209,13 +211,6 @@ public class IdempotentRedeliveryPolicyTestCase extends AbstractMuleContextTestC
   }
 
   @Test
-  public void objectStoreIsClosed() throws Exception {
-    irp.setObjectStore(mockObjectStore);
-    irp.dispose();
-    verify(mockObjectStore).close();
-  }
-
-  @Test
   public void javaObject() throws MuleException {
     final Object payloadValue = mock(Object.class);
     event = spy(CoreEvent.builder(testEvent()).addVariable("hash", payloadValue.hashCode()).build());
@@ -230,10 +225,69 @@ public class IdempotentRedeliveryPolicyTestCase extends AbstractMuleContextTestC
   }
 
   @Test
-  public void objectStoreIsRemovedWhenDisposed() throws Exception {
-    irp.setObjectStore(mockObjectStore);
+  @Issue("W-11985583")
+  public void objectStoreIsClosedOnDisposeWhenItIsOwnedByTheRedeliveryPolicy() throws Exception {
+    irp.setPrivateObjectStore(mockObjectStore);
+    irp.initialise();
+    irp.start();
+    irp.stop();
+    irp.dispose();
+    verify(mockObjectStore).close();
+  }
+
+  @Test
+  @Issue("W-11985583")
+  public void objectStoreIsRemovedOnDisposeWhenItIsOwnedByTheRedeliveryPolicy() throws Exception {
+    irp.setPrivateObjectStore(mockObjectStore);
+    irp.initialise();
+    irp.start();
+    irp.stop();
     irp.dispose();
     verify(mockObjectStoreManager)
+        .disposeStore(TEST_CONNECTOR_LOCATION.getRootContainerName() + "." + IdempotentRedeliveryPolicy.class.getName());
+  }
+
+  @Test
+  @Issue("W-11985583")
+  public void objectStoreIsClosedOnDisposeWhenItIsTheImplicitOne() throws Exception {
+    irp.initialise();
+    irp.start();
+    irp.stop();
+    irp.dispose();
+    verify(inMemoryObjectStore).close();
+  }
+
+  @Test
+  @Issue("W-11985583")
+  public void objectStoreIsRemovedOnDisposeWhenItIsTheImplicitOne() throws Exception {
+    irp.initialise();
+    irp.start();
+    irp.stop();
+    irp.dispose();
+    verify(mockObjectStoreManager)
+        .disposeStore(TEST_CONNECTOR_LOCATION.getRootContainerName() + "." + IdempotentRedeliveryPolicy.class.getName());
+  }
+
+  @Test
+  @Issue("W-11985583")
+  public void objectStoreIsNotClosedOnDisposeWhenTheRedeliveryPolicyReferencesItByName() throws Exception {
+    irp.setObjectStore(mockObjectStore);
+    irp.initialise();
+    irp.start();
+    irp.stop();
+    irp.dispose();
+    verify(mockObjectStore, never()).close();
+  }
+
+  @Test
+  @Issue("W-11985583")
+  public void objectStoreIsNotRemovedOnDisposeWhenTheRedeliveryPolicyReferencesItByName() throws Exception {
+    irp.setObjectStore(mockObjectStore);
+    irp.initialise();
+    irp.start();
+    irp.stop();
+    irp.dispose();
+    verify(mockObjectStoreManager, never())
         .disposeStore(TEST_CONNECTOR_LOCATION.getRootContainerName() + "." + IdempotentRedeliveryPolicy.class.getName());
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/processor/IdempotentRedeliveryPolicy.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/processor/IdempotentRedeliveryPolicy.java
@@ -103,6 +103,7 @@ public class IdempotentRedeliveryPolicy extends AbstractRedeliveryPolicy {
   private ObjectStore<RedeliveryCounter> store;
   private ObjectStore<RedeliveryCounter> privateStore;
   private String idrId;
+  private boolean isOwnedObjectStore;
 
 
   /**
@@ -158,6 +159,9 @@ public class IdempotentRedeliveryPolicy extends AbstractRedeliveryPolicy {
 
   private void initialiseStore() throws InitialisationException {
     idrId = format("%s-%s-%s", muleContext.getConfiguration().getId(), getLocation().getRootContainerName(), "idr");
+
+    isOwnedObjectStore = privateStore != null || store == null;
+
     if (store != null && privateStore != null) {
       throw new InitialisationException(
                                         createStaticMessage("Ambiguous definition of object store, both reference and private were configured"),
@@ -167,27 +171,29 @@ public class IdempotentRedeliveryPolicy extends AbstractRedeliveryPolicy {
     if (store == null) {
       // If no object store was defined, create one
       if (privateStore == null) {
-        this.store = internalObjectStoreSupplier().get();
+        this.store = createInternalObjectStore();
       } else {
         // If object store was defined privately
         this.store = privateStore;
       }
     }
-    initialiseIfNeeded(store, true, muleContext);
+
+    if (isOwnedObjectStore) {
+      initialiseIfNeeded(store, true, muleContext);
+    }
   }
 
-  private Supplier<ObjectStore> internalObjectStoreSupplier() {
-    return () -> objectStoreManager.createObjectStore(getObjectStoreName(),
-                                                      ObjectStoreSettings.builder()
-                                                          .persistent(false)
-                                                          .entryTtl((long) 60 * 5 * 1000)
-                                                          .expirationInterval(6000L).build());
+  private ObjectStore<RedeliveryCounter> createInternalObjectStore() {
+    return objectStoreManager.createObjectStore(getObjectStoreName(), ObjectStoreSettings.builder().persistent(false)
+        .entryTtl((long) 60 * 5 * 1000).expirationInterval(6000L).build());
   }
 
   @Override
   public void dispose() {
+    if (isOwnedObjectStore) {
+      disposeStore();
+    }
     super.dispose();
-    disposeStore();
   }
 
   private void disposeStore() {
@@ -209,13 +215,17 @@ public class IdempotentRedeliveryPolicy extends AbstractRedeliveryPolicy {
   @Override
   public void start() throws MuleException {
     super.start();
-    startIfNeeded(store);
+    if (isOwnedObjectStore) {
+      startIfNeeded(store);
+    }
   }
 
   @Override
   public void stop() throws MuleException {
+    if (isOwnedObjectStore) {
+      stopIfNeeded(store);
+    }
     super.stop();
-    stopIfNeeded(store);
   }
 
   @Override


### PR DESCRIPTION
(cherry picked from commit 6d5e5c0a0464967f345bfdd7fc3660b403efbb12)