### PR TITLE
W 15708770 - Adding logger statements to increase traceability for sdk context

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -36,7 +36,9 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @since 4.3
  */
 public class SdkInternalContext implements EventInternalContext<SdkInternalContext> {
+
   private static final Logger LOGGER = getLogger(SdkInternalContext.class);
+
   /**
    * Extracts an instance stored in the given {@code event}
    *

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -60,12 +60,12 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
   private Function<Context, Context> innerChainSubscriberContextMapping = identity();
 
   public void removeContext(ComponentLocation location, String eventId) {
-    LOGGER.debug("Removing context at location - {} for event - {}", location.getLocation(), eventId);
+    LOGGER.debug("Removing context at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
     locationSpecificContext.remove(new Pair<>(location, eventId));
   }
 
   public void putContext(ComponentLocation location, String eventId) {
-    LOGGER.debug("Adding new context at location - {} for event - {}", location.getLocation(), eventId);
+    LOGGER.debug("Adding new context at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
     locationSpecificContext.put(new Pair<>(location, eventId), new LocationSpecificSdkInternalContext());
   }
 
@@ -77,7 +77,7 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
    */
   public void setConfiguration(ComponentLocation location, String eventId,
                                Optional<ConfigurationInstance> configuration) {
-    LOGGER.debug("Adding configuration at location - {} for event - {}", location.getLocation(), eventId);
+    LOGGER.debug("Adding configuration at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setConfiguration(configuration);
   }
 
@@ -89,7 +89,7 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
                                           Optional<ConfigurationInstance> configuration,
                                           Map<String, Object> parameters, CoreEvent operationEvent, ExecutorCallback callback,
                                           ExecutionContextAdapter executionContextAdapter) {
-    LOGGER.debug("Setting Operation Parameters at location - {} for event - {}", location.getLocation(), eventId);
+    LOGGER.debug("Setting Operation Parameters at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setOperationExecutionParams(configuration, parameters,
                                                                                            operationEvent,
                                                                                            callback, executionContextAdapter);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -60,12 +60,13 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
   private Function<Context, Context> innerChainSubscriberContextMapping = identity();
 
   public void removeContext(ComponentLocation location, String eventId) {
-    LOGGER.debug("Removing context at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
+    LOGGER.debug("Removing context at location - {} for event - {}", location != null ? location.getLocation() : "null", eventId);
     locationSpecificContext.remove(new Pair<>(location, eventId));
   }
 
   public void putContext(ComponentLocation location, String eventId) {
-    LOGGER.debug("Adding new context at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
+    LOGGER.debug("Adding new context at location - {} for event - {}", location != null ? location.getLocation() : "null",
+                 eventId);
     locationSpecificContext.put(new Pair<>(location, eventId), new LocationSpecificSdkInternalContext());
   }
 
@@ -77,7 +78,8 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
    */
   public void setConfiguration(ComponentLocation location, String eventId,
                                Optional<ConfigurationInstance> configuration) {
-    LOGGER.debug("Adding configuration at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
+    LOGGER.debug("Adding configuration at location - {} for event - {}", location != null ? location.getLocation() : "null",
+                 eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setConfiguration(configuration);
   }
 
@@ -89,7 +91,8 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
                                           Optional<ConfigurationInstance> configuration,
                                           Map<String, Object> parameters, CoreEvent operationEvent, ExecutorCallback callback,
                                           ExecutionContextAdapter executionContextAdapter) {
-    LOGGER.debug("Setting Operation Parameters at location - {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, eventId);
+    LOGGER.debug("Setting Operation Parameters at location - {} for event - {}",
+                 location != null ? location.getLocation() : "null", eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setOperationExecutionParams(configuration, parameters,
                                                                                            operationEvent,
                                                                                            callback, executionContextAdapter);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -87,7 +87,7 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
                                           Optional<ConfigurationInstance> configuration,
                                           Map<String, Object> parameters, CoreEvent operationEvent, ExecutorCallback callback,
                                           ExecutionContextAdapter executionContextAdapter) {
-    LOGGER.debug("CCE - Setting Operation Parameters at location - {} for event - {}", location.getLocation(), eventId);
+    LOGGER.debug("Setting Operation Parameters at location - {} for event - {}", location.getLocation(), eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setOperationExecutionParams(configuration, parameters,
                                                                                            operationEvent,
                                                                                            callback, executionContextAdapter);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import reactor.util.context.Context;
+import org.slf4j.Logger;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Contains internal context handled by SDK operations.
@@ -34,7 +36,7 @@ import reactor.util.context.Context;
  * @since 4.3
  */
 public class SdkInternalContext implements EventInternalContext<SdkInternalContext> {
-
+  private static final Logger LOGGER = getLogger(SdkInternalContext.class);
   /**
    * Extracts an instance stored in the given {@code event}
    *
@@ -56,10 +58,12 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
   private Function<Context, Context> innerChainSubscriberContextMapping = identity();
 
   public void removeContext(ComponentLocation location, String eventId) {
+    LOGGER.debug("Removing context at location - {} for event - {}", location.getLocation(), eventId);
     locationSpecificContext.remove(new Pair<>(location, eventId));
   }
 
   public void putContext(ComponentLocation location, String eventId) {
+    LOGGER.debug("Adding new context at location - {} for event - {}", location.getLocation(), eventId);
     locationSpecificContext.put(new Pair<>(location, eventId), new LocationSpecificSdkInternalContext());
   }
 
@@ -71,6 +75,7 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
    */
   public void setConfiguration(ComponentLocation location, String eventId,
                                Optional<ConfigurationInstance> configuration) {
+    LOGGER.debug("Adding configuration at location - {} for event - {}", location.getLocation(), eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setConfiguration(configuration);
   }
 
@@ -82,6 +87,7 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
                                           Optional<ConfigurationInstance> configuration,
                                           Map<String, Object> parameters, CoreEvent operationEvent, ExecutorCallback callback,
                                           ExecutionContextAdapter executionContextAdapter) {
+    LOGGER.debug("CCE - Setting Operation Parameters at location - {} for event - {}", location.getLocation(), eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setOperationExecutionParams(configuration, parameters,
                                                                                            operationEvent,
                                                                                            callback, executionContextAdapter);

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -739,7 +739,6 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
           .getOperationExecutionParams(getLocation(), event.getContext().getId());
     } catch (NullPointerException npe) {
       LOGGER.debug("Null SDK Context at {} for event - {}", getLocation().getLocation(), event.getContext().getId());
-      LOGGER.debug("Null SDK Context at {} for event - {}", getLocation().getLocation(), event.getContext().getId());
       throw propagateWrappingFatal(new EventProcessingException(createStaticMessage("Maybe the non-blocking operation @ '"
           + getLocation().getLocation() + "' used its callback more than once?"),
                                                                 event, npe));

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -738,7 +738,8 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
       return from(event)
           .getOperationExecutionParams(getLocation(), event.getContext().getId());
     } catch (NullPointerException npe) {
-      LOGGER.debug("Null SDK Context at {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, event.getContext().getId());
+      LOGGER.debug("Null SDK Context at {} for event - {}", getLocation() != null ? getLocation().getLocation() : "null",
+                   event.getContext().getId());
       throw propagateWrappingFatal(new EventProcessingException(createStaticMessage("Maybe the non-blocking operation @ '"
           + getLocation().getLocation() + "' used its callback more than once?"),
                                                                 event, npe));

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -735,8 +735,11 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
   protected OperationExecutionParams getOperationExecutionParams(final CoreEvent event) {
     try {
-      return from(event)
-          .getOperationExecutionParams(getLocation(), event.getContext().getId());
+      SdkInternalContext SdkCtx = from(event);
+      if (SdkCtx == null) {
+        LOGGER.debug("Null SDK Context at {} for event - {}", getLocation().getLocation(), event.getContext().getId());
+      }
+      return SdkCtx.getOperationExecutionParams(getLocation(), event.getContext().getId());
     } catch (NullPointerException npe) {
       throw propagateWrappingFatal(new EventProcessingException(createStaticMessage("Maybe the non-blocking operation @ '"
           + getLocation().getLocation() + "' used its callback more than once?"),

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -738,7 +738,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
       return from(event)
           .getOperationExecutionParams(getLocation(), event.getContext().getId());
     } catch (NullPointerException npe) {
-      LOGGER.debug("Null SDK Context at {} for event - {}", getLocation().getLocation(), event.getContext().getId());
+      LOGGER.debug("Null SDK Context at {} for event - {}", () -> {location != null ? location.getLocation() : "null"}, event.getContext().getId());
       throw propagateWrappingFatal(new EventProcessingException(createStaticMessage("Maybe the non-blocking operation @ '"
           + getLocation().getLocation() + "' used its callback more than once?"),
                                                                 event, npe));

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -735,12 +735,11 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
 
   protected OperationExecutionParams getOperationExecutionParams(final CoreEvent event) {
     try {
-      SdkInternalContext SdkCtx = from(event);
-      if (SdkCtx == null) {
-        LOGGER.debug("Null SDK Context at {} for event - {}", getLocation().getLocation(), event.getContext().getId());
-      }
-      return SdkCtx.getOperationExecutionParams(getLocation(), event.getContext().getId());
+      return from(event)
+          .getOperationExecutionParams(getLocation(), event.getContext().getId());
     } catch (NullPointerException npe) {
+      LOGGER.debug("Null SDK Context at {} for event - {}", getLocation().getLocation(), event.getContext().getId());
+      LOGGER.debug("Null SDK Context at {} for event - {}", getLocation().getLocation(), event.getContext().getId());
       throw propagateWrappingFatal(new EventProcessingException(createStaticMessage("Maybe the non-blocking operation @ '"
           + getLocation().getLocation() + "' used its callback more than once?"),
                                                                 event, npe));


### PR DESCRIPTION
###  Description
Adding logger statements to SdkInternalContext is modified in the execution path.
### Reason For Change
As part of the parent investigation [W-15618324](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001q7MTlYAM/view) we encountered NPE sporadically. To understand what is causing the issue, it would be beneficial to add logger statements while creating, removing and configuring the SdkInternalContext to an event