### PR TITLE
W-12412001: Refactoring the remaining BootstrapConfigurers.

### DIFF
--- a/modules/boot-api/pom.xml
+++ b/modules/boot-api/pom.xml
@@ -24,9 +24,24 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
 
+        <!-- Needed by the MuleLog4jConfigurer -->
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-log4j-boot-configurator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Needed by the BootModuleLayerValidationBootstrapConfigurer and for creating the container ClassLoader -->
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-jpms-utils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Needed by the SLF4JBridgeHandlerBootstrapConfigurer, but also to make the logging modules available from the boot layer -->
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-logging</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/modules/boot-api/src/main/java/module-info.java
+++ b/modules/boot-api/src/main/java/module-info.java
@@ -18,7 +18,14 @@ module org.mule.boot.api {
   // exports org.mule.runtime.module.reboot.internal to org.mule.boot.tanuki,org.mule.runtime.launcher,com.mulesoft.mule.runtime.plugin;
   exports org.mule.runtime.module.boot.internal;
 
+  // Needed by the MuleLog4jConfigurer
   requires org.mule.runtime.boot.log4j;
+
+  // Needed by the BootModuleLayerValidationBootstrapConfigurer and for creating the container ClassLoader
+  requires org.mule.runtime.jpms.utils;
+
+  // Needed by the SLF4JBridgeHandlerBootstrapConfigurer, but also to make the logging modules available from the boot layer
+  requires org.mule.runtime.logging;
 
   requires commons.cli;
 }

--- a/modules/boot-api/src/main/java/org/mule/runtime/module/boot/internal/BootModuleLayerValidationBootstrapConfigurer.java
+++ b/modules/boot-api/src/main/java/org/mule/runtime/module/boot/internal/BootModuleLayerValidationBootstrapConfigurer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.boot.internal;
+
+import static org.mule.runtime.jpms.api.JpmsUtils.validateNoBootModuleLayerTweaking;
+
+/**
+ * A {@link BootstrapConfigurer} that takes care of validating the boot module layer has not been tampered with.
+ *
+ * @since 4.6
+ */
+public class BootModuleLayerValidationBootstrapConfigurer implements BootstrapConfigurer {
+
+  public boolean configure() throws BootstrapConfigurationException {
+    try {
+      validateNoBootModuleLayerTweaking();
+      return true;
+    } catch (Exception e) {
+      throw new BootstrapConfigurationException(1, e);
+    }
+  }
+}

--- a/modules/boot-api/src/main/java/org/mule/runtime/module/boot/internal/DefaultMuleClassPathConfig.java
+++ b/modules/boot-api/src/main/java/org/mule/runtime/module/boot/internal/DefaultMuleClassPathConfig.java
@@ -21,7 +21,6 @@ import java.util.List;
 /**
  * Constructs a default set of JAR Urls located under Mule home folder.
  */
-// TODO this duplicates DefaultMuleClassPathConfig in the boot module. See if this class can be moved to mule-core
 public class DefaultMuleClassPathConfig {
 
   private static final String JAVA_8_VERSION = "1.8";

--- a/modules/boot-api/src/main/java/org/mule/runtime/module/boot/internal/SLF4JBridgeHandlerBootstrapConfigurer.java
+++ b/modules/boot-api/src/main/java/org/mule/runtime/module/boot/internal/SLF4JBridgeHandlerBootstrapConfigurer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.boot.internal;
+
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+/**
+ * A {@link BootstrapConfigurer} that takes care of installing the bridge/router for all JUL log records to the SLF4J API.
+ *
+ * @since 4.6
+ */
+public class SLF4JBridgeHandlerBootstrapConfigurer implements BootstrapConfigurer {
+
+  public boolean configure() throws BootstrapConfigurationException {
+    try {
+      // Optionally remove existing handlers attached to j.u.l root logger
+      SLF4JBridgeHandler.removeHandlersForRootLogger(); // (since SLF4J 1.6.5)
+
+      // add SLF4JBridgeHandler to j.u.l's root logger
+      SLF4JBridgeHandler.install();
+      return true;
+    } catch (Exception e) {
+      throw new BootstrapConfigurationException(1, e);
+    }
+  }
+}

--- a/modules/reboot/pom.xml
+++ b/modules/reboot/pom.xml
@@ -22,23 +22,7 @@
             <artifactId>mule-module-boot-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-jpms-utils</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-module-logging</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
-        <!-- TODO W-12412001: remove this once we move the JUL to SLF4J bridge setup to a configurer -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-        
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>

--- a/modules/reboot/src/main/java/module-info.java
+++ b/modules/reboot/src/main/java/module-info.java
@@ -13,12 +13,6 @@
 module org.mule.boot {
 
   requires org.mule.boot.api;
-  requires org.mule.runtime.jpms.utils;
-  requires org.mule.runtime.logging;
 
   requires commons.cli;
-
-  // TODO W-12412001: remove these once we move the JUL to SLF4J bridge setup to a configurer
-  requires jul.to.slf4j;
-  requires java.logging;
 }

--- a/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/CEMuleContainerFactory.java
+++ b/modules/reboot/src/main/java/org/mule/runtime/module/reboot/internal/CEMuleContainerFactory.java
@@ -6,17 +6,11 @@
  */
 package org.mule.runtime.module.reboot.internal;
 
-import static org.mule.runtime.jpms.api.JpmsUtils.createModuleLayerClassLoader;
-import static org.mule.runtime.jpms.api.MultiLevelClassLoaderFactory.MULTI_LEVEL_URL_CLASSLOADER_FACTORY;
-
-import static java.lang.ClassLoader.getSystemClassLoader;
-
 import org.mule.runtime.module.boot.internal.AbstractMuleContainerFactory;
 import org.mule.runtime.module.boot.internal.DefaultMuleClassPathConfig;
 import org.mule.runtime.module.boot.internal.MuleContainer;
 
 import java.io.File;
-import java.net.URL;
 
 /**
  * A factory for {@link MuleContainer} instances. Responsible for choosing the right implementation class and setting up its
@@ -30,20 +24,8 @@ public class CEMuleContainerFactory extends AbstractMuleContainerFactory {
     super(muleHomeDirectoryPropertyName, muleBaseDirectoryPropertyName);
   }
 
-  /**
-   * Creates the Container's {@link ClassLoader} from the given MULE_HOME and MULE_BASE locations.
-   *
-   * @param muleHome The location of the MULE_HOME directory.
-   * @param muleBase The location of the MULE_BASE directory.
-   * @return A {@link ClassLoader} suitable for loading the {@link MuleContainer} class and all its dependencies.
-   */
   @Override
-  protected ClassLoader createContainerSystemClassLoader(File muleHome, File muleBase) {
-    DefaultMuleClassPathConfig config = new DefaultMuleClassPathConfig(muleHome, muleBase);
-
-    return createModuleLayerClassLoader(config.getOptURLs().toArray(new URL[config.getOptURLs().size()]),
-                                        config.getMuleURLs().toArray(new URL[config.getMuleURLs().size()]),
-                                        MULTI_LEVEL_URL_CLASSLOADER_FACTORY,
-                                        getSystemClassLoader());
+  protected DefaultMuleClassPathConfig createMuleClassPathConfig(File muleHome, File muleBase) {
+    return new DefaultMuleClassPathConfig(muleHome, muleBase);
   }
 }


### PR DESCRIPTION
Refactoring the boot module layer validation and the setup of the JUL to SLF4J bridge to `BootstrapConfigurers`.
Also promoting them to `boot-api` so they can also be consumed by `boot-ee`.
Eventually we could even go one step further and put them in a separate jar file so the `boot-api` remains as light as possible. But it is not a huge gain at this moment.

Finally, we are also promoting the creation of the container classloader to `boot-api` in the `AbstractMuleContainerFactory`. This way we avoid repetition between the CE and EE versions and we can remove the requires against `jpms.utils` from `reboot` and `boot-ee`.