### PR TITLE
W-14654712: avoid disposing `DataWeaveExpressionLanguageAdaptor`'s `ExpressionLanguage` if not initialised (#13098)

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/el/dataweave/DataWeaveExpressionLanguageAdaptor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/dataweave/DataWeaveExpressionLanguageAdaptor.java
@@ -290,7 +290,9 @@ public class DataWeaveExpressionLanguageAdaptor implements ExtendedExpressionLan
 
   @Override
   public void dispose() {
-    expressionExecutor.dispose();
+    if (expressionExecutor != null) {
+      expressionExecutor.dispose();
+    }
   }
 
   @Override


### PR DESCRIPTION
(cherry picked from commit d43722109614baa3c84b38115aa2b04434db3800)