### PR TITLE
W-13815733: Broken test - Fix and unignore broken tests payloadInfoNo…

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/api/MessagingExceptionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/MessagingExceptionTestCase.java
@@ -256,24 +256,6 @@ public class MessagingExceptionTestCase extends AbstractMuleContextTestCase {
   }
 
   @Test
-  @Ignore("MULE-10266 review how the transformationService is obtained when building an exception.")
-  public void payloadInfoNonConsumable() throws Exception {
-    MuleException.verboseExceptions = true;
-
-    CoreEvent testEvent = mock(CoreEvent.class);
-    Object payload = mock(Object.class);
-    // This has to be done this way since mockito doesn't allow to verify toString()
-    when(payload.toString()).then(new FailAnswer("toString() expected not to be called."));
-    Message muleMessage = of(payload);
-
-    when(transformationService.transform(muleMessage, DataType.STRING)).thenReturn(of(value));
-    when(testEvent.getMessage()).thenReturn(muleMessage);
-    MessagingException e = new MessagingException(createStaticMessage(message), testEvent);
-
-    assertThat(e.getInfo().get(PAYLOAD_INFO_KEY), is(value));
-  }
-
-  @Test
   public void payloadInfoConsumable() throws Exception {
     MuleException.verboseExceptions = true;
 
@@ -287,26 +269,6 @@ public class MessagingExceptionTestCase extends AbstractMuleContextTestCase {
     assertThat((String) e.getInfo().get(PAYLOAD_INFO_KEY), containsString(ByteArrayInputStream.class.getName() + "@"));
 
     verify(transformationService, never()).transform(muleMessage, DataType.STRING);
-  }
-
-  @Test
-  @Ignore("MULE-10266 review how the transformationService is obtained when building an exception.")
-  public void payloadInfoException() throws Exception {
-    MuleException.verboseExceptions = true;
-
-    CoreEvent testEvent = mock(CoreEvent.class);
-    Object payload = mock(Object.class);
-    // This has to be done this way since mockito doesn't allow to verify toString()
-    when(payload.toString()).then(new FailAnswer("toString() expected not to be called."));
-    Message muleMessage = of(payload);
-
-    when(transformationService.transform(muleMessage, DataType.STRING))
-        .thenThrow(new TransformerException(createStaticMessage("exception thrown")));
-    when(testEvent.getMessage()).thenReturn(muleMessage);
-    MessagingException e = new MessagingException(createStaticMessage(message), testEvent);
-
-    assertThat(e.getInfo().get(PAYLOAD_INFO_KEY),
-               is(TransformerException.class.getName() + " while getting payload: exception thrown"));
   }
 
   @Test

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/MessagingException.java
@@ -105,17 +105,6 @@ public class MessagingException extends EventProcessingException {
         } else {
           if (payload != null) {
             addInfo(PAYLOAD_TYPE_INFO_KEY, muleMessage.getPayload().getDataType().getType().getName());
-            if (muleContext != null) {
-              // TODO MULE-10266 review how the transformationService is obtained when building an exception.
-              try {
-                addInfo(PAYLOAD_INFO_KEY,
-                        muleContext.getTransformationService().transform(muleMessage, DataType.STRING).getPayload()
-                            .getValue());
-              } catch (Exception e) {
-                addInfo(PAYLOAD_INFO_KEY, format("%s while getting payload: %s", e.getClass().getName(), e.getMessage()));
-              }
-              addInfo(PAYLOAD_INFO_KEY, muleMessage.toString());
-            }
           } else {
             addInfo(PAYLOAD_TYPE_INFO_KEY, Objects.toString(null));
             addInfo(PAYLOAD_INFO_KEY, Objects.toString(null));


### PR DESCRIPTION
…nConsumable and payloadInfoException from MessagingExceptionTestCase

These tests were failing because the behavior they were testing was in fact not happening. The tests were ignored on [this](https://github.com/mulesoft/mule/commit/7f54ae96c3eabd9846462c06cfdb35376d2356b4) commit. 
The following block of code was removed, since it was never executed:
```java
            if (muleContext != null) {
              // TODO MULE-10266 review how the transformationService is obtained when building an exception.
              try {
                addInfo(PAYLOAD_INFO_KEY,
                        muleContext.getTransformationService().transform(muleMessage, DataType.STRING).getPayload()
                            .getValue());
              } catch (Exception e) {
                addInfo(PAYLOAD_INFO_KEY, format("%s while getting payload: %s", e.getClass().getName(), e.getMessage()));
              }
              addInfo(PAYLOAD_INFO_KEY, muleMessage.toString());
            }
```

Method `generateMessage(I18nMessage message, MuleContext muleContext)` is a protected method that was always called with muleContext -> null.
Since this code was never used and also caused tests to be ignored. We are removing it.