### PR TITLE
W-12761115: `xml-apis` shadows classes already present in Java 11/17 `java.xml` module

### DIFF
--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/DefaultMuleClassPathConfig.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/DefaultMuleClassPathConfig.java
@@ -7,6 +7,8 @@
 package org.mule.runtime.module.reboot.internal;
 
 import static java.lang.System.getProperty;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -14,8 +16,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -116,14 +116,14 @@ public class DefaultMuleClassPathConfig {
       try {
         return pathname.getCanonicalPath().endsWith(".jar");
       } catch (IOException e) {
-        throw new RuntimeException(e.getMessage());
+        throw new RuntimeException(e);
       }
     });
 
     if (jars != null) {
-      return Arrays.asList(jars);
+      return asList(jars);
     }
-    return Collections.emptyList();
+    return emptyList();
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -968,6 +968,58 @@
             </build>
         </profile>
         <profile>
+            <id>testJdkWithoutXmlModule</id>
+            <activation>
+                <!-- This profile cannot be activated based on the jdk because the jdk on which this has to be activated or not -->
+                <!-- is the one used to run the tests, not the one used to run Maven. -->
+                <property>
+                    <name>!testJdkWithXmlModule</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <version>${maven.surefire.plugin.version}</version>
+                            <configuration>
+                                <additionalClasspathElements>
+                                    <!-- Add this to the classpath so it is available when running tests with jvm8 -->
+                                    <!-- but it does not interfere with the module system --> 
+                                    <!-- (it has colliding packages with java.xml module) when running with java11+ -->
+                                    <additionalClasspathElement>${org.mule.apache:xerces2-xsd11:jar:}</additionalClasspathElement>
+                                </additionalClasspathElements>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>properties</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                    <!-- This is needed only for jdk8, the required classes from here -->
+                    <!-- are already available in the jdk on versions 11+ -->
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>mac</id>
             <activation>
                 <os>


### PR DESCRIPTION
...effectively causing a split package error when starting up as module