### PR TITLE
W-13742405: Create a module layer instead of a classloader for the container - Prework

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/serialization/JavaExternalSerializerProtocolTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/serialization/JavaExternalSerializerProtocolTestCase.java
@@ -19,7 +19,7 @@ import io.qameta.allure.Story;
 
 @Feature(SERIALIZATION)
 @Story(MESSAGE_SERIALIZATION)
-public class JavaExternalSerializerProtocolProtocolTestCase extends AbstractSerializerProtocolContractTestCase {
+public class JavaExternalSerializerProtocolTestCase extends AbstractSerializerProtocolContractTestCase {
 
   @Before
   public void setUp() {

--- a/core/src/main/java/org/mule/runtime/core/internal/serialization/AbstractSerializationProtocol.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/serialization/AbstractSerializationProtocol.java
@@ -93,7 +93,7 @@ public abstract class AbstractSerializationProtocol implements SerializationProt
    */
   @Override
   public <T> T deserialize(byte[] bytes, ClassLoader classLoader) throws SerializationException {
-    requireNonNull(bytes != null, "The byte[] must not be null");
+    requireNonNull(bytes, "The byte[] must not be null");
     return deserialize(new ByteArrayInputStream(bytes), classLoader);
   }
 
@@ -111,8 +111,8 @@ public abstract class AbstractSerializationProtocol implements SerializationProt
    */
   @Override
   public <T> T deserialize(InputStream inputStream, ClassLoader classLoader) throws SerializationException {
-    requireNonNull(inputStream != null, "Cannot deserialize a null stream");
-    requireNonNull(classLoader != null, "Cannot deserialize with a null classloader");
+    requireNonNull(inputStream, "Cannot deserialize a null stream");
+    requireNonNull(classLoader, "Cannot deserialize with a null classloader");
     try {
       return (T) postInitialize(doDeserialize(inputStream, classLoader));
     } catch (Exception e) {

--- a/core/src/main/java/org/mule/runtime/core/internal/serialization/AbstractSerializationProtocol.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/serialization/AbstractSerializationProtocol.java
@@ -3,9 +3,10 @@
  */
 package org.mule.runtime.core.internal.serialization;
 
-import static java.lang.String.format;
-import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.api.util.IOUtils.closeQuietly;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 import org.mule.runtime.api.serialization.SerializationException;
 import org.mule.runtime.api.serialization.SerializationProtocol;
@@ -92,7 +93,7 @@ public abstract class AbstractSerializationProtocol implements SerializationProt
    */
   @Override
   public <T> T deserialize(byte[] bytes, ClassLoader classLoader) throws SerializationException {
-    checkArgument(bytes != null, "The byte[] must not be null");
+    requireNonNull(bytes != null, "The byte[] must not be null");
     return deserialize(new ByteArrayInputStream(bytes), classLoader);
   }
 
@@ -110,8 +111,8 @@ public abstract class AbstractSerializationProtocol implements SerializationProt
    */
   @Override
   public <T> T deserialize(InputStream inputStream, ClassLoader classLoader) throws SerializationException {
-    checkArgument(inputStream != null, "Cannot deserialize a null stream");
-    checkArgument(classLoader != null, "Cannot deserialize with a null classloader");
+    requireNonNull(inputStream != null, "Cannot deserialize a null stream");
+    requireNonNull(classLoader != null, "Cannot deserialize with a null classloader");
     try {
       return (T) postInitialize(doDeserialize(inputStream, classLoader));
     } catch (Exception e) {

--- a/core/src/main/java/org/mule/runtime/core/internal/serialization/JavaExternalSerializerProtocol.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/serialization/JavaExternalSerializerProtocol.java
@@ -4,12 +4,14 @@
 package org.mule.runtime.core.internal.serialization;
 
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
-import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.api.util.IOUtils.toByteArray;
-import org.mule.runtime.api.streaming.bytes.CursorStream;
-import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+
+import static java.util.Objects.requireNonNull;
+
 import org.mule.runtime.api.serialization.SerializationException;
 import org.mule.runtime.api.serialization.SerializationProtocol;
+import org.mule.runtime.api.streaming.bytes.CursorStream;
+import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
 import org.mule.runtime.core.internal.util.SerializationUtils;
 
 import java.io.IOException;
@@ -64,8 +66,8 @@ public class JavaExternalSerializerProtocol extends AbstractSerializationProtoco
    */
   @Override
   protected <T> T doDeserialize(InputStream inputStream, ClassLoader classLoader) throws Exception {
-    checkArgument(inputStream != null, "Cannot deserialize a null stream");
-    checkArgument(classLoader != null, "Cannot deserialize with a null classloader");
+    requireNonNull(inputStream, "Cannot deserialize a null stream");
+    requireNonNull(classLoader, "Cannot deserialize with a null classloader");
 
     return (T) SerializationUtils.deserialize(inputStream, classLoader, muleContext);
   }

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/serializer/protocol/CustomJavaSerializationProtocol.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/serializer/protocol/CustomJavaSerializationProtocol.java
@@ -3,14 +3,16 @@
  */
 package org.mule.runtime.module.artifact.api.serializer.protocol;
 
-import static java.lang.String.format;
-import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.runtime.core.api.util.IOUtils.toByteArray;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
 import org.mule.api.annotation.NoInstantiate;
+import org.mule.runtime.api.serialization.SerializationException;
 import org.mule.runtime.api.streaming.bytes.CursorStream;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
 import org.mule.runtime.core.internal.serialization.AbstractSerializationProtocol;
-import org.mule.runtime.api.serialization.SerializationException;
 import org.mule.runtime.module.artifact.api.classloader.ClassLoaderRepository;
 import org.mule.runtime.module.artifact.api.serializer.ArtifactClassLoaderObjectInputStream;
 import org.mule.runtime.module.artifact.api.serializer.ArtifactClassLoaderObjectOutputStream;
@@ -40,7 +42,7 @@ public class CustomJavaSerializationProtocol extends AbstractSerializationProtoc
    *
    */
   public CustomJavaSerializationProtocol(ClassLoaderRepository classLoaderRepository) {
-    checkArgument(classLoaderRepository != null, "artifactClassLoaderRepository cannot be null");
+    requireNonNull(classLoaderRepository, "artifactClassLoaderRepository cannot be null");
     this.classLoaderRepository = classLoaderRepository;
   }
 
@@ -73,8 +75,8 @@ public class CustomJavaSerializationProtocol extends AbstractSerializationProtoc
    */
   @Override
   protected <T> T doDeserialize(InputStream inputStream, ClassLoader classLoader) throws Exception {
-    checkArgument(inputStream != null, "Cannot deserialize a null stream");
-    checkArgument(classLoader != null, "Cannot deserialize with a null classloader");
+    requireNonNull(inputStream, "Cannot deserialize a null stream");
+    requireNonNull(classLoader, "Cannot deserialize with a null classloader");
 
     try (ObjectInputStream in = new ArtifactClassLoaderObjectInputStream(classLoaderRepository, inputStream)) {
       Object obj = in.readObject();

--- a/modules/deployment-model-impl/pom.xml
+++ b/modules/deployment-model-impl/pom.xml
@@ -195,5 +195,26 @@
                 <directory>${basedir}/src/test/resources</directory>
             </testResource>
         </testResources>
+        
+        <plugins>
+			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+							<includes>
+								<include>org/mule/runtime/module/deployment/impl/internal/builder/**</include>
+							</includes>
+                        </configuration>
+                    </execution>
+                </executions>				
+			</plugin>
+			
+		</plugins>
     </build>
 </project>

--- a/modules/deployment-model-impl/pom.xml
+++ b/modules/deployment-model-impl/pom.xml
@@ -197,7 +197,7 @@
         </testResources>
         
         <plugins>
-			<plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
@@ -207,17 +207,16 @@
                             <goal>test-jar</goal>
                         </goals>
                         <configuration>
-							<includes>
-								<include>org/mule/runtime/module/deployment/impl/internal/base/**</include>
-								<include>org/mule/runtime/module/deployment/impl/internal/builder/**</include>
-								<include>org/mule/runtime/module/deployment/impl/internal/application/wrapper/**</include>
-								<include>org/mule/runtime/module/deployment/impl/internal/domain/wrapper/**</include>
-							</includes>
+                            <includes>
+                                <include>org/mule/runtime/module/deployment/impl/internal/base/**</include>
+                                <include>org/mule/runtime/module/deployment/impl/internal/builder/**</include>
+                                <include>org/mule/runtime/module/deployment/impl/internal/application/wrapper/**</include>
+                                <include>org/mule/runtime/module/deployment/impl/internal/domain/wrapper/**</include>
+                            </includes>
                         </configuration>
                     </execution>
-                </executions>				
-			</plugin>
-			
-		</plugins>
+                </executions>                
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/modules/deployment-model-impl/pom.xml
+++ b/modules/deployment-model-impl/pom.xml
@@ -208,7 +208,10 @@
                         </goals>
                         <configuration>
 							<includes>
+								<include>org/mule/runtime/module/deployment/impl/internal/base/**</include>
 								<include>org/mule/runtime/module/deployment/impl/internal/builder/**</include>
+								<include>org/mule/runtime/module/deployment/impl/internal/application/wrapper/**</include>
+								<include>org/mule/runtime/module/deployment/impl/internal/domain/wrapper/**</include>
 							</includes>
                         </configuration>
                     </execution>

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationStartedSplashScreenTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationStartedSplashScreenTestCase.java
@@ -17,7 +17,7 @@ import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderConfiguration;
 import org.mule.runtime.module.artifact.api.descriptor.ClassLoaderConfiguration.ClassLoaderConfigurationBuilder;
-import org.mule.runtime.module.deployment.impl.internal.AbstractSplashScreenTestCase;
+import org.mule.runtime.module.deployment.impl.internal.base.AbstractSplashScreenTestCase;
 
 import java.io.File;
 import java.io.IOException;

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/wrapper/TestApplicationWrapper.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/application/wrapper/TestApplicationWrapper.java
@@ -1,13 +1,14 @@
 /*
  * Copyright 2023 Salesforce, Inc. All rights reserved.
  */
-package org.mule.runtime.module.deployment.impl.internal.application;
+package org.mule.runtime.module.deployment.impl.internal.application.wrapper;
 
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 
 import org.mule.runtime.deployment.model.api.DeploymentException;
 import org.mule.runtime.deployment.model.api.DeploymentStopException;
 import org.mule.runtime.deployment.model.api.application.Application;
+import org.mule.runtime.module.deployment.impl.internal.application.ApplicationWrapper;
 
 import java.io.IOException;
 

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/base/AbstractSplashScreenTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/base/AbstractSplashScreenTestCase.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2023 Salesforce, Inc. All rights reserved.
  */
-package org.mule.runtime.module.deployment.impl.internal;
+package org.mule.runtime.module.deployment.impl.internal.base;
 
 import static org.junit.Assert.assertThat;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_HOME_DIRECTORY_PROPERTY;

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/domain/DomainStartedSplashScreenTestCase.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/domain/DomainStartedSplashScreenTestCase.java
@@ -12,7 +12,7 @@ import static org.mule.tck.junit4.matcher.IsEqualIgnoringLineBreaks.equalToIgnor
 import static org.mule.test.allure.AllureConstants.SplashScreenFeature.SPLASH_SCREEN;
 
 import org.mule.runtime.deployment.model.api.domain.DomainDescriptor;
-import org.mule.runtime.module.deployment.impl.internal.AbstractSplashScreenTestCase;
+import org.mule.runtime.module.deployment.impl.internal.base.AbstractSplashScreenTestCase;
 
 import java.io.File;
 import java.io.IOException;

--- a/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/domain/wrapper/TestDomainWrapper.java
+++ b/modules/deployment-model-impl/src/test/java/org/mule/runtime/module/deployment/impl/internal/domain/wrapper/TestDomainWrapper.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2023 Salesforce, Inc. All rights reserved.
  */
-package org.mule.runtime.module.deployment.impl.internal.domain;
+package org.mule.runtime.module.deployment.impl.internal.domain.wrapper;
 
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.connectivity.ConnectivityTestingService;

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestApplicationFactory.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestApplicationFactory.java
@@ -31,7 +31,7 @@ import org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor;
 import org.mule.runtime.module.artifact.api.descriptor.DescriptorLoaderRepository;
 import org.mule.runtime.module.deployment.impl.internal.application.ApplicationDescriptorFactory;
 import org.mule.runtime.module.deployment.impl.internal.application.DefaultApplicationFactory;
-import org.mule.runtime.module.deployment.impl.internal.application.TestApplicationWrapper;
+import org.mule.runtime.module.deployment.impl.internal.application.wrapper.TestApplicationWrapper;
 import org.mule.runtime.module.deployment.impl.internal.artifact.DefaultArtifactDescriptorFactoryProvider;
 import org.mule.runtime.module.deployment.impl.internal.artifact.DefaultClassLoaderManager;
 import org.mule.runtime.module.deployment.impl.internal.domain.DomainManager;

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestDomainFactory.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/internal/TestDomainFactory.java
@@ -38,7 +38,7 @@ import org.mule.runtime.module.deployment.impl.internal.artifact.DefaultClassLoa
 import org.mule.runtime.module.deployment.impl.internal.domain.DefaultDomainFactory;
 import org.mule.runtime.module.deployment.impl.internal.domain.DefaultDomainManager;
 import org.mule.runtime.module.deployment.impl.internal.domain.DomainDescriptorFactory;
-import org.mule.runtime.module.deployment.impl.internal.domain.TestDomainWrapper;
+import org.mule.runtime.module.deployment.impl.internal.domain.wrapper.TestDomainWrapper;
 import org.mule.runtime.module.deployment.impl.internal.plugin.ArtifactPluginDescriptorLoader;
 import org.mule.runtime.module.license.api.LicenseValidator;
 

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/config/ConfigurationProviderObjectFactory.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/config/ConfigurationProviderObjectFactory.java
@@ -42,7 +42,7 @@ import java.util.Optional;
  *
  * @since 4.0
  */
-class ConfigurationProviderObjectFactory extends AbstractExtensionObjectFactory<ConfigurationProvider>
+public class ConfigurationProviderObjectFactory extends AbstractExtensionObjectFactory<ConfigurationProvider>
     implements ObjectFactory<ConfigurationProvider> {
 
   private final ExtensionModel extensionModel;
@@ -53,11 +53,11 @@ class ConfigurationProviderObjectFactory extends AbstractExtensionObjectFactory<
   private Optional<ConnectionProviderValueResolver> connectionProviderResolver = empty();
   private ConfigurationProvider instance;
   private boolean requiresConnection = false;
-  private LazyValue<String> configName = new LazyValue<>(this::getName);
+  private final LazyValue<String> configName = new LazyValue<>(this::getName);
 
-  ConfigurationProviderObjectFactory(ExtensionModel extensionModel,
-                                     ConfigurationModel configurationModel,
-                                     MuleContext muleContext) {
+  public ConfigurationProviderObjectFactory(ExtensionModel extensionModel,
+                                            ConfigurationModel configurationModel,
+                                            MuleContext muleContext) {
     super(muleContext);
     this.extensionModel = extensionModel;
     this.configurationModel = configurationModel;

--- a/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/config/dsl/XmlSdkConfigurationProviderFactory.java
+++ b/modules/extensions-xml-support/src/main/java/org/mule/runtime/extension/internal/config/dsl/XmlSdkConfigurationProviderFactory.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-class XmlSdkConfigurationProviderFactory extends AbstractExtensionObjectFactory<ConfigurationProvider> {
+public class XmlSdkConfigurationProviderFactory extends AbstractExtensionObjectFactory<ConfigurationProvider> {
 
   private final ExtensionModel extensionModel;
   private final ConfigurationModel configurationModel;

--- a/modules/launcher/src/test/java/org/mule/runtime/module/launcher/MuleContainerStartupSplashScreenTestCase.java
+++ b/modules/launcher/src/test/java/org/mule/runtime/module/launcher/MuleContainerStartupSplashScreenTestCase.java
@@ -4,14 +4,15 @@
 package org.mule.runtime.module.launcher;
 
 import static org.hamcrest.Matchers.not;
+
+import org.mule.runtime.module.deployment.impl.internal.base.AbstractSplashScreenTestCase;
+
 import static org.mule.runtime.container.api.MuleFoldersUtil.ARTIFACT_PATCHES_FOLDER;
 import static org.mule.runtime.core.api.util.FileUtils.newFile;
 import static org.mule.tck.junit4.matcher.StringContainsIgnoringLineBreaks.containsStringIgnoringLineBreaks;
 import static org.mule.test.allure.AllureConstants.ArtifactPatchingFeature.ARTIFACT_PATCHING;
 
 import static java.util.Arrays.asList;
-
-import org.mule.runtime.module.deployment.impl.internal.AbstractSplashScreenTestCase;
 
 import java.io.File;
 import java.util.List;

--- a/modules/service/src/main/java/org/mule/runtime/module/service/api/discoverer/MuleServiceModelLoader.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/api/discoverer/MuleServiceModelLoader.java
@@ -5,6 +5,7 @@ package org.mule.runtime.module.service.api.discoverer;
 
 import static org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor.MULE_ARTIFACT_JSON_DESCRIPTOR;
 import static org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor.MULE_ARTIFACT_PATH_INSIDE_JAR;
+import static org.mule.runtime.module.service.internal.util.ClassUtils.instantiateClass;
 
 import static java.lang.String.format;
 
@@ -12,7 +13,6 @@ import org.mule.runtime.api.deployment.meta.MuleServiceContractModel;
 import org.mule.runtime.api.deployment.meta.MuleServiceModel;
 import org.mule.runtime.api.deployment.persistence.MuleServiceModelJsonSerializer;
 import org.mule.runtime.api.service.ServiceProvider;
-import org.mule.runtime.core.api.util.ClassUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,9 +39,13 @@ public class MuleServiceModelLoader {
 
   public static ServiceProvider instantiateServiceProvider(MuleServiceContractModel contractModel) throws ServiceResolutionError {
     final String className = contractModel.getServiceProviderClassName();
+    return doInstantiateServiceProvider(className);
+  }
+
+  public static ServiceProvider doInstantiateServiceProvider(final String className) throws ServiceResolutionError {
     Object reflectedObject;
     try {
-      reflectedObject = ClassUtils.instantiateClass(className);
+      reflectedObject = instantiateClass(className);
     } catch (Exception e) {
       throw new ServiceResolutionError("Unable to create service from class: " + className, e);
     }
@@ -53,4 +57,5 @@ public class MuleServiceModelLoader {
 
     return (ServiceProvider) reflectedObject;
   }
+
 }

--- a/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/DefaultMethodInvoker.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/DefaultMethodInvoker.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2023 Salesforce, Inc. All rights reserved.
  */
-package org.mule.runtime.core.internal.util;
+package org.mule.runtime.module.service.internal.manager;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/LazyServiceProxy.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/LazyServiceProxy.java
@@ -26,8 +26,6 @@ import org.mule.runtime.api.util.LazyValue;
 import org.mule.runtime.core.api.Injector;
 import org.mule.runtime.core.api.util.func.CheckedRunnable;
 import org.mule.runtime.core.api.util.func.CheckedSupplier;
-import org.mule.runtime.core.internal.util.DefaultMethodInvoker;
-import org.mule.runtime.core.internal.util.MethodInvoker;
 import org.mule.runtime.core.internal.util.TypeSupplier;
 import org.mule.runtime.module.artifact.api.classloader.DisposableClassLoader;
 import org.mule.runtime.module.service.api.discoverer.ServiceAssembly;

--- a/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/LazyServiceProxyApplicationDecorator.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/LazyServiceProxyApplicationDecorator.java
@@ -5,7 +5,6 @@ package org.mule.runtime.module.service.internal.manager;
 
 import org.mule.runtime.api.service.Service;
 import org.mule.runtime.api.util.LazyValue;
-import org.mule.runtime.core.internal.util.MethodInvoker;
 import org.mule.runtime.module.service.api.discoverer.ServiceAssembly;
 
 /**

--- a/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/MethodInvoker.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/internal/manager/MethodInvoker.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2023 Salesforce, Inc. All rights reserved.
  */
-package org.mule.runtime.core.internal.util;
+package org.mule.runtime.module.service.internal.manager;
 
 import java.lang.reflect.Method;
 

--- a/modules/service/src/main/java/org/mule/runtime/module/service/internal/util/ClassUtils.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/internal/util/ClassUtils.java
@@ -25,24 +25,8 @@ import java.util.Set;
  */
 public class ClassUtils {
 
-  // public static final Object[] NO_ARGS = new Object[] {};
-  // public static final Class<?>[] NO_ARGS_TYPE = new Class<?>[] {};
-  //
   private static final Map<Class<?>, Class<?>> wrapperToPrimitiveMap = new HashMap<>();
   private static final Map<String, Class<?>> primitiveTypeNameMap = new HashMap<>(32);
-  // public static final String MULE_DESIGN_MODE = "mule.designMode";
-  //
-  // private static LazyValue<ClassLoaderResourceNotFoundExceptionFactory> resourceNotFoundExceptionFactoryLazyValue =
-  // new LazyValue(() -> {
-  // return stream(((Iterable<ClassLoaderResourceNotFoundExceptionFactory>) () ->
-  // load(ClassLoaderResourceNotFoundExceptionFactory.class,
-  // ClassUtils.class.getClassLoader())
-  // .iterator())
-  // .spliterator(),
-  // false)
-  // .findFirst()
-  // .orElseGet(() -> getDefaultFactory());
-  // });
 
   static {
     wrapperToPrimitiveMap.put(Boolean.class, Boolean.TYPE);
@@ -225,13 +209,6 @@ public class ClassUtils {
       NoSuchMethodException, IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException {
     return instantiateClass(name, constructorArgs, (ClassLoader) null);
   }
-
-  // public static Object instantiateClass(String name, Object[] constructorArgs, Class<?> callingClass)
-  // throws ClassNotFoundException, SecurityException, NoSuchMethodException, IllegalArgumentException, InstantiationException,
-  // IllegalAccessException, InvocationTargetException {
-  // Class<?> clazz = loadClass(name, callingClass);
-  // return instantiateClass(clazz, constructorArgs);
-  // }
 
   public static Object instantiateClass(String name, Object[] constructorArgs, ClassLoader classLoader)
       throws ClassNotFoundException, SecurityException, NoSuchMethodException, IllegalArgumentException, InstantiationException,

--- a/modules/service/src/main/java/org/mule/runtime/module/service/internal/util/ClassUtils.java
+++ b/modules/service/src/main/java/org/mule/runtime/module/service/internal/util/ClassUtils.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ */
+package org.mule.runtime.module.service.internal.util;
+
+import static org.mule.metadata.java.api.utils.ClassUtils.getInnerClassName;
+import static org.mule.runtime.core.api.util.ClassLoaderResourceNotFoundExceptionFactory.getDefaultFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Extend the Apache Commons ClassUtils to provide additional functionality.
+ * <p/>
+ * <p>
+ * This class is useful for loading resources and classes in a fault tolerant manner that works across different applications
+ * servers. The resource and classloading methods are SecurityManager friendly.
+ * </p>
+ */
+public class ClassUtils {
+
+  // public static final Object[] NO_ARGS = new Object[] {};
+  // public static final Class<?>[] NO_ARGS_TYPE = new Class<?>[] {};
+  //
+  private static final Map<Class<?>, Class<?>> wrapperToPrimitiveMap = new HashMap<>();
+  private static final Map<String, Class<?>> primitiveTypeNameMap = new HashMap<>(32);
+  // public static final String MULE_DESIGN_MODE = "mule.designMode";
+  //
+  // private static LazyValue<ClassLoaderResourceNotFoundExceptionFactory> resourceNotFoundExceptionFactoryLazyValue =
+  // new LazyValue(() -> {
+  // return stream(((Iterable<ClassLoaderResourceNotFoundExceptionFactory>) () ->
+  // load(ClassLoaderResourceNotFoundExceptionFactory.class,
+  // ClassUtils.class.getClassLoader())
+  // .iterator())
+  // .spliterator(),
+  // false)
+  // .findFirst()
+  // .orElseGet(() -> getDefaultFactory());
+  // });
+
+  static {
+    wrapperToPrimitiveMap.put(Boolean.class, Boolean.TYPE);
+    wrapperToPrimitiveMap.put(Byte.class, Byte.TYPE);
+    wrapperToPrimitiveMap.put(Character.class, Character.TYPE);
+    wrapperToPrimitiveMap.put(Short.class, Short.TYPE);
+    wrapperToPrimitiveMap.put(Integer.class, Integer.TYPE);
+    wrapperToPrimitiveMap.put(Long.class, Long.TYPE);
+    wrapperToPrimitiveMap.put(Double.class, Double.TYPE);
+    wrapperToPrimitiveMap.put(Float.class, Float.TYPE);
+    wrapperToPrimitiveMap.put(Void.TYPE, Void.TYPE);
+
+    Set<Class<?>> primitiveTypes = new HashSet<>(32);
+    primitiveTypes.addAll(wrapperToPrimitiveMap.values());
+    for (Class<?> primitiveType : primitiveTypes) {
+      primitiveTypeNameMap.put(primitiveType.getName(), primitiveType);
+    }
+  }
+
+  /**
+   * Load a class with a given name.
+   * <p/>
+   * It will try to load the class in the following order:
+   * <ul>
+   * <li>From {@link Thread#getContextClassLoader() Thread.currentThread().getContextClassLoader()}
+   * <li>Using the basic {@link Class#forName(java.lang.String) }
+   * <li>From {@link Class#getClassLoader() ClassLoaderUtil.class.getClassLoader()}
+   * <li>From the {@link Class#getClassLoader() callingClass.getClassLoader() }
+   * </ul>
+   *
+   * @param className    The name of the class to load
+   * @param callingClass The Class object of the calling object
+   * @return The Class instance
+   * @throws ClassNotFoundException If the class cannot be found anywhere.
+   */
+  public static Class loadClass(final String className, final Class<?> callingClass) throws ClassNotFoundException {
+    return loadClass(className, callingClass, Object.class);
+  }
+
+  /**
+   * Load a class with a given name.
+   * <p/>
+   * It will try to load the class in the following order:
+   * <ul>
+   * <li>From {@link Thread#getContextClassLoader() Thread.currentThread().getContextClassLoader()}
+   * <li>Using the basic {@link Class#forName(java.lang.String) }
+   * <li>From {@link Class#getClassLoader() ClassLoaderUtil.class.getClassLoader()}
+   * <li>From the {@link Class#getClassLoader() callingClass.getClassLoader() }
+   * </ul>
+   *
+   * @param className    The name of the class to load
+   * @param callingClass The Class object of the calling object
+   * @param type         the class type to expect to load
+   * @return The Class instance
+   * @throws ClassNotFoundException If the class cannot be found anywhere.
+   */
+  public static <T extends Class> T loadClass(final String className, final Class<?> callingClass, T type)
+      throws ClassNotFoundException {
+    if (className.length() <= 8) {
+      // Could be a primitive - likely.
+      if (primitiveTypeNameMap.containsKey(className)) {
+        return (T) primitiveTypeNameMap.get(className);
+      }
+    }
+
+    Class<?> clazz = AccessController.doPrivileged((PrivilegedAction<Class<?>>) () -> {
+      try {
+        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        return cl != null ? cl.loadClass(className) : null;
+
+      } catch (ClassNotFoundException e) {
+        return null;
+      }
+    });
+
+    if (clazz == null) {
+      clazz = AccessController.doPrivileged((PrivilegedAction<Class<?>>) () -> {
+        try {
+          return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+          return null;
+        }
+      });
+    }
+
+    if (clazz == null) {
+      clazz = AccessController.doPrivileged((PrivilegedAction<Class<?>>) () -> {
+        try {
+          return ClassUtils.class.getClassLoader().loadClass(className);
+        } catch (ClassNotFoundException e) {
+          return null;
+        }
+      });
+    }
+
+    if (clazz == null) {
+      clazz = AccessController.doPrivileged((PrivilegedAction<Class<?>>) () -> {
+        try {
+          return callingClass.getClassLoader().loadClass(className);
+        } catch (ClassNotFoundException e) {
+          return null;
+        }
+      });
+    }
+
+    if (clazz == null) {
+      throw new ClassNotFoundException(className);
+    }
+
+    if (type.isAssignableFrom(clazz)) {
+      return (T) clazz;
+    } else {
+      throw new IllegalArgumentException(String.format("Loaded class '%s' is not assignable from type '%s'", clazz.getName(),
+                                                       type.getName()));
+    }
+  }
+
+  /**
+   * Load a class with a given name from the given classloader.
+   * <p/>
+   * This method must be used when the resource to load it's dependant on user configuration.
+   *
+   * @param className   the name of the class to load
+   * @param classLoader the loader to load it from
+   * @return the instance of the class
+   * @throws ClassNotFoundException if the class is not available in the class loader
+   */
+  public static Class loadClass(final String className, final ClassLoader classLoader) throws ClassNotFoundException {
+    Class<?> clazz;
+    try {
+      clazz = classLoader.loadClass(className);
+    } catch (ClassNotFoundException e) {
+      try {
+        clazz = classLoader.loadClass(getInnerClassName(className));
+      } catch (ClassNotFoundException e2) {
+        throw getDefaultFactory().createClassNotFoundException(className, classLoader);
+      }
+    }
+    return clazz;
+  }
+
+  public static <T> T instantiateClass(Class<? extends T> clazz, Object... constructorArgs) throws SecurityException,
+      NoSuchMethodException, IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException {
+    Class<?>[] args;
+    if (constructorArgs != null) {
+      args = new Class[constructorArgs.length];
+      for (int i = 0; i < constructorArgs.length; i++) {
+        if (constructorArgs[i] == null) {
+          args[i] = null;
+        } else {
+          args[i] = constructorArgs[i].getClass();
+        }
+      }
+    } else {
+      args = new Class[0];
+    }
+
+    // try the arguments as given
+    // Constructor ctor = clazz.getConstructor(args);
+    Constructor<?> ctor = getConstructor(clazz, args);
+
+    if (ctor == null) {
+      // try again but adapt value classes to primitives
+      ctor = getConstructor(clazz, wrappersToPrimitives(args));
+    }
+
+    if (ctor == null) {
+      StringBuilder argsString = new StringBuilder(100);
+      for (Class<?> arg : args) {
+        argsString.append(arg.getName()).append(", ");
+      }
+      throw new NoSuchMethodException("could not find constructor on class: " + clazz + ", with matching arg params: "
+          + argsString);
+    }
+
+    return (T) ctor.newInstance(constructorArgs);
+  }
+
+  public static Object instantiateClass(String name, Object... constructorArgs) throws ClassNotFoundException, SecurityException,
+      NoSuchMethodException, IllegalArgumentException, InstantiationException, IllegalAccessException, InvocationTargetException {
+    return instantiateClass(name, constructorArgs, (ClassLoader) null);
+  }
+
+  // public static Object instantiateClass(String name, Object[] constructorArgs, Class<?> callingClass)
+  // throws ClassNotFoundException, SecurityException, NoSuchMethodException, IllegalArgumentException, InstantiationException,
+  // IllegalAccessException, InvocationTargetException {
+  // Class<?> clazz = loadClass(name, callingClass);
+  // return instantiateClass(clazz, constructorArgs);
+  // }
+
+  public static Object instantiateClass(String name, Object[] constructorArgs, ClassLoader classLoader)
+      throws ClassNotFoundException, SecurityException, NoSuchMethodException, IllegalArgumentException, InstantiationException,
+      IllegalAccessException, InvocationTargetException {
+    Class<?> clazz;
+    if (classLoader != null) {
+      clazz = loadClass(name, classLoader);
+    } else {
+      clazz = loadClass(name, ClassUtils.class);
+    }
+    if (clazz == null) {
+      throw new ClassNotFoundException(name);
+    }
+    return instantiateClass(clazz, constructorArgs);
+  }
+
+  public static Constructor getConstructor(Class clazz, Class[] paramTypes) {
+    return getConstructor(clazz, paramTypes, false);
+  }
+
+  /**
+   * Returns available constructor in the target class that as the parameters specified.
+   *
+   * @param clazz      the class to search
+   * @param paramTypes the param types to match against
+   * @param exactMatch should exact types be used (i.e. equals rather than isAssignableFrom.)
+   * @return The matching constructor or null if no matching constructor is found
+   */
+  public static Constructor getConstructor(Class clazz, Class[] paramTypes, boolean exactMatch) {
+    for (Constructor ctor : clazz.getConstructors()) {
+      Class[] types = ctor.getParameterTypes();
+      if (types.length == paramTypes.length) {
+        int matchCount = 0;
+        for (int x = 0; x < types.length; x++) {
+          if (paramTypes[x] == null) {
+            matchCount++;
+          } else {
+            if (exactMatch) {
+              if (paramTypes[x].equals(types[x]) || types[x].equals(paramTypes[x])) {
+                matchCount++;
+              }
+            } else {
+              if (paramTypes[x].isAssignableFrom(types[x]) || types[x].isAssignableFrom(paramTypes[x])) {
+                matchCount++;
+              }
+            }
+          }
+        }
+        if (matchCount == types.length) {
+          return ctor;
+        }
+      }
+    }
+    return null;
+  }
+
+  public static Class[] wrappersToPrimitives(Class[] wrappers) {
+    if (wrappers == null) {
+      return null;
+    }
+
+    if (wrappers.length == 0) {
+      return wrappers;
+    }
+
+    Class[] primitives = new Class[wrappers.length];
+
+    for (int i = 0; i < wrappers.length; i++) {
+      primitives[i] = wrapperToPrimitiveMap.getOrDefault(wrappers[i], wrappers[i]);
+    }
+
+    return primitives;
+  }
+
+  private ClassUtils() {}
+}

--- a/modules/service/src/test/java/org/mule/runtime/module/service/internal/test/manager/DefaultMethodInvokerTestCase.java
+++ b/modules/service/src/test/java/org/mule/runtime/module/service/internal/test/manager/DefaultMethodInvokerTestCase.java
@@ -1,12 +1,13 @@
 /*
  * Copyright 2023 Salesforce, Inc. All rights reserved.
  */
-package org.mule.runtime.core.internal.util;
+package org.mule.runtime.module.service.internal.test.manager;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.rules.ExpectedException.none;
 
+import org.mule.runtime.module.service.internal.manager.DefaultMethodInvoker;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
 
@@ -26,7 +27,7 @@ public class DefaultMethodInvokerTestCase extends AbstractMuleTestCase {
   @Rule
   public ExpectedException expectedException = none();
 
-  private DefaultMethodInvoker defaultMethodInvoker = new DefaultMethodInvoker();
+  private final DefaultMethodInvoker defaultMethodInvoker = new DefaultMethodInvoker();
 
   @Test
   public void callCorrectMethod() throws Throwable {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/service/InjectParamsFromContextServiceMethodInvoker.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/service/InjectParamsFromContextServiceMethodInvoker.java
@@ -14,8 +14,8 @@ import org.mule.runtime.api.service.Service;
 import org.mule.runtime.api.util.Pair;
 import org.mule.runtime.core.api.registry.IllegalDependencyInjectionException;
 import org.mule.runtime.core.internal.config.preferred.PreferredObjectSelector;
-import org.mule.runtime.core.internal.util.DefaultMethodInvoker;
-import org.mule.runtime.core.internal.util.MethodInvoker;
+import org.mule.runtime.module.service.internal.manager.DefaultMethodInvoker;
+import org.mule.runtime.module.service.internal.manager.MethodInvoker;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ObjectFactoryClassRepository.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/spring/ObjectFactoryClassRepository.java
@@ -70,10 +70,15 @@ public class ObjectFactoryClassRepository {
       String name;
       boolean callingSuper = ObjectTypeProvider.class.isAssignableFrom(objectFactoryType);
 
+      // Make sure the generated class exists in a module that has visibility on all the required superclasses and interfaces.
+      // spring-config has that scope.
+      String packageName = this.getClass().getPackage().getName();
       if (callingSuper) {
-        name = objectFactoryType.getName() + "_ByteBuddy_CallingSuperGetObjectType";
+        name = packageName + "." +
+            objectFactoryType.getSimpleName() + "_ByteBuddy_CallingSuperGetObjectType";
       } else {
-        name = objectFactoryType.getName() + "_ByteBuddy_" + objectTypeClass.getName().replace(".", "_");
+        name = packageName + "." +
+            objectFactoryType.getSimpleName() + "_ByteBuddy_" + objectTypeClass.getName().replace(".", "_");
       }
 
       ClassLoader classLoader = multiParentClassLoaderFor(objectFactoryType.getClassLoader());
@@ -82,7 +87,9 @@ public class ObjectFactoryClassRepository {
       } catch (ClassNotFoundException e) {
         // class doesn't exist, generate
       }
-      return createObjectFactoryDynamicClass(objectFactoryType, name, classLoader, callingSuper, objectTypeClass);
+      final Class createObjectFactoryDynamicClass =
+          createObjectFactoryDynamicClass(objectFactoryType, name, classLoader, callingSuper, objectTypeClass);
+      return createObjectFactoryDynamicClass;
     }
   }
 

--- a/tests/component-plugin/src/main/java/org/mule/functional/api/component/StacktraceLogChecker.java
+++ b/tests/component-plugin/src/main/java/org/mule/functional/api/component/StacktraceLogChecker.java
@@ -158,9 +158,12 @@ public class StacktraceLogChecker extends AbstractLogChecker {
             return false;
           }
           if (thisCall.packageName != null && otherCall.packageName != null) {
-            final Matcher matcher = PACKAGE_WITH_MODULE_PATTERN.matcher(otherCall.packageName);
-            if (!matcher.matches() || !thisCall.packageName.equals(matcher.group(1))) {
-              return false;
+            if (!thisCall.packageName.equals(otherCall.packageName)) {
+              // It may be different because it has module information...
+              final Matcher matcher = PACKAGE_WITH_MODULE_PATTERN.matcher(otherCall.packageName);
+              if (!matcher.matches() || !thisCall.packageName.equals(matcher.group(1))) {
+                return false;
+              }
             }
           }
           if (thisCall.lineNumber != null && otherCall.lineNumber != null && !thisCall.lineNumber.equals(otherCall.lineNumber)) {

--- a/tests/unit/src/main/java/org/mule/tck/core/internal/serialization/AbstractSerializerProtocolContractTestCase.java
+++ b/tests/unit/src/main/java/org/mule/tck/core/internal/serialization/AbstractSerializerProtocolContractTestCase.java
@@ -6,11 +6,10 @@ package org.mule.tck.core.internal.serialization;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.tck.util.MuleContextUtils.eventBuilder;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
 
 import org.mule.runtime.api.serialization.SerializationProtocol;
 import org.mule.runtime.core.api.event.CoreEvent;
@@ -38,7 +37,7 @@ public abstract class AbstractSerializerProtocolContractTestCase extends Abstrac
 
     private final InputStream inputStream;
 
-    private AtomicInteger closeCount = new AtomicInteger();
+    private final AtomicInteger closeCount = new AtomicInteger();
 
     public CloseCounterInputStreamWrapper(InputStream inputStream) {
       this.inputStream = inputStream;
@@ -49,6 +48,7 @@ public abstract class AbstractSerializerProtocolContractTestCase extends Abstrac
       return inputStream.read();
     }
 
+    @Override
     public void close() throws IOException {
       closeCount.incrementAndGet();
       inputStream.close();
@@ -63,12 +63,12 @@ public abstract class AbstractSerializerProtocolContractTestCase extends Abstrac
 
   protected SerializationProtocol serializationProtocol;
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public final void nullBytes() throws Exception {
     serializationProtocol.deserialize((byte[]) null);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public final void nullStream() throws Exception {
     serializationProtocol.deserialize((InputStream) null);
   }
@@ -77,7 +77,7 @@ public abstract class AbstractSerializerProtocolContractTestCase extends Abstrac
   public final void nullObject() throws Exception {
     byte[] bytes = serializationProtocol.serialize(null);
     Object object = serializationProtocol.deserialize(bytes);
-    assertNull(object);
+    assertThat(object, nullValue());
   }
 
   @Test
@@ -105,7 +105,7 @@ public abstract class AbstractSerializerProtocolContractTestCase extends Abstrac
     InternalMessage message = serializationProtocol.deserialize(bytes);
     DateTime deserealized = (DateTime) message.getPayload().getValue();
 
-    assertEquals(calendar, deserealized.toCalendar());
-    assertEquals(dateTime.format(), deserealized.format());
+    assertThat(calendar, equalTo(deserealized.toCalendar()));
+    assertThat(dateTime.format(), equalTo(deserealized.format()));
   }
 }


### PR DESCRIPTION
* Move `MethodInvoker` to service module
* Make stack trace checker aware of modules
* Generate dynamic classes in the module where it has the required visibility to required modules
* Avoid split packages between deployment-model-impl and its test-jar