### PR TITLE
W-12412027: MuleContainerBasicWrapper

### DIFF
--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/AbstractMuleContainerWrapper.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/AbstractMuleContainerWrapper.java
@@ -83,7 +83,11 @@ public abstract class AbstractMuleContainerWrapper implements MuleContainerWrapp
 
   public void dispose() {
     for (BootstrapConfigurer bootstrapConfigurer : bootstrapConfigurers) {
-      bootstrapConfigurer.dispose();
+      try {
+        bootstrapConfigurer.dispose();
+      } catch (Throwable t) {
+        t.printStackTrace();
+      }
     }
   }
 

--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/AbstractMuleContainerWrapper.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/AbstractMuleContainerWrapper.java
@@ -82,12 +82,20 @@ public abstract class AbstractMuleContainerWrapper implements MuleContainerWrapp
   }
 
   public void dispose() {
+    RuntimeException disposalException = null;
     for (BootstrapConfigurer bootstrapConfigurer : bootstrapConfigurers) {
       try {
         bootstrapConfigurer.dispose();
       } catch (Throwable t) {
-        t.printStackTrace();
+        // Records the first exception but don't throw just yet, to let the other Configurers to run their disposal.
+        if (disposalException == null) {
+          disposalException = new RuntimeException(t);
+        }
       }
+    }
+
+    if (disposalException != null) {
+      throw disposalException;
     }
   }
 

--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/MuleContainerBasicWrapper.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/MuleContainerBasicWrapper.java
@@ -9,7 +9,7 @@ package org.mule.runtime.module.reboot.internal;
 import static java.lang.String.format;
 import static java.lang.System.exit;
 import static java.lang.Thread.currentThread;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
@@ -80,9 +80,8 @@ public class MuleContainerBasicWrapper extends AbstractMuleContainerWrapper {
   }
 
   private void startWithContainerClassLoader() throws Exception {
-    Optional<Long> javaPid = getPid();
-    List<String> additionalSplashEntries = asList("Wrapper PID: Running Wrapperless",
-                                                  format("Java PID: %s", javaPid.map(String::valueOf).orElse("N/A")));
+    String javaPid = getPid().map(String::valueOf).orElse("N/A");
+    List<String> additionalSplashEntries = singletonList(format("Java PID: %s", javaPid));
     ClassLoader originalClassLoader = currentThread().getContextClassLoader();
     currentThread().setContextClassLoader(muleContainer.getClass().getClassLoader());
     try {

--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/MuleContainerBasicWrapper.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/MuleContainerBasicWrapper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.reboot.internal;
+
+import static java.lang.String.format;
+import static java.lang.System.exit;
+import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+/**
+ * Implementation of {@link MuleContainerWrapper} that interacts with the {@link MuleContainer} directly. Other implementations
+ * may use an intermediary (e.g.: Tanuki).
+ *
+ * @since 4.5
+ */
+public class MuleContainerBasicWrapper extends AbstractMuleContainerWrapper {
+
+  private MuleContainer muleContainer;
+  private boolean isStarted = false;
+
+  @Override
+  protected void start(MuleContainerFactory muleContainerFactory, String[] args) {
+    try {
+      muleContainer = muleContainerFactory.create(args);
+      startWithContainerClassLoader();
+    } catch (Exception e) {
+      muleContainer = null;
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void haltAndCatchFire(int exitCode, String message) {
+    throw new RuntimeException(message);
+  }
+
+  @Override
+  public void restart() {
+    // Mimics the message printed by the Tanuki Wrapper (we have tests expecting this string)
+    System.out.println("JVM requested a restart.");
+
+    // TODO: NO-OP for now until we define if we actually need to support it.
+    // Starting a new JVM will not be really achievable without some kind of wrapper.
+    // We could aim for gracefully shutting down the current Container and creating a new Container from a new ClassLoader, but
+    // we may face CL leaks (actually a quick test confirmed that, but we didn't want to spend additional time investigating for
+    // now).
+    // Just restarting the same Container instance will not be enough because there are static finals that need to be reset.
+  }
+
+  @Override
+  public void stop(int exitCode) {
+    dispose();
+
+    // Gracefully shutdowns the container
+    doStop();
+    muleContainer = null;
+
+    // Quits the JVM now
+    exit(exitCode);
+  }
+
+  private void doStop() {
+    try {
+      if (muleContainer != null && isStarted) {
+        muleContainer.shutdown();
+        isStarted = false;
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  private void startWithContainerClassLoader() throws Exception {
+    // TODO: add Java PID
+    List<String> additionalSplashEntries = asList(format("Wrapper PID: %s", "Running Wrapperless"),
+                                                  format("Java PID: %s", "N/A"));
+    ClassLoader originalClassLoader = currentThread().getContextClassLoader();
+    currentThread().setContextClassLoader(muleContainer.getClass().getClassLoader());
+    try {
+      muleContainer.start(getAllConfigurersReady(), additionalSplashEntries);
+      isStarted = true;
+    } finally {
+      currentThread().setContextClassLoader(originalClassLoader);
+    }
+  }
+}

--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/MuleContainerBasicWrapper.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/MuleContainerBasicWrapper.java
@@ -48,7 +48,7 @@ public class MuleContainerBasicWrapper extends AbstractMuleContainerWrapper {
     // Mimics the message printed by the Tanuki Wrapper (we have tests expecting this string)
     System.out.println("JVM requested a restart.");
 
-    // TODO: NO-OP for now until we define if we actually need to support it.
+    // TODO W-14142823: NO-OP for now until we define if we actually need to support it.
     // Starting a new JVM will not be really achievable without some kind of wrapper.
     // We could aim for gracefully shutting down the current Container and creating a new Container from a new ClassLoader, but
     // we may face CL leaks (actually a quick test confirmed that, but we didn't want to spend additional time investigating for

--- a/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
+++ b/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
@@ -1224,4 +1224,15 @@ public interface AllureConstants {
       String JDK_ENVIRONMENT_CONFIGURATION = "JDK environment configuration";
     }
   }
+
+  interface WrapperlessBootstrapFeature {
+
+    String WRAPPERLESS_BOOTSTRAP = "Wrapper-less bootstrapping";
+
+    interface WrapperlessBootstrapStory {
+
+      String WRAPPERLESS_CONTAINER_MANAGEMENT = "Managing a container bootstrapped in wrapper-less mode";
+      String WRAPPERLESS_PARAMETERS_RESOLUTION = "Resolution of parameters to use in a wrapper-less bootstrapping";
+    }
+  }
 }

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/AbstractOSController.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/AbstractOSController.java
@@ -21,18 +21,22 @@ import org.mule.tck.probe.PollingProber;
 import org.mule.tck.probe.Probe;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-import java.util.Arrays;
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecuteResultHandler;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.exec.ExecuteStreamHandler;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.PumpStreamHandler;
@@ -163,55 +167,87 @@ public abstract class AbstractOSController {
     return runSync(commandLine, null);
   }
 
-  protected int runSync(CommandLine commandLine, OutputStream outAndErr) {
+  protected int runSync(CommandLine commandLine, ExecuteStreamHandler streamHandler) {
     Map<String, String> newEnv = copyEnvironmentVariables();
-    return executeSyncCommand(commandLine, newEnv, outAndErr, timeout);
+    return executeSyncCommand(commandLine, newEnv, streamHandler, timeout);
   }
 
-  private int executeSyncCommand(CommandLine commandLine, Map<String, String> newEnv,
-                                 OutputStream outAndErr, int timeout) {
+  protected Process runAsync(CommandLine commandLine, ExecuteStreamHandler streamHandler) {
+    Map<String, String> newEnv = copyEnvironmentVariables();
+    return executeAsyncCommand(commandLine, newEnv, streamHandler);
+  }
+
+  private int executeSyncCommand(CommandLine commandLine, Map<String, String> newEnv, ExecuteStreamHandler streamHandler,
+                                 int timeout) {
     Executor executor = new DefaultExecutor();
     ExecuteWatchdog watchdog = new ExecuteWatchdog(timeout);
     executor.setWatchdog(watchdog);
 
-    if (outAndErr == null) {
-      // TODO: review if we should use a NullOutputStream
-      outAndErr = new ByteArrayOutputStream();
-    }
-    executor.setStreamHandler(new PumpStreamHandler(outAndErr));
+    setStreamHandler(executor, streamHandler);
     return doExecution(executor, commandLine, newEnv);
   }
 
+  private Process executeAsyncCommand(CommandLine commandLine, Map<String, String> newEnv, ExecuteStreamHandler streamHandler) {
+    ProcessCapturingExecutor executor = new ProcessCapturingExecutor();
+
+    // We don't want to set up a watchdog in this mode because the process is allowed to last as long as the test lasts
+    // The timeout specified in the constructor of this class is sized for short-lived processes like "mule start", not the mule
+    // process itself.
+
+    setStreamHandler(executor, streamHandler);
+    doAsyncExecution(executor, commandLine, newEnv);
+    return executor.getProcess();
+  }
+
+  private void setStreamHandler(Executor executor, ExecuteStreamHandler streamHandler) {
+    if (streamHandler == null) {
+      // TODO: review if we should use a NullOutputStream for improved performance
+      streamHandler = new PumpStreamHandler(new ByteArrayOutputStream());
+    }
+    executor.setStreamHandler(streamHandler);
+  }
+
   protected int doExecution(Executor executor, CommandLine commandLine, Map<String, String> env) {
+    String maskedCommandLine = getMaskedCommandLineForLogging(commandLine);
+
+    try {
+      logger.info("Executing: {}", maskedCommandLine);
+      return executor.execute(commandLine, env);
+    } catch (ExecuteException e) {
+      logger.error("Error executing {}", maskedCommandLine);
+      return e.getExitValue();
+    } catch (Exception e) {
+      throw new MuleControllerException(format("Error executing [%s]", maskedCommandLine), e);
+    }
+  }
+
+  private void doAsyncExecution(Executor executor, CommandLine commandLine, Map<String, String> env) {
+    String maskedCommandLine = getMaskedCommandLineForLogging(commandLine);
+
+    try {
+      logger.info("Executing: {}", maskedCommandLine);
+      executor.execute(commandLine, env, new DefaultExecuteResultHandler());
+    } catch (ExecuteException e) {
+      logger.error("Error executing {}", maskedCommandLine);
+    } catch (Exception e) {
+      throw new MuleControllerException(format("Error executing [%s]", maskedCommandLine), e);
+    }
+  }
+
+  private String getMaskedCommandLineForLogging(CommandLine commandLine) {
     final StringJoiner paramsJoiner = new StringJoiner(" ");
     for (String cmdArg : commandLine.toStrings()) {
       paramsJoiner.add(cmdArg.replaceAll("(?<=\\.password=)(.*)", "****"));
     }
-
-    try {
-      logger.info("Executing: {}", paramsJoiner);
-      return executor.execute(commandLine, env);
-    } catch (ExecuteException e) {
-      logger.error("Error executing " + paramsJoiner);
-      return e.getExitValue();
-    } catch (Exception e) {
-      throw new MuleControllerException("Error executing [" + commandLine.getExecutable() + " "
-          + Arrays.toString(commandLine.getArguments())
-          + "]", e);
-    }
+    return paramsJoiner.toString();
   }
 
   protected Map<String, String> copyEnvironmentVariables() {
     Map<String, String> env = System.getenv();
-    Map<String, String> newEnv = new HashMap<>();
-    for (Map.Entry<String, String> it : env.entrySet()) {
-      newEnv.put(it.getKey(), it.getValue());
-    }
+    Map<String, String> newEnv = new HashMap<>(env);
 
     if (this.testEnvVars != null) {
-      for (Map.Entry<String, String> it : this.testEnvVars.entrySet()) {
-        newEnv.put(it.getKey(), it.getValue());
-      }
+      newEnv.putAll(this.testEnvVars);
     }
 
     newEnv.put(MULE_HOME_VARIABLE, muleHome);
@@ -219,7 +255,6 @@ public abstract class AbstractOSController {
       newEnv.put(MULE_APP_VARIABLE, muleAppName);
       newEnv.put(MULE_APP_LONG_VARIABLE, muleAppLongName);
     }
-
 
     // Use the jvm running the tests as configured in surefire to run the Mule Runtime...
     String jvmProperty = System.getProperty("jvm");
@@ -233,5 +268,25 @@ public abstract class AbstractOSController {
     }
 
     return newEnv;
+  }
+
+  private static class ProcessCapturingExecutor extends DefaultExecutor {
+
+    private final CompletableFuture<Process> processFuture = new CompletableFuture<>();
+
+    @Override
+    protected Process launch(CommandLine command, Map<String, String> env, File dir) throws IOException {
+      Process process = super.launch(command, env, dir);
+      processFuture.complete(process);
+      return process;
+    }
+
+    public Process getProcess() {
+      try {
+        return processFuture.get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new MuleControllerException(e.getCause());
+      }
+    }
   }
 }

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/AbstractOSController.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/AbstractOSController.java
@@ -201,7 +201,7 @@ public abstract class AbstractOSController {
 
   private void setStreamHandler(Executor executor, ExecuteStreamHandler streamHandler) {
     if (streamHandler == null) {
-      // TODO: review if we should use a NullOutputStream for improved performance
+      // TODO W-14142832: review if we should use a NullOutputStream for improved performance
       streamHandler = new PumpStreamHandler(new ByteArrayOutputStream());
     }
     executor.setStreamHandler(streamHandler);

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/MuleProcessControllerFactory.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/MuleProcessControllerFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.infrastructure.process;
+
+public class MuleProcessControllerFactory {
+
+  public MuleProcessController create(String muleHome) {
+    return new MuleProcessController(muleHome);
+  }
+
+  public MuleProcessController create(String muleHome, int timeout) {
+    return new MuleProcessController(muleHome, timeout);
+  }
+
+  public MuleProcessController create(String muleHome, String locationSuffix) {
+    return new MuleProcessController(muleHome, locationSuffix);
+  }
+}

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
@@ -131,6 +131,10 @@ public class MuleDeployment extends MuleInstallation {
       deployment = new MuleDeployment(zippedDistribution);
     }
 
+    Builder(MuleDeployment deployment) {
+      this.deployment = deployment;
+    }
+
     /**
      * Deploys and starts the Mule instance with the specified configuration.
      *
@@ -291,6 +295,9 @@ public class MuleDeployment extends MuleInstallation {
     return new Builder(zippedDistribution);
   }
 
+  public static MuleDeployment.Builder builder(MuleDeployment deployment) {
+    return new Builder(deployment);
+  }
 
   protected MuleDeployment() {
     super();

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/process/rules/MuleDeployment.java
@@ -26,6 +26,7 @@ import org.mule.runtime.core.privileged.util.MapUtils;
 import org.mule.tck.probe.JUnitProbe;
 import org.mule.tck.probe.PollingProber;
 import org.mule.test.infrastructure.process.MuleProcessController;
+import org.mule.test.infrastructure.process.MuleProcessControllerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -109,6 +110,7 @@ public class MuleDeployment extends MuleInstallation {
   private final List<String> domains = new ArrayList<>();
   private final List<String> domainBundles = new ArrayList<>();
   private final List<String> libraries = new ArrayList<>();
+  private MuleProcessControllerFactory muleProcessControllerFactory = new MuleProcessControllerFactory();
   private MuleProcessController mule;
   private final Map<String, String> properties = new HashMap<>();
   private final Map<String, Supplier<String>> propertiesUsingLambdas = new HashMap<>();
@@ -274,6 +276,11 @@ public class MuleDeployment extends MuleInstallation {
       return this;
     }
 
+    public Builder withMuleProcessControllerFactory(MuleProcessControllerFactory muleProcessControllerFactory) {
+      deployment.muleProcessControllerFactory = muleProcessControllerFactory;
+      return this;
+    }
+
   }
 
   public static MuleDeployment.Builder builder() {
@@ -325,9 +332,9 @@ public class MuleDeployment extends MuleInstallation {
     super.before();
     prober = new PollingProber(deploymentTimeout, POLL_DELAY_MILLIS);
     if (locationSuffix != null && !locationSuffix.isEmpty()) {
-      mule = new MuleProcessController(getMuleHome(), locationSuffix);
+      mule = muleProcessControllerFactory.create(getMuleHome(), locationSuffix);
     } else {
-      mule = new MuleProcessController(getMuleHome());
+      mule = muleProcessControllerFactory.create(getMuleHome());
     }
     addShutdownHooks();
     try {


### PR DESCRIPTION
### Summary
There is only one small class added to production code: `MuleContainerBasicWrapper` (and no additional dependencies).
Hence it didn't look valuable to separate this into yet another module. We are just adding it to `mule-module-reboot`.

### Test Infrastructure Upgrades
Other than that, this PR contains changes to `mule-test-infrastructure` to support the new system tests added in the PR to `mule-ee-distributions`.