### PR TITLE
W-15194847: [Windows] Fix test org.mule.runtime.core.internal.util.store.PartitionedPersistentObjectStoreTestCase.allowsAnyPartitionName

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/util/store/PartitionedPersistentObjectStoreTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/util/store/PartitionedPersistentObjectStoreTestCase.java
@@ -144,7 +144,7 @@ public class PartitionedPersistentObjectStoreTestCase extends AbstractMuleTestCa
 
   @Test
   public void allowsAnyPartitionName() throws Exception {
-    os.open("asdfsadfsa#$%@#$@#$@$%$#&8******ASDFWER??!?!");
+    os.open("asdfsadfsa#$%@#$@#$@$%$#&8ASDFWER!!");
   }
 
   @Test


### PR DESCRIPTION
(cherry picked from commit 3c0383dc4fc3076c9c5507356223402161cf67e5)