### PR TITLE
W-12975498: java.lang.NullPointerException is thrown from org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.ExtensionsOAuthUtils.refreshTokenIfNecessary

### DIFF
--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/source/ExtensionMessageSourceTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/source/ExtensionMessageSourceTestCase.java
@@ -15,6 +15,7 @@ import static org.mule.test.heisenberg.extension.exception.HeisenbergConnectionE
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.mockExceptionEnricher;
 
 import static java.util.Arrays.asList;
+import static java.util.Optional.of;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static org.apache.commons.lang3.exception.ExceptionUtils.getThrowables;
@@ -44,6 +45,7 @@ import static org.slf4j.event.Level.ERROR;
 import static org.slf4j.event.Level.INFO;
 
 import org.mule.runtime.api.connection.ConnectionException;
+import org.mule.runtime.api.connection.ConnectionProvider;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.Disposable;
@@ -63,6 +65,7 @@ import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.runtime.core.internal.logger.CustomLogger;
 import org.mule.runtime.core.internal.registry.MuleRegistry;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
+import org.mule.sdk.api.connectivity.oauth.AccessTokenExpiredException;
 import org.mule.sdk.api.runtime.exception.ExceptionHandler;
 import org.mule.sdk.api.runtime.source.Source;
 import org.mule.sdk.api.runtime.source.SourceCallback;
@@ -319,6 +322,20 @@ public class ExtensionMessageSourceTestCase extends AbstractExtensionMessageSour
     messageSource.initialise();
     messageSource.start();
     messageSource.onException(new ConnectionException(ERROR_MESSAGE));
+
+    new PollingProber(TEST_TIMEOUT, TEST_POLL_DELAY).check(new JUnitLambdaProbe(() -> {
+      verify(source, times(2)).onStart(sourceCallback);
+      verify(source, times(1)).onStop();
+      return true;
+    }));
+  }
+
+  @Test
+  public void failOnExceptionWithAccessTokenExpiredExceptionInConnectionExceptionAndGetsReconnected() throws Exception {
+    messageSource.initialise();
+    messageSource.start();
+    when(configurationInstance.getConnectionProvider()).thenReturn(of(mock(ConnectionProvider.class)));
+    messageSource.onException(new ConnectionException(new AccessTokenExpiredException(ERROR_MESSAGE)));
 
     new PollingProber(TEST_TIMEOUT, TEST_POLL_DELAY).check(new JUnitLambdaProbe(() -> {
       verify(source, times(2)).onStart(sourceCallback);


### PR DESCRIPTION
(ExtensionsOAuthUtils.java:290)