### PR TITLE
W-12672758: Missing mule.enable.statistics system property in mule 3.9.5

### DIFF
--- a/core/src/main/java/org/mule/api/config/MuleProperties.java
+++ b/core/src/main/java/org/mule/api/config/MuleProperties.java
@@ -224,5 +224,12 @@ public class MuleProperties
     public static final String MULE_DISABLE_SET_VARIABLE_INHERITED_MIME_TYPE = SYSTEM_PROPERTY_PREFIX + "setVariable.inheritedMimeType.disable";
     public static final String MULE_CXF_PROXY_DISABLE_BINDING_OPERATION_INFO_OVERWRITE = SYSTEM_PROPERTY_PREFIX + "cxf.proxy.bindingOperationInfo.overwrite.disable";
 
+    /**
+     * When enabled this System Property, the statistics are enabled even if the monitoring service is not activated. This
+     * property is only read on deploying an app.
+     *
+     * @since 4.4, 4.3.1
+     */
+    public static final String MULE_ENABLE_STATISTICS = SYSTEM_PROPERTY_PREFIX + "enable.statistics";
 
 }

--- a/core/src/main/java/org/mule/management/stats/AllStatistics.java
+++ b/core/src/main/java/org/mule/management/stats/AllStatistics.java
@@ -6,6 +6,10 @@
  */
 package org.mule.management.stats;
 
+import static org.mule.api.config.MuleProperties.MULE_ENABLE_STATISTICS;
+
+import static java.lang.Boolean.getBoolean;
+
 import org.mule.management.stats.printers.AbstractTablePrinter;
 import org.mule.management.stats.printers.SimplePrinter;
 
@@ -19,7 +23,8 @@ import java.util.Map;
  */
 public class AllStatistics
 {
-    private boolean isStatisticsEnabled;
+
+    private boolean isStatisticsEnabled = getBoolean(MULE_ENABLE_STATISTICS);
     private long startTime;
     private final ApplicationStatistics appStats;
     private final FlowsSummaryStatistics flowSummaryStatistics;


### PR DESCRIPTION
Partial cherry pick into 3.x of `EE-7419: Provide a way to enable statistics without monitoring`