### PR TITLE
W-12683061: Generate MRJARs during the build process (#12403)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,17 @@
                     </dependencies>
                 </plugin>
                 <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco.version}</version>
+                    <configuration>
+                        <!-- Exclude alternate versions for multi-release modules-->
+                        <excludes>
+                            <exclude>META-INF/**/*</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>${war.plugin.version}</version>


### PR DESCRIPTION
Configure jacoco to skip mrjar alternate vesions, since that is still not supported by jacoco (ref:
https://stackoverflow.com/questions/47664723/jacoco-and-mr-jars)