### PR TITLE
W-13682699: Parse Template Component doesn't support absolute paths

### DIFF
--- a/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExist.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExist.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.config.internal.validation;
 
 import static org.mule.runtime.api.meta.model.parameter.ParameterGroupModel.DEFAULT_GROUP_NAME;
+import static org.mule.runtime.api.util.IOUtils.getResourceAsUrl;
 import static org.mule.runtime.ast.api.util.ComponentAstPredicatesFactory.currentElemement;
 import static org.mule.runtime.ast.api.util.ComponentAstPredicatesFactory.equalsIdentifier;
 import static org.mule.runtime.ast.api.util.MuleAstUtils.hasPropertyPlaceholder;
@@ -82,7 +83,7 @@ public class ParseTemplateResourceExist implements Validation {
     ComponentParameterAst locationParam = component.getParameter(DEFAULT_GROUP_NAME, LOCATION_PARAM);
     String location = (String) locationParam.getValue().getRight();
 
-    if (artifactRegionClassLoader.getResource(location) == null) {
+    if (getResourceAsUrl(location, getClass()) == null) {
       return of(create(component, locationParam, this, "Template location: '" + location + "' not found"));
     }
 

--- a/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
@@ -7,7 +7,6 @@
 package org.mule.runtime.config.internal.validation;
 
 import static org.mule.runtime.ast.api.validation.Validation.Level.ERROR;
-import static org.mule.runtime.ast.api.validation.Validation.Level.WARN;
 import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
 import static org.mule.test.allure.AllureConstants.MuleDsl.MULE_DSL;
 
@@ -71,7 +70,8 @@ public class ParseTemplateResourceExistTestCase extends AbstractCoreValidationTe
 
   @Test
   public void locationWithAbsolutePath() {
-    File templateFile = new File("template.txt");
+    File templateFile = new File("test-classes/template.txt");
+    assertThat(templateFile.exists(), is(true));
     String absolutePath = templateFile.getAbsolutePath();
 
     final Optional<ValidationResultItem> msg = runValidation("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +

--- a/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.internal.validation;
+
+import static org.mule.runtime.ast.api.validation.Validation.Level.ERROR;
+import static org.mule.runtime.ast.api.validation.Validation.Level.WARN;
+import static org.mule.test.allure.AllureConstants.MuleDsl.DslValidationStory.DSL_VALIDATION_STORY;
+import static org.mule.test.allure.AllureConstants.MuleDsl.MULE_DSL;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.mule.runtime.ast.api.validation.Validation;
+import org.mule.runtime.ast.api.validation.ValidationResultItem;
+
+import java.io.File;
+import java.util.Optional;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.junit.Test;
+
+@Feature(MULE_DSL)
+@Story(DSL_VALIDATION_STORY)
+public class ParseTemplateResourceExistTestCase extends AbstractCoreValidationTestCase {
+
+  @Override
+  protected Validation getValidation() {
+    return new ParseTemplateResourceExist(Thread.currentThread().getContextClassLoader(), false);
+  }
+
+  @Test
+  public void unexistentLocation() {
+    final Optional<ValidationResultItem> msg = runValidation("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<mule xmlns=\"http://www.mulesoft.org/schema/mule/core\"\n" +
+        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
+        "xsi:schemaLocation=\"http://www.mulesoft.org/schema/mule/core " +
+        "http://www.mulesoft.org/schema/mule/core/current/mule.xsd\" >\n" +
+        "<flow name=\"test-projectFlow\" >\n" +
+        "<parse-template outputMimeType=\"text/html\" location=\"unexistent.txt\" />\n" +
+        "</flow>\n" +
+        "</mule>")
+            .stream().findFirst();
+
+    assertThat(msg.get().getValidation().getLevel(), is(ERROR));
+    assertThat(msg.get().getMessage(),
+               containsString("Template location: 'unexistent.txt' not found"));
+  }
+
+  @Test
+  public void locationInResourcesFolder() {
+    final Optional<ValidationResultItem> msg = runValidation("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<mule xmlns=\"http://www.mulesoft.org/schema/mule/core\"\n" +
+        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
+        "xsi:schemaLocation=\"http://www.mulesoft.org/schema/mule/core " +
+        "http://www.mulesoft.org/schema/mule/core/current/mule.xsd\" >\n" +
+        "<flow name=\"test-projectFlow\" >\n" +
+        "<parse-template outputMimeType=\"text/html\" location=\"template.txt\" />\n" +
+        "</flow>\n" +
+        "</mule>")
+            .stream().findFirst();
+
+    // No errors
+    assertThat(msg.isPresent(), is(false));
+  }
+
+  @Test
+  public void locationWithAbsolutePath() {
+    File templateFile = new File("template.txt");
+    assertThat(templateFile.exists(), is(true));
+    String absolutePath = templateFile.getAbsolutePath();
+
+    final Optional<ValidationResultItem> msg = runValidation("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<mule xmlns=\"http://www.mulesoft.org/schema/mule/core\"\n" +
+        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
+        "xsi:schemaLocation=\"http://www.mulesoft.org/schema/mule/core " +
+        "http://www.mulesoft.org/schema/mule/core/current/mule.xsd\" >\n" +
+        "<flow name=\"test-projectFlow\" >\n" +
+        "<parse-template outputMimeType=\"text/html\" location=\"" + absolutePath + "\" />\n" +
+        "</flow>\n" +
+        "</mule>")
+            .stream().findFirst();
+
+    // No errors
+    assertThat(msg.isPresent(), is(false));
+  }
+}

--- a/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
@@ -72,7 +72,6 @@ public class ParseTemplateResourceExistTestCase extends AbstractCoreValidationTe
   @Test
   public void locationWithAbsolutePath() {
     File templateFile = new File("template.txt");
-    assertThat(templateFile.exists(), is(true));
     String absolutePath = templateFile.getAbsolutePath();
 
     final Optional<ValidationResultItem> msg = runValidation("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +

--- a/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
+++ b/runtime-extension-model/src/test/java/org/mule/runtime/config/internal/validation/ParseTemplateResourceExistTestCase.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.Optional;
 
 import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
 import io.qameta.allure.Story;
 import org.junit.Test;
 
@@ -69,6 +70,7 @@ public class ParseTemplateResourceExistTestCase extends AbstractCoreValidationTe
   }
 
   @Test
+  @Issue("W-13682699")
   public void locationWithAbsolutePath() {
     File templateFile = new File("test-classes/template.txt");
     assertThat(templateFile.exists(), is(true));


### PR DESCRIPTION
The problem was that the validation method was calling `ClassLoader#getResourceAsStrem`, and then only the resources accessible by the classloader were able to be loaded.
Now we use the utility method [`IOUtils#getResourceAsUrl`](https://github.com/mulesoft/mule-api/blob/3858279cda736349dcc688c7be506c77ecf10cc6/src/main/java/org/mule/runtime/api/util/IOUtils.java#L54), since it also tries to use the File api to search the resource.