### PR TITLE
W-15782010: TemplateParser optimizations and repeatability of token assignation

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/TemplateParserTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/TemplateParserTestCase.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.qameta.allure.Issue;
 import org.junit.Test;
@@ -261,6 +262,25 @@ public class TemplateParserTestCase extends AbstractMuleTestCase {
       clearProperty(ENABLE_TEMPLATE_PARSER_COMPATIBILITY_MODE);
       TemplateParser.reloadKillSwitches();
     }
+  }
+
+  @Test
+  @Issue("W-15782010")
+  public void muleParserTokenizesAlwaysTheSameForSameInput() {
+    TemplateParser tp = createMuleStyleParser();
+    String template = "#[hello #[world] #[var.apple]]";
+
+    List<String> tokens = new ArrayList<>();
+    tp.parse(null, template, token -> {
+      tokens.add(token);
+      return token;
+    });
+
+    AtomicInteger i = new AtomicInteger();
+    tp.parse(null, template, token -> {
+      assertThat(token, is(tokens.get(i.getAndIncrement())));
+      return token;
+    });
   }
 
   @Test

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/el/TemplateParserTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/el/TemplateParserTestCase.java
@@ -284,6 +284,16 @@ public class TemplateParserTestCase extends AbstractMuleTestCase {
   }
 
   @Test
+  public void muleParserReplacesCorrectlyWhenTokenIsRepeatedByCallback() {
+    TemplateParser tp = createMuleStyleParser();
+    String template = "#[hello #[world]]";
+
+    String result = tp.parse(null, template, token -> token + token);
+
+    assertThat(result, is("hello worldworldhello worldworld"));
+  }
+
+  @Test
   public void muleParserManagesConcatenation() {
     TemplateParser tp = createMuleStyleParser();
 

--- a/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParser.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParser.java
@@ -7,7 +7,6 @@
 package org.mule.runtime.core.internal.el;
 
 import static java.lang.Boolean.parseBoolean;
-import static java.lang.Integer.MAX_VALUE;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
 
@@ -20,10 +19,8 @@ import org.mule.runtime.api.util.collection.SmallMap;
 import org.mule.runtime.core.api.util.CaseInsensitiveHashMap;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -76,7 +73,6 @@ public final class TemplateParser {
    */
   protected static final Logger logger = LoggerFactory.getLogger(TemplateParser.class);
 
-  private static final Random RANDOM = new Random();
 
   @Deprecated
   private static boolean IS_COMPATIBILITY_MODE_ENABLED = isCompatibilityModeEnabled();
@@ -158,7 +154,8 @@ public final class TemplateParser {
     validateBalanceMuleStyle(template);
 
     // Will be storing the tokens candidate for callback evaluation
-    Map<String, String> tokens = new LinkedHashMap<>();
+    List<TemplateParserToken.Replacement> tokenReplacements = new ArrayList<>();
+    TemplateParserToken.Provider tokenProvider = new TemplateParserToken.Provider();
 
     boolean lastIsBackSlash = false;
     boolean lastStartedExpression = false;
@@ -193,13 +190,11 @@ public final class TemplateParser {
       if (c == OPEN_EXPRESSION && lastStartedExpression) {
         int closing = closingBracesPosition(template, currentPosition);
         String enclosingTemplate = template.substring(currentPosition + 1, closing);
-        // TODO: performance - pool the IDs and use compiled Patterns
-        // The token ID needs to be valid in any context in which the original expression was valid -> using an integer
-        String tokenId = '1' + format("%010d", RANDOM.nextInt() & MAX_VALUE);
+        TemplateParserToken token = tokenProvider.getToken();
         // Remember the token and its associated ID
-        tokens.put(tokenId, enclosingTemplate);
+        tokenReplacements.add(token.buildReplacement(enclosingTemplate));
         // Append the token ID on the result as a reference, so we can replace it at the end with the evaluated token value
-        result.append(tokenId);
+        result.append(token.getId());
         currentPosition = closing;
       } else if ((c != START_EXPRESSION || lastIsBackSlash) && c != '\\') {
         result.append(c);
@@ -215,11 +210,10 @@ public final class TemplateParser {
     String evaluatedTokenizedTemplate = depth > 0 ? evaluateToken(callback, result.toString()) : result.toString();
 
     // Parses any token found and replaces on the tokenized result
-    for (Map.Entry<String, String> tokenEntry : tokens.entrySet()) {
-      // TODO: performance - avoid parsing the value if there is no match
-      evaluatedTokenizedTemplate = evaluatedTokenizedTemplate.replace(tokenEntry.getKey(),
-                                                                      parseMule(props, tokenEntry.getValue(), callback,
-                                                                                depth + 1));
+    for (TemplateParserToken.Replacement tokenReplacement : tokenReplacements) {
+      evaluatedTokenizedTemplate = tokenReplacement.replace(evaluatedTokenizedTemplate,
+                                                            (innerTemplate) -> parseMule(props, innerTemplate, callback,
+                                                                                         depth + 1));
     }
 
     return evaluatedTokenizedTemplate;

--- a/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.internal.el;
+
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class TemplateParserToken {
+
+  private static final Random RANDOM = new Random();
+
+  private final String id;
+  private final Pattern searchPattern;
+
+  public static TemplateParserToken getNewToken() {
+    // The token ID needs to be valid in any context in which the original expression was valid -> using an integer
+    String id = '1' + format("%010d", RANDOM.nextInt() & MAX_VALUE);
+    return new TemplateParserToken(id);
+  }
+
+  private TemplateParserToken(String id) {
+    this.id = id;
+    this.searchPattern = Pattern.compile(id);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Pattern getSearchPattern() {
+    return searchPattern;
+  }
+
+  public Replacement buildReplacement(String replacement) {
+    return new Replacement(this, replacement);
+  }
+
+  static class Provider {
+
+    private static final List<TemplateParserToken> tokensPool = new ArrayList<>();
+
+    private int curOffset = 0;
+
+    public TemplateParserToken getToken() {
+      // TODO: thread safety
+      if (tokensPool.size() <= curOffset) {
+        tokensPool.add(TemplateParserToken.getNewToken());
+      }
+
+      return tokensPool.get(curOffset++);
+    }
+  }
+
+  static class Replacement {
+
+    private final TemplateParserToken token;
+    private final String replacement;
+
+    private Replacement(TemplateParserToken token, String replacement) {
+      this.token = token;
+      this.replacement = replacement;
+    }
+
+    public String replace(String original, Function<String, String> replacementMapper) {
+      Matcher matcher = token.getSearchPattern().matcher(original);
+      if (!matcher.find()) {
+        return original;
+      }
+
+      // Can't use replaceFirst or appendReplacement because those make special treatment for backslashes and dollar signs,
+      // we don't want that
+      return original.substring(0, matcher.start())
+          + replacementMapper.apply(this.replacement)
+          + original.substring(matcher.end());
+    }
+  }
+}

--- a/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
@@ -78,11 +78,21 @@ class TemplateParserToken {
         return original;
       }
 
+      // Now that we know there was a match, we can apply the mapper
+      String mappedReplacement = replacementMapper.apply(replacement);
+
       // Can't use replaceFirst or appendReplacement because those make special treatment for backslashes and dollar signs,
       // we don't want that
-      return original.substring(0, matcher.start())
-          + replacementMapper.apply(this.replacement)
-          + original.substring(matcher.end());
+      int lastEndOfMatch = 0;
+      StringBuilder sb = new StringBuilder();
+      do {
+        sb.append(original, lastEndOfMatch, matcher.start());
+        sb.append(mappedReplacement);
+        lastEndOfMatch = matcher.end();
+      } while (matcher.find());
+
+      sb.append(original, lastEndOfMatch, original.length());
+      return sb.toString();
     }
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
@@ -18,32 +18,26 @@ import java.util.regex.Pattern;
 
 class TemplateParserToken {
 
-  private static final Random RANDOM = new Random();
-
-  private final String id;
-  private final Pattern searchPattern;
-
-  public static TemplateParserToken getNewToken() {
+  private static TemplateParserToken getNewToken() {
     // The token ID needs to be valid in any context in which the original expression was valid -> using an integer
     String id = '1' + format("%010d", RANDOM.nextInt() & MAX_VALUE);
     return new TemplateParserToken(id);
   }
 
+  private static final Random RANDOM = new Random();
+
+  private final Pattern searchPattern;
+
   private TemplateParserToken(String id) {
-    this.id = id;
     this.searchPattern = Pattern.compile(id);
   }
 
   public String getId() {
-    return id;
-  }
-
-  public Pattern getSearchPattern() {
-    return searchPattern;
+    return searchPattern.pattern();
   }
 
   public Replacement buildReplacement(String replacement) {
-    return new Replacement(this, replacement);
+    return new Replacement(replacement);
   }
 
   static class Provider {
@@ -62,18 +56,16 @@ class TemplateParserToken {
     }
   }
 
-  static class Replacement {
+  class Replacement {
 
-    private final TemplateParserToken token;
     private final String replacement;
 
-    private Replacement(TemplateParserToken token, String replacement) {
-      this.token = token;
+    private Replacement(String replacement) {
       this.replacement = replacement;
     }
 
     public String replace(String original, Function<String, String> replacementMapper) {
-      Matcher matcher = token.getSearchPattern().matcher(original);
+      Matcher matcher = searchPattern.matcher(original);
       if (!matcher.find()) {
         return original;
       }

--- a/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/el/TemplateParserToken.java
@@ -27,13 +27,13 @@ import java.util.regex.Pattern;
  */
 class TemplateParserToken {
 
+  private static final Random RANDOM = new Random();
+
   private static TemplateParserToken getNewToken() {
     // The token ID needs to be valid in any context in which the original expression was valid -> using an integer
     String id = '1' + format("%010d", RANDOM.nextInt() & MAX_VALUE);
     return new TemplateParserToken(id);
   }
-
-  private static final Random RANDOM = new Random();
 
   private final Pattern searchPattern;
 


### PR DESCRIPTION
Tokens will be taken from a pool that grows depending on demand.

This improves performance by avoiding the computation of the random and the transformation to decimal string. We also cache the associated search `Pattern`.

Tokens in the pool are not globally reserved. This means they are allowed to be shared by different templates under parsing. The only thing we don't want is for them to be reused within the same template.

Reusing the tokens like this also provides repeatability, meaning that for the same template source, the same tokens IDs will be assigned. This allows potential callback implementations (typically DW's evaluate) to take advantage from caching the (compiled) expressions.

Finally, another optimization: if the token is not found in the string after callback evaluation, we skip evaluating the associated inner-template.