### PR TITLE
W-12276645: Reverting back to ComponentMessageProcessor for legacy ExtensionsClient API.

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClient.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/DefaultExtensionsClient.java
@@ -8,8 +8,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.stopIfNeeded;
-import static org.mule.runtime.core.internal.util.FunctionalUtils.withNullEvent;
-import static org.mule.runtime.internal.dsl.DslConstants.CONFIG_ATTRIBUTE_NAME;
+import static org.mule.runtime.core.api.rx.Exceptions.unwrap;
 import static org.mule.runtime.module.extension.internal.runtime.client.operation.OperationClient.from;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.findOperation;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.findSource;
@@ -21,7 +20,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static org.slf4j.LoggerFactory.getLogger;
+import static reactor.core.publisher.Mono.just;
 
+import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
 import org.mule.runtime.api.exception.MuleException;
@@ -38,6 +39,8 @@ import org.mule.runtime.core.api.el.ExpressionManager;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.core.api.streaming.StreamingManager;
+import org.mule.runtime.core.internal.exception.MessagingException;
+import org.mule.runtime.core.internal.policy.PolicyManager;
 import org.mule.runtime.core.privileged.exception.ErrorTypeLocator;
 import org.mule.runtime.extension.api.client.ExtensionsClient;
 import org.mule.runtime.extension.api.client.OperationParameterizer;
@@ -46,32 +49,26 @@ import org.mule.runtime.extension.api.client.source.SourceHandler;
 import org.mule.runtime.extension.api.client.source.SourceParameterizer;
 import org.mule.runtime.extension.api.client.source.SourceResultHandler;
 import org.mule.runtime.extension.api.runtime.operation.Result;
-import org.mule.runtime.extension.internal.client.ComplexParameter;
-import org.mule.runtime.extension.internal.property.PagedOperationModelProperty;
 import org.mule.runtime.module.extension.internal.runtime.client.operation.DefaultOperationParameterizer;
-import org.mule.runtime.module.extension.internal.runtime.client.operation.EventedOperationsParameterDecorator;
 import org.mule.runtime.module.extension.internal.runtime.client.operation.OperationClient;
 import org.mule.runtime.module.extension.internal.runtime.client.operation.OperationKey;
 import org.mule.runtime.module.extension.internal.runtime.client.source.DefaultSourceHandler;
 import org.mule.runtime.module.extension.internal.runtime.client.source.SourceClient;
 import org.mule.runtime.module.extension.internal.runtime.connectivity.ExtensionConnectionSupplier;
-import org.mule.runtime.module.extension.internal.runtime.objectbuilder.DefaultObjectBuilder;
-import org.mule.runtime.module.extension.internal.runtime.resolver.StaticValueResolver;
-import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolvingContext;
+import org.mule.runtime.module.extension.internal.runtime.operation.OperationMessageProcessor;
 import org.mule.runtime.module.extension.internal.util.ReflectionCache;
 import org.mule.runtime.tracer.api.component.ComponentTracerFactory;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import javax.inject.Inject;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.slf4j.Logger;
@@ -124,6 +121,14 @@ public final class DefaultExtensionsClient implements ExtensionsClient, Initiali
   private ExecutorService cacheShutdownExecutor;
   private LoadingCache<OperationKey, OperationClient> operationClientCache;
   private Set<SourceClient> sourceClients = new HashSet<>();
+
+  // TODO: remove once performance degradation is fixed.
+  @Inject
+  private Registry registry;
+  @Inject
+  private PolicyManager policyManager;
+  private Cache<String, OperationMessageProcessor> operationMessageProcessorCache;
+  private ExtensionsClientProcessorsHelper extensionsClientProcessorsHelper;
 
   @Override
   public <T, A> CompletableFuture<Result<T, A>> execute(String extensionName,
@@ -213,6 +218,31 @@ public final class DefaultExtensionsClient implements ExtensionsClient, Initiali
         .build(this::createOperationClient);
   }
 
+  private Cache<String, OperationMessageProcessor> createOperationMessageProcessorCache() {
+    return Caffeine.newBuilder()
+        .maximumSize(100)
+        // Since the removal listener runs asynchronously, force waiting for all cleanup tasks to be complete before proceeding
+        // (and finalizing) the context disposal.
+        // Ref: https://github.com/ben-manes/caffeine/issues/104#issuecomment-238068997
+        .executor(cacheShutdownExecutor)
+        .expireAfterAccess(10, MINUTES)
+        .<String, OperationMessageProcessor>removalListener((key, operationMessageProcessor,
+                                                             removalCause) -> disposeProcessor(operationMessageProcessor))
+        .build();
+  }
+
+  private static void disposeProcessor(OperationMessageProcessor processor) {
+    if (processor == null) {
+      return;
+    }
+    try {
+      processor.stop();
+      processor.dispose();
+    } catch (MuleException e) {
+      throw new MuleRuntimeException(createStaticMessage("Error while disposing the executing operation"), e);
+    }
+  }
+
   private OperationClient createOperationClient(OperationKey key) {
     OperationClient client = from(
                                   key,
@@ -268,49 +298,22 @@ public final class DefaultExtensionsClient implements ExtensionsClient, Initiali
   public <T, A> CompletableFuture<Result<T, A>> executeAsync(String extensionName,
                                                              String operationName,
                                                              OperationParameters parameters) {
-
-    final ExtensionModel extensionModel = findExtension(extensionName);
-    final OperationModel operationModel = findOperationModel(extensionModel, operationName);
-
-    return execute(
-                   extensionName,
-                   operationName,
-                   parameterizer -> {
-                     setContextEvent(parameterizer, parameters);
-                     parameters.getConfigName().ifPresent(parameterizer::withConfigRef);
-                     resolveLegacyParameters(parameterizer, parameters);
-                     configureLegacyRepeatableStreaming(parameterizer, operationModel);
-                   });
-  }
-
-  protected void resolveLegacyParameters(OperationParameterizer parameterizer, OperationParameters legacyParameters) {
-    resolveLegacyParameters(legacyParameters.get(), parameterizer::withParameter);
-  }
-
-  private void resolveLegacyParameters(Map<String, Object> parameters,
-                                       BiConsumer<String, Object> resolvedValueConsumer) {
-    parameters.forEach((paramName, value) -> {
-      if (CONFIG_ATTRIBUTE_NAME.equals(paramName)) {
-        return;
-      }
-
-      if (value instanceof ComplexParameter) {
-        ComplexParameter complex = (ComplexParameter) value;
-        DefaultObjectBuilder<?> builder = new DefaultObjectBuilder<>(complex.getType(), reflectionCache);
-        resolveLegacyParameters(complex.getParameters(), (propertyName, propertyValue) -> builder
-            .addPropertyResolver(propertyName, new StaticValueResolver<>(propertyValue)));
-
-        value = withNullEvent(event -> {
-          try (ValueResolvingContext ctx = ValueResolvingContext.builder(event).build()) {
-            return builder.build(ctx);
-          } catch (MuleException e) {
-            throw new MuleRuntimeException(createStaticMessage(format("Could not construct parameter [%s]", paramName)), e);
+    // TODO: delegate to the new API once the performance degradation is fixed
+    OperationMessageProcessor processor =
+        extensionsClientProcessorsHelper.getOperationMessageProcessor(extensionName, operationName, parameters);
+    final CoreEvent eventFromParams = extensionsClientProcessorsHelper.getEvent(parameters);
+    return just(eventFromParams)
+        .transform(processor)
+        .map(event -> Result.<T, A>builder(event.getMessage()).build())
+        .onErrorMap(t -> {
+          Throwable unwrapped = unwrap(t);
+          if (unwrapped instanceof MessagingException) {
+            return unwrapped;
+          } else {
+            return new MessagingException(eventFromParams, unwrapped, processor);
           }
-        });
-      }
-
-      resolvedValueConsumer.accept(paramName, value);
-    });
+        })
+        .toFuture();
   }
 
   /**
@@ -336,32 +339,14 @@ public final class DefaultExtensionsClient implements ExtensionsClient, Initiali
     }
   }
 
-  private void configureLegacyRepeatableStreaming(OperationParameterizer parameterizer, OperationModel operationModel) {
-    if (operationModel.getModelProperty(PagedOperationModelProperty.class).isPresent()) {
-      setDefaultRepeatableIterables(parameterizer);
-    } else if (operationModel.supportsStreaming()) {
-      setDefaultRepeatableStreaming(parameterizer);
-    }
-  }
-
-  private void setDefaultRepeatableStreaming(OperationParameterizer parameterizer) {
-    parameterizer.withDefaultRepeatableStreaming();
-  }
-
-  private void setDefaultRepeatableIterables(OperationParameterizer parameterizer) {
-    parameterizer.withDefaultRepeatableIterables();
-  }
-
-  private void setContextEvent(OperationParameterizer parameterizer, OperationParameters parameters) {
-    if (parameters instanceof EventedOperationsParameterDecorator) {
-      parameterizer.inTheContextOf(((EventedOperationsParameterDecorator) parameters).getContextEvent());
-    }
-  }
-
   @Override
   public void initialise() throws InitialisationException {
     cacheShutdownExecutor = new ShutdownExecutor();
     operationClientCache = createOperationClientCache();
+    operationMessageProcessorCache = createOperationMessageProcessorCache();
+    extensionsClientProcessorsHelper =
+        new ExtensionsClientProcessorsHelper(extensionManager, registry, muleContext, policyManager, reflectionCache,
+                                             operationMessageProcessorCache);
   }
 
   @Override
@@ -373,6 +358,10 @@ public final class DefaultExtensionsClient implements ExtensionsClient, Initiali
 
     if (operationClientCache != null) {
       operationClientCache.invalidateAll();
+    }
+
+    if (operationMessageProcessorCache != null) {
+      operationMessageProcessorCache.invalidateAll();
     }
 
     if (cacheShutdownExecutor != null) {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/ExtensionsClientProcessorsHelper.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/client/ExtensionsClientProcessorsHelper.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ */
+package org.mule.runtime.module.extension.internal.runtime.client;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.Comparator.naturalOrder;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_POSTFIX;
+import static org.mule.runtime.core.api.el.ExpressionManager.DEFAULT_EXPRESSION_PREFIX;
+import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
+import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
+import static org.mule.runtime.core.privileged.util.TemplateParser.createMuleStyleParser;
+import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.findOperation;
+
+import org.mule.runtime.api.artifact.Registry;
+import org.mule.runtime.api.event.Event;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.exception.MuleRuntimeException;
+import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.api.meta.model.operation.OperationModel;
+import org.mule.runtime.api.metadata.DataType;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.extension.ExtensionManager;
+import org.mule.runtime.core.internal.policy.PolicyManager;
+import org.mule.runtime.core.privileged.util.TemplateParser;
+import org.mule.runtime.extension.api.client.OperationParameters;
+import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
+import org.mule.runtime.extension.internal.client.ComplexParameter;
+import org.mule.runtime.module.extension.internal.policy.NoOpPolicyManager;
+import org.mule.runtime.module.extension.internal.runtime.client.operation.EventedOperationsParameterDecorator;
+import org.mule.runtime.module.extension.internal.runtime.client.operation.OperationClient;
+import org.mule.runtime.module.extension.internal.runtime.objectbuilder.DefaultObjectBuilder;
+import org.mule.runtime.module.extension.internal.runtime.operation.OperationMessageProcessor;
+import org.mule.runtime.module.extension.internal.runtime.operation.OperationMessageProcessorBuilder;
+import org.mule.runtime.module.extension.internal.runtime.resolver.ExpressionValueResolver;
+import org.mule.runtime.module.extension.internal.runtime.resolver.StaticValueResolver;
+import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolver;
+import org.mule.runtime.module.extension.internal.runtime.resolver.ValueResolvingContext;
+import org.mule.runtime.module.extension.internal.util.ReflectionCache;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+// TODO: Remove this class and use {@link OperationClient} once the performance issues are fixed.
+/**
+ * Provides help for executing extension operations.
+ * <p>
+ * The {@link OperationMessageProcessor}s created by this helper are cached in the cache given in the constructor.
+ *
+ * @deprecated Use {@link OperationClient}.
+ */
+@Deprecated
+public class ExtensionsClientProcessorsHelper {
+
+  private static final PolicyManager DEFAULT_POLICY_MANAGER = new NoOpPolicyManager();
+  private static final String INTERNAL_VARIABLE_PREFIX = "INTERNAL_VARIABLE_";
+
+  private final TemplateParser parser = createMuleStyleParser();
+
+  private final ExtensionManager extensionManager;
+  private final Registry registry;
+  private final MuleContext muleContext;
+  private final PolicyManager policyManager;
+  private final ReflectionCache reflectionCache;
+  private final Cache<String, OperationMessageProcessor> operationMessageProcessorCache;
+
+  /**
+   * Creates a new instance
+   */
+  public ExtensionsClientProcessorsHelper(ExtensionManager extensionManager, Registry registry, MuleContext muleContext,
+                                          PolicyManager policyManager, ReflectionCache reflectionCache,
+                                          Cache<String, OperationMessageProcessor> operationMessageProcessorCache) {
+    this.extensionManager = extensionManager;
+    this.registry = registry;
+    this.muleContext = muleContext;
+    this.policyManager = policyManager != null ? policyManager : DEFAULT_POLICY_MANAGER;
+    this.reflectionCache = reflectionCache;
+    this.operationMessageProcessorCache = operationMessageProcessorCache;
+  }
+
+  /**
+   * @param extensionName the name of the extension to run the operation.
+   * @param operationName the name of the operation to run.
+   * @param parameters    the operation parameters used to run the operation
+   * @return the appropriate {@link OperationMessageProcessor} to be used for executing the operation.
+   */
+  public OperationMessageProcessor getOperationMessageProcessor(String extensionName, String operationName,
+                                                                OperationParameters parameters) {
+    String key = buildKey(extensionName, operationName, parameters);
+    return operationMessageProcessorCache.get(key, (cacheKey) -> {
+      Map<String, ValueResolver<?>> params = parameters.get().entrySet().stream()
+          .collect(toMap(Map.Entry::getKey, e -> {
+            ExpressionValueResolver<?> resolver =
+                new ExpressionValueResolver<>(DEFAULT_EXPRESSION_PREFIX + "vars.'" + INTERNAL_VARIABLE_PREFIX + e.getKey() + "'"
+                    + DEFAULT_EXPRESSION_POSTFIX);
+            try {
+              initialiseIfNeeded(resolver, true, muleContext);
+            } catch (InitialisationException ex) {
+              throw new MuleRuntimeException(ex);
+            }
+            return resolver;
+          }));
+      return createProcessor(extensionName, operationName, parameters.getConfigName(), params);
+    });
+  }
+
+  /**
+   * @param parameters the {@link OperationParameters} used to execute the operation.
+   * @return the appropriate event to be used to run de desired operation with the {@link OperationParameters} given.
+   */
+  public CoreEvent getEvent(OperationParameters parameters) {
+    if (parameters instanceof EventedOperationsParameterDecorator) {
+      Event contextEvent = ((EventedOperationsParameterDecorator) parameters).getContextEvent();
+      if (contextEvent instanceof CoreEvent) {
+        return buildChildEvent((CoreEvent) contextEvent, parameters);
+      }
+    }
+    return buildChildEvent(getNullEvent(), parameters);
+  }
+
+  private OperationMessageProcessor createProcessor(String extensionName, String operationName, Optional<String> configName,
+                                                    Map<String, ValueResolver<?>> parameters) {
+    ExtensionModel extension = findExtension(extensionName);
+    OperationModel operation = findOperation(extension, operationName)
+        .orElseThrow(() -> new MuleRuntimeException(createStaticMessage("No Operation [" + operationName + "] Found")));
+    ConfigurationProvider config = configName.map(this::findConfiguration).orElse(null);
+    try {
+      OperationMessageProcessor processor =
+          new OperationMessageProcessorBuilder(extension, operation, emptyList(), policyManager, muleContext, registry)
+              .setConfigurationProvider(config)
+              .setParameters(parameters)
+              .setTerminationTimeout(-1)
+              .build();
+
+      initialiseIfNeeded(processor, muleContext);
+      processor.start();
+      return processor;
+    } catch (Exception e) {
+      throw new MuleRuntimeException(createStaticMessage("Could not create Operation Message Processor"), e);
+    }
+  }
+
+  private ConfigurationProvider findConfiguration(String configName) {
+    return extensionManager.getConfigurationProvider(configName)
+        .orElseThrow(() -> new MuleRuntimeException(createStaticMessage("No configuration [" + configName + "] found")));
+  }
+
+  private ExtensionModel findExtension(String extensionName) {
+    return extensionManager.getExtension(extensionName)
+        .orElseThrow(() -> new MuleRuntimeException(createStaticMessage("No Extension [" + extensionName + "] Found")));
+  }
+
+  private CoreEvent buildChildEvent(CoreEvent event, OperationParameters parameters) {
+    CoreEvent.Builder childEventBuilder = CoreEvent.builder(event);
+    Map<String, ValueResolver<?>> operationParameters = resolveParameters(parameters.get(), event);
+    for (String key : operationParameters.keySet()) {
+      ValueResolver<?> valueResolver = operationParameters.get(key);
+      try {
+        Object value = valueResolver.resolve(ValueResolvingContext.builder(event).build());
+        childEventBuilder.addVariable(INTERNAL_VARIABLE_PREFIX + key, value, DataType.fromObject(value));
+      } catch (MuleException e) {
+        throw new MuleRuntimeException(e);
+      }
+    }
+    return childEventBuilder.build();
+  }
+
+  private String buildKey(String extension, String operation, OperationParameters parameters) {
+    char separator = '&';
+    StringBuilder keyBuilder = new StringBuilder(256);
+    keyBuilder.append(extension).append(separator)
+        .append(operation).append(separator)
+        .append(parameters.getConfigName().orElse(""));
+    List<String> keyList = parameters.get().keySet()
+        .stream()
+        .sorted(naturalOrder())
+        .collect(toList());
+    for (String key : keyList) {
+      keyBuilder.append(separator).append(key);
+    }
+    return keyBuilder.toString();
+  }
+
+  protected Map<String, ValueResolver<?>> resolveParameters(Map<String, Object> parameters, CoreEvent event) {
+    LinkedHashMap<String, ValueResolver<?>> values = new LinkedHashMap<>();
+    parameters.forEach((name, value) -> {
+      ValueResolver<?> valueResolver;
+      if (value instanceof ComplexParameter) {
+        ComplexParameter complex = (ComplexParameter) value;
+        DefaultObjectBuilder<?> builder = new DefaultObjectBuilder<>(complex.getType(), reflectionCache);
+        resolveParameters(complex.getParameters(), event).forEach(builder::addPropertyResolver);
+        try {
+          valueResolver = new StaticValueResolver<>(builder.build(ValueResolvingContext.builder(event).build()));
+        } catch (MuleException e) {
+          throw new MuleRuntimeException(createStaticMessage(format("Could not construct parameter [%s]", name)), e);
+        }
+      } else {
+        if (value instanceof String && parser.isContainsTemplate((String) value)) {
+          valueResolver = new ExpressionValueResolver<>((String) value);
+        } else {
+          valueResolver = new StaticValueResolver<>(value);
+        }
+      }
+      try {
+        initialiseIfNeeded(valueResolver, true, muleContext);
+      } catch (InitialisationException e) {
+        throw new MuleRuntimeException(e);
+      }
+      values.put(name, valueResolver);
+    });
+    return values;
+  }
+}


### PR DESCRIPTION
PoC for temporarily reverting back to the previous implementation of the ExtensionsClient API using cached ComponentMessageProcessor instances.

The new implementation is much better in terms of memory footprint but is less performant in terms of throughput. While we work on fixing the root cause for the performance issue, we can revert back to the previous impl.