### PR TITLE
W-14067425: Avoid excesive creations of test flows in ComponentMessageProcessorTestCase. (#12759)

### DIFF
--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessorTestCase.java
@@ -4,6 +4,7 @@
 package org.mule.runtime.module.extension.internal.runtime.operation;
 
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
+import static org.mule.runtime.core.api.event.EventContextFactory.create;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
@@ -14,6 +15,7 @@ import static org.mule.test.allure.AllureConstants.ExecutionEngineFeature.EXECUT
 import static org.mule.test.allure.AllureConstants.ExecutionEngineFeature.ExecutionEngineStory.REACTOR;
 
 import static java.util.Optional.of;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -36,10 +38,12 @@ import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.meta.model.EnrichableModel;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.XmlDslModel;
+import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
 import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.core.internal.exception.MessagingException;
+import org.mule.runtime.core.internal.message.InternalEvent;
 import org.mule.runtime.core.internal.policy.PolicyManager;
 import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
 import org.mule.runtime.metadata.api.cache.MetadataCacheIdGeneratorFactory;
@@ -84,6 +88,10 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
   protected ExtensionManager extensionManager;
   protected PolicyManager mockPolicyManager;
 
+  // A cached flow for creating test events. It doesn't even have to contain the processor we are going to test, because we will
+  // be sending the events directly through the processor, without using the flow.
+  private Flow testFlow;
+
   @Before
   public void before() throws MuleException {
     extensionModel = mock(ExtensionModel.class);
@@ -97,6 +105,9 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
     extensionManager = mock(ExtensionManager.class);
     mockPolicyManager = mock(PolicyManager.class);
     when(mockPolicyManager.createOperationPolicy(any(), any(), any())).thenReturn(noPolicyOperation());
+
+    testFlow = getTestFlow(muleContext);
+    initialiseIfNeeded(testFlow, muleContext);
 
     processor = createProcessor();
     processor.setAnnotations(getAppleFlowComponentLocationAnnotations());
@@ -115,6 +126,9 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
   public void after() throws MuleException {
     stopIfNeeded(processor);
     disposeIfNeeded(processor, LOGGER);
+
+    stopIfNeeded(testFlow);
+    disposeIfNeeded(testFlow, LOGGER);
   }
 
   protected ComponentMessageProcessor<ComponentModel> createProcessor() {
@@ -133,6 +147,12 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
         return ProcessingType.CPU_LITE;
       }
     };
+  }
+
+  @Override
+  protected CoreEvent.Builder getEventBuilder() {
+    // Overrides to avoid creating a new test flow for each new test event
+    return InternalEvent.builder(create(testFlow, TEST_CONNECTOR_LOCATION));
   }
 
   @Test
@@ -225,10 +245,13 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
 
     eventsEmitter.start();
     eventsEmitter2.start();
-    eventsConsumer.await();
-    eventsEmitter.stop();
-    eventsConsumer2.await();
-    eventsEmitter2.stop();
+    try {
+      assertThat(eventsConsumer.await(RECEIVE_TIMEOUT, MILLISECONDS), is(true));
+      assertThat(eventsConsumer2.await(RECEIVE_TIMEOUT, MILLISECONDS), is(true));
+    } finally {
+      eventsEmitter.stop();
+      eventsEmitter2.stop();
+    }
   }
 
   @Test
@@ -270,8 +293,11 @@ public class ComponentMessageProcessorTestCase extends AbstractMuleContextTestCa
         .subscribe(eventsConsumer);
 
     eventsEmitter.start();
-    eventsConsumer.await();
-    eventsEmitter.stop();
+    try {
+      assertThat(eventsConsumer.await(RECEIVE_TIMEOUT, MILLISECONDS), is(true));
+    } finally {
+      eventsEmitter.stop();
+    }
   }
 
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/InfiniteEmitter.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/InfiniteEmitter.java
@@ -68,11 +68,15 @@ class InfiniteEmitter<T> implements Consumer<FluxSink<T>> {
   /**
    * Stops the emission of items and signals the completion of the source.
    * <p>
+   * Stopping an already stopped emitter is a no-op.
+   * <p>
    * Note: it does not support restarting.
    */
   public void stop() throws InterruptedException {
-    stopRequested = true;
-    producerThread.join();
-    sink.complete();
+    if (!stopRequested) {
+      stopRequested = true;
+      producerThread.join();
+      sink.complete();
+    }
   }
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ItemsConsumer.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/operation/ItemsConsumer.java
@@ -4,6 +4,7 @@
 package org.mule.runtime.module.extension.internal.runtime.operation;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -34,14 +35,19 @@ class ItemsConsumer<T> extends BaseSubscriber<T> {
    * <p>
    * If an error is received by this subscriber while waiting, the waiting thread is awakened and a {@link RuntimeException} is
    * raised with the received error as cause.
-   * 
+   *
+   * @param timeout the maximum time to wait.
+   * @param unit    the time unit of the {@code timeout} argument.
+   * @return {@code true} if the expected number of items have been consumed and {@code false} if the waiting time elapsed before
+   *         that happened.
    * @throws InterruptedException if the current thread is interrupted while waiting
    */
-  public void await() throws InterruptedException {
-    expectedItemsConsumedCountDownLatch.await();
+  public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+    boolean result = expectedItemsConsumedCountDownLatch.await(timeout, unit);
     if (error != null) {
       throw new RuntimeException(error);
     }
+    return result;
   }
 
   @Override


### PR DESCRIPTION
- Also making sure InfiniteEmitters are stopped even when the test fails.

(cherry picked from commit 6e630b6561f16af13d3f1ff9b09f77ad2d182562)