### PR TITLE
W-13829786: Avoid reading mule-module.properties for modules with module-info

### DIFF
--- a/modules/extensions-support/src/main/java/module-info.java
+++ b/modules/extensions-support/src/main/java/module-info.java
@@ -109,6 +109,7 @@ module org.mule.runtime.extensions.support {
   exports org.mule.runtime.module.extension.internal.runtime.execution.executor to
       org.mule.runtime.core;
   exports org.mule.runtime.module.extension.internal.runtime.resolver to
+      org.mule.runtime.spring.config,
       org.mule.runtime.tooling.support;
   exports org.mule.runtime.module.extension.internal.runtime.source to
       org.mule.runtime.core;

--- a/modules/spring-config/src/main/java/module-info.java
+++ b/modules/spring-config/src/main/java/module-info.java
@@ -69,7 +69,9 @@ module org.mule.runtime.spring.config {
   requires spring.context;
   requires spring.core;
 
+  requires org.apache.commons.lang3;
   requires com.google.common;
+
   requires net.bytebuddy;
 
   // Still needed for the deprecated properties support


### PR DESCRIPTION
* Properly handling transitive requires
* Remove privileged packages from exported packages collection.