### PR TITLE
W-10781591: Add an override to re-enable org.mule.runtime.core.privileged.registry.ObjectProcessor

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/JSR250ObjectLifcycleTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/lifecycle/JSR250ObjectLifcycleTestCase.java
@@ -3,21 +3,30 @@
  */
 package org.mule.runtime.core.internal.lifecycle;
 
+import static org.mule.runtime.api.util.MuleSystemProperties.DISABLE_APPLY_OBJECT_PROCESSOR_PROPERTY;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.junit4.rule.SystemProperty;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * Test lifecycle behaviour and restrictions on lifecyce methods
  */
+// TODO W-10781591 Remove this test
 public class JSR250ObjectLifcycleTestCase extends AbstractMuleContextTestCase {
+
+  // This tests specifically tests features provided by ObjectProcessors
+  @Rule
+  public SystemProperty disableApplyObjectProcessor = new SystemProperty(DISABLE_APPLY_OBJECT_PROCESSOR_PROPERTY, "false");
 
   @Test
   public void testNormalBehaviour() throws Exception {

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/registry/AbstractLifecycleTracker.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/registry/AbstractLifecycleTracker.java
@@ -3,14 +3,16 @@
  */
 package org.mule.runtime.core.internal.registry;
 
-import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.core.api.context.MuleContextAware;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.lifecycle.Lifecycle;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.context.MuleContextAware;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.inject.Inject;
 
 public abstract class AbstractLifecycleTracker implements Lifecycle, MuleContextAware {
 
@@ -24,22 +26,27 @@ public abstract class AbstractLifecycleTracker implements Lifecycle, MuleContext
     tracker.add("setProperty");
   }
 
+  @Inject
   public void setMuleContext(final MuleContext context) {
     tracker.add("setMuleContext");
   }
 
+  @Override
   public void initialise() throws InitialisationException {
     tracker.add("initialise");
   }
 
+  @Override
   public void start() throws MuleException {
     tracker.add("start");
   }
 
+  @Override
   public void stop() throws MuleException {
     tracker.add("stop");
   }
 
+  @Override
   public void dispose() {
     tracker.add("dispose");
   }

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/registry/RegistrationAndInjectionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/registry/RegistrationAndInjectionTestCase.java
@@ -3,6 +3,7 @@
  */
 package org.mule.runtime.core.internal.registry;
 
+import static org.mule.runtime.api.util.MuleSystemProperties.DISABLE_APPLY_OBJECT_PROCESSOR_PROPERTY;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_STORE_MANAGER;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -21,10 +22,12 @@ import org.mule.runtime.core.api.lifecycle.LifecycleStateAware;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.junit4.rule.SystemProperty;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 public class RegistrationAndInjectionTestCase extends AbstractMuleContextTestCase {
@@ -32,6 +35,10 @@ public class RegistrationAndInjectionTestCase extends AbstractMuleContextTestCas
   private static final String KEY = "key";
   private static final String KEY2 = "key2";
   private static final String EXTENDED_KEY = "extendedKey";
+
+  // TODO W-10781591 Remove this, some tests specifically tests features provided by ObjectProcessors
+  @Rule
+  public SystemProperty disableApplyObjectProcessor = new SystemProperty(DISABLE_APPLY_OBJECT_PROCESSOR_PROPERTY, "false");
 
   public RegistrationAndInjectionTestCase() {
     setStartContext(true);
@@ -87,6 +94,7 @@ public class RegistrationAndInjectionTestCase extends AbstractMuleContextTestCas
     assertThat(object.getKey2Child(), is(sameInstance(child2)));
   }
 
+  // TODO W-10781591 Remove this test
   @Test
   public void muleContextAware() throws Exception {
     MuleContextAware muleContextAware = mock(MuleContextAware.class);
@@ -95,6 +103,7 @@ public class RegistrationAndInjectionTestCase extends AbstractMuleContextTestCas
     verify(muleContextAware).setMuleContext(muleContext);
   }
 
+  //TODO W-10781591 Remove this test
   @Test
   public void lifecycleSateAware() throws Exception {
     LifecycleStateAware lifecycleStateAware = mock(LifecycleStateAware.class);

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/registry/RegistrationAndInjectionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/registry/RegistrationAndInjectionTestCase.java
@@ -103,7 +103,7 @@ public class RegistrationAndInjectionTestCase extends AbstractMuleContextTestCas
     verify(muleContextAware).setMuleContext(muleContext);
   }
 
-  //TODO W-10781591 Remove this test
+  // TODO W-10781591 Remove this test
   @Test
   public void lifecycleSateAware() throws Exception {
     LifecycleStateAware lifecycleStateAware = mock(LifecycleStateAware.class);

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/registry/SimpleRegistryTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/registry/SimpleRegistryTestCase.java
@@ -28,9 +28,11 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
 
 import org.junit.Test;
-import org.slf4j.Logger;
 
 public class SimpleRegistryTestCase extends AbstractMuleContextTestCase {
 
@@ -243,6 +245,7 @@ public class SimpleRegistryTestCase extends AbstractMuleContextTestCase {
     }
 
     @Override
+    @Inject
     public void setMuleContext(MuleContext context) {
       tracker.add("setMuleContext");
     }

--- a/core/api-changes.json
+++ b/core/api-changes.json
@@ -1,4 +1,50 @@
 {
+  "4.6.0": {
+    "revapi": {
+      "ignore": [
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext)",
+          "new": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext)",
+          "annotation": "@javax.inject.Inject",
+          "justification": "W-10781591: Migrate uses of MuleContextAware to @Inject"
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.api.util.compression.AbstractCompressionTransformer",
+          "new": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.api.util.compression.AbstractCompressionTransformer",
+          "annotation": "@javax.inject.Inject",
+          "justification": "W-10781591: Migrate uses of MuleContextAware to @Inject"
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.privileged.transformer.simple.ByteArrayToObject",
+          "new": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.privileged.transformer.simple.ByteArrayToObject",
+          "annotation": "@javax.inject.Inject",
+          "justification": "W-10781591: Migrate uses of MuleContextAware to @Inject"
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.privileged.transformer.simple.ByteArrayToSerializable",
+          "new": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.privileged.transformer.simple.ByteArrayToSerializable",
+          "annotation": "@javax.inject.Inject",
+          "justification": "W-10781591: Migrate uses of MuleContextAware to @Inject"
+        },
+        {
+          "ignore": true,
+          "code": "java.annotation.added",
+          "old": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.privileged.transformer.simple.SerializableToByteArray",
+          "new": "method void org.mule.runtime.core.api.transformer.AbstractTransformer::setMuleContext(org.mule.runtime.core.api.MuleContext) @ org.mule.runtime.core.privileged.transformer.simple.SerializableToByteArray",
+          "annotation": "@javax.inject.Inject",
+          "justification": "W-10781591: Migrate uses of MuleContextAware to @Inject"
+        }
+      ]
+    }
+  },
   "4.5.0": {
     "revapi": {
       "ignore": [

--- a/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractTransformer.java
+++ b/core/src/main/java/org/mule/runtime/core/api/transformer/AbstractTransformer.java
@@ -3,13 +3,14 @@
  */
 package org.mule.runtime.core.api.transformer;
 
-import static java.lang.String.format;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Objects.hash;
 import static org.mule.runtime.api.metadata.DataType.builder;
 import static org.mule.runtime.core.api.config.i18n.CoreMessages.transformOnObjectUnsupportedTypeOfEndpoint;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
 import static org.mule.runtime.core.privileged.transformer.TransformerUtils.checkTransformerReturnClass;
+
+import static java.lang.String.format;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.hash;
 
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.exception.MuleException;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import javax.inject.Inject;
 import javax.xml.transform.stream.StreamSource;
 
 import org.slf4j.Logger;
@@ -324,6 +326,7 @@ public abstract class AbstractTransformer extends AbstractComponent implements T
   }
 
   @Override
+  @Inject
   public void setMuleContext(MuleContext context) {
     this.muleContext = context;
   }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
@@ -416,6 +416,7 @@ public abstract class ExtensionComponent<T extends ComponentModel> extends Abstr
   }
 
   @Override
+  @Inject
   public void setMuleContext(MuleContext context) {
     this.muleContext = context;
   }


### PR DESCRIPTION
* Add missing `@Inject`s in place of `MuleContextAware` as well

The change in versions here [https://github.com/mulesoft/mule/commit/eab4a07ed81edb1b6d165891a83fffd89574d793#diff-79bb75c81a90314417641f26bc4[…]bc4e502ede56b7ba101b898d171L1445](https://github.com/mulesoft/mule/commit/eab4a07ed81edb1b6d165891a83fffd89574d793#diff-79bb75c81a90314417641f26bc4782e51ec70bc4e502ede56b7ba101b898d171L1445) broke tests because it applied the FF to disable the application of `org.mule.runtime.core.privileged.registry.ObjectProcessor`s