### PR TITLE
W-16433612: Java SDK parser for ChainInputTypeResolver now uses route alias as key instead of parameter name. (#13705)

### DIFF
--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataOperationTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataOperationTestCase.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 
@@ -437,6 +438,27 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
 
     MessageMetadataType routeInputType = inputMetadata.getRouteInputMessageTypes().get("metaroute");
     assertThat(routeInputType.getPayloadType().get(), is(STRING_TYPE));
+  }
+
+  @Test
+  @Issue("W-16433612")
+  public void routerWithChainInputResolverOnAliasedRoute() {
+    location = builderFromStringRepresentation("routerWithChainInputResolverOnAliasedRoute/processors/0").build();
+
+    MessageMetadataType inputMessageType = MessageMetadataType.builder()
+        .payload(typeBuilder.withFormat(JAVA).objectType().build())
+        .attributes(typeBuilder.withFormat(JAVA).objectType().build())
+        .build();
+
+    MetadataResult<RouterInputMetadataDescriptor> inputMetadataResult =
+        metadataService.getRouterInputMetadata(location, null, () -> inputMessageType);
+
+    assertThat(inputMetadataResult.getFailures(), is(empty()));
+    RouterInputMetadataDescriptor inputMetadata = inputMetadataResult.get();
+
+    assertThat(inputMetadata.getRouteInputMessageTypes().keySet(), containsInAnyOrder("aliasedRoute"));
+    MessageMetadataType routeInputType = inputMetadata.getRouteInputMessageTypes().get("aliasedRoute");
+    assertThat(routeInputType.getPayloadType().get().getMetadataFormat(), is(JSON));
   }
 
   @Test

--- a/modules/extensions-spring-support/src/test/resources/metadata-tests.xml
+++ b/modules/extensions-spring-support/src/test/resources/metadata-tests.xml
@@ -334,4 +334,12 @@
         </metadata:router-with-only-chain-input-metadata-resolver>
     </flow>
 
+    <flow name="routerWithChainInputResolverOnAliasedRoute">
+        <metadata:router-with-chain-input-resolver-on-aliased-route>
+            <metadata:aliased-route>
+                <metadata:output-and-multiple-input-with-key-id config-ref="config" type="PERSON"/>
+            </metadata:aliased-route>
+        </metadata:router-with-chain-input-resolver-on-aliased-route>
+    </flow>
+
 </mule>

--- a/modules/extensions-spring-support/src/test/resources/models/metadata.json
+++ b/modules/extensions-spring-support/src/test/resources/models/metadata.json
@@ -37798,6 +37798,453 @@
             }
           }
         },
+        "hasDynamicType": false,
+        "description": "",
+        "modelProperties": {}
+      },
+      "outputAttributes": {
+        "type": {
+          "format": "java",
+          "type": "Void"
+        },
+        "hasDynamicType": false,
+        "description": "",
+        "modelProperties": {}
+      },
+      "transactional": false,
+      "requiresConnection": false,
+      "supportsStreaming": false,
+      "notifications": [],
+      "nestedComponents": [
+        {
+          "minOccurs": 1,
+          "errors": [],
+          "semanticTerms": [],
+          "visibility": "PUBLIC",
+          "parameterGroupModels": [],
+          "name": "aliasedRoute",
+          "description": "",
+          "modelProperties": {},
+          "childComponents": [
+            {
+              "executionOccurrence": "UNKNOWN",
+              "isRequired": true,
+              "allowedStereotypes": [
+                {
+                  "type": "PROCESSOR",
+                  "namespace": "MULE"
+                }
+              ],
+              "minOccurs": 1,
+              "maxOccurs": 1,
+              "nestedComponents": [],
+              "errors": [],
+              "semanticTerms": [],
+              "visibility": "PUBLIC",
+              "parameterGroupModels": [],
+              "name": "processors",
+              "description": "",
+              "modelProperties": {},
+              "kind": "chain"
+            }
+          ],
+          "kind": "route"
+        }
+      ],
+      "errors": [],
+      "semanticTerms": [],
+      "visibility": "PUBLIC",
+      "stereotype": {
+        "type": "ROUTER_WITH_CHAIN_INPUT_RESOLVER_ON_ALIASED_ROUTE",
+        "namespace": "METADATA",
+        "parent": {
+          "type": "PROCESSOR",
+          "namespace": "METADATA",
+          "parent": {
+            "type": "PROCESSOR",
+            "namespace": "MULE"
+          }
+        }
+      },
+      "minMuleVersion": "4.5.0",
+      "parameterGroupModels": [
+        {
+          "parameters": [
+            {
+              "type": {
+                "format": "json",
+                "type": "Any",
+                "annotations": {
+                  "classInformation": {
+                    "classname": "java.lang.String",
+                    "hasDefaultConstructor": true,
+                    "isInterface": false,
+                    "isInstantiable": true,
+                    "isAbstract": false,
+                    "isFinal": true,
+                    "implementedInterfaces": [],
+                    "parent": "",
+                    "genericTypes": [],
+                    "isMap": false
+                  }
+                }
+              },
+              "hasDynamicType": false,
+              "required": false,
+              "isConfigOverride": false,
+              "isComponentId": false,
+              "fieldValueProviderModels": [],
+              "expressionSupport": "SUPPORTED",
+              "role": "BEHAVIOUR",
+              "dslConfiguration": {
+                "allowsInlineDefinition": false,
+                "allowsReferences": false,
+                "allowTopLevelDefinition": false
+              },
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 1
+              },
+              "allowedStereotypeModels": [],
+              "semanticTerms": [],
+              "name": "jsonValue",
+              "description": "",
+              "modelProperties": {}
+            },
+            {
+              "type": {
+                "format": "java",
+                "type": "String"
+              },
+              "hasDynamicType": false,
+              "required": false,
+              "isConfigOverride": false,
+              "isComponentId": false,
+              "fieldValueProviderModels": [],
+              "expressionSupport": "SUPPORTED",
+              "role": "BEHAVIOUR",
+              "dslConfiguration": {
+                "allowsInlineDefinition": false,
+                "allowsReferences": false,
+                "allowTopLevelDefinition": false
+              },
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 2,
+                "tabName": "Advanced"
+              },
+              "allowedStereotypeModels": [],
+              "semanticTerms": [],
+              "name": "outputMimeType",
+              "description": "The mime type of the payload that this operation outputs.",
+              "modelProperties": {
+                "sinceMuleVersion": {
+                  "version": "4.2.0"
+                }
+              }
+            },
+            {
+              "type": {
+                "format": "java",
+                "type": "String"
+              },
+              "hasDynamicType": false,
+              "required": false,
+              "isConfigOverride": false,
+              "isComponentId": false,
+              "fieldValueProviderModels": [],
+              "expressionSupport": "SUPPORTED",
+              "role": "BEHAVIOUR",
+              "dslConfiguration": {
+                "allowsInlineDefinition": false,
+                "allowsReferences": false,
+                "allowTopLevelDefinition": false
+              },
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 3,
+                "tabName": "Advanced"
+              },
+              "allowedStereotypeModels": [],
+              "semanticTerms": [],
+              "name": "outputEncoding",
+              "description": "The encoding of the payload that this operation outputs.",
+              "modelProperties": {
+                "sinceMuleVersion": {
+                  "version": "4.2.0"
+                }
+              }
+            }
+          ],
+          "exclusiveParametersModels": [],
+          "layoutModel": {
+            "password": false,
+            "text": false,
+            "query": false,
+            "order": 1
+          },
+          "showInDsl": false,
+          "name": "General",
+          "description": "",
+          "modelProperties": {}
+        },
+        {
+          "parameters": [
+            {
+              "type": {
+                "format": "java",
+                "type": "String"
+              },
+              "hasDynamicType": false,
+              "required": false,
+              "isConfigOverride": false,
+              "isComponentId": false,
+              "fieldValueProviderModels": [],
+              "expressionSupport": "NOT_SUPPORTED",
+              "role": "BEHAVIOUR",
+              "dslConfiguration": {
+                "allowsInlineDefinition": false,
+                "allowsReferences": false,
+                "allowTopLevelDefinition": false
+              },
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 4,
+                "tabName": "Advanced"
+              },
+              "allowedStereotypeModels": [],
+              "semanticTerms": [],
+              "name": "target",
+              "displayModel": {
+                "displayName": "Target Variable"
+              },
+              "description": "The name of a variable on which the operation\u0027s output will be placed",
+              "modelProperties": {}
+            },
+            {
+              "type": {
+                "format": "java",
+                "type": "String"
+              },
+              "hasDynamicType": false,
+              "required": false,
+              "isConfigOverride": false,
+              "isComponentId": false,
+              "fieldValueProviderModels": [],
+              "expressionSupport": "REQUIRED",
+              "defaultValue": "#[payload]",
+              "role": "BEHAVIOUR",
+              "dslConfiguration": {
+                "allowsInlineDefinition": false,
+                "allowsReferences": false,
+                "allowTopLevelDefinition": false
+              },
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 5,
+                "tabName": "Advanced"
+              },
+              "allowedStereotypeModels": [],
+              "semanticTerms": [],
+              "name": "targetValue",
+              "displayModel": {
+                "displayName": "Target Value"
+              },
+              "description": "An expression that will be evaluated against the operation\u0027s output and the outcome of that expression will be stored in the target variable",
+              "modelProperties": {}
+            }
+          ],
+          "exclusiveParametersModels": [],
+          "layoutModel": {
+            "password": false,
+            "text": false,
+            "query": false,
+            "order": 2
+          },
+          "showInDsl": false,
+          "name": "Output",
+          "description": "",
+          "modelProperties": {}
+        },
+        {
+          "parameters": [
+            {
+              "type": {
+                "format": "java",
+                "type": "Array",
+                "annotations": {
+                  "infrastructureType": {},
+                  "description": {
+                    "value": "Determines that an error thrown by this operation should be mapped to another"
+                  },
+                  "typeDsl": {
+                    "allowInlineDefinition": true,
+                    "allowTopLevelDefinition": false
+                  }
+                },
+                "item": {
+                  "type": "Object",
+                  "annotations": {
+                    "typeId": "errorMapping",
+                    "infrastructureType": {}
+                  },
+                  "fields": [
+                    {
+                      "key": {
+                        "name": "source"
+                      },
+                      "model": {
+                        "format": {
+                          "id": "text",
+                          "label": "Text",
+                          "validMimeTypes": [
+                            "text/plain"
+                          ]
+                        },
+                        "type": "String",
+                        "annotations": {
+                          "typeId": "errorTypeMatcher",
+                          "enum": {
+                            "type": "[Ljava.lang.String;",
+                            "values": [
+                              "ANY",
+                              "REDELIVERY_EXHAUSTED",
+                              "TRANSFORMATION",
+                              "EXPRESSION",
+                              "SECURITY",
+                              "CLIENT_SECURITY",
+                              "SERVER_SECURITY",
+                              "ROUTING",
+                              "CONNECTIVITY",
+                              "RETRY_EXHAUSTED",
+                              "TIMEOUT"
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "name": "target",
+                        "required": "true"
+                      },
+                      "model": {
+                        "format": {
+                          "id": "text",
+                          "label": "Text",
+                          "validMimeTypes": [
+                            "text/plain"
+                          ]
+                        },
+                        "type": "String",
+                        "annotations": {
+                          "typeId": "errorTypeDefinition"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "hasDynamicType": false,
+              "required": false,
+              "isConfigOverride": false,
+              "isComponentId": false,
+              "fieldValueProviderModels": [],
+              "expressionSupport": "NOT_SUPPORTED",
+              "role": "BEHAVIOUR",
+              "dslConfiguration": {
+                "allowsInlineDefinition": true,
+                "allowsReferences": false,
+                "allowTopLevelDefinition": false
+              },
+              "layoutModel": {
+                "password": false,
+                "text": false,
+                "query": false,
+                "order": 6,
+                "tabName": "Error Mapping"
+              },
+              "allowedStereotypeModels": [],
+              "semanticTerms": [],
+              "name": "errorMappings",
+              "description": "Set of error mappings",
+              "modelProperties": {
+                "org.mule.runtime.extension.api.property.QNameModelProperty": {
+                  "value": {
+                    "namespaceURI": "http://www.mulesoft.org/schema/mule/core",
+                    "localPart": "error-mappings",
+                    "prefix": "mule"
+                  }
+                },
+                "sinceMuleVersion": {
+                  "version": "4.4.0"
+                },
+                "org.mule.runtime.extension.api.property.InfrastructureParameterModelProperty": {
+                  "sequence": 12
+                }
+              }
+            }
+          ],
+          "exclusiveParametersModels": [],
+          "layoutModel": {
+            "password": false,
+            "text": false,
+            "query": false,
+            "order": 3
+          },
+          "showInDsl": false,
+          "name": "Error Mappings",
+          "description": "",
+          "modelProperties": {}
+        }
+      ],
+      "name": "routerWithChainInputResolverOnAliasedRoute",
+      "description": "",
+      "modelProperties": {},
+      "kind": "operation"
+    },
+    {
+      "blocking": false,
+      "executionType": "CPU_LITE",
+      "output": {
+        "type": {
+          "format": {
+            "id": "*/*",
+            "label": "*/*",
+            "validMimeTypes": [
+              "*/*"
+            ]
+          },
+          "type": "Any",
+          "annotations": {
+            "typeId": "java.lang.Object",
+            "classInformation": {
+              "classname": "java.lang.Object",
+              "hasDefaultConstructor": true,
+              "isInterface": false,
+              "isInstantiable": true,
+              "isAbstract": false,
+              "isFinal": false,
+              "implementedInterfaces": [],
+              "parent": "",
+              "genericTypes": [],
+              "isMap": false
+            },
+            "typeAlias": {
+              "value": "Object"
+            }
+          }
+        },
         "hasDynamicType": true,
         "description": "",
         "modelProperties": {}

--- a/modules/extensions-spring-support/src/test/resources/schemas/metadata.xsd
+++ b/modules/extensions-spring-support/src/test/resources/schemas/metadata.xsd
@@ -2227,6 +2227,49 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:element xmlns="http://www.mulesoft.org/schema/mule/metadata" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="RouterWithChainInputResolverOnAliasedRouteType" substitutionGroup="mule:abstract-operator" name="router-with-chain-input-resolver-on-aliased-route"></xs:element>
+  <xs:complexType name="RouterWithChainInputResolverOnAliasedRouteType">
+    <xs:complexContent>
+      <xs:extension xmlns:mule="http://www.mulesoft.org/schema/mule/core" base="mule:abstractOperatorType">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+          <xs:element minOccurs="1" maxOccurs="1" name="aliased-route">
+            <xs:complexType>
+              <xs:complexContent>
+                <xs:extension base="mule:abstractExtensionType">
+                  <xs:sequence minOccurs="1">
+                    <xs:choice minOccurs="1" maxOccurs="unbounded">
+                      <xs:group minOccurs="1" ref="mule:messageProcessorOrMixedContentMessageProcessor"></xs:group>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:extension>
+              </xs:complexContent>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute type="xs:string" use="optional" name="jsonValue"></xs:attribute>
+        <xs:attribute type="mule:expressionString" use="optional" name="outputMimeType">
+          <xs:annotation>
+            <xs:documentation>The mime type of the payload that this operation outputs.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="mule:expressionString" use="optional" name="outputEncoding">
+          <xs:annotation>
+            <xs:documentation>The encoding of the payload that this operation outputs.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="xs:string" use="optional" name="target">
+          <xs:annotation>
+            <xs:documentation>The name of a variable on which the operation's output will be placed</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="mule:expressionString" use="optional" default="#[payload]" name="targetValue">
+          <xs:annotation>
+            <xs:documentation>An expression that will be evaluated against the operation's output and the outcome of that expression will be stored in the target variable</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:element xmlns="http://www.mulesoft.org/schema/mule/metadata" xmlns:mule="http://www.mulesoft.org/schema/mule/core" type="RouterWithMetadataResolverType" substitutionGroup="mule:abstract-operator" name="router-with-metadata-resolver"></xs:element>
   <xs:complexType name="RouterWithMetadataResolverType">
     <xs:complexContent>

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/metadata/JavaRoutesChainInputTypesResolverModelParser.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/metadata/JavaRoutesChainInputTypesResolverModelParser.java
@@ -34,7 +34,7 @@ public class JavaRoutesChainInputTypesResolverModelParser implements RoutesChain
   @Override
   public Map<String, ChainInputTypeResolver> getRoutesChainInputResolvers() {
     return routes.stream().collect(toMap(
-                                         ExtensionParameter::getName,
+                                         ExtensionParameter::getAlias,
                                          route -> getChainInputTypeResolver(route).orElse(NULL_INSTANCE)));
   }
 }

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/MetadataOperations.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/MetadataOperations.java
@@ -29,6 +29,7 @@ import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
 import org.mule.runtime.extension.api.runtime.route.Chain;
 import org.mule.runtime.extension.api.runtime.streaming.PagingProvider;
+import org.mule.sdk.api.annotation.Alias;
 import org.mule.sdk.api.annotation.metadata.ChainInputResolver;
 import org.mule.sdk.api.annotation.metadata.PassThroughInputChainResolver;
 import org.mule.tck.message.StringAttributes;
@@ -422,5 +423,12 @@ public class MetadataOperations {
                                                        @Optional String jsonValue,
                                                        CompletionCallback<Object, Void> cb) {
     metaroute.getChain().process(jsonValue, null, cb::success, (t, e) -> cb.error(t));
+  }
+
+  @MediaType(value = ANY, strict = false)
+  public void routerWithChainInputResolverOnAliasedRoute(@ChainInputResolver(TestChainInputTypeResolver.class) @Alias("aliasedRoute") MetadataRoute metaroute,
+                                                         @TypeResolver(AnyJsonTypeStaticResolver.class) @Optional String jsonValue,
+                                                         CompletionCallback<Object, Void> cb) {
+    metaroute.getChain().process(cb::success, (t, e) -> cb.error(t));
   }
 }


### PR DESCRIPTION
(cherry picked from commit 0260171374323593976244797aadec60ff1d299e)