### PR TITLE
W-14581111: Tooling cannot find `empty-app` config when running in a …

### DIFF
--- a/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/AbstractArtifactAgnosticServiceBuilder.java
+++ b/modules/tooling-support/src/main/java/org/mule/runtime/module/tooling/internal/AbstractArtifactAgnosticServiceBuilder.java
@@ -24,6 +24,7 @@ import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.commons.io.IOUtils.copy;
 
 import org.mule.maven.client.api.MavenClient;
 import org.mule.maven.client.api.MavenClientProvider;
@@ -166,6 +167,10 @@ public abstract class AbstractArtifactAgnosticServiceBuilder<T extends ArtifactA
                 .load(applicationFolder, singletonMap(BundleDescriptor.class.getName(),
                                                       createTempBundleDescriptor()),
                       ArtifactType.APP);
+      }
+
+      for (String config : configs) {
+        copy(this.getClass().getClassLoader().getResource(config), new File(applicationFolder, config));
       }
 
       File destinationFolder =

--- a/tests/infrastructure/src/main/java/org/mule/test/infrastructure/deployment/AbstractFakeMuleServerTestCase.java
+++ b/tests/infrastructure/src/main/java/org/mule/test/infrastructure/deployment/AbstractFakeMuleServerTestCase.java
@@ -39,11 +39,9 @@ public class AbstractFakeMuleServerTestCase extends AbstractMuleTestCase {
   public SystemProperty jvmVersionExtensionEnforcementLoose =
       new SystemProperty("mule.jvm.version.extension.enforcement", "LOOSE");
 
-  // These tests just create a container form the test classpath. There are no modules involved in these tests, so code relying on
-  // modules from the container doesn't work (i.e.: class.getModule().getLayer() returns null).
   @Rule
   public SystemProperty classloaderContainerJpmsModuleLayer =
-      new SystemProperty(CLASSLOADER_CONTAINER_JPMS_MODULE_LAYER, "false");
+      new SystemProperty(CLASSLOADER_CONTAINER_JPMS_MODULE_LAYER, "" + classloaderContainerJpmsModuleLayer());
 
   @Rule
   public TemporaryFolder muleHome = new TemporaryFolder();
@@ -78,6 +76,12 @@ public class AbstractFakeMuleServerTestCase extends AbstractMuleTestCase {
     if (addExpressionLanguageMetadataService()) {
       muleServer.addZippedService(cachedELMService);
     }
+  }
+
+  // These tests just create a container form the test classpath. There are no modules involved in these tests, so code relying on
+  // modules from the container doesn't work (i.e.: class.getModule().getLayer() returns null).
+  protected boolean classloaderContainerJpmsModuleLayer() {
+    return false;
   }
 
   protected boolean addExpressionLanguageMetadataService() {
@@ -129,4 +133,5 @@ public class AbstractFakeMuleServerTestCase extends AbstractMuleTestCase {
   protected File getHttpService() throws IOException {
     return testServicesSetup.getHttpService();
   }
+
 }


### PR DESCRIPTION
…modularized environment (#13062)