### PR TITLE
W-12271999: Improve performance of ExtensionComponent by caching some static values

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
@@ -128,6 +128,7 @@ public abstract class ExtensionComponent<T extends ComponentModel> extends Abstr
   private final MetadataMediator<T> metadataMediator;
   private final ClassTypeLoader typeLoader;
   private final LazyValue<Boolean> requiresConfig = new LazyValue<>(this::computeRequiresConfig);
+  private final LazyValue<Boolean> usesDynamicConfiguration = new LazyValue<>(this::computeUsesDynamicConfiguration);
   private final LazyValue<Optional<ConfigurationProvider>> staticallyResolvedConfigurationProvider =
       new LazyValue<>(this::doResolveConfigurationProviderStatically);
 
@@ -484,6 +485,10 @@ public abstract class ExtensionComponent<T extends ComponentModel> extends Abstr
   }
 
   protected boolean usesDynamicConfiguration() {
+    return usesDynamicConfiguration.get();
+  }
+
+  private boolean computeUsesDynamicConfiguration() {
     // TODO W-11267571: if not being able to resolve the ValueResolver<ConfigurationProvider> at this point, hence
     // treating it as dynamic, ends up causing performance issues.
     return isConfigurationSpecified()


### PR DESCRIPTION
### Motivation
We found a performance regression introduced by [this other change](https://github.com/mulesoft/mule/commit/7b04c1c43de0131250925a7524cb080cabf70fd1) (config-refs with expressions).

The problem came from what we thought would be a relatively inexpensive operation (resolving a `StaticValueResolver`) was actually not. To be fair, the [resolution](https://github.com/mulesoft/mule/blob/2a87abccb12f634037000cc782b1e46318fa9b2f/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/resolver/StaticValueResolver.java#L49) itself was not expensive of course. The problem came from the fact that we were creating a dummy `ValueResolvingContext` from a Null Event every time ([here](https://github.com/mulesoft/mule/blob/2a87abccb12f634037000cc782b1e46318fa9b2f/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java#L456)).

<img width="1331" alt="cpu-trace-resolveConfigurationProviderStatically" src="https://user-images.githubusercontent.com/6237096/225422922-e93e7ad8-6023-41c3-a59e-a8df83a2eda2.png">

Having noticed that, we realized that we were also doing [the same](https://github.com/mulesoft/mule/blob/2a87abccb12f634037000cc782b1e46318fa9b2f/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java#L495) for retrieving the configuration instance from a static configuration provider. This was previous to the regression. In this PR we also want to take the opportunity to improve that one.

### Proposal

The Null Event concept was coined to resolve things during initialization, where a real event was not available. Using a Null Event in runtime is a smell.
In this particular case, we are using it to comply with the `ValueResolver` interface, knowing that the resolved value actually does not depend on the Events (we know that because `StaticValueResolver#isDynamic` returns false).
With that in mind (subsequent invocations of the resolve method will return the same value) we can very well cache the result.
Similarly, if the resolved `ConfigurationProvider` is static, we can also cache the `ConfigurationInstance` provided.

### Results

The preliminary results in the Scatter Gather scenario are showing about 15% improvement. See this [Kibana dashboard](https://stats.perf.anypoint.mulesoft.com/goto/36a819e1becf99989d25ebdcf5878514).
It is probably augmented in this scenario vs others because it has many operations with configs for each request that goes through.