### PR TITLE
W-14608096: timeout is not being considered for local transactions and rollbacks are being silently executed

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/execution/BeginAndResolveTransactionInterceptorTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/execution/BeginAndResolveTransactionInterceptorTestCase.java
@@ -59,7 +59,7 @@ public class BeginAndResolveTransactionInterceptorTestCase extends AbstractMuleT
   @Before
   public void before() {
     beginAndResolveTransactionInterceptor =
-        new BeginAndResolveTransactionInterceptor(executionInterceptor, transactionConfig, "APP", null, null, true, true);
+        new BeginAndResolveTransactionInterceptor(executionInterceptor, transactionConfig, "APP", null, null, true, true, true);
   }
 
   @Test

--- a/core/src/main/java/org/mule/runtime/core/api/exception/Errors.java
+++ b/core/src/main/java/org/mule/runtime/core/api/exception/Errors.java
@@ -31,6 +31,7 @@ import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE
 import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE_SEND_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.error.Errors.Identifiers.STREAM_MAXIMUM_SIZE_EXCEEDED_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.error.Errors.Identifiers.TIMEOUT_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.TRANSACTION_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.error.Errors.Identifiers.TRANSFORMATION_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.error.Errors.Identifiers.UNKNOWN_ERROR_IDENTIFIER;
 import static org.mule.runtime.core.api.error.Errors.Identifiers.VALIDATION_ERROR_IDENTIFIER;
@@ -255,6 +256,9 @@ public abstract class Errors extends org.mule.runtime.core.api.error.Errors {
           builder().namespace(CORE_NAMESPACE_NAME).name(SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER).build();
       public static final ComponentIdentifier SOURCE_ERROR_RESPONSE_SEND =
           builder().namespace(CORE_NAMESPACE_NAME).name(SOURCE_ERROR_RESPONSE_SEND_ERROR_IDENTIFIER).build();
+
+      public static final ComponentIdentifier TRANSACTION =
+          builder().namespace(CORE_NAMESPACE_NAME).name(TRANSACTION_ERROR_IDENTIFIER).build();
 
     }
 

--- a/core/src/main/java/org/mule/runtime/core/api/execution/TransactionalExecutionTemplate.java
+++ b/core/src/main/java/org/mule/runtime/core/api/execution/TransactionalExecutionTemplate.java
@@ -48,12 +48,12 @@ public final class TransactionalExecutionTemplate<T> implements ExecutionTemplat
 
   private TransactionalExecutionTemplate(String applicationName, NotificationDispatcher notificationDispatcher,
                                          TransactionManager transactionManager, TransactionConfig transactionConfig) {
-    this(applicationName, notificationDispatcher, transactionManager, transactionConfig, true, false);
+    this(applicationName, notificationDispatcher, transactionManager, transactionConfig, true, false, true);
   }
 
   private TransactionalExecutionTemplate(String applicationName, NotificationDispatcher notificationDispatcher,
                                          TransactionManager transactionManager, TransactionConfig transactionConfig,
-                                         boolean resolveAnyTransaction, boolean resolvePreviousTx) {
+                                         boolean resolveAnyTransaction, boolean resolvePreviousTx, boolean errorAtTimeout) {
     if (transactionConfig == null) {
       transactionConfig = new MuleTransactionConfig();
     }
@@ -65,7 +65,7 @@ public final class TransactionalExecutionTemplate<T> implements ExecutionTemplat
                                                                            notificationDispatcher,
                                                                            transactionManager,
                                                                            processTransactionOnException,
-                                                                           resolveAnyTransaction);
+                                                                           resolveAnyTransaction, errorAtTimeout);
     if (resolvePreviousTx) {
       tempExecutionInterceptor = new ResolvePreviousTransactionInterceptor<>(tempExecutionInterceptor, transactionConfig);
     }
@@ -121,7 +121,7 @@ public final class TransactionalExecutionTemplate<T> implements ExecutionTemplat
     return new TransactionalExecutionTemplate<>(getApplicationName(muleContext),
                                                 getNotificationDispatcher((MuleContextWithRegistry) muleContext),
                                                 muleContext.getTransactionManager(),
-                                                transactionConfig, true, true);
+                                                transactionConfig, true, true, true);
   }
 
   private static NotificationDispatcher getNotificationDispatcher(MuleContextWithRegistry muleContext) {
@@ -156,7 +156,7 @@ public final class TransactionalExecutionTemplate<T> implements ExecutionTemplat
     return new TransactionalExecutionTemplate<>(getApplicationName(muleContext),
                                                 getNotificationDispatcher((MuleContextWithRegistry) muleContext),
                                                 muleContext.getTransactionManager(),
-                                                transactionConfig, false, false);
+                                                transactionConfig, false, false, true);
   }
 
   /**
@@ -171,7 +171,23 @@ public final class TransactionalExecutionTemplate<T> implements ExecutionTemplat
     return new TransactionalExecutionTemplate<>(getApplicationName(muleConfiguration),
                                                 notificationDispatcher,
                                                 transactionManager,
-                                                transactionConfig, false, false);
+                                                transactionConfig, false, false, true);
+  }
+
+  /**
+   * Creates a TransactionalExecutionTemplate for inner scopes within a flow
+   *
+   * @return <T>
+   */
+  public static <T> TransactionalExecutionTemplate<T> createScopeTransactionalExecutionTemplate(MuleConfiguration muleConfiguration,
+                                                                                                NotificationDispatcher notificationDispatcher,
+                                                                                                TransactionManager transactionManager,
+                                                                                                TransactionConfig transactionConfig,
+                                                                                                boolean errorAfterTimeout) {
+    return new TransactionalExecutionTemplate<>(getApplicationName(muleConfiguration),
+                                                notificationDispatcher,
+                                                transactionManager,
+                                                transactionConfig, false, false, errorAfterTimeout);
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
@@ -1579,7 +1579,7 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
 
   private static void configureErrorAndRollbackTxWhenTimeout() {
     FeatureFlaggingRegistry featureFlaggingRegistry = FeatureFlaggingRegistry.getInstance();
-    featureFlaggingRegistry.registerFeatureFlag(ERROR_AND_ROLLBACK_TX_WHEN_TIMEOUT, minMuleVersion("4.6.0"));
+    featureFlaggingRegistry.registerFeatureFlag(ERROR_AND_ROLLBACK_TX_WHEN_TIMEOUT, minMuleVersion("4.6.1"));
   }
 
   private static Predicate<FeatureContext> minMuleVersion(String version) {

--- a/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContext.java
@@ -23,6 +23,7 @@ import static org.mule.runtime.api.config.MuleRuntimeFeature.ENFORCE_ERROR_TYPES
 import static org.mule.runtime.api.config.MuleRuntimeFeature.ENFORCE_EXPRESSION_VALIDATION;
 import static org.mule.runtime.api.config.MuleRuntimeFeature.ENFORCE_REQUIRED_EXPRESSION_VALIDATION;
 import static org.mule.runtime.api.config.MuleRuntimeFeature.ENTITY_RESOLVER_FAIL_ON_FIRST_ERROR;
+import static org.mule.runtime.api.config.MuleRuntimeFeature.ERROR_AND_ROLLBACK_TX_WHEN_TIMEOUT;
 import static org.mule.runtime.api.config.MuleRuntimeFeature.FOREACH_ROUTER_REJECTS_MAP_EXPRESSIONS;
 import static org.mule.runtime.api.config.MuleRuntimeFeature.HANDLE_SPLITTER_EXCEPTION;
 import static org.mule.runtime.api.config.MuleRuntimeFeature.HONOUR_ERROR_MAPPINGS_WHEN_POLICY_APPLIED_ON_OPERATION;
@@ -356,6 +357,7 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
       configureCreateChildPolicyContextForParallelScopes();
       configureCommonsPool2DisableJmx();
       configureDisableSchedulerLogging();
+      configureErrorAndRollbackTxWhenTimeout();
     }
   }
 
@@ -1573,6 +1575,11 @@ public class DefaultMuleContext implements MuleContextWithRegistry, PrivilegedMu
   private static void configureDisableSchedulerLogging() {
     FeatureFlaggingRegistry featureFlaggingRegistry = FeatureFlaggingRegistry.getInstance();
     featureFlaggingRegistry.registerFeatureFlag(DISABLE_SCHEDULER_LOGGING, minMuleVersion("4.6.0"));
+  }
+
+  private static void configureErrorAndRollbackTxWhenTimeout() {
+    FeatureFlaggingRegistry featureFlaggingRegistry = FeatureFlaggingRegistry.getInstance();
+    featureFlaggingRegistry.registerFeatureFlag(ERROR_AND_ROLLBACK_TX_WHEN_TIMEOUT, minMuleVersion("4.6.0"));
   }
 
   private static Predicate<FeatureContext> minMuleVersion(String version) {

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorTypeLocatorFactory.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/ErrorTypeLocatorFactory.java
@@ -18,6 +18,7 @@ import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handle
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SECURITY;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SERVER_SECURITY;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.STREAM_MAXIMUM_SIZE_EXCEEDED;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TRANSACTION;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TRANSFORMATION;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.UNKNOWN;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.VALIDATION;
@@ -34,6 +35,7 @@ import org.mule.runtime.api.security.NotPermittedException;
 import org.mule.runtime.api.security.SecurityException;
 import org.mule.runtime.api.security.ServerSecurityException;
 import org.mule.runtime.api.streaming.exception.StreamingBufferSizeExceededException;
+import org.mule.runtime.api.tx.TransactionException;
 import org.mule.runtime.core.api.exception.ExceptionMapper;
 import org.mule.runtime.core.api.expression.ExpressionRuntimeException;
 import org.mule.runtime.core.api.retry.policy.RetryPolicyExhaustedException;
@@ -89,6 +91,7 @@ public class ErrorTypeLocatorFactory {
             .addExceptionMapping(StreamingBufferSizeExceededException.class,
                                  errorTypeRepository.lookupErrorType(STREAM_MAXIMUM_SIZE_EXCEEDED).get())
             .addExceptionMapping(MuleFatalException.class, errorTypeRepository.getErrorType(FATAL).get())
+            .addExceptionMapping(TransactionException.class, errorTypeRepository.lookupErrorType(TRANSACTION).get())
             .build())
         .defaultError(unknown)
         .build();

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandler.java
@@ -109,10 +109,9 @@ public class OnErrorPropagateHandler extends TemplateOnErrorHandler {
     try {
       tx.rollback();
     } catch (TransactionException e) {
-      if (e.getCause() instanceof TimeoutException) {
-        ex.addSuppressed(e.getCause());
-      } else {
-        logger.error("Cannot rollback current transaction", e);
+      Throwable cause = e.getCause();
+      if (cause != null) {
+        ex.addSuppressed(cause);
       }
     }
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandler.java
@@ -24,8 +24,10 @@ import org.mule.runtime.api.message.error.matcher.ErrorTypeMatcher;
 import org.mule.runtime.api.profiling.ProfilingDataProducer;
 import org.mule.runtime.api.profiling.ProfilingService;
 import org.mule.runtime.api.profiling.type.context.TransactionProfilingEventContext;
+import org.mule.runtime.api.tx.TransactionException;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.api.processor.Processor;
+import org.mule.runtime.core.api.transaction.Transaction;
 import org.mule.runtime.core.api.transaction.TransactionCoordination;
 import org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler;
 
@@ -34,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /**
@@ -99,7 +102,19 @@ public class OnErrorPropagateHandler extends TemplateOnErrorHandler {
   }
 
   public void rollback(Exception ex) {
-    TransactionCoordination.getInstance().rollbackCurrentTransaction();
+    Transaction tx = TransactionCoordination.getInstance().getTransaction();
+    if (tx == null) {
+      return;
+    }
+    try {
+      tx.rollback();
+    } catch (TransactionException e) {
+      if (e.getCause() instanceof TimeoutException) {
+        ex.addSuppressed(e.getCause());
+      } else {
+        logger.error("Cannot rollback current transaction", e);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandler.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/exception/OnErrorPropagateHandler.java
@@ -109,10 +109,7 @@ public class OnErrorPropagateHandler extends TemplateOnErrorHandler {
     try {
       tx.rollback();
     } catch (TransactionException e) {
-      Throwable cause = e.getCause();
-      if (cause != null) {
-        ex.addSuppressed(cause);
-      }
+      ex.addSuppressed(e);
     }
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/execution/BeginAndResolveTransactionInterceptor.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/execution/BeginAndResolveTransactionInterceptor.java
@@ -16,6 +16,7 @@ import org.mule.runtime.core.internal.exception.MessagingException;
 
 import javax.transaction.TransactionManager;
 
+import org.mule.runtime.core.privileged.transaction.TransactionAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,11 +30,13 @@ public class BeginAndResolveTransactionInterceptor<T> implements ExecutionInterc
   private final NotificationDispatcher notificationDispatcher;
   private final boolean processOnException;
   private final boolean mustResolveAnyTransaction;
+  private final boolean errorAtTimeout;
 
   public BeginAndResolveTransactionInterceptor(ExecutionInterceptor<T> next, TransactionConfig transactionConfig,
                                                String applicationName, NotificationDispatcher notificationDispatcher,
                                                TransactionManager transactionManager,
-                                               boolean processOnException, boolean mustResolveAnyTransaction) {
+                                               boolean processOnException, boolean mustResolveAnyTransaction,
+                                               boolean errorAtTimeout) {
     this.next = next;
     this.transactionConfig = transactionConfig;
     this.applicationName = applicationName;
@@ -41,6 +44,7 @@ public class BeginAndResolveTransactionInterceptor<T> implements ExecutionInterc
     this.transactionManager = transactionManager;
     this.processOnException = processOnException;
     this.mustResolveAnyTransaction = mustResolveAnyTransaction;
+    this.errorAtTimeout = errorAtTimeout;
   }
 
   @Override
@@ -62,6 +66,9 @@ public class BeginAndResolveTransactionInterceptor<T> implements ExecutionInterc
                                                            notificationDispatcher,
                                                            transactionManager);
       tx.setTimeout(timeout);
+      if (tx instanceof TransactionAdapter) {
+        ((TransactionAdapter) tx).setRollbackIfTimeout(errorAtTimeout);
+      }
       resolveStartedTransaction = true;
       if (logger.isDebugEnabled()) {
         logger.debug("Transaction successfully started: " + tx);

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
@@ -266,5 +266,10 @@ public class DelegateTransaction extends AbstractTransaction {
     public void setComponentLocation(ComponentLocation componentLocation) {
 
     }
+
+    @Override
+    public void setRollbackIfTimeout(boolean errorIfTimeout) {
+
+    }
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
@@ -162,7 +162,7 @@ public class DelegateTransaction extends AbstractTransaction {
 
   @Override
   public void setTimeout(int timeout) {
-    this.timeout = timeout;
+    super.setTimeout(timeout);
     delegate.setTimeout(timeout);
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
@@ -162,6 +162,7 @@ public class DelegateTransaction extends AbstractTransaction {
 
   @Override
   public void setTimeout(int timeout) {
+    this.timeout = timeout;
     delegate.setTimeout(timeout);
   }
 

--- a/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractSingleResourceTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractSingleResourceTransaction.java
@@ -88,8 +88,11 @@ public abstract class AbstractSingleResourceTransaction extends AbstractTransact
 
   @Override
   public void rollback() throws TransactionException {
-    super.rollback();
-    rolledBack.compareAndSet(false, true);
+    try {
+      super.rollback();
+    } finally {
+      rolledBack.compareAndSet(false, true);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractTransaction.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.privileged.transaction;
 
+import static java.lang.System.err;
 import static java.lang.System.identityHashCode;
 import static java.text.MessageFormat.format;
 import static java.time.Duration.between;
@@ -229,6 +230,11 @@ public abstract class AbstractTransaction implements TransactionAdapter {
   @Override
   public void setComponentLocation(ComponentLocation componentLocation) {
     this.componentLocation = componentLocation;
+  }
+
+  @Override
+  public void setRollbackIfTimeout(boolean rollbackAfterTimeout) {
+    this.rollbackAfterTimeout = rollbackAfterTimeout;
   }
 
   @Override

--- a/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractTransaction.java
@@ -6,19 +6,19 @@
  */
 package org.mule.runtime.core.privileged.transaction;
 
-import static java.lang.System.err;
-import static java.lang.System.identityHashCode;
-import static java.text.MessageFormat.format;
-import static java.time.Duration.between;
-import static java.time.Instant.now;
-import static java.util.Optional.ofNullable;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.notification.TransactionNotification.TRANSACTION_BEGAN;
 import static org.mule.runtime.api.notification.TransactionNotification.TRANSACTION_COMMITTED;
 import static org.mule.runtime.api.notification.TransactionNotification.TRANSACTION_ROLLEDBACK;
 import static org.mule.runtime.core.api.config.i18n.CoreMessages.notMuleXaTransaction;
 import static org.mule.runtime.core.api.config.i18n.CoreMessages.transactionMarkedForRollback;
+import static java.lang.System.identityHashCode;
+import static java.text.MessageFormat.format;
+import static java.time.Duration.between;
+import static java.time.Instant.now;
+import static java.util.Optional.ofNullable;
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.notification.NotificationDispatcher;

--- a/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transaction/AbstractTransaction.java
@@ -116,9 +116,6 @@ public abstract class AbstractTransaction implements TransactionAdapter {
       }
       if (rollbackAfterTimeout && timeoutReached()) {
         rollback();
-        throw new TransactionException(createStaticMessage("Couldn't commit transaction. Transaction rolled back."),
-                                       new TimeoutException(format("Execution time for transaction exceeded timeout ({0} ms)",
-                                                                   timeout)));
       }
       doCommit();
       fireNotification(new TransactionNotification(getId(), TRANSACTION_COMMITTED, getApplicationName()));
@@ -140,6 +137,11 @@ public abstract class AbstractTransaction implements TransactionAdapter {
       setRollbackOnly();
       doRollback();
       fireNotification(new TransactionNotification(getId(), TRANSACTION_ROLLEDBACK, getApplicationName()));
+      if (rollbackAfterTimeout && timeoutReached()) {
+        throw new TransactionException(createStaticMessage("Timeout Reached. Transaction rolled back."),
+                                       new TimeoutException(format("Execution time for transaction exceeded timeout ({0} ms)",
+                                                                   timeout)));
+      }
     } finally {
       unbindTransaction();
     }

--- a/core/src/main/java/org/mule/runtime/core/privileged/transaction/TransactionAdapter.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transaction/TransactionAdapter.java
@@ -30,5 +30,10 @@ public interface TransactionAdapter extends Transaction {
    */
   void setComponentLocation(ComponentLocation componentLocation);
 
+  /**
+   * Set if the transaction should be rolled back in case of timeout, or not.
+   * 
+   * @param rollbackIfTimeout
+   */
   void setRollbackIfTimeout(boolean rollbackIfTimeout);
 }

--- a/core/src/main/java/org/mule/runtime/core/privileged/transaction/TransactionAdapter.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/transaction/TransactionAdapter.java
@@ -29,4 +29,6 @@ public interface TransactionAdapter extends Transaction {
    * @param componentLocation
    */
   void setComponentLocation(ComponentLocation componentLocation);
+
+  void setRollbackIfTimeout(boolean rollbackIfTimeout);
 }

--- a/modules/core-components/src/main/java/org/mule/runtime/core/internal/processor/TryScope.java
+++ b/modules/core-components/src/main/java/org/mule/runtime/core/internal/processor/TryScope.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.core.internal.processor;
 
+import static org.mule.runtime.api.config.MuleRuntimeFeature.ERROR_AND_ROLLBACK_TX_WHEN_TIMEOUT;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_COMMIT;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_CONTINUE;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_START;
@@ -40,6 +41,7 @@ import static reactor.core.publisher.Flux.deferContextual;
 import static reactor.core.publisher.Flux.from;
 import static reactor.core.publisher.Mono.just;
 
+import org.mule.runtime.api.config.FeatureFlaggingService;
 import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.i18n.I18nMessage;
@@ -105,6 +107,9 @@ public class TryScope extends AbstractMessageProcessorOwner implements Scope {
   @Inject
   private ComponentTracerFactory componentTracerFactory;
 
+  @Inject
+  private FeatureFlaggingService featureFlaggingService;
+
   private ProfilingDataProducer<TransactionProfilingEventContext, Object> continueProducer;
   private ProfilingDataProducer<TransactionProfilingEventContext, Object> startProducer;
   private ProfilingDataProducer<TransactionProfilingEventContext, Object> commitProducer;
@@ -122,10 +127,10 @@ public class TryScope extends AbstractMessageProcessorOwner implements Scope {
           .transform(nestedChain);
     }
 
-    ExecutionTemplate<CoreEvent> executionTemplate = createScopeTransactionalExecutionTemplate(muleConfiguration,
-                                                                                               notificationDispatcher,
-                                                                                               transactionManager.orElse(null),
-                                                                                               transactionConfig);
+    boolean errorAfterTimeout = featureFlaggingService.isEnabled(ERROR_AND_ROLLBACK_TX_WHEN_TIMEOUT);
+    ExecutionTemplate<CoreEvent> executionTemplate =
+        createScopeTransactionalExecutionTemplate(muleConfiguration, notificationDispatcher, transactionManager.orElse(null),
+                                                  transactionConfig, errorAfterTimeout);
     final I18nMessage txErrorMessage = errorInvokingMessageProcessorWithinTransaction(nestedChain, transactionConfig);
 
     return deferContextual(ctx -> from(publisher)

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.core.internal.processor;
 
-import static java.util.Arrays.asList;
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_COMMIT;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_CONTINUE;
@@ -16,8 +15,11 @@ import static org.mule.runtime.core.api.transaction.Transaction.STATUS_ROLLEDBAC
 import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
 import static org.mule.runtime.core.internal.processor.TryScopeTestUtils.createTryScope;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -85,7 +87,7 @@ public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase
 
   @Test
   public void transactionIsRolledBackAfterTimeout() throws Exception {
-    TryScope scope = createTryScope(true, muleContext, profilingService, isXa, TIMEOUT);
+    TryScope scope = createTryScope(muleContext, profilingService, of(isXa), of(TIMEOUT));
     scope.setMessageProcessors(singletonList(new SleepyProcesssor()));
     scope.initialise();
     try {
@@ -106,10 +108,10 @@ public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase
     // tx is being attempted to be committed after the execution of its potential error handling
     // (i.e. no failure, or its on-error-continue). Therefore, a tx timeout error has to be handled in the
     // next level (a surrounding try, flow, etc...).
-    TryScope scope = createTryScope(true, muleContext, profilingService, isXa, TIMEOUT);
+    TryScope scope = createTryScope(muleContext, profilingService, of(isXa), of(TIMEOUT));
     scope.setMessageProcessors(singletonList(new SleepyProcesssor()));
 
-    TryScope outer = createTryScope(false, muleContext, profilingService);
+    TryScope outer = createTryScope(muleContext, profilingService, empty());
     outer.setMessageProcessors(singletonList(scope));
     outer.setExceptionListener(new OnErrorContinueHandler());
     outer.initialise();

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.processor;
+
+import static java.util.Arrays.asList;
+import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
+import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_COMMIT;
+import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_CONTINUE;
+import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_START;
+import static org.mule.runtime.core.api.construct.Flow.builder;
+import static org.mule.runtime.core.api.transaction.Transaction.STATUS_ROLLEDBACK;
+import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
+import static org.mule.runtime.core.internal.processor.TryScopeTestUtils.createTryScope;
+import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static java.lang.Thread.sleep;
+
+import org.mule.runtime.api.profiling.ProfilingDataProducer;
+import org.mule.runtime.api.profiling.ProfilingService;
+import org.mule.runtime.api.tx.TransactionException;
+import org.mule.runtime.core.api.construct.Flow;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.processor.Processor;
+import org.mule.runtime.core.api.transaction.Transaction;
+import org.mule.runtime.core.api.transaction.TransactionCoordination;
+import org.mule.runtime.core.internal.exception.OnErrorContinueHandler;
+import org.mule.runtime.core.privileged.registry.RegistrationException;
+import org.mule.tck.junit4.AbstractMuleContextTestCase;
+
+import javax.transaction.TransactionManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.concurrent.TimeoutException;
+
+@RunWith(Parameterized.class)
+public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase {
+
+  private static final int TIMEOUT = 1000;
+  private static final int EXECUTION_TIME = 2 * TIMEOUT;
+
+  private static Transaction transaction;
+  private ProfilingService profilingService = mock(ProfilingService.class);
+  private TransactionManager manager = mock(TransactionManager.class);
+  private Flow flow;
+  private boolean isXa;
+
+  @Parameterized.Parameters(name = "isXa: {0}")
+  public static Collection<Boolean> getParameters() {
+    return asList(false, true);
+  }
+
+  public TransactionalTryTimeoutTestCase(Boolean isXa) {
+    this.isXa = isXa;
+  }
+
+  @Before
+  public void before() throws RegistrationException {
+    flow = builder("flow", mockContextWithServices()).build();
+    flow.setAnnotations(singletonMap(LOCATION_KEY, TEST_CONNECTOR_LOCATION));
+  }
+
+  @Before
+  public void setup() throws Exception {
+    when(profilingService.getProfilingDataProducer(TX_CONTINUE)).thenReturn(mock(ProfilingDataProducer.class));
+    when(profilingService.getProfilingDataProducer(TX_START)).thenReturn(mock(ProfilingDataProducer.class));
+    when(profilingService.getProfilingDataProducer(TX_COMMIT)).thenReturn(mock(ProfilingDataProducer.class));
+    muleContext.setTransactionManager(manager);
+  }
+
+  @Test
+  public void transactionIsRolledBackAfterTimeout() throws Exception {
+    TryScope scope = createTryScope(true, muleContext, profilingService, isXa, TIMEOUT);
+    scope.setMessageProcessors(singletonList(new SleepyProcesssor()));
+    scope.initialise();
+    try {
+      scope.process(getNullEvent());
+      fail("Should have finished with a Tx Exception");
+    } catch (TransactionException ex) {
+      assertThat(ex.getCause(), instanceOf(TimeoutException.class));
+      assertThat(transaction, is(notNullValue()));;
+      assertThat(transaction.getStatus(), is(STATUS_ROLLEDBACK));
+    } finally {
+      scope.dispose();
+    }
+  }
+
+  @Test
+  public void transactionTimeoutErrorCanBeHandledOutsideFailingTry() throws Exception {
+    // If we add the error handler to the failing TryScope, it won't work since the
+    // tx is being attempted to be committed after the execution of its potential error handling
+    // (i.e. no failure, or its on-error-continue). Therefore, a tx timeout error has to be handled in the
+    // next level (a surrounding try, flow, etc...).
+    TryScope scope = createTryScope(true, muleContext, profilingService, isXa, TIMEOUT);
+    scope.setMessageProcessors(singletonList(new SleepyProcesssor()));
+
+    TryScope outer = createTryScope(false, muleContext, profilingService);
+    outer.setMessageProcessors(singletonList(scope));
+    outer.setExceptionListener(new OnErrorContinueHandler());
+    outer.initialise();
+    try {
+      outer.process(getNullEvent());
+      assertThat(transaction, is(notNullValue()));
+      assertThat(transaction.getStatus(), is(STATUS_ROLLEDBACK));
+    } finally {
+      outer.dispose();
+    }
+  }
+
+  public static class SleepyProcesssor implements Processor {
+
+    @Override
+    public CoreEvent process(CoreEvent event) {
+      Transaction tx = TransactionCoordination.getInstance().getTransaction();
+      transaction = tx;
+      try {
+        sleep(EXECUTION_TIME);
+        return event;
+      } catch (InterruptedException e) {
+        return event;
+      }
+    }
+  }
+
+}

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
@@ -170,7 +170,9 @@ public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase
       fail("Should have finished with a Tx Exception");
     } catch (MuleException ex) {
       assertThat(ex.getSuppressed().length, is(1));
-      assertThat(ex.getSuppressed()[0], instanceOf(TimeoutException.class));
+      Throwable suppressed = ex.getSuppressed()[0];
+      assertThat(suppressed, instanceOf(TransactionException.class));
+      assertThat(suppressed.getCause(), instanceOf(TimeoutException.class));
       assertThat(transaction, is(notNullValue()));;
       assertThat(transaction.getStatus(), is(STATUS_ROLLEDBACK));
       assertThat(processor.executed(), is(true));

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
@@ -7,12 +7,14 @@
 package org.mule.runtime.core.internal.processor;
 
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
+import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_COMMIT;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_CONTINUE;
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_START;
 import static org.mule.runtime.core.api.construct.Flow.builder;
 import static org.mule.runtime.core.api.transaction.Transaction.STATUS_ROLLEDBACK;
 import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
+import static org.mule.runtime.core.internal.processor.TryScopeTestUtils.createPropagateErrorHandler;
 import static org.mule.runtime.core.internal.processor.TryScopeTestUtils.createTryScope;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
 import static java.util.Arrays.asList;
@@ -29,6 +31,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static java.lang.Thread.sleep;
 
+import org.mule.runtime.api.exception.DefaultMuleException;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.profiling.ProfilingDataProducer;
 import org.mule.runtime.api.profiling.ProfilingService;
 import org.mule.runtime.api.tx.TransactionException;
@@ -38,6 +43,7 @@ import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.transaction.Transaction;
 import org.mule.runtime.core.api.transaction.TransactionCoordination;
 import org.mule.runtime.core.internal.exception.OnErrorContinueHandler;
+import org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
@@ -75,6 +81,7 @@ public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase
   public void before() throws RegistrationException {
     flow = builder("flow", mockContextWithServices()).build();
     flow.setAnnotations(singletonMap(LOCATION_KEY, TEST_CONNECTOR_LOCATION));
+    transaction = null;
   }
 
   @Before
@@ -89,6 +96,23 @@ public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase
   public void transactionIsRolledBackAfterTimeout() throws Exception {
     TryScope scope = createTryScope(muleContext, profilingService, of(isXa), of(TIMEOUT));
     scope.setMessageProcessors(singletonList(new SleepyProcesssor()));
+    scope.initialise();
+    try {
+      scope.process(getNullEvent());
+      fail("Should have finished with a Tx Exception");
+    } catch (TransactionException ex) {
+      assertThat(ex.getCause(), instanceOf(TimeoutException.class));
+      assertThat(transaction, is(notNullValue()));;
+      assertThat(transaction.getStatus(), is(STATUS_ROLLEDBACK));
+    } finally {
+      scope.dispose();
+    }
+  }
+
+  @Test
+  public void markedAsRollbackExternallyWhenTimeout() throws Exception {
+    TryScope scope = createTryScope(muleContext, profilingService, of(isXa), of(TIMEOUT));
+    scope.setMessageProcessors(singletonList(new SleepyProcesssor(true, false)));
     scope.initialise();
     try {
       scope.process(getNullEvent());
@@ -124,7 +148,45 @@ public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase
     }
   }
 
+  @Test
+  public void originalErrorHasPrecedence() throws Exception {
+    // If we end up having both an error and also a timeout (e.g. an operation that failed, did so because of
+    // a connection issue, and it also exceded timeout), then the original error should have precedence over
+    // the timeout, and it should be handled by the try's error handler.
+    TryScope scope = createTryScope(muleContext, profilingService, of(isXa), of(TIMEOUT));
+    scope.setMessageProcessors(singletonList(new SleepyProcesssor(false, true)));
+    TemplateOnErrorHandler handler = createPropagateErrorHandler();
+    HandlerProcessor processor = new HandlerProcessor();
+    handler.setMessageProcessors(singletonList(processor));
+    scope.setExceptionListener(handler);
+    scope.initialise();
+    try {
+      scope.process(getNullEvent());
+      fail("Should have finished with a Tx Exception");
+    } catch (MuleException ex) {
+      assertThat(ex.getSuppressed().length, is(1));
+      assertThat(ex.getSuppressed()[0], instanceOf(TimeoutException.class));
+      assertThat(transaction, is(notNullValue()));;
+      assertThat(transaction.getStatus(), is(STATUS_ROLLEDBACK));
+      assertThat(processor.executed(), is(true));
+    } finally {
+      scope.dispose();
+    }
+  }
+
   public static class SleepyProcesssor implements Processor {
+
+    private final boolean markAsRollback;
+    private final boolean raiseError;
+
+    public SleepyProcesssor() {
+      this(false, false);
+    }
+
+    public SleepyProcesssor(boolean markAsRollback, boolean raiseError) {
+      this.markAsRollback = markAsRollback;
+      this.raiseError = raiseError;
+    }
 
     @Override
     public CoreEvent process(CoreEvent event) {
@@ -132,10 +194,31 @@ public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase
       transaction = tx;
       try {
         sleep(EXECUTION_TIME);
+        if (markAsRollback) {
+          TransactionCoordination.getInstance().getTransaction().setRollbackOnly();
+        }
+        if (raiseError) {
+          throw new MuleRuntimeException(createStaticMessage("some error"));
+        }
         return event;
-      } catch (InterruptedException e) {
+      } catch (InterruptedException | TransactionException e) {
         return event;
       }
+    }
+  }
+
+  public static class HandlerProcessor implements Processor {
+
+    private boolean wasExecuted = false;
+
+    @Override
+    public CoreEvent process(CoreEvent event) throws MuleException {
+      wasExecuted = true;
+      return event;
+    }
+
+    public boolean executed() {
+      return wasExecuted;
     }
   }
 

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TransactionalTryTimeoutTestCase.java
@@ -30,8 +30,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static java.lang.Thread.sleep;
+import static org.mule.test.allure.AllureConstants.TransactionFeature.TRANSACTION;
+import static org.mule.test.allure.AllureConstants.TransactionFeature.TimeoutStory.TRANSACTION_TIMEOUT;
 
-import org.mule.runtime.api.exception.DefaultMuleException;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.profiling.ProfilingDataProducer;
@@ -47,6 +48,8 @@ import org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
 import javax.transaction.TransactionManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +60,8 @@ import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 
 @RunWith(Parameterized.class)
+@Feature(TRANSACTION)
+@Story(TRANSACTION_TIMEOUT)
 public class TransactionalTryTimeoutTestCase extends AbstractMuleContextTestCase {
 
   private static final int TIMEOUT = 1000;

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TryScopeTestUtils.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TryScopeTestUtils.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.tck.junit4.AbstractMuleTestCase.TEST_CONNECTOR_LOCATION;
 
+import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.notification.NotificationDispatcher;
 import org.mule.runtime.api.profiling.ProfilingService;
 import org.mule.runtime.core.api.MuleContext;
@@ -30,12 +31,14 @@ public class TryScopeTestUtils {
 
   }
 
-  public static TryScope createTryScope(boolean begintx, MuleContext muleContext, ProfilingService profilingService) {
+  public static TryScope createTryScope(boolean begintx, MuleContext muleContext, ProfilingService profilingService)
+      throws MuleException {
     return createTryScope(begintx, muleContext, profilingService, true, 0);
   }
 
   public static TryScope createTryScope(boolean begintx, MuleContext muleContext, ProfilingService profilingService,
-                                        boolean isXa, int timeout) {
+                                        boolean isXa, int timeout)
+      throws MuleException {
     TryScope scope = new TryScope();
     Map<QName, Object> annotations = new HashMap<>();
     annotations.put(LOCATION_KEY, TEST_CONNECTOR_LOCATION);
@@ -52,6 +55,7 @@ public class TryScopeTestUtils {
     scope.setTransactionManager(muleContext.getTransactionManager());
     scope.setMuleContext(muleContext);
     scope.setNotificationDispatcher(mock(NotificationDispatcher.class));
+    muleContext.getInjector().inject(scope);
     return scope;
   }
 

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TryScopeTestUtils.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TryScopeTestUtils.java
@@ -6,11 +6,13 @@
  */
 package org.mule.runtime.core.internal.processor;
 
+import static org.mockito.Mockito.when;
 import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
 import static org.mule.tck.junit4.AbstractMuleTestCase.TEST_CONNECTOR_LOCATION;
 import static java.util.Optional.empty;
 import static org.mockito.Mockito.mock;
 
+import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.notification.NotificationDispatcher;
 import org.mule.runtime.api.profiling.ProfilingService;
@@ -18,7 +20,9 @@ import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.MuleConfiguration;
 import org.mule.runtime.core.api.exception.FlowExceptionHandler;
 import org.mule.runtime.core.api.transaction.MuleTransactionConfig;
+import org.mule.runtime.core.internal.exception.OnErrorPropagateHandler;
 import org.mule.runtime.core.internal.profiling.DummyComponentTracerFactory;
+import org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler;
 import org.mule.tck.testmodels.mule.TestTransactionFactory;
 
 import javax.xml.namespace.QName;
@@ -75,6 +79,22 @@ public class TryScopeTestUtils {
     transactionConfig.setFactory(new TestTransactionFactory(isXa));
     transactionConfig.setTimeout(timeout.orElse(0));
     return transactionConfig;
+  }
+
+  private static ComponentLocation mockComponentLocation() {
+    ComponentLocation cl = mock(ComponentLocation.class);
+    when(cl.getLocation()).thenReturn("test/error-handler/0");
+    when(cl.getRootContainerName()).thenReturn(TEST_CONNECTOR_LOCATION.getRootContainerName());
+    when(cl.getParts()).thenReturn(TEST_CONNECTOR_LOCATION.getParts());
+    return cl;
+  }
+
+  public static TemplateOnErrorHandler createPropagateErrorHandler() {
+    TemplateOnErrorHandler handler = new OnErrorPropagateHandler();
+    Map<QName, Object> annotations = new HashMap<>();
+    annotations.put(LOCATION_KEY, mockComponentLocation());
+    handler.setAnnotations(annotations);
+    return handler;
   }
 
 }

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TryScopeTestUtils.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/TryScopeTestUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.processor;
+
+import static org.mockito.Mockito.mock;
+import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
+import static org.mule.tck.junit4.AbstractMuleTestCase.TEST_CONNECTOR_LOCATION;
+
+import org.mule.runtime.api.notification.NotificationDispatcher;
+import org.mule.runtime.api.profiling.ProfilingService;
+import org.mule.runtime.core.api.MuleContext;
+import org.mule.runtime.core.api.config.MuleConfiguration;
+import org.mule.runtime.core.api.exception.FlowExceptionHandler;
+import org.mule.runtime.core.api.transaction.MuleTransactionConfig;
+import org.mule.runtime.core.internal.profiling.DummyComponentTracerFactory;
+import org.mule.tck.testmodels.mule.TestTransactionFactory;
+
+import javax.xml.namespace.QName;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class TryScopeTestUtils {
+
+  private TryScopeTestUtils() {
+
+  }
+
+  public static TryScope createTryScope(boolean begintx, MuleContext muleContext, ProfilingService profilingService) {
+    return createTryScope(begintx, muleContext, profilingService, true, 0);
+  }
+
+  public static TryScope createTryScope(boolean begintx, MuleContext muleContext, ProfilingService profilingService,
+                                        boolean isXa, int timeout) {
+    TryScope scope = new TryScope();
+    Map<QName, Object> annotations = new HashMap<>();
+    annotations.put(LOCATION_KEY, TEST_CONNECTOR_LOCATION);
+    scope.setAnnotations(annotations);
+    if (begintx) {
+      scope.setTransactionConfig(createTransactionConfig("ALWAYS_BEGIN", timeout, isXa));
+    } else {
+      scope.setTransactionConfig(createTransactionConfig("INDIFFERENT", timeout, isXa));
+    }
+    scope.setComponentTracerFactory(new DummyComponentTracerFactory());
+    scope.setExceptionListener(mock(FlowExceptionHandler.class));
+    scope.setProfilingService(profilingService);
+    scope.setMuleConfiguration(mock(MuleConfiguration.class));
+    scope.setTransactionManager(muleContext.getTransactionManager());
+    scope.setMuleContext(muleContext);
+    scope.setNotificationDispatcher(mock(NotificationDispatcher.class));
+    return scope;
+  }
+
+  private static MuleTransactionConfig createTransactionConfig(String action, int timeout, boolean isXa) {
+    MuleTransactionConfig transactionConfig = new MuleTransactionConfig();
+    transactionConfig.setActionAsString(action);
+    transactionConfig.setFactory(new TestTransactionFactory(isXa));
+    transactionConfig.setTimeout(timeout);
+    return transactionConfig;
+  }
+
+}

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/XaNestedTransactionsTestCase.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/XaNestedTransactionsTestCase.java
@@ -12,6 +12,7 @@ import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_
 import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_START;
 import static org.mule.runtime.core.api.construct.Flow.builder;
 import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
+import static org.mule.runtime.core.internal.processor.TryScopeTestUtils.createPropagateErrorHandler;
 import static org.mule.runtime.core.internal.processor.TryScopeTestUtils.createTryScope;
 import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
 import static org.mule.test.allure.AllureConstants.TransactionFeature.TRANSACTION;
@@ -149,22 +150,6 @@ public class XaNestedTransactionsTestCase extends AbstractMuleContextTestCase {
     } finally {
       surrounding.dispose();
     }
-  }
-
-  private static ComponentLocation mockComponentLocation() {
-    ComponentLocation cl = mock(ComponentLocation.class);
-    when(cl.getLocation()).thenReturn("test/error-handler/0");
-    when(cl.getRootContainerName()).thenReturn(TEST_CONNECTOR_LOCATION.getRootContainerName());
-    when(cl.getParts()).thenReturn(TEST_CONNECTOR_LOCATION.getParts());
-    return cl;
-  }
-
-  private static TemplateOnErrorHandler createPropagateErrorHandler() {
-    TemplateOnErrorHandler handler = new OnErrorPropagateHandler();
-    Map<QName, Object> annotations = new HashMap<>();
-    annotations.put(LOCATION_KEY, mockComponentLocation());
-    handler.setAnnotations(annotations);
-    return handler;
   }
 
   public static class TxCaptor implements Processor {

--- a/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/XaNestedTransactionsTestCase.java
+++ b/modules/core-components/src/test/java/org/mule/runtime/core/internal/processor/XaNestedTransactionsTestCase.java
@@ -6,6 +6,16 @@
  */
 package org.mule.runtime.core.internal.processor;
 
+import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
+import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_CONTINUE;
+import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_COMMIT;
+import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_START;
+import static org.mule.runtime.core.api.construct.Flow.builder;
+import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
+import static org.mule.runtime.core.internal.processor.TryScopeTestUtils.createTryScope;
+import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
+import static org.mule.test.allure.AllureConstants.TransactionFeature.TRANSACTION;
+import static org.mule.test.allure.AllureConstants.TransactionFeature.XaStory.XA_TRANSACTION;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -14,17 +24,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mule.runtime.api.component.AbstractComponent.LOCATION_KEY;
-import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_CONTINUE;
-import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_COMMIT;
-import static org.mule.runtime.api.profiling.type.RuntimeProfilingEventTypes.TX_START;
-import static org.mule.runtime.core.api.construct.Flow.builder;
-import static org.mule.runtime.core.internal.event.NullEventFactory.getNullEvent;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.mule.tck.util.MuleContextUtils.mockContextWithServices;
-import static org.mule.test.allure.AllureConstants.TransactionFeature.TRANSACTION;
-import static org.mule.test.allure.AllureConstants.TransactionFeature.XaStory.XA_TRANSACTION;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -33,24 +34,18 @@ import org.junit.Test;
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.api.notification.NotificationDispatcher;
 import org.mule.runtime.api.profiling.ProfilingDataProducer;
 import org.mule.runtime.api.profiling.ProfilingService;
-import org.mule.runtime.core.api.config.MuleConfiguration;
 import org.mule.runtime.core.api.construct.Flow;
 import org.mule.runtime.core.api.event.CoreEvent;
-import org.mule.runtime.core.api.exception.FlowExceptionHandler;
 import org.mule.runtime.core.api.processor.Processor;
-import org.mule.runtime.core.api.transaction.MuleTransactionConfig;
 import org.mule.runtime.core.api.transaction.Transaction;
 import org.mule.runtime.core.api.transaction.TransactionCoordination;
 import org.mule.runtime.core.internal.exception.OnErrorContinueHandler;
 import org.mule.runtime.core.internal.exception.OnErrorPropagateHandler;
-import org.mule.runtime.core.internal.profiling.DummyComponentTracerFactory;
 import org.mule.runtime.core.privileged.exception.TemplateOnErrorHandler;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
-import org.mule.tck.testmodels.mule.TestTransactionFactory;
 
 import javax.transaction.TransactionManager;
 import javax.xml.namespace.QName;
@@ -64,13 +59,8 @@ import java.util.Map;
 public class XaNestedTransactionsTestCase extends AbstractMuleContextTestCase {
 
   private static List<Transaction> transactions;
-  private FlowExceptionHandler exceptionHandler = mock(FlowExceptionHandler.class);
   private ProfilingService profilingService = mock(ProfilingService.class);
   private TransactionManager manager = mock(TransactionManager.class);
-
-  private MuleConfiguration configuration = mock(MuleConfiguration.class);
-  private NotificationDispatcher notificationDispatcher = mock(NotificationDispatcher.class);
-
   private Flow flow;
 
   @Before
@@ -88,31 +78,11 @@ public class XaNestedTransactionsTestCase extends AbstractMuleContextTestCase {
     muleContext.setTransactionManager(manager);
   }
 
-  private TryScope createTryScope(boolean begintx) {
-    TryScope scope = new TryScope();
-    Map<QName, Object> annotations = new HashMap<>();
-    annotations.put(LOCATION_KEY, TEST_CONNECTOR_LOCATION);
-    scope.setAnnotations(annotations);
-    if (begintx) {
-      scope.setTransactionConfig(createTransactionConfig("ALWAYS_BEGIN"));
-    } else {
-      scope.setTransactionConfig(createTransactionConfig("INDIFFERENT"));
-    }
-    scope.setComponentTracerFactory(new DummyComponentTracerFactory());
-    scope.setExceptionListener(exceptionHandler);
-    scope.setProfilingService(profilingService);
-    scope.setMuleConfiguration(configuration);
-    scope.setTransactionManager(manager);
-    scope.setMuleContext(muleContext);
-    scope.setNotificationDispatcher(notificationDispatcher);
-    return scope;
-  }
-
   @Test
   public void xaAllowsNestedTx() throws Exception {
-    TryScope inner = createTryScope(true);
+    TryScope inner = createTryScope(true, muleContext, profilingService);
     inner.setMessageProcessors(singletonList(new TxCaptor()));
-    TryScope outer = createTryScope(true);
+    TryScope outer = createTryScope(true, muleContext, profilingService);
     outer.setMessageProcessors(asList(new TxCaptor(), inner, new TxCaptor()));
 
     outer.initialise();
@@ -128,17 +98,17 @@ public class XaNestedTransactionsTestCase extends AbstractMuleContextTestCase {
 
   @Test
   public void xaErrorInNestedTx() throws Exception {
-    TryScope inner = createTryScope(true);
+    TryScope inner = createTryScope(true, muleContext, profilingService);
     inner.setMessageProcessors(asList(new TxCaptor(), new ErrorProcessor()));
     TemplateOnErrorHandler handler = createPropagateErrorHandler();
     handler.setMessageProcessors(singletonList(new TxCaptor()));
     inner.setExceptionListener(handler);
 
-    TryScope withHandler = createTryScope(false);
+    TryScope withHandler = createTryScope(false, muleContext, profilingService);
     withHandler.setMessageProcessors(singletonList(inner));
     withHandler.setExceptionListener(new OnErrorContinueHandler());
 
-    TryScope outer = createTryScope(true);
+    TryScope outer = createTryScope(true, muleContext, profilingService);
     outer.setMessageProcessors(asList(new TxCaptor(), withHandler, new TxCaptor()));
     outer.setExceptionListener(new OnErrorContinueHandler());
     outer.initialise();
@@ -157,14 +127,14 @@ public class XaNestedTransactionsTestCase extends AbstractMuleContextTestCase {
 
   @Test
   public void xaErrorInOuterTx() throws Exception {
-    TryScope inner = createTryScope(true);
+    TryScope inner = createTryScope(true, muleContext, profilingService);
     inner.setMessageProcessors(singletonList(new TxCaptor()));
 
-    TryScope outer = createTryScope(true);
+    TryScope outer = createTryScope(true, muleContext, profilingService);
     outer.setMessageProcessors(asList(new TxCaptor(), inner, new ErrorProcessor()));
     outer.setExceptionListener(createPropagateErrorHandler());
 
-    TryScope surrounding = createTryScope(false);
+    TryScope surrounding = createTryScope(false, muleContext, profilingService);
     surrounding.setMessageProcessors(singletonList(outer));
     surrounding.setExceptionListener(new OnErrorContinueHandler());
     surrounding.initialise();
@@ -177,13 +147,6 @@ public class XaNestedTransactionsTestCase extends AbstractMuleContextTestCase {
     } finally {
       surrounding.dispose();
     }
-  }
-
-  private MuleTransactionConfig createTransactionConfig(String action) {
-    MuleTransactionConfig transactionConfig = new MuleTransactionConfig();
-    transactionConfig.setActionAsString(action);
-    transactionConfig.setFactory(new TestTransactionFactory(true));
-    return transactionConfig;
   }
 
   private static ComponentLocation mockComponentLocation() {

--- a/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/error/MuleCoreErrorTypeRepository.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/config/internal/error/MuleCoreErrorTypeRepository.java
@@ -30,6 +30,7 @@ import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handle
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_RESPONSE_SEND;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.STREAM_MAXIMUM_SIZE_EXCEEDED;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TIMEOUT;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TRANSACTION;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TRANSFORMATION;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.UNKNOWN;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.VALIDATION;
@@ -117,6 +118,7 @@ public final class MuleCoreErrorTypeRepository implements ErrorTypeRepository {
     doAddErrorType(SERVER_SECURITY, getErrorType(SECURITY).get());
     doAddErrorType(NOT_PERMITTED, getErrorType(SERVER_SECURITY).get());
     doAddErrorType(STREAM_MAXIMUM_SIZE_EXCEEDED, getAnyErrorType());
+    doAddErrorType(TRANSACTION, getAnyErrorType());
 
     doAddInternalErrorType(OVERLOAD, getCriticalErrorType());
     doAddInternalErrorType(FLOW_BACK_PRESSURE, getErrorType(OVERLOAD).get());

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/error/Errors.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/error/Errors.java
@@ -145,6 +145,11 @@ public abstract class Errors {
     public static final String SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER = "SOURCE_ERROR_RESPONSE_GENERATE";
 
     /**
+     * Indicates that an error occurred related to transactions commit or rollback (e.g. transaction timeout).
+     */
+    public static final String TRANSACTION_ERROR_IDENTIFIER = "TRANSACTION";
+
+    /**
      * Indicates that an unknown and unexpected error occurred. Cannot be handled directly, only through ANY.
      */
     public static final String UNKNOWN_ERROR_IDENTIFIER = "UNKNOWN";
@@ -170,11 +175,6 @@ public abstract class Errors {
      * Indicates that a fatal error occurred (such as stack overflow). Cannot be handled.
      */
     public static final String FATAL_ERROR_IDENTIFIER = "FATAL_JVM_ERROR";
-
-    /**
-     * Indicates that an error occurred related to transactions commit or rollback (e.g. transaction timeout).
-     */
-    public static final String TRANSACTION_ERROR_IDENTIFIER = "TRANSACTION_ERROR";
   }
 
   public static final class ComponentIdentifiers {

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/error/Errors.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/error/Errors.java
@@ -7,33 +7,7 @@
 package org.mule.runtime.core.api.error;
 
 import static org.mule.runtime.api.component.ComponentIdentifier.builder;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.ANY_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.CLIENT_SECURITY_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.COMPOSITE_ROUTING_ERROR;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.CONNECTIVITY_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.CRITICAL_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.DUPLICATE_MESSAGE_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.EXPRESSION_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.FATAL_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.FLOW_BACK_PRESSURE_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.NOT_PERMITTED_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.OVERLOAD_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.REDELIVERY_EXHAUSTED_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.RETRY_EXHAUSTED_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.ROUTING_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SECURITY_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SERVER_SECURITY_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_ERROR_RESPONSE_SEND_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE_GENERATE_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE_SEND_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.STREAM_MAXIMUM_SIZE_EXCEEDED_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.TIMEOUT_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.TRANSFORMATION_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.UNKNOWN_ERROR_IDENTIFIER;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.VALIDATION_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.*;
 import static org.mule.runtime.internal.dsl.DslConstants.CORE_PREFIX;
 
 import org.mule.api.annotation.NoExtend;
@@ -196,6 +170,11 @@ public abstract class Errors {
      * Indicates that a fatal error occurred (such as stack overflow). Cannot be handled.
      */
     public static final String FATAL_ERROR_IDENTIFIER = "FATAL_JVM_ERROR";
+
+    /**
+     * Indicates that an error occurred related to transactions commit or rollback (e.g. transaction timeout).
+     */
+    public static final String TRANSACTION_ERROR_IDENTIFIER = "TRANSACTION_ERROR";
   }
 
   public static final class ComponentIdentifiers {
@@ -249,6 +228,9 @@ public abstract class Errors {
           builder().namespace(CORE_NAMESPACE_NAME).name(SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER).build();
       public static final ComponentIdentifier SOURCE_ERROR_RESPONSE_SEND =
           builder().namespace(CORE_NAMESPACE_NAME).name(SOURCE_ERROR_RESPONSE_SEND_ERROR_IDENTIFIER).build();
+
+      public static final ComponentIdentifier TRANSACTION =
+          builder().namespace(CORE_NAMESPACE_NAME).name(TRANSACTION_ERROR_IDENTIFIER).build();
 
     }
 

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/error/Errors.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/error/Errors.java
@@ -7,7 +7,34 @@
 package org.mule.runtime.core.api.error;
 
 import static org.mule.runtime.api.component.ComponentIdentifier.builder;
-import static org.mule.runtime.core.api.error.Errors.Identifiers.*;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.ANY_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.CLIENT_SECURITY_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.COMPOSITE_ROUTING_ERROR;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.CONNECTIVITY_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.CRITICAL_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.DUPLICATE_MESSAGE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.EXPRESSION_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.FATAL_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.FLOW_BACK_PRESSURE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.NOT_PERMITTED_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.OVERLOAD_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.REDELIVERY_EXHAUSTED_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.RETRY_EXHAUSTED_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.ROUTING_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SECURITY_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SERVER_SECURITY_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_ERROR_RESPONSE_GENERATE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_ERROR_RESPONSE_SEND_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE_GENERATE_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.SOURCE_RESPONSE_SEND_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.STREAM_MAXIMUM_SIZE_EXCEEDED_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.TIMEOUT_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.TRANSACTION_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.TRANSFORMATION_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.UNKNOWN_ERROR_IDENTIFIER;
+import static org.mule.runtime.core.api.error.Errors.Identifiers.VALIDATION_ERROR_IDENTIFIER;
 import static org.mule.runtime.internal.dsl.DslConstants.CORE_PREFIX;
 
 import org.mule.api.annotation.NoExtend;

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelDeclarer.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelDeclarer.java
@@ -20,29 +20,7 @@ import static org.mule.runtime.api.meta.model.parameter.ParameterRole.PRIMARY_CO
 import static org.mule.runtime.api.meta.model.stereotype.StereotypeModelBuilder.newStereotype;
 import static org.mule.runtime.api.util.MuleSystemProperties.REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY;
 import static org.mule.runtime.api.util.MuleSystemProperties.isParseTemplateUseLegacyDefaultTargetValue;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.ANY;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.CLIENT_SECURITY;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.COMPOSITE_ROUTING;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.CONNECTIVITY;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.DUPLICATE_MESSAGE;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.EXPRESSION;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.NOT_PERMITTED;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.REDELIVERY_EXHAUSTED;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.RETRY_EXHAUSTED;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.ROUTING;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SECURITY;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SERVER_SECURITY;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_ERROR_RESPONSE_GENERATE;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_ERROR_RESPONSE_SEND;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_RESPONSE;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_RESPONSE_GENERATE;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_RESPONSE_SEND;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.STREAM_MAXIMUM_SIZE_EXCEEDED;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TIMEOUT;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TRANSFORMATION;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.UNKNOWN;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.VALIDATION;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.*;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Unhandleable.CRITICAL;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Unhandleable.FATAL;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Unhandleable.FLOW_BACK_PRESSURE;
@@ -153,6 +131,7 @@ class MuleExtensionModelDeclarer {
   final ErrorModel compositeRoutingError = newError(COMPOSITE_ROUTING).withParent(routingError).build();
   final ErrorModel validationError = newError(VALIDATION).withParent(anyError).build();
   final ErrorModel duplicateMessageError = newError(DUPLICATE_MESSAGE).withParent(validationError).build();
+  final ErrorModel transactionError = newError(TRANSACTION).withParent(anyError).build();
 
   private static final String BUSINESS_EVENTS = "Business Events";
   private static final String TRACKING_NAMESPACE = "tracking";
@@ -867,7 +846,8 @@ class MuleExtensionModelDeclarer {
   private void declareTry(ExtensionDeclarer extensionDeclarer) {
     ConstructDeclarer tryScope = extensionDeclarer.withConstruct("try")
         .describedAs("Processes the nested list of message processors, "
-            + "within a transaction and with it's own error handler if required.");
+            + "within a transaction and with it's own error handler if required.")
+        .withErrorModel(transactionError);
 
     tryScope.onDefaultParameterGroup()
         .withOptionalParameter("transactionalAction")

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelDeclarer.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelDeclarer.java
@@ -20,7 +20,30 @@ import static org.mule.runtime.api.meta.model.parameter.ParameterRole.PRIMARY_CO
 import static org.mule.runtime.api.meta.model.stereotype.StereotypeModelBuilder.newStereotype;
 import static org.mule.runtime.api.util.MuleSystemProperties.REVERT_SUPPORT_EXPRESSIONS_IN_VARIABLE_NAME_IN_SET_VARIABLE_PROPERTY;
 import static org.mule.runtime.api.util.MuleSystemProperties.isParseTemplateUseLegacyDefaultTargetValue;
-import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.*;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.ANY;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.CLIENT_SECURITY;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.COMPOSITE_ROUTING;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.CONNECTIVITY;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.DUPLICATE_MESSAGE;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.EXPRESSION;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.NOT_PERMITTED;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.REDELIVERY_EXHAUSTED;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.RETRY_EXHAUSTED;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.ROUTING;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SECURITY;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SERVER_SECURITY;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_ERROR_RESPONSE_GENERATE;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_ERROR_RESPONSE_SEND;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_RESPONSE;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_RESPONSE_GENERATE;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.SOURCE_RESPONSE_SEND;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.STREAM_MAXIMUM_SIZE_EXCEEDED;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TIMEOUT;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TRANSACTION;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.TRANSFORMATION;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.UNKNOWN;
+import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Handleable.VALIDATION;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Unhandleable.CRITICAL;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Unhandleable.FATAL;
 import static org.mule.runtime.core.api.error.Errors.ComponentIdentifiers.Unhandleable.FLOW_BACK_PRESSURE;
@@ -994,6 +1017,7 @@ class MuleExtensionModelDeclarer {
 
     extensionDeclarer.withErrorModel(validationError);
     extensionDeclarer.withErrorModel(duplicateMessageError);
+    extensionDeclarer.withErrorModel(transactionError);
 
     extensionDeclarer.withErrorModel(securityError);
     extensionDeclarer.withErrorModel(serverSecurityError);


### PR DESCRIPTION
This can also involve XA Transactions, when there is no error but timeout has been reached, the tx should be rolled back and an error has to be thrown so the execution doesn't continue as if nothing happened (and also allows for error handling for TryScope scenarios).  