### PR TITLE
W-15617764: IllegalAccessException using ItemSequenceInfo through DataWeave in J17

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/DefaultMessageContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/DefaultMessageContextTestCase.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.mule.runtime.api.event.EventContext;
+import org.mule.runtime.api.message.ItemSequenceInfo;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.FlowConstruct;
@@ -79,10 +80,29 @@ public class DefaultMessageContextTestCase extends AbstractMuleTestCase {
   }
 
   @Test
-  public void overrideCorrelationIdInContext() {
+  public void overrideCorrelationIdInContextWithGroupCorrelation() {
     final Message message = of(TEST_PAYLOAD);
     final CoreEvent event = CoreEvent.builder(executionContextWithCorrelation).message(message)
         .groupCorrelation(empty()).build();
+
+    assertThat(event.getCorrelationId(), is(CUSTOM_CORRELATION_ID));
+  }
+
+  @Test
+  public void overrideCorrelationIdInContextSequenceWithGroupCorrelation() {
+    final Message message = of(TEST_PAYLOAD);
+    final CoreEvent event =
+        PrivilegedEvent.builder(executionContextWithCorrelation).message(message).correlationId(CUSTOM_CORRELATION_ID)
+            .groupCorrelation(Optional.of(GroupCorrelation.of(6))).build();
+
+    assertThat(event.getCorrelationId(), is(CUSTOM_CORRELATION_ID));
+  }
+
+  @Test
+  public void overrideCorrelationIdInContext() {
+    final Message message = of(TEST_PAYLOAD);
+    final CoreEvent event = CoreEvent.builder(executionContextWithCorrelation).message(message)
+        .itemSequenceInfo(empty()).build();
 
     assertThat(event.getCorrelationId(), is(CUSTOM_CORRELATION_ID));
   }
@@ -92,7 +112,7 @@ public class DefaultMessageContextTestCase extends AbstractMuleTestCase {
     final Message message = of(TEST_PAYLOAD);
     final CoreEvent event =
         PrivilegedEvent.builder(executionContextWithCorrelation).message(message).correlationId(CUSTOM_CORRELATION_ID)
-            .groupCorrelation(Optional.of(GroupCorrelation.of(6))).build();
+            .itemSequenceInfo(Optional.of(ItemSequenceInfo.of(6))).build();
 
     assertThat(event.getCorrelationId(), is(CUSTOM_CORRELATION_ID));
   }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -484,6 +484,7 @@ module org.mule.runtime.core {
   exports org.mule.runtime.core.internal.util.mediatype to
       org.mule.runtime.extensions.support;
   exports org.mule.runtime.core.internal.util.message to
+      org.mule.runtime.core.components,
       org.mule.runtime.extensions.support;
   exports org.mule.runtime.core.internal.util.message.stream to
       org.mule.runtime.extensions.support;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -484,7 +484,6 @@ module org.mule.runtime.core {
   exports org.mule.runtime.core.internal.util.mediatype to
       org.mule.runtime.extensions.support;
   exports org.mule.runtime.core.internal.util.message to
-      org.mule.runtime.core.components,
       org.mule.runtime.extensions.support;
   exports org.mule.runtime.core.internal.util.message.stream to
       org.mule.runtime.extensions.support;

--- a/modules/core-components/src/main/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyFactory.java
+++ b/modules/core-components/src/main/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyFactory.java
@@ -9,7 +9,6 @@ package org.mule.runtime.core.internal.routing.forkjoin;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.internal.exception.ErrorHandlerContextManager.ERROR_HANDLER_CONTEXT;
 import static org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair.of;
-import static org.mule.runtime.core.internal.util.message.ItemSequenceInfoUtils.fromGroupCorrelation;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContextDontComplete;
 
 import static java.lang.Long.MAX_VALUE;
@@ -33,7 +32,6 @@ import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.scheduler.Scheduler;
 import org.mule.runtime.api.util.Pair;
 import org.mule.runtime.core.api.event.CoreEvent;
-import org.mule.runtime.core.api.message.GroupCorrelation;
 import org.mule.runtime.core.api.processor.ReactiveProcessor;
 import org.mule.runtime.core.api.processor.strategy.ProcessingStrategy;
 import org.mule.runtime.core.internal.event.DefaultEventBuilder;
@@ -43,7 +41,6 @@ import org.mule.runtime.core.internal.routing.ForkJoinStrategy;
 import org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair;
 import org.mule.runtime.core.internal.routing.ForkJoinStrategyFactory;
 import org.mule.runtime.core.internal.routing.result.CompositeRoutingException;
-import org.mule.runtime.core.internal.util.message.ItemSequenceInfoUtils;
 import org.mule.runtime.core.privileged.exception.EventProcessingException;
 import org.mule.runtime.core.privileged.routing.RoutingResult;
 

--- a/modules/core-components/src/main/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyFactory.java
+++ b/modules/core-components/src/main/java/org/mule/runtime/core/internal/routing/forkjoin/AbstractForkJoinStrategyFactory.java
@@ -9,10 +9,12 @@ package org.mule.runtime.core.internal.routing.forkjoin;
 import static org.mule.runtime.core.api.event.CoreEvent.builder;
 import static org.mule.runtime.core.internal.exception.ErrorHandlerContextManager.ERROR_HANDLER_CONTEXT;
 import static org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair.of;
+import static org.mule.runtime.core.internal.util.message.ItemSequenceInfoUtils.fromGroupCorrelation;
 import static org.mule.runtime.core.privileged.processor.MessageProcessors.processWithChildContextDontComplete;
 
 import static java.lang.Long.MAX_VALUE;
 import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
 import static reactor.core.Exceptions.propagate;
@@ -23,6 +25,7 @@ import static reactor.core.publisher.Mono.just;
 
 import org.mule.runtime.api.message.Error;
 import org.mule.runtime.api.message.ErrorType;
+import org.mule.runtime.api.message.ItemSequenceInfo;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.CollectionDataType;
 import org.mule.runtime.api.metadata.DataType;
@@ -40,6 +43,7 @@ import org.mule.runtime.core.internal.routing.ForkJoinStrategy;
 import org.mule.runtime.core.internal.routing.ForkJoinStrategy.RoutingPair;
 import org.mule.runtime.core.internal.routing.ForkJoinStrategyFactory;
 import org.mule.runtime.core.internal.routing.result.CompositeRoutingException;
+import org.mule.runtime.core.internal.util.message.ItemSequenceInfoUtils;
 import org.mule.runtime.core.privileged.exception.EventProcessingException;
 import org.mule.runtime.core.privileged.routing.RoutingResult;
 
@@ -156,7 +160,7 @@ public abstract class AbstractForkJoinStrategyFactory implements ForkJoinStrateg
                                                                             CoreEvent.Builder resultBuilder);
 
   private Function<RoutingPair, RoutingPair> addSequence(AtomicInteger count) {
-    return pair -> of(builder(pair.getEvent()).groupCorrelation(Optional.of(GroupCorrelation.of(count.getAndIncrement())))
+    return pair -> of(builder(pair.getEvent()).itemSequenceInfo(ofNullable(ItemSequenceInfo.of(count.getAndIncrement())))
         .build(), pair.getRoute());
   }
 


### PR DESCRIPTION
* piggybacks: replace deprecated `groupCorrelation` with `itemGroupInfo`