### PR TITLE
Revert "W-13503186: Split package between spring-jcl and jcl-over-slf4j (#12498)"

### DIFF
--- a/modules/extensions-support/pom.xml
+++ b/modules/extensions-support/pom.xml
@@ -87,13 +87,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <exclusions>
-                <!-- Mule uses jcl-over-slf4j, no need for this module -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/modules/spring-config/pom.xml
+++ b/modules/spring-config/pom.xml
@@ -108,13 +108,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <exclusions>
-                <!-- Mule uses jcl-over-slf4j, no need for this module -->
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jcl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
This reverts commit cf1276ad539637549f447a02364acc0f24efe861.

The change was done in mule-runtime-bom repository instead.