### PR TITLE
W-14067425: Avoid excesive creations of test flows in ComponentMessageProcessorTestCase. (#12759)

### DIFF
--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/InfiniteEmitter.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/InfiniteEmitter.java
@@ -71,11 +71,15 @@ class InfiniteEmitter<T> implements Consumer<FluxSink<T>> {
   /**
    * Stops the emission of items and signals the completion of the source.
    * <p>
+   * Stopping an already stopped emitter is a no-op.
+   * <p>
    * Note: it does not support restarting.
    */
   public void stop() throws InterruptedException {
-    stopRequested = true;
-    producerThread.join();
-    sink.complete();
+    if (!stopRequested) {
+      stopRequested = true;
+      producerThread.join();
+      sink.complete();
+    }
   }
 }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ItemsConsumer.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/ItemsConsumer.java
@@ -7,6 +7,7 @@
 package org.mule.runtime.module.extension.internal.runtime;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
@@ -38,14 +39,19 @@ class ItemsConsumer<T> extends BaseSubscriber<T> {
    * <p>
    * If an error is received by this subscriber while waiting, the waiting thread is awakened and a {@link RuntimeException} is
    * raised with the received error as cause.
-   * 
+   *
+   * @param timeout the maximum time to wait.
+   * @param unit    the time unit of the {@code timeout} argument.
+   * @return {@code true} if the expected number of items have been consumed and {@code false} if the waiting time elapsed before
+   *         that happened.
    * @throws InterruptedException if the current thread is interrupted while waiting
    */
-  public void await() throws InterruptedException {
-    expectedItemsConsumedCountDownLatch.await();
+  public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+    boolean result = expectedItemsConsumedCountDownLatch.await(timeout, unit);
     if (error != null) {
       throw new RuntimeException(error);
     }
+    return result;
   }
 
   @Override


### PR DESCRIPTION
- Also making sure InfiniteEmitters are stopped even when the test fails.

(cherry picked from commit 6e630b6561f16af13d3f1ff9b09f77ad2d182562)