### PR TITLE
W-13822757: Adding basic micro benchmarks for the DefaultExtensionsClient.

### DIFF
--- a/tests/performance/src/main/java/org/mule/AbstractBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/AbstractBenchmark.java
@@ -3,6 +3,7 @@
  */
 package org.mule;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
@@ -70,6 +71,7 @@ public class AbstractBenchmark {
     builderList.add(new SimpleConfigurationBuilder(getStartUpRegistryObjects()));
     builderList.add(new BasicRuntimeServicesConfigurationBuilder());
     builderList.add(new MinimalConfigurationBuilder());
+    builderList.addAll(getAdditionalConfigurationBuilders());
     return muleContextFactory.createMuleContext(builderList.toArray(new ConfigurationBuilder[] {}));
   }
 
@@ -81,6 +83,10 @@ public class AbstractBenchmark {
 
   protected Map<String, Object> getStartUpRegistryObjects() {
     return new HashMap<>();
+  }
+
+  protected List<ConfigurationBuilder> getAdditionalConfigurationBuilders() {
+    return emptyList();
   }
 
   public CoreEvent createEvent(Flow flow) {

--- a/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClientBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClientBenchmark.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ */
+package org.mule.runtime.module.extension.internal.runtime.client;
+
+import static org.mule.runtime.api.dsl.DslResolvingContext.getDefault;
+import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_EXTENSION_MANAGER;
+import static org.mule.runtime.extension.api.loader.ExtensionModelLoadingRequest.builder;
+import static org.mule.runtime.module.extension.internal.loader.java.AbstractJavaExtensionModelLoader.TYPE_PROPERTY_NAME;
+import static org.mule.runtime.module.extension.internal.loader.java.AbstractJavaExtensionModelLoader.VERSION;
+import static org.mule.runtime.module.extension.internal.runtime.client.DefaultExtensionsClientTestExtension.DEFAULT_EXTENSIONS_CLIENT_TEST_EXTENSION_NAME;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import org.mule.AbstractBenchmark;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.config.ConfigurationBuilder;
+import org.mule.runtime.core.api.config.builders.AbstractConfigurationBuilder;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
+import org.mule.runtime.core.internal.registry.MuleRegistry;
+import org.mule.runtime.core.privileged.registry.RegistrationException;
+import org.mule.runtime.extension.api.client.OperationParameterizer;
+import org.mule.runtime.extension.api.loader.ExtensionModelLoadingRequest;
+import org.mule.runtime.extension.api.runtime.operation.Result;
+import org.mule.runtime.module.extension.api.manager.DefaultExtensionManagerFactory;
+import org.mule.runtime.module.extension.internal.loader.java.DefaultJavaExtensionModelLoader;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+@OutputTimeUnit(NANOSECONDS)
+public class DefaultExtensionsClientBenchmark extends AbstractBenchmark {
+
+  private MuleContext muleContext;
+  private DefaultExtensionsClient extensionsClient;
+
+  @Setup
+  public void setup() throws MuleException {
+    muleContext = createMuleContextWithServices();
+    muleContext.start();
+
+    extensionsClient = new DefaultExtensionsClient();
+    muleContext.getInjector().inject(extensionsClient);
+    extensionsClient.initialise();
+  }
+
+  @TearDown
+  public void tearDown() {
+    extensionsClient.dispose();
+    muleContext.dispose();
+  }
+
+  @Benchmark
+  public Result<?, ?> basicNoOp() {
+    return execute("basicNoOp");
+  }
+
+  @Benchmark
+  public Result<?, ?> multipleParametersNoOp() {
+    return execute("multipleParametersNoOp", parameterizer -> {
+      parameterizer.withParameter("stringParameter", "Hey");
+      parameterizer.withParameter("intParameter", 9);
+      parameterizer.withParameter("strings", asList("a", "b", "c"));
+    });
+  }
+
+  @Benchmark
+  public Result<?, ?> simplePayloadOutput() {
+    return execute("simplePayloadOutput");
+  }
+
+  @Benchmark
+  public Result<?, ?> simpleResultOutput() {
+    return execute("simpleResultOutput");
+  }
+
+  @Benchmark
+  public Result<?, ?> simpleIdentity() {
+    return execute("simpleIdentity", parameterizer -> {
+      parameterizer.withParameter("content", new ByteArrayInputStream("Some payload".getBytes()));
+    });
+  }
+
+  @Override
+  protected List<ConfigurationBuilder> getAdditionalConfigurationBuilders() {
+    return singletonList(new ExtensionManagerConfigurationBuilder());
+  }
+
+  private Result<?, ?> execute(String operationName) {
+    return execute(operationName, operationParameterizer -> {
+    });
+  }
+
+  private Result<?, ?> execute(String operationName, Consumer<OperationParameterizer> parameterizerConsumer) {
+    try {
+      return extensionsClient.execute(DEFAULT_EXTENSIONS_CLIENT_TEST_EXTENSION_NAME, operationName, parameterizerConsumer).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static class ExtensionManagerConfigurationBuilder extends AbstractConfigurationBuilder {
+
+    @Override
+    protected void doConfigure(MuleContext muleContext) throws RegistrationException {
+      ExtensionManager extensionManager = new DefaultExtensionManagerFactory().create(muleContext);
+      extensionManager.registerExtension(loadTestExtensionModel());
+
+      MuleRegistry registry = ((MuleContextWithRegistry) muleContext).getRegistry();
+      registry.registerObject(OBJECT_EXTENSION_MANAGER, extensionManager);
+    }
+  }
+
+  private static ExtensionModel loadTestExtensionModel() {
+    ExtensionModelLoadingRequest loadingRequest = builder(currentThread().getContextClassLoader(), getDefault(emptySet()))
+        .addParameter(TYPE_PROPERTY_NAME, DefaultExtensionsClientTestExtension.class.getName())
+        .addParameter(VERSION, "1.0.0-SNAPSHOT")
+        .build();
+    return new DefaultJavaExtensionModelLoader().loadExtensionModel(loadingRequest);
+  }
+}

--- a/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClientTestExtension.java
+++ b/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClientTestExtension.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ */
+package org.mule.runtime.module.extension.internal.runtime.client;
+
+import org.mule.sdk.api.annotation.Extension;
+import org.mule.sdk.api.annotation.Operations;
+
+@Extension(name = DefaultExtensionsClientTestExtension.DEFAULT_EXTENSIONS_CLIENT_TEST_EXTENSION_NAME)
+@Operations(DefaultExtensionsClientTestOperations.class)
+public class DefaultExtensionsClientTestExtension {
+
+  public static final String DEFAULT_EXTENSIONS_CLIENT_TEST_EXTENSION_NAME = "Default Extensions Client Test";
+}

--- a/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClientTestOperations.java
+++ b/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClientTestOperations.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ */
+package org.mule.runtime.module.extension.internal.runtime.client;
+
+import static org.openjdk.jmh.infra.Blackhole.consumeCPU;
+
+import org.mule.sdk.api.annotation.param.Content;
+import org.mule.sdk.api.runtime.operation.Result;
+
+import java.io.InputStream;
+import java.util.List;
+
+public class DefaultExtensionsClientTestOperations {
+
+  public void basicNoOp() {
+    // Prevents this call from being optimized out
+    consumeCPU(10);
+  }
+
+  public void multipleParametersNoOp(String stringParameter,
+                                     int intParameter,
+                                     List<String> strings) {
+    // Prevents this call from being optimized out
+    consumeCPU(10);
+  }
+
+  public String simplePayloadOutput() {
+    return "Hello world";
+  }
+
+  public Result<String, String> simpleResultOutput() {
+    return Result.<String, String>builder()
+        .output("Hello world")
+        .attributes("Attributes")
+        .build();
+  }
+
+  public Result<InputStream, Void> simpleIdentity(@Content InputStream content) {
+    return Result.<InputStream, Void>builder()
+        .output(content)
+        .build();
+  }
+}


### PR DESCRIPTION
See #12642 for the full story and context.

This PR is just an extract from that one.

In order to iterate faster and test different improvements we decided to create some micro benchmarks for the `DefaultExtensionClient`.
Having that micro benchmark will also helps us if we ever need to do a similar investigation in the future.

The micro benchmark added as part of this PR is pretty basic, but is enough to replicate the performance degradation. Actually, it was magnified, because the test operations in this case are mostly No Ops that are extremely cheap.

The overhead introduced by the `ExtensionsClient` is responsible for the majority of the test duration.

The benchmarks were executed using the `micro-benchmark` profile because the `becnhmark-jar` profile is currently broken due to conflicting META-INF files in the shaded jar (some service impls are not found because of that).

We used the following command line:
`mvn clean integration-test -Pmicro-benchmark -Djmh.benchmark='DefaultExtensionsClientBenchmark' -Dtest='-' -Dsurefire.failIfNoSpecifiedTests=false`

And disabled the GC profiling and Json report generation from the `pom.xml`.

These were the results:
```
4.5.0-rc9
Benchmark                                                Mode  Cnt       Score      Error  Units
DefaultExtensionsClientBenchmark.basicNoOp               avgt   10   10303.021 ±  260.601  ns/op
DefaultExtensionsClientBenchmark.multipleParametersNoOp  avgt   10  190719.080 ± 8446.808  ns/op
DefaultExtensionsClientBenchmark.simpleIdentity          avgt   10  130576.343 ± 6088.984  ns/op
DefaultExtensionsClientBenchmark.simplePayloadOutput     avgt   10   85799.617 ± 2212.369  ns/op
DefaultExtensionsClientBenchmark.simpleResultOutput      avgt   10   84798.926 ± 4052.471  ns/op

4.5.0-rc9-withPRChanges
Benchmark                                                Mode  Cnt      Score      Error  Units
DefaultExtensionsClientBenchmark.basicNoOp               avgt   10   2994.564 ±  132.218  ns/op
DefaultExtensionsClientBenchmark.multipleParametersNoOp  avgt   10  86614.496 ± 4264.044  ns/op
DefaultExtensionsClientBenchmark.simpleIdentity          avgt   10  30239.374 ± 1406.124  ns/op
DefaultExtensionsClientBenchmark.simplePayloadOutput     avgt   10   3870.321 ±  146.262  ns/op
DefaultExtensionsClientBenchmark.simpleResultOutput      avgt   10   3147.966 ±  153.932  ns/op

4.5.0-rc9-withRevert
Benchmark                                                Mode  Cnt      Score      Error  Units
DefaultExtensionsClientBenchmark.basicNoOp               avgt   10   4912.869 ±  235.264  ns/op
DefaultExtensionsClientBenchmark.multipleParametersNoOp  avgt   10  47043.952 ± 1958.167  ns/op
DefaultExtensionsClientBenchmark.simpleIdentity          avgt   10  27635.634 ± 1058.083  ns/op
DefaultExtensionsClientBenchmark.simplePayloadOutput     avgt   10   9723.304 ±  515.829  ns/op
DefaultExtensionsClientBenchmark.simpleResultOutput      avgt   10   9739.521 ±  964.353  ns/op
```