### PR TITLE
W-13038823 - Groovy Resource Releaser

### DIFF
--- a/modules/artifact/src/main/java/org/mule/module/artifact/classloader/GroovyResourceReleaser.java
+++ b/modules/artifact/src/main/java/org/mule/module/artifact/classloader/GroovyResourceReleaser.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 
 import org.slf4j.Logger;
+
 /**
  * A utility class to release all resources associated to Groovy Dependency on un-deployment to prevent classloader leaks.
  *
@@ -68,7 +69,7 @@ public class GroovyResourceReleaser implements ResourceReleaser {
             clazz = getTheClassMethod.invoke(classInfo);
             removeClassMethod.invoke(null, clazz);
           } catch (IllegalAccessException | InvocationTargetException | ClassCastException e) {
-            String className = clazz instanceof Class ? ((Class) clazz).getName(): "Unknown";
+            String className = clazz instanceof Class ? ((Class) clazz).getName() : "Unknown";
             LOGGER.warn("Could not remove the {} class from the Groovy's InvokerHelper", className, e);
           }
         }
@@ -95,7 +96,7 @@ public class GroovyResourceReleaser implements ResourceReleaser {
           Class<?> configurationClass = loadClass(LOGGER_CONFIGURATION, this.classLoader);
           Method getScriptManagerMethod = configurationClass.getMethod("getScriptManager");
           Object scriptManager = getScriptManagerMethod.invoke(configuration);
-          if(scriptManager!=null) {
+          if (scriptManager != null) {
             Object manager = getFieldValue(scriptManager, "manager", true);
             HashSet engineSpis = getFieldValue(manager, "engineSpis", true);
             Class groovy = loadClass(GROOVY_SCRIPT_ENGINE_FACTORY, this.classLoader);

--- a/modules/artifact/src/main/java/org/mule/module/artifact/classloader/GroovyResourceReleaser.java
+++ b/modules/artifact/src/main/java/org/mule/module/artifact/classloader/GroovyResourceReleaser.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.artifact.classloader;
+
+import static org.mule.runtime.core.api.util.ClassUtils.getField;
+import static org.mule.runtime.core.api.util.ClassUtils.loadClass;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.mule.runtime.module.artifact.api.classloader.ResourceReleaser;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+
+import org.slf4j.Logger;
+
+/**
+ * A utility class to release all resources associated to Groovy Dependency on un-deployment to prevent classloader leaks
+ */
+public class GroovyResourceReleaser implements ResourceReleaser {
+
+  private final ClassLoader classLoader;
+  private static final Logger LOGGER = getLogger(GroovyResourceReleaser.class);
+  private static final String GROOVY_CLASS_INFO = "org.codehaus.groovy.reflection.ClassInfo";
+  private static final String GROOVY_INVOKER_HELPER = "org.codehaus.groovy.runtime.InvokerHelper";
+  private static final String GROOVY_SCRIPT_ENGINE_FACTORY = "org.codehaus.groovy.jsr223.GroovyScriptEngineFactory";
+  private static final String LOGGER_ABSTRACT_MANAGER = "org.apache.logging.log4j.core.appender.AbstractManager";
+  private static final String LOGGER_ROLLING_FILE_MANAGER = "org.apache.logging.log4j.core.appender.rolling.RollingFileManager";
+  private static final String LOGGER_OUTPUT_STREAM_MANAGER = "org.apache.logging.log4j.core.appender.OutputStreamManager";
+  private static final String LOGGER_ABSTRACT_LAYOUT = "org.apache.logging.log4j.core.layout.AbstractLayout";
+  private static final String LOGGER_CONFIGURATION = "org.apache.logging.log4j.core.config.Configuration";
+  private static final String LOGGER_SCRIPT_MANAGER = "org.apache.logging.log4j.core.script.ScriptManager";
+  private static final String LOGGER_SCRIPT_ENGINE_MANAGER = "javax.script.ScriptEngineManager";
+
+
+
+  /**
+   * Creates a new Instance of GroovyResourceReleaser
+   *
+   * @param classLoader ClassLoader which loaded the Groovy Dependency.
+   */
+  public GroovyResourceReleaser(ClassLoader classLoader) {
+    this.classLoader = classLoader;
+  }
+
+  @Override
+  public void release() {
+    unregisterInvokerHelper();
+    cleanSpisEngines();
+  }
+
+  private void unregisterInvokerHelper() {
+    try {
+      Class classInfoClass = this.classLoader.loadClass(GROOVY_CLASS_INFO);
+      Method getAllClassInfoMethod = classInfoClass.getMethod("getAllClassInfo");
+      Method getTheClassMethod = classInfoClass.getMethod("getTheClass");
+      Class invokerHelperClass = this.classLoader.loadClass(GROOVY_INVOKER_HELPER);
+      Method removeClassMethod = invokerHelperClass.getMethod("removeClass", Class.class);
+      Object classes = getAllClassInfoMethod.invoke(null);
+      if (classes != null && classes instanceof Collection) {
+        for (Object classInfo : ((Collection) classes)) {
+          String className = "";
+          try {
+            Object clazz = getTheClassMethod.invoke(classInfo);
+            className = clazz.getClass().getName();
+            removeClassMethod.invoke(null, clazz);
+          } catch (IllegalAccessException | InvocationTargetException e) {
+            LOGGER.warn("Could not remove the {} class from the Groovy's InvokerHelper", className, e);
+          }
+        }
+      }
+    } catch (IllegalAccessException | InvocationTargetException | ClassNotFoundException | NoSuchMethodException e) {
+      LOGGER.warn("Error trying to remove the Groovy's InvokerHelper classes", e);
+    }
+  }
+
+  private void cleanSpisEngines() {
+    try {
+      HashMap hashMap = (HashMap) getValue(LOGGER_ABSTRACT_MANAGER, "MAP");
+      Iterator it = hashMap.values().iterator();
+      Class<?> rollingFileManagerClass = loadClass(LOGGER_ROLLING_FILE_MANAGER, this.classLoader);
+      Object rfmInstance = null;
+      while (it.hasNext()) {
+        Object o = it.next();
+        if (rollingFileManagerClass.isInstance(o)) {
+          rfmInstance = o;
+          Object layout = getValue(LOGGER_OUTPUT_STREAM_MANAGER, "layout", rfmInstance);
+          Object configuration = getValue(LOGGER_ABSTRACT_LAYOUT, "configuration", layout);
+
+          Class<?> configurationClass = loadClass(LOGGER_CONFIGURATION, this.classLoader);
+          Method getScriptManagerMethod = configurationClass.getMethod("getScriptManager");
+          Object scriptManager = getScriptManagerMethod.invoke(configuration);
+
+          Object manager = getValue(LOGGER_SCRIPT_MANAGER, "manager", scriptManager);
+          HashSet engineSpis = (HashSet) getValue(LOGGER_SCRIPT_ENGINE_MANAGER, "engineSpis", manager);
+          Class groovy = loadClass(GROOVY_SCRIPT_ENGINE_FACTORY, this.classLoader);
+          Iterator engineSpisIterator = engineSpis.iterator();
+          while (engineSpisIterator.hasNext()) {
+            Object i = engineSpisIterator.next();
+            if (groovy.isInstance(i) && i.getClass().getClassLoader().equals(groovy.getClassLoader())) {
+              engineSpis.remove(i);
+            }
+          }
+        }
+      }
+    } catch (ClassNotFoundException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      LOGGER.warn("Error trying to unregister the Groovy's Scripting Engine", e);
+    }
+  }
+
+  private Object getValue(String classname, String methodName)
+      throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+    return getValue(classname, methodName, null);
+  }
+
+  private Object getValue(String classname, String methodName, Object instance)
+      throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+    Class<?> knownLevelClass = loadClass(classname, this.classLoader);
+    Field levelObjectField = getField(knownLevelClass, methodName, false);
+    Boolean aux = levelObjectField.isAccessible();
+    levelObjectField.setAccessible(true);
+    Object value = levelObjectField.get(instance);
+    levelObjectField.setAccessible(aux);
+    return value;
+  }
+}

--- a/modules/artifact/src/main/java/org/mule/module/artifact/classloader/GroovyResourceReleaser.java
+++ b/modules/artifact/src/main/java/org/mule/module/artifact/classloader/GroovyResourceReleaser.java
@@ -112,7 +112,8 @@ public class GroovyResourceReleaser implements ResourceReleaser {
           }
         }
       }
-    } catch (ClassNotFoundException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+    } catch (ClassNotFoundException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException
+        | IllegalAccessException e) {
       LOGGER.warn("Error trying to unregister the Groovy's Scripting Engine", e);
     }
   }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
@@ -19,6 +19,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import org.mule.module.artifact.classloader.ClassLoaderResourceReleaser;
 import org.mule.module.artifact.classloader.IBMMQResourceReleaser;
 import org.mule.module.artifact.classloader.ActiveMQResourceReleaser;
+import org.mule.module.artifact.classloader.GroovyResourceReleaser;
 import org.mule.module.artifact.classloader.ScalaClassValueReleaser;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
@@ -102,6 +103,7 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
   private volatile boolean shouldReleaseJdbcReferences = false;
   private volatile boolean shouldReleaseIbmMQResources = false;
   private volatile boolean shouldReleaseActiveMQReferences = false;
+  private volatile boolean shouldReleaseGroovyReferences = false;
   private ResourceReleaser jdbcResourceReleaserInstance;
   private final ResourceReleaser scalaClassValueReleaserInstance;
   private final ArtifactDescriptor artifactDescriptor;
@@ -270,6 +272,12 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
     if (!shouldReleaseActiveMQReferences && name.startsWith("org.apache.activemq")) {
       shouldReleaseActiveMQReferences = true;
     }
+
+    if (!shouldReleaseGroovyReferences && name.startsWith("org.codehaus.groovy")) {
+      shouldReleaseGroovyReferences = true;
+    }
+
+
     return clazz;
   }
 
@@ -324,7 +332,9 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
     if (shouldReleaseActiveMQReferences) {
       new ActiveMQResourceReleaser(this).release();
     }
-
+    if (shouldReleaseGroovyReferences) {
+      new GroovyResourceReleaser(this).release();
+    }
     super.dispose();
     shutdownListeners();
   }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
@@ -332,8 +332,12 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
     if (shouldReleaseActiveMQReferences) {
       new ActiveMQResourceReleaser(this).release();
     }
-    if (shouldReleaseGroovyReferences) {
-      new GroovyResourceReleaser(this).release();
+    try {
+      if (shouldReleaseGroovyReferences) {
+        new GroovyResourceReleaser(this).release();
+      }
+    } catch (Exception e) {
+      reportPossibleLeak(e, artifactId);
     }
     super.dispose();
     shutdownListeners();

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.artifact.classloader;
+
+import static org.mule.maven.client.api.MavenClientProvider.discoverProvider;
+import static org.mule.maven.client.api.model.MavenConfiguration.newMavenConfigurationBuilder;
+import static org.mule.runtime.core.api.util.ClassUtils.getFieldValue;
+import static org.mule.runtime.core.internal.util.CompositeClassLoader.from;
+import static org.mule.runtime.module.artifact.api.classloader.ChildFirstLookupStrategy.CHILD_FIRST;
+import static org.mule.test.allure.AllureConstants.LeakPrevention.LEAK_PREVENTION;
+import static org.mule.test.allure.AllureConstants.LeakPrevention.LeakPreventionMetaspace.METASPACE_LEAK_PREVENTION_ON_REDEPLOY;
+
+import static java.lang.Thread.currentThread;
+import static org.apache.commons.io.FileUtils.toFile;
+import static org.mockito.Mockito.mock;
+
+import org.mule.maven.client.api.MavenClient;
+import org.mule.maven.client.api.MavenClientProvider;
+import org.mule.maven.client.api.model.BundleDependency;
+import org.mule.maven.client.api.model.BundleDescriptor;
+import org.mule.maven.client.api.model.MavenConfiguration;
+import org.mule.runtime.core.internal.util.CompositeClassLoader;
+import org.mule.runtime.module.artifact.api.classloader.ClassLoaderLookupPolicy;
+import org.mule.runtime.module.artifact.api.classloader.LookupStrategy;
+import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
+import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@Feature(LEAK_PREVENTION)
+@RunWith(Parameterized.class)
+@Story(METASPACE_LEAK_PREVENTION_ON_REDEPLOY)
+public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
+
+  private final static String GROOVY_ARTIFACT_ID = "groovy";
+  private final static String GROOVY_GROUP_ID = "org.codehaus.groovy";
+  private static final String GROOVY_SCRIPT_ENGINE = "groovy.util.GroovyScriptEngine";
+  private static final String GROOVY_LANG_BINDING = "groovy.lang.Binding";
+  private Object scriptEngine;
+  String groovyVersion;
+  private final ClassLoaderLookupPolicy testLookupPolicy;
+  MuleArtifactClassLoader artifactClassLoader = null;
+
+  public GroovyResourceReleaserTestCase(String driverVersion) {
+    this.groovyVersion = driverVersion;
+    this.testLookupPolicy = new ClassLoaderLookupPolicy() {
+
+      @Override
+      public LookupStrategy getClassLookupStrategy(String className) {
+        return CHILD_FIRST;
+      }
+
+      @Override
+      public LookupStrategy getPackageLookupStrategy(String packageName) {
+        return null;
+      }
+
+      @Override
+      public ClassLoaderLookupPolicy extend(Map<String, LookupStrategy> lookupStrategies) {
+        return null;
+      }
+
+      @Override
+      public ClassLoaderLookupPolicy extend(Map<String, LookupStrategy> lookupStrategies, boolean overwrite) {
+        return null;
+      }
+    };
+  }
+
+  @Parameterized.Parameters(name = "Testing artifact {0}")
+  public static String[] data() throws NoSuchFieldException, IllegalAccessException {
+    return new String[] {
+        "2.4.21",
+        "2.5.22",
+        "3.0.0",
+        "3.0.17"
+    };
+  }
+
+  @Before
+  public void setup() throws Exception {
+
+    URL settingsUrl = getClass().getClassLoader().getResource("custom-settings.xml");
+    final MavenClientProvider mavenClientProvider = discoverProvider(this.getClass().getClassLoader());
+
+    final Supplier<File> localMavenRepository =
+        mavenClientProvider.getLocalRepositorySuppliers().environmentMavenRepositorySupplier();
+
+    final MavenConfiguration.MavenConfigurationBuilder mavenConfigurationBuilder =
+        newMavenConfigurationBuilder().globalSettingsLocation(toFile(settingsUrl));
+
+    MavenClient mavenClient = mavenClientProvider
+        .createMavenClient(mavenConfigurationBuilder.localMavenRepositoryLocation(localMavenRepository.get()).build());
+
+    BundleDescriptor bundleDescriptor = new BundleDescriptor.Builder().setGroupId(GROOVY_GROUP_ID)
+        .setArtifactId(GROOVY_ARTIFACT_ID).setVersion(groovyVersion).build();
+
+    BundleDependency dependency = mavenClient.resolveBundleDescriptor(bundleDescriptor);
+    artifactClassLoader =
+        new MuleArtifactClassLoader("test", mock(ArtifactDescriptor.class),
+                                    new URL[] {dependency.getBundleUri().toURL()}, currentThread().getContextClassLoader(),
+                                    testLookupPolicy);
+
+    CompositeClassLoader classLoader = from(artifactClassLoader);
+    currentThread().setContextClassLoader(classLoader);
+  }
+
+  @Test
+  public void runGroovyScriptAndDispose() throws ClassNotFoundException,
+          NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException {
+    try {
+      Assert.assertFalse(getFieldValue(artifactClassLoader, "shouldReleaseGroovyReferences", false));
+      String[] roots = new String[]{"src/test/resources/groovy/"};
+      Class<?> groovyScriptEngineClass = Class.forName(GROOVY_SCRIPT_ENGINE, true, artifactClassLoader);
+      scriptEngine = groovyScriptEngineClass.getConstructor(String[].class, ClassLoader.class).newInstance(roots, artifactClassLoader);
+      Class<?> groovyBinding = Class.forName(GROOVY_LANG_BINDING, true, artifactClassLoader);
+      Method runMethod = groovyScriptEngineClass.getMethod("run", String.class, groovyBinding);
+      String scriptBody = "example.groovy";
+      String result = (String) runMethod.invoke(scriptEngine, scriptBody, groovyBinding.getConstructor().newInstance());
+      Assert.assertEquals("TEST", result);
+      Assert.assertTrue(getFieldValue(artifactClassLoader, "shouldReleaseGroovyReferences", false));
+      artifactClassLoader.dispose();
+    } finally {
+      System.gc();
+    }
+  }
+}

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -103,6 +103,7 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
     return new String[] {
         "2.4.21",
         "2.5.22",
+        "3.0.0",
         "3.0.17"
     };
   }

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -148,10 +148,10 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
 
   private String runScript() throws ClassNotFoundException,
       NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-    String[] roots = new String[] {"src/test/resources/groovy/"};
+    URL[] roots = new URL[] {artifactClassLoader.getResource("groovy/example.groovy")};
     Class<?> groovyScriptEngineClass = forName(GROOVY_SCRIPT_ENGINE, true, artifactClassLoader);
     Object scriptEngine =
-        groovyScriptEngineClass.getConstructor(String[].class, ClassLoader.class).newInstance(roots, artifactClassLoader);
+        groovyScriptEngineClass.getConstructor(URL[].class, ClassLoader.class).newInstance(roots, artifactClassLoader);
     Class<?> groovyBinding = forName(GROOVY_LANG_BINDING, true, artifactClassLoader);
     Method runMethod = groovyScriptEngineClass.getMethod("run", String.class, groovyBinding);
     String scriptBody = "example.groovy";

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -61,8 +61,8 @@ import org.junit.runners.Parameterized;
 @Story(METASPACE_LEAK_PREVENTION_ON_REDEPLOY)
 public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
 
-  private static final int PROBER_POLLING_INTERVAL = 100;
-  private static final int PROBER_POLLING_TIMEOUT = 5000;
+  private static final int PROBER_POLLING_INTERVAL = 150;
+  private static final int PROBER_POLLING_TIMEOUT = 6000;
   private final static String GROOVY_ARTIFACT_ID = "groovy";
   private final static String GROOVY_GROUP_ID = "org.codehaus.groovy";
   private static final String GROOVY_SCRIPT_ENGINE = "groovy.util.GroovyScriptEngine";
@@ -103,7 +103,6 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
     return new String[] {
         "2.4.21",
         "2.5.22",
-        "3.0.0",
         "3.0.17"
     };
   }
@@ -131,9 +130,6 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
         new MuleArtifactClassLoader("test", mock(ArtifactDescriptor.class),
                                     new URL[] {dependency.getBundleUri().toURL()}, currentThread().getContextClassLoader(),
                                     testLookupPolicy);
-
-    CompositeClassLoader classLoader = from(artifactClassLoader);
-    currentThread().setContextClassLoader(classLoader);
   }
 
   @Test
@@ -143,6 +139,7 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
     assertEquals("TEST", runScript());
     assertTrue(getFieldValue(artifactClassLoader, "shouldReleaseGroovyReferences", false));
     artifactClassLoader.dispose();
+    artifactClassLoader = null;
     gc();
   }
 
@@ -159,8 +156,7 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  @Ignore
-  public void releaserCanBeCalledMultipleTimes() {
+  public void releaseClassloader() {
     try {
       runScript();
     } catch (Exception e) {

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -138,24 +138,26 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
 
   @Test
   public void runGroovyScriptAndDispose() throws ClassNotFoundException,
-          NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException {
-      assertFalse(getFieldValue(artifactClassLoader, "shouldReleaseGroovyReferences", false));
-      assertEquals("TEST", runScript());
-      assertTrue(getFieldValue(artifactClassLoader, "shouldReleaseGroovyReferences", false));
-      artifactClassLoader.dispose();
-      gc();
+      NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException {
+    assertFalse(getFieldValue(artifactClassLoader, "shouldReleaseGroovyReferences", false));
+    assertEquals("TEST", runScript());
+    assertTrue(getFieldValue(artifactClassLoader, "shouldReleaseGroovyReferences", false));
+    artifactClassLoader.dispose();
+    gc();
   }
 
   private String runScript() throws ClassNotFoundException,
-          NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-    String[] roots = new String[]{"src/test/resources/groovy/"};
+      NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+    String[] roots = new String[] {"src/test/resources/groovy/"};
     Class<?> groovyScriptEngineClass = forName(GROOVY_SCRIPT_ENGINE, true, artifactClassLoader);
-    Object scriptEngine = groovyScriptEngineClass.getConstructor(String[].class, ClassLoader.class).newInstance(roots, artifactClassLoader);
+    Object scriptEngine =
+        groovyScriptEngineClass.getConstructor(String[].class, ClassLoader.class).newInstance(roots, artifactClassLoader);
     Class<?> groovyBinding = forName(GROOVY_LANG_BINDING, true, artifactClassLoader);
     Method runMethod = groovyScriptEngineClass.getMethod("run", String.class, groovyBinding);
     String scriptBody = "example.groovy";
     return (String) runMethod.invoke(scriptEngine, scriptBody, groovyBinding.getConstructor().newInstance());
   }
+
   @Test
   @Ignore
   public void releaserCanBeCalledMultipleTimes() {

--- a/modules/artifact/src/test/resources/groovy/example.groovy
+++ b/modules/artifact/src/test/resources/groovy/example.groovy
@@ -1,0 +1,3 @@
+reportType = "test";
+reportType = reportType.toUpperCase(Locale.US);
+return reportType;

--- a/modules/artifact/src/test/resources/groovy/example.groovy
+++ b/modules/artifact/src/test/resources/groovy/example.groovy
@@ -1,3 +1,2 @@
-reportType = "test";
-reportType = reportType.toUpperCase(Locale.US);
-return reportType;
+package groovy
+return "TEST"


### PR DESCRIPTION
When the scripting module was used with Groovy 3.0.0+, we had a classloader leak.
Two things were eliminated:

The removeClass of all the classes cached in the InvokerHelper of Groovy is done.
The org.apache.logging.log4j.core.appender.AbstractManager has a static map that stores a structure that after browsing it you get to a list of detected ScriptingEngine. When I undeploy an application, I delete the GroovyScriptEngineFactory corresponding to that classloader.