### PR TITLE
Avoid NullPointer

### DIFF
--- a/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/validation/AbstractErrorTypesValidation.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/validation/AbstractErrorTypesValidation.java
@@ -64,7 +64,7 @@ public abstract class AbstractErrorTypesValidation extends AbstractErrorValidati
     }
 
     if (ignoreParamsWithProperties) {
-      if (getErrorTypeParam(component).getRawValue().contains("${")) {
+      if (getErrorTypeParam(component).getRawValue() != null && getErrorTypeParam(component).getRawValue().contains("${")) {
         return false;
       }
     }


### PR DESCRIPTION
Case Number 00358157
on 
<on-error-propagate doc:id="18436f77-63f8-443f-9eea-84ee08cfc270" doc:name="On Error Propagate" enableNotifications="true" logException="true">

Caused by: java.lang.NullPointerException
at org.mule.runtime.config.internal.validation.AbstractErrorTypesValidation.isErrorTypePresent (AbstractErrorTypesValidation.java:67) at org.mule.runtime.config.internal.validation.ErrorHandlerOnErrorTypeExists.lambda$applicable$0 (ErrorHandlerOnErrorTypeExists.java:53)