### PR TITLE
W-13153500: MMP version greater than 3.5.4 giving error--Caused by: j…

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/infrastructure/ExtensionsTestInfrastructureDiscoverer.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/infrastructure/ExtensionsTestInfrastructureDiscoverer.java
@@ -80,10 +80,14 @@ public class ExtensionsTestInfrastructureDiscoverer {
    * @throws IllegalStateException if no extensions can be described
    */
   public ExtensionModel discoverExtension(Class<?> annotatedClass, ExtensionModelLoader loader) {
+    return discoverExtension(annotatedClass, loader, getDefault(singleton(MuleExtensionModelProvider.getExtensionModel())));
+  }
+
+  public ExtensionModel discoverExtension(Class<?> annotatedClass, ExtensionModelLoader loader,
+                                          DslResolvingContext dslResolvingContext) {
     Map<String, Object> params = new HashMap<>();
     params.put(TYPE_PROPERTY_NAME, annotatedClass.getName());
     params.put(VERSION, getProductVersion());
-    DslResolvingContext dslResolvingContext = getDefault(singleton(MuleExtensionModelProvider.getExtensionModel()));
     ExtensionModel model = loader.loadExtensionModel(annotatedClass.getClassLoader(), dslResolvingContext, params);
     extensionManager.registerExtension(model);
     return model;


### PR DESCRIPTION
…ava.lang.IllegalStateException: Model for 'OAuth:oauth:proxy-config @ HTTP_Request_configuration/connection/1/0/0' (a 'Optional.empty)' is not parameterizable.