### PR TITLE
W-16262196 SNAPSHOTS for DW in latest DryRun required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,18 +92,6 @@
         </developer>
         <developer>
             <id>estebanwasinger</id>                                        
-                                        <requireReleaseDeps>
-                                            <message>No Snapshots Allowed in Deps!</message>
-                                            <excludes>
-                                                <exclude>org.mule.weave:*</exclude>
-                                                <exclude>org.mule.runtime:mule-dwb-api</exclude>
-                                                <exclude>org.mule.services:*</exclude>
-                                                <exclude>org.mule.tools.maven:mule-classloader-model</exclude>
-
-                                                <exclude>org.raml:raml-parser-2</exclude>
-                                                <exclude>org.raml:yagi</exclude>
-                                            </excludes>
-                                        </requireReleaseDeps>
             <name>Esteban Wasinger</name>
         </developer>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
             <name>Alejandro Garcia Marra</name>
         </developer>
         <developer>
-            <id>estebanwasinger</id>                                        
+            <id>estebanwasinger</id>
             <name>Esteban Wasinger</name>
         </developer>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,18 @@
             <name>Alejandro Garcia Marra</name>
         </developer>
         <developer>
-            <id>estebanwasinger</id>
+            <id>estebanwasinger</id>                                        <requireReleaseDeps>
+                                            <message>No Snapshots Allowed in Deps!</message>
+                                            <excludes>
+                                                <exclude>org.mule.weave:*</exclude>
+                                                <exclude>org.mule.runtime:mule-dwb-api</exclude>
+                                                <exclude>org.mule.services:*</exclude>
+                                                <exclude>org.mule.tools.maven:mule-classloader-model</exclude>
+
+                                                <exclude>org.raml:raml-parser-2</exclude>
+                                                <exclude>org.raml:yagi</exclude>
+                                            </excludes>
+                                        </requireReleaseDeps>
             <name>Esteban Wasinger</name>
         </developer>
         <developer>
@@ -867,6 +878,14 @@
                         </goals>
                         <configuration>
                             <rules>
+                                <requireReleaseDeps>
+                                   <message>No Snapshots Allowed in Deps!</message>
+                                   <excludes>
+                                       <exclude>org.mule.weave:*</exclude>
+                                       <exclude>org.mule.runtime:mule-dwb-api</exclude>
+                                       <exclude>org.mule.services:*</exclude>
+                                   </excludes>
+                               </requireReleaseDeps>
                                 <requireMavenVersion>
                                     <version>[3.3.1,)</version>
                                 </requireMavenVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,8 @@
             <name>Alejandro Garcia Marra</name>
         </developer>
         <developer>
-            <id>estebanwasinger</id>                                        <requireReleaseDeps>
+            <id>estebanwasinger</id>                                        
+                                        <requireReleaseDeps>
                                             <message>No Snapshots Allowed in Deps!</message>
                                             <excludes>
                                                 <exclude>org.mule.weave:*</exclude>


### PR DESCRIPTION
W-16262196 This specific exclude helps avoiding errors when building dryRun SNAPSHOTS for latest before monthly cycle releases.