### PR TITLE
W-12975498: java.lang.NullPointerException is thrown from org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.ExtensionsOAuthUtils.refreshTokenIfNecessary

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/ExtensionsOAuthUtils.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/connectivity/oauth/ExtensionsOAuthUtils.java
@@ -282,7 +282,7 @@ public final class ExtensionsOAuthUtils {
     }
 
     OAuthConnectionProviderWrapper oauthConnectionProvider = getOAuthConnectionProvider(connectionProvider);
-    if (connectionProvider == null) {
+    if (oauthConnectionProvider == null) {
       return false;
     }
 


### PR DESCRIPTION
(ExtensionsOAuthUtils.java:290)