### PR TITLE
W-16386058: mule repo ApplicationDeploymentTestCase restartAppWithStartedFlowWithInitialStateStoppedAfter48 is failing in previous support branches than support/4.8.x for J8, J11 and J17

### DIFF
--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/test/internal/AbstractApplicationDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/test/internal/AbstractApplicationDeploymentTestCase.java
@@ -44,8 +44,6 @@ public abstract class AbstractApplicationDeploymentTestCase extends AbstractDepl
   protected ApplicationFileBuilder dummyAppDescriptorWithPropsFileBuilder;
   protected ApplicationFileBuilder dummyAppDescriptorWithStoppedFlowFileBuilder;
 
-  protected ApplicationFileBuilder dummyAppDescriptorWithStoppedFlowFileBuilderMinMuleVersion48;
-
   public AbstractApplicationDeploymentTestCase(boolean parallelDeployment) {
     super(parallelDeployment);
   }

--- a/modules/deployment/src/test/java/org/mule/runtime/module/deployment/test/internal/ApplicationDeploymentTestCase.java
+++ b/modules/deployment/src/test/java/org/mule/runtime/module/deployment/test/internal/ApplicationDeploymentTestCase.java
@@ -175,12 +175,6 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
         .dependingOn(callbackExtensionPlugin)
         .containingClass(echoTestClassFile,
                          "org/foo/EchoTest.class");
-    dummyAppDescriptorWithStoppedFlowFileBuilderMinMuleVersion48 = appFileBuilder("dummy-app-with-stopped-flow-config")
-        .withMinMuleVersion("4.8.0")
-        .definedBy("dummy-app-with-stopped-flow-config.xml")
-        .dependingOn(callbackExtensionPlugin)
-        .containingClass(echoTestClassFile,
-                         "org/foo/EchoTest.class");
   }
 
   @Test
@@ -1144,22 +1138,6 @@ public class ApplicationDeploymentTestCase extends AbstractApplicationDeployment
     final Application app2 = assertAppDeploymentAndStatus(dummyAppDescriptorWithStoppedFlowFileBuilder, STARTED);
     for (Flow flow : app2.getArtifactContext().getRegistry().lookupAllByType(Flow.class)) {
       assertThat(flow.getLifecycleState().isStarted(), is(false));
-    }
-  }
-
-  @Test
-  @Issue("W-15750334")
-  public void restartAppWithStartedFlowWithInitialStateStoppedAfter48() throws Exception {
-    final Application app = deployApplication(dummyAppDescriptorWithStoppedFlowFileBuilderMinMuleVersion48);
-    for (Flow flow : app.getArtifactContext().getRegistry().lookupAllByType(Flow.class)) {
-      flow.start();
-    }
-    reset(applicationDeploymentListener);
-    redeploy(deploymentService, dummyAppDescriptorWithStoppedFlowFileBuilderMinMuleVersion48.getId());
-
-    final Application app2 = assertAppDeploymentAndStatus(dummyAppDescriptorWithStoppedFlowFileBuilderMinMuleVersion48, STARTED);
-    for (Flow flow : app2.getArtifactContext().getRegistry().lookupAllByType(Flow.class)) {
-      assertThat(flow.getLifecycleState().isStarted(), is(true));
     }
   }
 


### PR DESCRIPTION
(cherry picked from commit f85215fce0ee8f6d0caf0d8ea89280fed7349e71)