### PR TITLE
W-15489755: Race condition between wrapper start and  halt and catch fire mangement in tanuki wrapper bootstrap

### DIFF
--- a/modules/tanuki-boot/src/main/java/org/mule/runtime/module/boot/tanuki/internal/MuleContainerTanukiWrapper.java
+++ b/modules/tanuki-boot/src/main/java/org/mule/runtime/module/boot/tanuki/internal/MuleContainerTanukiWrapper.java
@@ -44,7 +44,7 @@ public class MuleContainerTanukiWrapper extends AbstractMuleContainerWrapper imp
   }
 
   @Override
-  protected void start(MuleContainerFactory muleContainerFactory, String[] args) {
+  protected synchronized void start(MuleContainerFactory muleContainerFactory, String[] args) {
     WrapperListener wrapperListener =
         new MuleContainerTanukiWrapperListener(muleContainerFactory, getAllConfigurersReady(), this::dispose);
     WrapperManager.start(wrapperListener, args);
@@ -52,7 +52,7 @@ public class MuleContainerTanukiWrapper extends AbstractMuleContainerWrapper imp
   }
 
   @Override
-  public void haltAndCatchFire(int exitCode, String message) {
+  public synchronized void haltAndCatchFire(int exitCode, String message) {
     // If #start has not been called yet, we need to start a NoOp WrapperListener to notify the native wrapper and allow
     // events to be processed
     if (!isStarted) {


### PR DESCRIPTION
There is a race condition between start and haltAndCatchFire which results in the tanuki wrapper bootsrap:

`new MuleContainerTanukiWrapperListener(muleContainerFactory, getAllConfigurersReady(), this::dispose);`
can trigger in an async way a haltAndCatchFire.

so the isStarted flag works incorrectly.
This results in the following exception which didn't appear when MuleContainerTanukiwrapper didn't exist or in wrapperless:


```
java.lang.IllegalStateException: WrapperManager has already been started with a WrapperListener.

Caused by: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: WrapperManager has already been started with a WrapperListener.

```