### PR TITLE
W-14350781: Enable GroovyResourceReleaser for each JDK. Removing incorrect cleaning method.

### DIFF
--- a/modules/artifact/pom.xml
+++ b/modules/artifact/pom.xml
@@ -15,6 +15,7 @@
         <surefire.args.base>
             -XX:+TieredCompilation
             -Dfile.encoding=UTF-8
+            -javaagent:${settings.localRepository}/org/aspectj/aspectjweaver/${aspectjVersion}/aspectjweaver-${aspectjVersion}.jar
             -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile='${session.executionRootDirectory}/target/jacoco.exec',excludes=mypackage.MyClass
         </surefire.args.base>
         <!-- open internal required stuff from org.mule.runtime.core to the test infrastructure -->
@@ -120,6 +121,12 @@
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-maven-client-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <version>${aspectjVersion}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/artifact/pom.xml
+++ b/modules/artifact/pom.xml
@@ -15,7 +15,6 @@
         <surefire.args.base>
             -XX:+TieredCompilation
             -Dfile.encoding=UTF-8
-            -javaagent:${settings.localRepository}/org/aspectj/aspectjweaver/${aspectjVersion}/aspectjweaver-${aspectjVersion}.jar
             -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile='${session.executionRootDirectory}/target/jacoco.exec',excludes=mypackage.MyClass
         </surefire.args.base>
         <!-- open internal required stuff from org.mule.runtime.core to the test infrastructure -->

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoader.java
@@ -322,7 +322,9 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
     if (IS_JAVA_VERSION_AT_MOST_11) {
       addLegacyExtensionsResourceReleasers();
     }
-
+    if (shouldReleaseGroovyReferences) {
+      resourceReleaserExecutor.addResourceReleaser(() -> new GroovyResourceReleaser(this));
+    }
     resourceReleaserExecutor.executeResourceReleasers();
 
     super.dispose();
@@ -342,9 +344,6 @@ public class MuleArtifactClassLoader extends FineGrainedControlClassLoader imple
     }
     if (shouldReleaseActiveMQReferences) {
       resourceReleaserExecutor.addResourceReleaser(() -> new ActiveMQResourceReleaser(this));
-    }
-    if (shouldReleaseGroovyReferences) {
-      resourceReleaserExecutor.addResourceReleaser(() -> new GroovyResourceReleaser(this));
     }
   }
 

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -32,10 +32,12 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.List;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
 import org.aspectj.weaver.loadtime.Aj;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,9 +49,17 @@ import org.junit.runners.Parameterized;
 @Story(METASPACE_LEAK_PREVENTION_ON_REDEPLOY)
 public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
 
+  private static List<String> oldAjLoadersToSkip;
+
   @BeforeClass
   public static void avoidAspectjAgentLeak() {
+    oldAjLoadersToSkip = Aj.loadersToSkip;
     Aj.loadersToSkip = singletonList(MuleArtifactClassLoader.class.getName());
+  }
+
+  @AfterClass
+  public static void restoreAjLoadersToSkip() {
+    Aj.loadersToSkip = oldAjLoadersToSkip;
   }
 
   private static final int PROBER_POLLING_INTERVAL = 150;

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -14,6 +14,7 @@ import static org.mule.test.allure.AllureConstants.LeakPrevention.LeakPrevention
 import static java.lang.Class.forName;
 import static java.lang.System.gc;
 import static java.lang.Thread.currentThread;
+import static java.util.Collections.singletonList;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -31,7 +32,6 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.ArrayList;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -49,8 +49,7 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
 
   @BeforeClass
   public static void avoidAspectjAgentLeak() {
-    Aj.loadersToSkip = new ArrayList<>();
-    Aj.loadersToSkip.add(MuleArtifactClassLoader.class.getName());
+    Aj.loadersToSkip = singletonList(MuleArtifactClassLoader.class.getName());
   }
 
   private static final int PROBER_POLLING_INTERVAL = 150;

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -6,10 +6,6 @@
  */
 package org.mule.runtime.module.artifact.classloader;
 
-import static org.mule.maven.client.api.MavenClientProvider.discoverProvider;
-import static org.mule.maven.client.api.model.MavenConfiguration.newMavenConfigurationBuilder;
-import static org.mule.runtime.core.api.util.ClassUtils.getFieldValue;
-import static org.mule.runtime.core.internal.util.CompositeClassLoader.from;
 import static org.mule.runtime.module.artifact.classloader.DependencyResolver.getDependencyFromMaven;
 import static org.mule.runtime.module.artifact.classloader.SimpleClassLoaderLookupPolicy.CHILD_FIRST_CLASSLOADER_LOOKUP_POLICY;
 import static org.mule.test.allure.AllureConstants.LeakPrevention.LEAK_PREVENTION;
@@ -18,36 +14,23 @@ import static org.mule.test.allure.AllureConstants.LeakPrevention.LeakPrevention
 import static java.lang.Class.forName;
 import static java.lang.System.gc;
 import static java.lang.Thread.currentThread;
-import static org.apache.commons.io.FileUtils.toFile;
-import static org.apache.commons.lang3.JavaVersion.JAVA_17;
-import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.mock;
 
-import org.mule.maven.client.api.MavenClient;
-import org.mule.maven.client.api.MavenClientProvider;
-import org.mule.maven.client.api.model.MavenConfiguration;
-import org.mule.maven.pom.parser.api.model.BundleDependency;
-import org.mule.runtime.core.internal.util.CompositeClassLoader;
 import org.mule.runtime.module.artifact.api.classloader.ClassLoaderLookupPolicy;
 import org.mule.runtime.module.artifact.api.classloader.MuleArtifactClassLoader;
 import org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptor;
-import org.mule.runtime.module.artifact.internal.classloader.MulePluginClassLoader;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.probe.JUnitLambdaProbe;
 import org.mule.tck.probe.PollingProber;
 
-import java.io.File;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.function.Supplier;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -88,9 +71,6 @@ public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
 
   @Before
   public void setup() throws Exception {
-    assumeThat("When running on Java 17, the resource releaser logic from the Mule Runtime will not be used. " +
-        "The resource releasing responsibility will be delegated to each connector instead.",
-               isJavaVersionAtLeast(JAVA_17), is(false));
     artifactClassLoader =
         new MuleArtifactClassLoader("GroovyResourceReleaserTestCase",
                                     mock(ArtifactDescriptor.class),

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/classloader/GroovyResourceReleaserTestCase.java
@@ -31,10 +31,13 @@ import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.ArrayList;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+import org.aspectj.weaver.loadtime.Aj;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -43,6 +46,12 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 @Story(METASPACE_LEAK_PREVENTION_ON_REDEPLOY)
 public class GroovyResourceReleaserTestCase extends AbstractMuleTestCase {
+
+  @BeforeClass
+  public static void avoidAspectjAgentLeak() {
+    Aj.loadersToSkip = new ArrayList<>();
+    Aj.loadersToSkip.add(MuleArtifactClassLoader.class.getName());
+  }
 
   private static final int PROBER_POLLING_INTERVAL = 150;
   private static final int PROBER_POLLING_TIMEOUT = 6000;


### PR DESCRIPTION
1. Groovy can be used without mule-scripting-module, so the releaser should be part of the Mule Runtime instead of being part of the extension.
2. Before this PR, the GroovyResourceReleaser has two parts:
  a. The "unregisterAllClassesFromInvokerHelper" only uses reflection to access public methods, so there is no problem with JDK 17. This cleaning should be moved to the runtime code, and be enabled for all JDKs (today the whole GroovyResourceReleaser is deprecated and enabled for JDK version at most 11).
  b. The "cleanSpisEngines" part uses setAccessible for not-opened fields in order to clean references to the Groovy script engine that log4j discovered via SPI. This part of the releaser can't be used in JDK 17.
3. The cleaning done by "cleanSpisEngines" was removed. Why?
  a. It was cutting the references to groovy script engines from some objects present in this map: https://github.com/apache/logging-log4j2/blob/dcd30cd6942fd285766360bb458b6f7e8dd2001f/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractManager.java#L82, but it wasn't cleaning the map itself, so it would be just a mitigation of the leak and not a fix.
  b. However, those objects are removed from the map when a LoggerContext is stopped. See this line: https://github.com/apache/logging-log4j2/blob/dcd30cd6942fd285766360bb458b6f7e8dd2001f/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractManager.java#L115. Calling the stop method is enough to fix the leak.
  c. Mule Runtime already calls the LoggerContext#stop method, but after a timeout: it keeps a LoggerContextCache that is composed by two internal caches (one for "active" contexts, and another for "disposed" contexts). When a context is passed to "LoggerContextCache#remove", it's moved from the "active" to the "disposed" cache. The "disposed" cache has an expiration timeout (default is 15 seconds), and when the timeout is elapsed, it calls the actual "LoggerContext#stop()". It removes the entry from the log4j's map mentioned above.
  This timeout was added to give async logging some grace time to log messages after an artifact is disposed. See this class: https://github.com/mulesoft/mule/blob/fb275627d738ad1c49183bbdc054980900bcdcd1/modules/log4j-configurator/src/main/java/org/mule/runtime/module/log4j/internal/LoggerContextCache.java#L73
  d. The timeout can be changed in order to repeat the tests without that cache noise, by setting the property "-M-Dmule.log.context.dispose.delay.millis=10". When you test these scenarios with that property, the OOM can't be reproduced, even after commenting the "cleanSpisEngines" call.

Therefore, the solution here is:
1. Remove the lifecycle listener from the scripting-module code.
2. Remove the cleanSpisEngines() method.
3. Un-deprecate the GroovyResourceReleaser and make it run with all JDKs.

NOTE (about the PR):
- It also removes the aspectj weaver agent, because it holds a reference to the classloaders created by the test (and the test asserts that there aren't references to such classloader)
- The regression test for this change is enabling the same existing test for JDK17.