### PR TITLE
W-12637937: Make featureFlaggingService non final so that we can inject fields without reflection 

### DIFF
--- a/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/validation/CoreValidationsProvider.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/validation/CoreValidationsProvider.java
@@ -38,7 +38,7 @@ public class CoreValidationsProvider implements ValidationsProvider {
   private boolean ignoreParamsWithProperties;
 
   @Inject
-  private final Optional<FeatureFlaggingService> featureFlaggingService = empty();
+  private Optional<FeatureFlaggingService> featureFlaggingService = empty();
 
   @Inject
   private ExpressionLanguage expressionLanguage;


### PR DESCRIPTION
Replacing feather with Guice

It could not inject `featureFlaggingService` if it was `final`