### PR TITLE
W-12436154: Patching c3p0 to fix driver load failure due to classloading isolation.

### DIFF
--- a/distributions/standalone/assembly-allowlist.txt
+++ b/distributions/standalone/assembly-allowlist.txt
@@ -243,7 +243,7 @@
 /mule-standalone-${productVersion}/lib/opt/jibx-schema-1.2.5.jar
 /mule-standalone-${productVersion}/lib/opt/jibx-run-1.2.5.jar
 /mule-standalone-${productVersion}/lib/opt/xpp3-1.1.3.4.O.jar
-/mule-standalone-${productVersion}/lib/opt/c3p0-0.9.5.4.jar
+/mule-standalone-${productVersion}/lib/opt/c3p0-0.9.5.4-MULE-001.jar
 /mule-standalone-${productVersion}/lib/opt/cxf-rt-frontend-jaxws-2.7.19-MULE-007.jar
 /mule-standalone-${productVersion}/lib/opt/cxf-rt-frontend-simple-2.7.19-MULE-007.jar
 /mule-standalone-${productVersion}/lib/opt/cxf-rt-transports-local-2.7.19-MULE-007.jar

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.mchange</groupId>
+            <groupId>org.mule.mchange</groupId>
             <artifactId>c3p0</artifactId>
         </dependency>
 

--- a/modules/schedulers/pom.xml
+++ b/modules/schedulers/pom.xml
@@ -24,7 +24,7 @@
          </dependency>
          <!-- Explicitly adding C3P0 dependency to replace quartz's excluded C3P0 version-->
          <dependency>
-             <groupId>com.mchange</groupId>
+             <groupId>org.mule.mchange</groupId>
              <artifactId>c3p0</artifactId>
          </dependency>
          <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <asyncHttpClientVersion>1.14-MULE-019</asyncHttpClientVersion>
         <bshVersion>2.0b4</bshVersion>
         <bouncycastleVersion>1.67</bouncycastleVersion>
-        <c3p0Version>0.9.5.4</c3p0Version>
+        <c3p0Version>0.9.5.4-MULE-001</c3p0Version>
         <cglibVersion>2.2</cglibVersion>
         <cometdVersion>6.1.26</cometdVersion>
         <commonsBeanUtilsVersion>1.9.4</commonsBeanUtilsVersion>
@@ -1480,7 +1480,7 @@
             </dependency>
 
             <dependency>
-                <groupId>com.mchange</groupId>
+                <groupId>org.mule.mchange</groupId>
                 <artifactId>c3p0</artifactId>
                 <version>${c3p0Version}</version>
             </dependency>

--- a/transports/quartz/pom.xml
+++ b/transports/quartz/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <!-- Explicitly adding C3P0 dependency to replace quartz's excluded C3P0 version-->
         <dependency>
-            <groupId>com.mchange</groupId>
+            <groupId>org.mule.mchange</groupId>
             <artifactId>c3p0</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bringing back patch removed when we upgraded to the latest version of c3p0 (#7757).