### PR TITLE
W-15832941: Avoid overwriting MuleConfiguration bean definition.

### DIFF
--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/MuleArtifactContext.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/MuleArtifactContext.java
@@ -49,7 +49,6 @@ import static java.util.stream.Collectors.toSet;
 
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.beans.CachedIntrospectionResults.clearClassLoader;
-import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
 
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.component.Component;
@@ -92,7 +91,6 @@ import org.mule.runtime.config.internal.bean.ServerNotificationManagerConfigurat
 import org.mule.runtime.config.internal.dsl.model.SpringComponentModel;
 import org.mule.runtime.config.internal.dsl.spring.BeanDefinitionFactory;
 import org.mule.runtime.config.internal.editors.MulePropertyEditorRegistrar;
-import org.mule.runtime.config.internal.factories.MuleConfigurationConfigurator;
 import org.mule.runtime.config.internal.model.ApplicationModel;
 import org.mule.runtime.config.internal.model.ApplicationModelAstPostProcessor;
 import org.mule.runtime.config.internal.model.ComponentBuildingDefinitionRegistryFactory;
@@ -694,10 +692,6 @@ public class MuleArtifactContext extends AbstractRefreshableConfigApplicationCon
   protected void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {
     BeanDefinitionRegistry beanDefinitionRegistry = (BeanDefinitionRegistry) beanFactory;
 
-    if (!findComponentDefinitionModel(applicationModel, CONFIGURATION_IDENTIFIER).isPresent()) {
-      registerMuleConfigurationBean(beanDefinitionRegistry);
-    }
-
     if (!findComponentDefinitionModel(applicationModel, NOTIFICATIONS_IDENTIFIER).isPresent()) {
       registerNotificationManagerBean(beanDefinitionRegistry);
     }
@@ -727,12 +721,6 @@ public class MuleArtifactContext extends AbstractRefreshableConfigApplicationCon
                                                                              ExtensionNotification.class))
                                         .build())
                                     .getBeanDefinition());
-  }
-
-  private void registerMuleConfigurationBean(BeanDefinitionRegistry beanDefinitionRegistry) {
-    beanDefinitionRegistry
-        .registerBeanDefinition(OBJECT_MULE_CONFIGURATION,
-                                genericBeanDefinition(MuleConfigurationConfigurator.class).getBeanDefinition());
   }
 
   private void registerAnnotationConfigProcessors(BeanDefinitionRegistry registry, ConfigurableListableBeanFactory beanFactory) {

--- a/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/SpringMuleContextServiceConfigurator.java
+++ b/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/SpringMuleContextServiceConfigurator.java
@@ -93,6 +93,7 @@ import org.mule.runtime.api.util.ResourceLocator;
 import org.mule.runtime.ast.api.ArtifactAst;
 import org.mule.runtime.config.api.dsl.model.metadata.ModelBasedMetadataCacheIdGeneratorFactory;
 import org.mule.runtime.config.internal.context.metrics.NoopMeterProvider;
+import org.mule.runtime.config.internal.factories.MuleConfigurationConfigurator;
 import org.mule.runtime.config.internal.model.dsl.config.DefaultComponentInitialStateManager;
 import org.mule.runtime.config.internal.factories.ConstantFactoryBean;
 import org.mule.runtime.config.internal.factories.ExtensionManagerFactoryBean;
@@ -101,7 +102,6 @@ import org.mule.runtime.config.internal.factories.TransactionManagerFactoryBean;
 import org.mule.runtime.config.internal.processor.MuleObjectNameProcessor;
 import org.mule.runtime.config.internal.registry.OptionalObjectsController;
 import org.mule.runtime.config.internal.registry.SpringRegistryBootstrap;
-import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
 import org.mule.runtime.core.api.config.bootstrap.ArtifactType;
 import org.mule.runtime.core.api.event.EventContextService;
 import org.mule.runtime.core.api.streaming.DefaultStreamingManager;
@@ -204,7 +204,7 @@ public class SpringMuleContextServiceConfigurator extends AbstractSpringMuleCont
       .put(OBJECT_EXTENSION_MANAGER, getBeanDefinition(ExtensionManagerFactoryBean.class))
       .put(OBJECT_TIME_SUPPLIER, getBeanDefinition(LocalTimeSupplier.class))
       .put(OBJECT_CONNECTION_MANAGER, getBeanDefinition(DelegateConnectionManagerAdapter.class))
-      .put(OBJECT_MULE_CONFIGURATION, getBeanDefinition(DefaultMuleConfiguration.class))
+      .put(OBJECT_MULE_CONFIGURATION, getBeanDefinition(MuleConfigurationConfigurator.class))
       .put(OBJECT_TRANSACTION_FACTORY_LOCATOR, getBeanDefinition(TransactionFactoryLocator.class))
       .put(OBJECT_OBJECT_NAME_PROCESSOR, getBeanDefinition(MuleObjectNameProcessor.class))
       .put(OBJECT_POLICY_MANAGER, getBeanDefinition(DefaultPolicyManager.class))

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/MuleConfigurationConfiguratorTestCase.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/MuleConfigurationConfiguratorTestCase.java
@@ -6,32 +6,51 @@
  */
 package org.mule.runtime.config;
 
+import static org.mule.runtime.api.util.MuleSystemProperties.MULE_DISABLE_RESPONSE_TIMEOUT;
+import static org.mule.runtime.api.util.MuleSystemProperties.MULE_ENCODING_SYSTEM_PROPERTY;
+import static org.mule.runtime.api.util.MuleSystemProperties.SYSTEM_PROPERTY_PREFIX;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_MULE_CONFIGURATION;
 import static org.mule.runtime.core.api.config.MuleProperties.OBJECT_TIME_SUPPLIER;
+import static org.mule.runtime.core.api.extension.provider.MuleExtensionModelProvider.getExtensionModel;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
+import static org.mule.tck.junit4.matcher.IsEmptyOptional.empty;
 import static org.mule.test.allure.AllureConstants.ConfigurationProperties.CONFIGURATION_PROPERTIES;
 import static org.mule.test.allure.AllureConstants.ConfigurationProperties.ComponentConfigurationAttributesStory.COMPONENT_CONFIGURATION_PROPERTIES_STORY;
 
+import static java.lang.System.clearProperty;
+import static java.lang.System.setProperty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
+import static org.junit.Assert.assertThrows;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import org.mule.runtime.api.config.custom.ServiceConfigurator;
+import org.mule.runtime.api.exception.MuleException;
+import org.mule.runtime.api.serialization.ObjectSerializer;
+import org.mule.runtime.api.serialization.SerializationProtocol;
 import org.mule.runtime.api.time.TimeSupplier;
 import org.mule.runtime.config.internal.SpringXmlConfigurationBuilder;
+import org.mule.runtime.config.internal.bean.TestCustomServiceDependingOnMuleConfiguration;
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.config.ConfigurationBuilder;
 import org.mule.runtime.core.api.config.ConfigurationException;
+import org.mule.runtime.core.api.config.DefaultMuleConfiguration;
+import org.mule.runtime.core.api.config.DynamicConfigExpiration;
 import org.mule.runtime.core.api.config.MuleConfiguration;
+import org.mule.runtime.core.api.config.builders.AbstractConfigurationBuilder;
 import org.mule.runtime.core.api.context.DefaultMuleContextFactory;
 import org.mule.runtime.core.internal.config.ImmutableExpirationPolicy;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistry;
@@ -46,7 +65,6 @@ import java.util.Calendar;
 import org.slf4j.Logger;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,6 +76,7 @@ import io.qameta.allure.Story;
 @Story(COMPONENT_CONFIGURATION_PROPERTIES_STORY)
 public class MuleConfigurationConfiguratorTestCase extends AbstractMuleTestCase {
 
+  private static final String CUSTOM_SERVICE_DEPENDING_ON_MULE_CONFIGURATION = "TestCustomServiceDependingOnMuleConfiguration";
   private static final Logger LOGGER = getLogger(MuleConfigurationConfiguratorTestCase.class);
 
   @Rule
@@ -65,28 +84,8 @@ public class MuleConfigurationConfiguratorTestCase extends AbstractMuleTestCase 
 
   private final TimeSupplier timeSupplier = mock(TimeSupplier.class);
 
+  // Lazily created through getMuleContext
   private MuleContextWithRegistry muleContext;
-
-  @Before
-  public void before() throws Exception {
-    muleContext = (MuleContextWithRegistry) new DefaultMuleContextFactory()
-        .createMuleContext(testServicesConfigurationBuilder,
-                           new ConfigurationBuilder() {
-
-                             @Override
-                             public void configure(MuleContext muleContext) throws ConfigurationException {
-                               muleContext.getCustomizationService().overrideDefaultServiceImpl(OBJECT_TIME_SUPPLIER,
-                                                                                                timeSupplier);
-                             }
-
-                             @Override
-                             public void addServiceConfigurator(ServiceConfigurator serviceConfigurator) {}
-                           },
-                           new MockExtensionManagerConfigurationBuilder(),
-                           new SpringXmlConfigurationBuilder(new String[0], emptyMap()));
-    muleContext.start();
-    muleContext.getRegistry().lookupByType(Calendar.class);
-  }
 
   @After
   public void after() {
@@ -96,9 +95,129 @@ public class MuleConfigurationConfiguratorTestCase extends AbstractMuleTestCase 
   }
 
   @Test
+  public void whenNotConfiguredThenHasSameDefaults() throws MuleException {
+    DefaultMuleConfiguration config = getMuleContext().getRegistry().lookupObject(OBJECT_MULE_CONFIGURATION);
+
+    // First make sure the config from the registry is equivalent to the one from the MuleContext
+    assertThat(config, is(getMuleContext().getConfiguration()));
+
+    // Second, checks a MuleConfiguration injected in a custom service is also the same
+    assertEqualsToMuleConfigurationInjectedInCustomService(config);
+
+    // Now checks that the values are the same as the ones on a fresh DefaultMuleConfiguration instance
+    // (except for the ID and system ID because they contain UUIDs, using equals won't do because of that).
+    DefaultMuleConfiguration defaultConfig = new DefaultMuleConfiguration();
+    assertThat(config.getDefaultResponseTimeout(), is(defaultConfig.getDefaultResponseTimeout()));
+    assertThat(config.getWorkingDirectory(), is(defaultConfig.getWorkingDirectory()));
+    assertThat(config.getMuleHomeDirectory(), is(defaultConfig.getMuleHomeDirectory()));
+    assertThat(config.getDefaultTransactionTimeout(), is(defaultConfig.getDefaultTransactionTimeout()));
+    assertThat(config.isClientMode(), is(defaultConfig.isClientMode()));
+    assertThat(config.getDefaultEncoding(), is(defaultConfig.getDefaultEncoding()));
+    assertThat(config.getDomainId(), is(defaultConfig.getDomainId()));
+    assertThat(config.getSystemModelType(), is(defaultConfig.getSystemModelType()));
+    assertThat(config.isAutoWrapMessageAwareTransform(), is(defaultConfig.isAutoWrapMessageAwareTransform()));
+    assertThat(config.isCacheMessageAsBytes(), is(defaultConfig.isCacheMessageAsBytes()));
+    assertThat(config.isEnableStreaming(), is(defaultConfig.isEnableStreaming()));
+    assertThat(config.isValidateExpressions(), is(defaultConfig.isValidateExpressions()));
+    assertThat(config.isLazyInit(), is(defaultConfig.isLazyInit()));
+    assertThat(config.getDefaultQueueTimeout(), is(defaultConfig.getDefaultQueueTimeout()));
+    assertThat(config.getShutdownTimeout(), is(defaultConfig.getShutdownTimeout()));
+    assertThat(config.getMaxQueueTransactionFilesSizeInMegabytes(),
+               is(defaultConfig.getMaxQueueTransactionFilesSizeInMegabytes()));
+    assertThat(config.isContainerMode(), is(defaultConfig.isContainerMode()));
+    assertThat(config.isStandalone(), is(defaultConfig.isStandalone()));
+    assertThat(config.getDefaultErrorHandlerName(), is(defaultConfig.getDefaultErrorHandlerName()));
+    assertThat(config.isDisableTimeouts(), is(defaultConfig.isDisableTimeouts()));
+    assertThat(config.getDefaultObjectSerializer(), is(defaultConfig.getDefaultObjectSerializer()));
+    assertThat(config.getDefaultProcessingStrategyFactory(), is(defaultConfig.getDefaultProcessingStrategyFactory()));
+    assertDynamicConfigExpirationEquals(config.getDynamicConfigExpiration(), defaultConfig.getDynamicConfigExpiration());
+    assertThat(config.isInheritIterableRepeatability(), is(defaultConfig.isInheritIterableRepeatability()));
+    assertThat(config.getMinMuleVersion(), is(defaultConfig.getMinMuleVersion()));
+    assertThat(config.getDefaultCorrelationIdGenerator(), is(defaultConfig.getDefaultCorrelationIdGenerator()));
+    assertThat(config.getArtifactCoordinates(), is(defaultConfig.getArtifactCoordinates()));
+
+    // These are DefaultMuleConfiguration-specific
+    // (getDataFolderName is not compared because it also contains a UUID by default)
+    assertThat(config.isFlowTrace(), is(defaultConfig.isFlowTrace()));
+    assertThat(config.getExtendedProperties(), is(defaultConfig.getExtendedProperties()));
+    assertThat(config.getExtensions(), is(defaultConfig.getExtensions()));
+  }
+
+  @Test
+  public void whenConfiguredThroughSystemPropertiesThenHasExpectedValues() throws MuleException {
+    setProperty(MULE_ENCODING_SYSTEM_PROPERTY, "UTF-16");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "systemModelType", "direct");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "workingDirectory", "some-working-dir");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "clientMode", "true");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "serverId", "MY_SERVER");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "domainId", "MY_DOMAIN");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "message.cacheBytes", "false");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "streaming.enable", "false");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "transform.autoWrap", "false");
+    setProperty(SYSTEM_PROPERTY_PREFIX + "validate.expressions", "false");
+    setProperty(MULE_DISABLE_RESPONSE_TIMEOUT, "true");
+
+    try {
+      whenNotConfiguredThenHasSameDefaults();
+      // server ID is not asserted in the defaults
+      assertThat(getMuleContext().getConfiguration().getId(), is(new DefaultMuleConfiguration().getId()));
+    } finally {
+      clearProperty(MULE_ENCODING_SYSTEM_PROPERTY);
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "systemModelType");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "workingDirectory");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "clientMode");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "serverId");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "domainId");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "message.cacheBytes");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "streaming.enable");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "transform.autoWrap");
+      clearProperty(SYSTEM_PROPERTY_PREFIX + "validate.expressions");
+      clearProperty(MULE_DISABLE_RESPONSE_TIMEOUT);
+    }
+  }
+
+  @Test
+  public void whenConfiguredFromConfigFileThenHasExpectedValues() throws MuleException {
+    initMuleContext("withGlobalConfig.xml");
+
+    DefaultMuleConfiguration config = getMuleContext().getRegistry().lookupObject(OBJECT_MULE_CONFIGURATION);
+
+    // First make sure the config from the registry is equivalent to the one from the MuleContext
+    assertThat(config, is(getMuleContext().getConfiguration()));
+
+    // Second, checks a MuleConfiguration injected in a custom service is also the same
+    assertEqualsToMuleConfigurationInjectedInCustomService(config);
+
+    // Now checks the values that are being overridden by the configuration file
+    assertThat(config.getDefaultErrorHandlerName(), is("errorHandler"));
+    assertThat(config.getDefaultResponseTimeout(), is(5000));
+    assertThat(config.getMaxQueueTransactionFilesSizeInMegabytes(), is(100));
+    assertThat(config.getDefaultTransactionTimeout(), is(20000));
+    assertThat(config.getShutdownTimeout(), is(2000L));
+    assertThat(config.getDefaultObjectSerializer(), isA(TestSerializationProtocol.class));
+    assertThat(config.isInheritIterableRepeatability(), is(true));
+
+    DynamicConfigExpiration dynamicConfigExpiration = config.getDynamicConfigExpiration();
+    assertThat(dynamicConfigExpiration.getFrequency().getTime(), is(7L));
+    assertThat(dynamicConfigExpiration.getFrequency().getUnit(), is(DAYS));
+    assertThat(dynamicConfigExpiration.getExpirationPolicy().getMaxIdleTime(), is(40L));
+    assertThat(dynamicConfigExpiration.getExpirationPolicy().getTimeUnit(), is(HOURS));
+
+    // We need an expression manager in order to generate a correlation ID, and it is not worth adding such overhead to this test.
+    // We will just assert the generator is not the default (empty).
+    assertThat(config.getDefaultCorrelationIdGenerator(), not(is(empty())));
+  }
+
+  @Test
+  public void whenMultipleConfigsInFileThenFails() {
+    ConfigurationException e = assertThrows(ConfigurationException.class, () -> initMuleContext("withMultipleGlobalConfig.xml"));
+    assertThat(e, hasMessage(containsString("The configuration element 'configuration' can only appear once")));
+  }
+
+  @Test
   @Issue("MULE-19006")
   public void configuratorExpirationPolicyUsesManagedTimeSupplier() throws Exception {
-    MuleConfiguration configuration = muleContext.getRegistry()
+    MuleConfiguration configuration = getMuleContext().getRegistry()
         .lookupObject(OBJECT_MULE_CONFIGURATION);
     ExpirationPolicy policy = configuration.getDynamicConfigExpiration().getExpirationPolicy();
     assertThat(policy, instanceOf(ImmutableExpirationPolicy.class));
@@ -110,8 +229,72 @@ public class MuleConfigurationConfiguratorTestCase extends AbstractMuleTestCase 
   @Test
   @Issue("MULE-20031")
   public void muleContextInjectedIntoTransformers() throws Exception {
-    ObjectToInputStream o2isTransformer = muleContext.getRegistry().lookupObject(ObjectToInputStream.class);
+    ObjectToInputStream o2isTransformer = getMuleContext().getRegistry().lookupObject(ObjectToInputStream.class);
 
     assertThat(o2isTransformer.doTransform(singletonMap("key", "value"), UTF_8), not(nullValue()));
   }
+
+  private void assertEqualsToMuleConfigurationInjectedInCustomService(MuleConfiguration actualConfig) throws MuleException {
+    TestCustomServiceDependingOnMuleConfiguration testService =
+        getMuleContext().getRegistry().lookupObject(CUSTOM_SERVICE_DEPENDING_ON_MULE_CONFIGURATION);
+    assertThat(actualConfig, is(testService.getMuleConfiguration()));
+  }
+
+  private void assertDynamicConfigExpirationEquals(DynamicConfigExpiration actual, DynamicConfigExpiration expected) {
+    assertThat(actual.getFrequency().getTime(), is(expected.getFrequency().getTime()));
+    assertThat(actual.getFrequency().getUnit(), is(expected.getFrequency().getUnit()));
+    assertThat(actual.getExpirationPolicy().getMaxIdleTime(), is(expected.getExpirationPolicy().getMaxIdleTime()));
+    assertThat(actual.getExpirationPolicy().getTimeUnit(), is(expected.getExpirationPolicy().getTimeUnit()));
+  }
+
+  private MuleContextWithRegistry getMuleContext() throws MuleException {
+    if (muleContext == null) {
+      initMuleContext();
+    }
+    return muleContext;
+  }
+
+  private void initMuleContext() throws MuleException {
+    initMuleContext(null);
+  }
+
+  private void initMuleContext(String configPath) throws MuleException {
+    String[] configFiles = configPath != null ? new String[] {configPath} : new String[] {};
+    muleContext = (MuleContextWithRegistry) new DefaultMuleContextFactory()
+        .createMuleContext(testServicesConfigurationBuilder,
+                           new AbstractConfigurationBuilder() {
+
+                             @Override
+                             protected void doConfigure(MuleContext muleContext) {
+                               muleContext.getCustomizationService().overrideDefaultServiceImpl(OBJECT_TIME_SUPPLIER,
+                                                                                                timeSupplier);
+                               muleContext.getCustomizationService()
+                                   .registerCustomServiceClass(CUSTOM_SERVICE_DEPENDING_ON_MULE_CONFIGURATION,
+                                                               TestCustomServiceDependingOnMuleConfiguration.class);
+                             }
+                           },
+                           new MockExtensionManagerConfigurationBuilder(singleton(getExtensionModel())),
+                           new SpringXmlConfigurationBuilder(configFiles, emptyMap()));
+    muleContext.start();
+    muleContext.getRegistry().lookupByType(Calendar.class);
+  }
+
+  /**
+   * Just a dummy serializer used for testing that a custom serializer can be configured globally.
+   * <p>
+   * Not really used for serializing.
+   */
+  public static class TestSerializationProtocol implements ObjectSerializer {
+
+    @Override
+    public SerializationProtocol getInternalProtocol() {
+      return null;
+    }
+
+    @Override
+    public SerializationProtocol getExternalProtocol() {
+      return null;
+    }
+  }
+
 }

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/bean/TestCustomServiceDependingOnMuleConfiguration.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/bean/TestCustomServiceDependingOnMuleConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.internal.bean;
+
+import org.mule.runtime.core.api.config.MuleConfiguration;
+
+import javax.inject.Inject;
+
+/**
+ * A test object that depends on the {@link MuleConfiguration}, to be used as a singleton bean.
+ */
+public class TestCustomServiceDependingOnMuleConfiguration {
+
+  @Inject
+  public MuleConfiguration muleConfiguration;
+
+  public MuleConfiguration getMuleConfiguration() {
+    return muleConfiguration;
+  }
+}

--- a/modules/spring-config/src/test/java/org/mule/runtime/config/internal/bean/TestProcessorDependingOnMuleConfiguration.java
+++ b/modules/spring-config/src/test/java/org/mule/runtime/config/internal/bean/TestProcessorDependingOnMuleConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.config.internal.bean;
+
+import org.mule.runtime.api.component.AbstractComponent;
+import org.mule.runtime.api.component.Component;
+import org.mule.runtime.api.message.Message;
+import org.mule.runtime.core.api.config.MuleConfiguration;
+import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.processor.Processor;
+
+import javax.inject.Inject;
+
+/**
+ * A simple {@link Processor} that has the {@link MuleConfiguration} as an injected dependency.
+ * <p>
+ * Needs to also implement {@link Component} in order to avoid an error when creating a dynamic subclass to add the annotations,
+ * because this package is not exported and the dynamic subclass is created with a different module (currently the unnamed).
+ */
+public class TestProcessorDependingOnMuleConfiguration extends AbstractComponent implements Processor {
+
+  @Inject
+  public MuleConfiguration muleConfiguration;
+
+  @Override
+  public CoreEvent process(CoreEvent event) {
+    return CoreEvent.builder(event).message(Message.of(muleConfiguration.getDefaultErrorHandlerName())).build();
+  }
+}

--- a/modules/spring-config/src/test/resources/withGlobalConfig.xml
+++ b/modules/spring-config/src/test/resources/withGlobalConfig.xml
@@ -6,6 +6,9 @@
     <object name="customObjectSerializer"
             class="org.mule.runtime.config.MuleConfigurationConfiguratorTestCase.TestSerializationProtocol"/>
 
+    <object name="testProcessor"
+            class="org.mule.runtime.config.internal.bean.TestProcessorDependingOnMuleConfiguration"/>
+
     <error-handler name="errorHandler">
         <on-error-continue type="ANY">
             <logger/>
@@ -25,8 +28,9 @@
         </dynamic-config-expiration>
     </configuration>
 
-    <flow name="service">
+    <flow name="mainFlow">
         <logger/>
+        <flow-ref name="testProcessor"/>
     </flow>
 
 </mule>

--- a/modules/spring-config/src/test/resources/withGlobalConfig.xml
+++ b/modules/spring-config/src/test/resources/withGlobalConfig.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <object name="customObjectSerializer"
+            class="org.mule.runtime.config.MuleConfigurationConfiguratorTestCase.TestSerializationProtocol"/>
+
+    <error-handler name="errorHandler">
+        <on-error-continue type="ANY">
+            <logger/>
+        </on-error-continue>
+    </error-handler>
+
+    <configuration defaultErrorHandler-ref="errorHandler"
+                   defaultResponseTimeout="5000"
+                   maxQueueTransactionFilesSize="100"
+                   defaultTransactionTimeout="20000"
+                   shutdownTimeout="2000"
+                   defaultObjectSerializer-ref="customObjectSerializer"
+                   inheritIterableRepeatability="true"
+                   correlationIdGeneratorExpression="#['correlationId']">
+        <dynamic-config-expiration frequency="7" timeUnit="DAYS">
+            <expiration-policy maxIdleTime="40" timeUnit="HOURS"/>
+        </dynamic-config-expiration>
+    </configuration>
+
+    <flow name="service">
+        <logger/>
+    </flow>
+
+</mule>

--- a/modules/spring-config/src/test/resources/withMultipleGlobalConfig.xml
+++ b/modules/spring-config/src/test/resources/withMultipleGlobalConfig.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+    <object name="customObjectSerializer"
+            class="org.mule.runtime.config.MuleConfigurationConfiguratorTestCase.TestSerializationProtocol"/>
+
+    <error-handler name="errorHandler">
+        <on-error-continue type="ANY">
+            <logger/>
+        </on-error-continue>
+    </error-handler>
+
+    <configuration defaultErrorHandler-ref="errorHandler"
+                   defaultResponseTimeout="5000"
+                   maxQueueTransactionFilesSize="100"
+                   defaultTransactionTimeout="20000"
+                   shutdownTimeout="2000"
+                   defaultObjectSerializer-ref="customObjectSerializer"
+                   inheritIterableRepeatability="true"
+                   correlationIdGeneratorExpression="#['correlationId']">
+        <dynamic-config-expiration frequency="7" timeUnit="DAYS">
+            <expiration-policy maxIdleTime="40" timeUnit="HOURS"/>
+        </dynamic-config-expiration>
+    </configuration>
+
+    <configuration defaultResponseTimeout="15000"/>
+
+    <flow name="service">
+        <logger/>
+    </flow>
+
+</mule>


### PR DESCRIPTION
### Context
The [MuleConfiguration](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/core/src/main/java/org/mule/runtime/core/api/config/MuleConfiguration.java) is a singleton bean we add to the registry of all deployable artifacts (domains, applications, policies) which allows for accessing [global configurations](https://docs.mulesoft.com/mule-runtime/latest/global-settings-configuration).

Currently we [register the bean definition using the DefaultMuleConfiguration as the class](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/SpringMuleContextServiceConfigurator.java#L207). We do this quite early as one of the default context services, before starting to process the artifact's configuration.

Additionally, we also [set a MuleConfiguration instance on the MuleContext itself](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/core/src/main/java/org/mule/runtime/core/internal/context/DefaultMuleContextBuilder.java#L87), which can later be retrieved by [MuleContext#getConfiguration](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/core/src/main/java/org/mule/runtime/core/api/MuleContext.java#L176).

At this point, the `MuleConfiguration` retrieved from the `MuleContext` and the one from the `Registry` are different instances. This is the first thing that is fishy with the current implementation.

We do modify the `MuleConfiguration`, for example with things like [the ID representing the artifact name](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/deployment-model-impl/src/main/java/org/mule/runtime/module/deployment/impl/internal/application/ApplicationMuleContextBuilder.java#L43). If some other bean was to retrieve the `MuleConfiguration` from the registry or by injection, they would not be able to see the correct ID. However, we are currently doing something else that, intentionally or not, fixes this. I'm explaining it in the next section.

### Modifying the global configuration using the `<configuration>` component
In order for an artifact to modify the global configuration we allow for a `<configuration>` bean to be added to the DSL. Only one of these is allowed per artifact.

For [this bean definition](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/spring-config/src/main/java/org/mule/runtime/config/internal/dsl/model/CoreComponentBuildingDefinitionProvider.java#L430) we use a factory bean called [MuleConfigurationConfigurator](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/MuleConfigurationConfigurator.java#L37).

This factory allows for tracking any overrides and eventually setting them on the `MuleConfiguration` instance that is held by the `MuleContext` [when trying to retrieve the bean](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/spring-config/src/main/java/org/mule/runtime/config/internal/factories/MuleConfigurationConfigurator.java#L125).
Notice how with this we are now synchronizing again the instance from the registry and the instance from the `MuleContext`. Fixing the potential issue mentioned before.

Notice also how that factory is declared for eager initialization of the bean. This, I assume, was added in order to make sure the `doGetObject` is called and the `MuleConfiguration` in the `MuleContext` is updated even if no other bean triggers the lookup.

Finally, notice that the registration name is the same as the one for the `DefaultMuleConfiguration`. This also means that when the bean definition is actually registered, it will override the previous one. This tells Spring that any previously created singleton instances for that bean name need to be invalidated as well as any other bean depending on them.

Now, when does that new bean definition registration actually happen?

It can happen if there is a `<configuration>` found in the DSL. This would occur during the [loadBeanDefinitions](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/MuleArtifactContext.java#L515) phase of the context.

But what if there was **no** `<configuration>` found in the DSL? In that case we had a backup plan. We would be forcing the registration of the bean definition [during the postProcessBeanFactory](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/MuleArtifactContext.java#L697) hook.

### It is all fun and games until... mule-spring-module
The [mule-spring-module](https://github.com/mulesoft/mule-spring-module) is an SDK extension that allows the user to define their own beans and spring configurations in their artifacts.
It works by creating [its own independent spring context](https://github.com/mulesoft/mule-spring-module/blob/883b3fa74958db063d51b54a8456726e6727cad8/module/src/main/java/org/mule/extension/spring/api/SpringConfig.java#L73). Which is only related with the artifact's context by a [custom bean factory](https://github.com/mulesoft/mule-spring-module/blob/883b3fa74958db063d51b54a8456726e6727cad8/module/src/main/java/org/mule/extension/spring/internal/beanfactory/ArtifactObjectsAwareBeanFactory.java) that delegates on an object provider that we [provide during our prepareBeanFactory](https://github.com/mulesoft/mule/blob/53df465ab83ba7a2f9d05c2949c03c173cf15076/modules/spring-config/src/main/java/org/mule/runtime/config/internal/context/MuleArtifactContext.java#L406).

Pay attention to the ordering of events now:
1- `loadBeanDefintions` <- This could register the updated bean definition for `MuleConfiguration` only if there was a `<configuration>` in the DSL
2- `prepareBeanFactory` <- This triggers the [refresh](https://github.com/mulesoft/mule-spring-module/blob/883b3fa74958db063d51b54a8456726e6727cad8/module/src/main/java/org/mule/extension/spring/api/SpringConfig.java#L75) of the `mule-spring-module`'s context, creating all its beans.
3- `postProcessBeanFactory` <- This could register the updated bean definition for `MuleConfiguration` only if there was **no** `<configuration>` in the DSL, invalidating all dependent beans in the artifact's Spring context, but not in the `mule-spring-module`'s context, leaving them with an invalid reference.

The consequence here is that if a bean created with the mule-spring-module depends on the MuleConfiguration bean, directly or indirectly, and there was no `<configuration>` in the DSL, the bean will contain invalid references to destroyed beans that will never go through the lifecycle process.

### Proposal
We propose to avoid overwriting the bean definition for the `MuleConfiguration` when there is no `<configuration>` in the DSL. Using the `MuleConfigurationConfigurator` factory right at the default context services.
If there is a `<configuration>` in the DSL, the bean definition will still be overwritten but it will occur at a stage that is early enough for the mule-spring-module to work properly (at the `loadBeanDefinitions` stage).
No other changes should be needed. This will ensure also that the `MuleConfiguration` from the `MuleContext` and the `Registry` are in sync.
