### PR TITLE
W-12625688: Avoid errors caused by using mock/spy to ClassLoader

### DIFF
--- a/modules/deployment-model/src/test/java/org/mule/runtime/artifact/activation/internal/TrackingArtifactClassLoaderResolverDecoratorTestCase.java
+++ b/modules/deployment-model/src/test/java/org/mule/runtime/artifact/activation/internal/TrackingArtifactClassLoaderResolverDecoratorTestCase.java
@@ -61,7 +61,7 @@ public class TrackingArtifactClassLoaderResolverDecoratorTestCase extends Abstra
                                                                 mock(RegionClassLoader.class),
                                                                 mock(ClassLoaderLookupPolicy.class));
     Function<String, MuleDeployableArtifactClassLoader> classLoaderWithPluginsFactory = (artifactName) -> {
-      MuleDeployableArtifactClassLoader classLoader = spy(classLoaderFactory.apply(artifactName));
+      MuleDeployableArtifactClassLoader classLoader = classLoaderFactory.apply(artifactName);
       List<ArtifactClassLoader> pluginClassLoaders = new ArrayList<>();
       pluginClassLoaders.add(classLoaderFactory.apply(artifactName + " Plugin Class loader 1"));
       pluginClassLoaders.add(classLoaderFactory.apply(artifactName + " Plugin Class loader 2"));


### PR DESCRIPTION
fix `TrackingArtifactClassLoaderResolverDecoratorTestCase` failing for the branch 'tests/java17'