### PR TITLE
Nested transactions / calling flows needs to be informed about the rollback

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/api/transaction/TransactionCoordination.java
+++ b/core/src/main/java/org/mule/runtime/core/api/transaction/TransactionCoordination.java
@@ -156,6 +156,7 @@ public final class TransactionCoordination {
         logger.debug("Transaction has been marked rollbackOnly, rolling it back: " + tx);
       }
       tx.rollback();
+      throw new TransactionRollbackException(CoreMessages.transactionMarkedForRollback());
     } else {
       if (logger.isDebugEnabled()) {
         logger.debug("Committing transaction " + tx);


### PR DESCRIPTION
The transaction may be rolledback tue to timeout and then the calling flow must not continue when the child transaction has been rolled back.
The parent needs to be "informed" via Exception that something went wrong.