### PR TITLE
W-13951850: Remove visibility on container internals from artifacts

### DIFF
--- a/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
+++ b/tests/runner/src/main/java/org/mule/test/runner/api/AetherClassPathClassifier.java
@@ -418,9 +418,7 @@ public class AetherClassPathClassifier implements ClassPathClassifier {
                   // Plugins may have ended up with a highest version due to transitive dependencies... therefore comparing
                   // without version
                   .anyMatch(artifactUrlClassification -> artifactUrlClassification.getArtifactId()
-                      .equals(toVersionlessId(artifact)))
-              && !applicationSharedLibUrls.stream()
-                  .anyMatch(applicationSharedLibUrl -> applicationSharedLibUrl.getArtifactId().equals(artifactId)));
+                      .equals(toVersionlessId(artifact))));
         })
         .map(depToTransform -> depToTransform.setScope(COMPILE))
         .collect(toList());


### PR DESCRIPTION
Some cases were wrongly working because they configured sharedLibraries. The fact that a library is shared by the app doesn't mean it cannot be part of the container as well (i.e.: spring use in container and spring-module)