### PR TITLE
W-14108905: Pass a timeout to the connectivity tester tryLock

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/connection/DefaultConnectivityTesterFactoryTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/connection/DefaultConnectivityTesterFactoryTestCase.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.connection;
+
+import static org.mule.test.allure.AllureConstants.JavaSdk.ConnectivityTestingStory.CONNECTIVITY_TEST;
+import static org.mule.test.allure.AllureConstants.JavaSdk.JAVA_SDK;
+
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.mule.runtime.api.connection.ConnectionProvider;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.lock.LockFactory;
+import org.mule.runtime.extension.api.runtime.config.ConfigurationInstance;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+import org.mule.tck.probe.JUnitLambdaProbe;
+import org.mule.tck.probe.PollingProber;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.inject.Inject;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@Feature(JAVA_SDK)
+@Story(CONNECTIVITY_TEST)
+public class DefaultConnectivityTesterFactoryTestCase extends AbstractMuleContextTestCase {
+
+  public static final PollingProber prober = new PollingProber();
+  private static final ExecutorService executorService = newSingleThreadExecutor();
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock
+  public LockFactory lockFactory;
+
+  @Mock
+  public ConnectionProvider provider;
+
+  @Mock
+  public ConfigurationInstance configurationInstance;
+
+  @Inject
+  public ConnectionManagerAdapter connectionManager;
+
+  private DefaultConnectivityTesterFactory connectivityTesterFactory;
+
+  private Lock lock;
+
+  @Before
+  public void setUp() throws MuleException {
+    connectivityTesterFactory = muleContext.getInjector().inject(new DefaultConnectivityTesterFactory());
+
+    lock = spy(new ReentrantLock());
+    when(lockFactory.createLock(anyString())).thenReturn(lock);
+    connectivityTesterFactory.setLockFactory(lockFactory);
+
+    connectionManager = spy(connectionManager);
+    connectivityTesterFactory.setConnectionManager(connectionManager);
+  }
+
+  @Override
+  protected boolean doTestClassInjection() {
+    return true;
+  }
+
+  @Test
+  public void connectivityTesterWaitsForTheLock() {
+    ConnectivityTester connectivityTester = connectivityTesterFactory.create("TestConnectivityTester");
+
+    // The lock is acquired so that connectivityTester's tryLock gets blocked
+    lock.lock();
+
+    // Run the testConnectivity in other thread
+    executorService.execute(() -> {
+      try {
+        connectivityTester.testConnectivity(provider, configurationInstance);
+      } catch (MuleException e) {
+        fail(e.getMessage());
+      }
+    });
+
+    // Eventually, the tryLock is called by the testConnectivity. We expect it to get blocked
+    prober.check(new JUnitLambdaProbe(() -> {
+      verify(lock).tryLock(anyLong(), any(TimeUnit.class));
+      return true;
+    }));
+
+    // Release the lock so that tryLock returns true
+    lock.unlock();
+
+    // And eventually, the testConnectivity is delegated to the connectionManager
+    prober.check(new JUnitLambdaProbe(() -> {
+      verify(connectionManager).testConnectivity(same(configurationInstance));
+      return true;
+    }));
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/connection/DefaultConnectivityTesterFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/connection/DefaultConnectivityTesterFactory.java
@@ -57,16 +57,28 @@ public class DefaultConnectivityTesterFactory implements ConnectivityTesterFacto
 
   private static final Logger LOGGER = getLogger(DefaultConnectivityTesterFactory.class);
 
-  @Inject
   private ConnectionManagerAdapter connectionManager;
 
-  @Inject
   private LockFactory lockFactory;
 
-  @Inject
   private SchedulerService schedulerService;
 
   private final LazyValue<Boolean> doTestConnectivity = new LazyValue<>(this::getDoTestConnectivityProperty);
+
+  @Inject
+  public void setSchedulerService(SchedulerService schedulerService) {
+    this.schedulerService = schedulerService;
+  }
+
+  @Inject
+  public void setLockFactory(LockFactory lockFactory) {
+    this.lockFactory = lockFactory;
+  }
+
+  @Inject
+  public void setConnectionManager(ConnectionManagerAdapter connectionManager) {
+    this.connectionManager = connectionManager;
+  }
 
   @Override
   public ConnectivityTester create(String name) {

--- a/core/src/main/java/org/mule/runtime/core/internal/connection/DefaultConnectivityTesterFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/connection/DefaultConnectivityTesterFactory.java
@@ -11,6 +11,8 @@ import static java.lang.Integer.getInteger;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.util.MuleSystemProperties.ASYNC_TEST_CONNECTIVITY_TIMEOUT_PROPERTY;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -88,7 +90,7 @@ public class DefaultConnectivityTesterFactory implements ConnectivityTesterFacto
           public void doWork(RetryContext context) throws Exception {
             try {
               if (testConnectivityLock != null) {
-                final boolean lockAcquired = testConnectivityLock.tryLock();
+                final boolean lockAcquired = testConnectivityLock.tryLock(10, SECONDS);
                 if (lockAcquired) {
                   LOGGER.debug("Doing testConnectivity() for config '{}'", name);
                   try {

--- a/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
+++ b/tests/allure/src/main/java/org/mule/test/allure/AllureConstants.java
@@ -1022,6 +1022,11 @@ public interface AllureConstants {
 
     }
 
+    interface ConnectivityTestingStory {
+
+      String CONNECTIVITY_TEST = "Connectivity test";
+    }
+
   }
 
   interface XmlSdk {


### PR DESCRIPTION
This gives some time to distributed locks to reach the quorum (otherwise they would return immediately false when the quorum isn't reached, making the connectivity tester assume that the lock is hold by other thread)