### PR TITLE
W-15586397: Ignore OTEL flakies (#13432)

### DIFF
--- a/modules/metrics/mule-metrics-exporter-impl/src/test/java/org/mule/runtime/metrics/exporter/impl/OpenTelemetryMeterExporterConfigTestCase.java
+++ b/modules/metrics/mule-metrics-exporter-impl/src/test/java/org/mule/runtime/metrics/exporter/impl/OpenTelemetryMeterExporterConfigTestCase.java
@@ -48,6 +48,7 @@ import com.linecorp.armeria.testing.junit4.server.SelfSignedCertificateRule;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -55,6 +56,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
 
+@Ignore("W-15586397")
 public class OpenTelemetryMeterExporterConfigTestCase {
 
   private static final int TIMEOUT_MILLIS = 30000;
@@ -73,7 +75,7 @@ public class OpenTelemetryMeterExporterConfigTestCase {
   private static final String UNIT_NAME = "test-unit";
 
   private static final DockerImageName COLLECTOR_IMAGE =
-      DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-java/otel-collector");
+      DockerImageName.parse("otel/opentelemetry-collector:0.99.0");
 
   private MeterExporter openTelemetryMeterExporter;
   private Meter meter;

--- a/modules/tracing/mule-tracer-exporter-impl/src/test/java/org/mule/runtime/tracer/exporter/impl/OpenTelemetryExporterConfigTestCase.java
+++ b/modules/tracing/mule-tracer-exporter-impl/src/test/java/org/mule/runtime/tracer/exporter/impl/OpenTelemetryExporterConfigTestCase.java
@@ -69,6 +69,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -77,12 +78,13 @@ import org.testcontainers.utility.DockerImageName;
 
 @Feature(PROFILING)
 @Story(OPEN_TELEMETRY_EXPORTER)
+@Ignore("W-15586397")
 public class OpenTelemetryExporterConfigTestCase {
 
   public static final String TEST_SERVICE_NAME = "test-service-name";
 
   private static final DockerImageName COLLECTOR_IMAGE =
-      DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-java/otel-collector");
+      DockerImageName.parse("otel/opentelemetry-collector:0.99.0");
 
   private static final Integer COLLECTOR_OTLP_GRPC_PORT = 4317;
   private static final Integer COLLECTOR_OTLP_HTTP_PORT = 4318;


### PR DESCRIPTION
* W-15586397: Investigate tests failing with otel collector image using testcontainers (#13412) (#13416)

* W-15586397: set a version to the otel image to avoid changes (#13419)

* W-15586397: Otel flaky tests. Ignore till full investigation (#13425)

---------

Co-authored-by: Axel Sanguinetti <asanguinetti@mulesoft.com>
(cherry picked from commit c92572686101342061fa170e54587ef9051e6193)