### PR TITLE
W-16517517: Cache loaded java types for an extension

### DIFF
--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/exception/ClassNotFoundInRegionException.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/exception/ClassNotFoundInRegionException.java
@@ -6,9 +6,9 @@
  */
 package org.mule.runtime.module.artifact.api.classloader.exception;
 
-import static java.lang.Boolean.getBoolean;
-import static java.lang.String.format;
 import static org.mule.runtime.api.exception.MuleException.MULE_VERBOSE_EXCEPTIONS;
+
+import static java.lang.Boolean.getBoolean;
 
 import org.mule.api.annotation.NoInstantiate;
 import org.mule.runtime.module.artifact.api.classloader.RegionClassLoader;
@@ -33,7 +33,7 @@ public final class ClassNotFoundInRegionException extends ClassNotFoundException
    * @param regionName the name of the region the class was being loaded from.
    */
   public ClassNotFoundInRegionException(String className, String regionName) {
-    super(format("Class '%s' has no package mapping for region '%s'.", className, regionName));
+    super("Class '" + className + "' has no package mapping for region '" + regionName + "'.");
     this.className = className;
     this.regionName = regionName;
   }
@@ -47,7 +47,8 @@ public final class ClassNotFoundInRegionException extends ClassNotFoundException
    * @param cause        the actual exception that was thrown when loading the class form the artifact classLoader.
    */
   public ClassNotFoundInRegionException(String className, String regionName, String artifactName, ClassNotFoundException cause) {
-    super(format("Class '%s' not found in classloader for artifact '%s' in region '%s'.", className, artifactName, regionName),
+    super("Class '" + className + "' not found in classloader for artifact '" + artifactName + "' in region '" + regionName
+        + "'.",
           cause);
     this.className = className;
     this.regionName = regionName;

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/DefaultExtensionBuildingDefinitionProvider.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/DefaultExtensionBuildingDefinitionProvider.java
@@ -6,12 +6,14 @@
  */
 package org.mule.runtime.module.extension.internal.config.dsl;
 
-import static java.util.Collections.emptySet;
 import static org.mule.runtime.api.util.Preconditions.checkState;
 import static org.mule.runtime.core.api.util.ClassUtils.withContextClassLoader;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.getSubstitutionGroup;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.getClassLoader;
 
+import static java.util.Collections.emptySet;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.ArrayType;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.ObjectType;
@@ -45,6 +47,7 @@ import org.mule.runtime.module.extension.internal.config.dsl.construct.Construct
 import org.mule.runtime.module.extension.internal.config.dsl.operation.OperationDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.parameter.ObjectTypeParameterParser;
 import org.mule.runtime.module.extension.internal.config.dsl.source.SourceDefinitionParser;
+import org.mule.runtime.module.extension.internal.loader.java.property.TypeLoaderModelProperty;
 import org.mule.runtime.module.extension.internal.util.IntrospectionUtils;
 import org.mule.runtime.module.extension.internal.util.ReflectionCache;
 
@@ -95,6 +98,8 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
     final ExtensionParsingContext parsingContext = createParsingContext(extensionModel);
     final Builder definitionBuilder = new Builder().withNamespace(xmlDslModel.getPrefix());
     final DslSyntaxResolver dslSyntaxResolver = DslSyntaxResolver.getDefault(extensionModel, dslResolvingContext);
+    final Optional<ClassTypeLoader> typeLoader =
+        extensionModel.getModelProperty(TypeLoaderModelProperty.class).map(TypeLoaderModelProperty::getTypeLoader);
 
     final ClassLoader extensionClassLoader = getClassLoader(extensionModel);
     withContextClassLoader(extensionClassLoader, () -> {
@@ -104,51 +109,53 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
         @Override
         public void onConfiguration(ConfigurationModel model) {
           parseWith(new ConfigurationDefinitionParser(definitionBuilder, extensionModel, model, dslSyntaxResolver,
-                                                      parsingContext));
+                                                      parsingContext, typeLoader));
         }
 
         @Override
         protected void onConstruct(ConstructModel model) {
           parseWith(new ConstructDefinitionParser(definitionBuilder, extensionModel,
-                                                  model, dslSyntaxResolver, parsingContext));
+                                                  model, dslSyntaxResolver, parsingContext, typeLoader));
         }
 
         @Override
         public void onOperation(OperationModel model) {
           parseWith(new OperationDefinitionParser(definitionBuilder, extensionModel,
-                                                  model, dslSyntaxResolver, parsingContext));
+                                                  model, dslSyntaxResolver, parsingContext, typeLoader));
         }
 
         @Override
         public void onConnectionProvider(ConnectionProviderModel model) {
           parseWith(new ConnectionProviderDefinitionParser(definitionBuilder, model, extensionModel, dslSyntaxResolver,
-                                                           parsingContext));
+                                                           parsingContext, typeLoader));
         }
 
         @Override
         public void onSource(SourceModel model) {
           parseWith(new SourceDefinitionParser(definitionBuilder, extensionModel, model, dslSyntaxResolver,
-                                               parsingContext));
+                                               parsingContext, typeLoader));
         }
 
         @Override
         protected void onParameter(ParameterGroupModel groupModel, ParameterModel model) {
           registerTopLevelParameter(model.getType(), definitionBuilder, extensionClassLoader, dslSyntaxResolver,
-                                    parsingContext, reflectionCache);
+                                    parsingContext, reflectionCache, typeLoader);
         }
 
       }.walk(extensionModel);
 
       registerExportedTypesTopLevelParsers(extensionModel, definitionBuilder, extensionClassLoader, dslSyntaxResolver,
-                                           parsingContext, reflectionCache);
+                                           parsingContext, reflectionCache, typeLoader);
 
-      registerSubTypes(definitionBuilder, extensionClassLoader, dslSyntaxResolver, parsingContext, reflectionCache);
+      registerSubTypes(definitionBuilder, extensionClassLoader, dslSyntaxResolver, parsingContext, reflectionCache,
+                       typeLoader);
     });
   }
 
   private void registerSubTypes(MetadataType type, Builder definitionBuilder,
                                 ClassLoader extensionClassLoader, DslSyntaxResolver dslSyntaxResolver,
-                                ExtensionParsingContext parsingContext, ReflectionCache reflectionCache) {
+                                ExtensionParsingContext parsingContext, ReflectionCache reflectionCache,
+                                Optional<ClassTypeLoader> typeLoader) {
     type.accept(new MetadataTypeVisitor() {
 
       @Override
@@ -168,7 +175,7 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
         } else {
           parsingContext.getSubTypes(objectType)
               .forEach(subtype -> registerTopLevelParameter(subtype, definitionBuilder, extensionClassLoader, dslSyntaxResolver,
-                                                            parsingContext, reflectionCache));
+                                                            parsingContext, reflectionCache, typeLoader));
         }
       }
     });
@@ -184,7 +191,8 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
 
   private void registerTopLevelParameter(final MetadataType parameterType, Builder definitionBuilder,
                                          ClassLoader extensionClassLoader, DslSyntaxResolver dslSyntaxResolver,
-                                         ExtensionParsingContext parsingContext, ReflectionCache reflectionCache) {
+                                         ExtensionParsingContext parsingContext, ReflectionCache reflectionCache,
+                                         Optional<ClassTypeLoader> typeLoader) {
     Optional<DslElementSyntax> dslElement = dslSyntaxResolver.resolve(parameterType);
     if (!dslElement.isPresent() ||
         parsingContext.isRegistered(dslElement.get().getElementName(), dslElement.get().getPrefix())
@@ -202,16 +210,17 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
             parsingContext.getAllSubTypes().contains(objectType)) {
 
           parseWith(new ObjectTypeParameterParser(definitionBuilder, objectType, extensionClassLoader, dslSyntaxResolver,
-                                                  parsingContext));
+                                                  parsingContext, typeLoader));
         }
 
-        registerSubTypes(objectType, definitionBuilder, extensionClassLoader, dslSyntaxResolver, parsingContext, reflectionCache);
+        registerSubTypes(objectType, definitionBuilder, extensionClassLoader, dslSyntaxResolver, parsingContext, reflectionCache,
+                         typeLoader);
       }
 
       @Override
       public void visitArrayType(ArrayType arrayType) {
         registerTopLevelParameter(arrayType.getType(), definitionBuilder, extensionClassLoader, dslSyntaxResolver,
-                                  parsingContext, reflectionCache);
+                                  parsingContext, reflectionCache, typeLoader);
       }
 
       @Override
@@ -225,18 +234,21 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
   private void registerExportedTypesTopLevelParsers(ExtensionModel extensionModel,
                                                     Builder definitionBuilder,
                                                     ClassLoader extensionClassLoader, DslSyntaxResolver dslSyntaxResolver,
-                                                    ExtensionParsingContext parsingContext, ReflectionCache reflectionCache) {
+                                                    ExtensionParsingContext parsingContext, ReflectionCache reflectionCache,
+                                                    Optional<ClassTypeLoader> typeLoader) {
     registerTopLevelParameters(extensionModel.getTypes().stream(),
                                definitionBuilder,
                                extensionClassLoader,
                                dslSyntaxResolver,
                                parsingContext,
-                               reflectionCache);
+                               reflectionCache,
+                               typeLoader);
   }
 
   private void registerSubTypes(Builder definitionBuilder,
                                 ClassLoader extensionClassLoader, DslSyntaxResolver dslSyntaxResolver,
-                                ExtensionParsingContext parsingContext, ReflectionCache reflectionCache) {
+                                ExtensionParsingContext parsingContext, ReflectionCache reflectionCache,
+                                Optional<ClassTypeLoader> typeLoader) {
 
 
     ImmutableList<MetadataType> mappedTypes = new ImmutableList.Builder<MetadataType>()
@@ -246,12 +258,13 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
 
     registerTopLevelParameters(mappedTypes.stream(), definitionBuilder, extensionClassLoader,
                                dslSyntaxResolver,
-                               parsingContext, reflectionCache);
+                               parsingContext, reflectionCache, typeLoader);
   }
 
   private void registerTopLevelParameters(Stream<? extends MetadataType> parameters, Builder definitionBuilder,
                                           ClassLoader extensionClassLoader, DslSyntaxResolver dslSyntaxResolver,
-                                          ExtensionParsingContext parsingContext, ReflectionCache reflectionCache) {
+                                          ExtensionParsingContext parsingContext, ReflectionCache reflectionCache,
+                                          Optional<ClassTypeLoader> typeLoader) {
 
     parameters.filter(p -> IntrospectionUtils.isInstantiable(p, reflectionCache))
         .forEach(subType -> registerTopLevelParameter(subType,
@@ -259,7 +272,8 @@ public class DefaultExtensionBuildingDefinitionProvider implements ExtensionBuil
                                                       extensionClassLoader,
                                                       dslSyntaxResolver,
                                                       parsingContext,
-                                                      reflectionCache));
+                                                      reflectionCache,
+                                                      typeLoader));
 
   }
 

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/config/ConfigurationDefinitionParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/config/ConfigurationDefinitionParser.java
@@ -11,6 +11,8 @@ import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fro
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromReferenceObject;
 import static org.mule.runtime.dsl.api.component.TypeDefinition.fromType;
 import static org.mule.runtime.extension.api.util.ExtensionModelUtils.supportsConnectivity;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.config.ConfigurationModel;
 import org.mule.runtime.core.api.MuleContext;
@@ -23,6 +25,8 @@ import org.mule.runtime.extension.api.runtime.config.ConfigurationProvider;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingContext;
 import org.mule.runtime.module.extension.internal.runtime.resolver.ConnectionProviderResolver;
+
+import java.util.Optional;
 
 /**
  * A {@link ExtensionDefinitionParser} for parsing {@link ConfigurationProvider} instances through a
@@ -39,8 +43,9 @@ public final class ConfigurationDefinitionParser extends ExtensionDefinitionPars
   public ConfigurationDefinitionParser(Builder definition, ExtensionModel extensionModel,
                                        ConfigurationModel configurationModel,
                                        DslSyntaxResolver dslResolver,
-                                       ExtensionParsingContext parsingContext) {
-    super(definition, dslResolver, parsingContext);
+                                       ExtensionParsingContext parsingContext,
+                                       Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslResolver, parsingContext, typeLoader);
     this.extensionModel = extensionModel;
     this.configurationModel = configurationModel;
     this.configDsl = dslResolver.resolve(configurationModel);

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/connection/ConnectionProviderDefinitionParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/connection/ConnectionProviderDefinitionParser.java
@@ -10,6 +10,8 @@ import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fro
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromFixedValue;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromReferenceObject;
 import static org.mule.runtime.dsl.api.component.TypeDefinition.fromType;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.config.PoolingProfile;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.connection.ConnectionProviderModel;
@@ -26,6 +28,8 @@ import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.cli
 import org.mule.runtime.module.extension.internal.runtime.connectivity.oauth.ocs.PlatformManagedOAuthHandler;
 import org.mule.runtime.module.extension.internal.runtime.resolver.ConnectionProviderResolver;
 
+import java.util.Optional;
+
 /**
  * A {@link ExtensionDefinitionParser} for parsing {@link ConnectionProviderResolver} instances through a
  * {@link ConnectionProviderObjectFactory}
@@ -40,8 +44,9 @@ public final class ConnectionProviderDefinitionParser extends ExtensionDefinitio
 
   public ConnectionProviderDefinitionParser(Builder definition, ConnectionProviderModel providerModel,
                                             ExtensionModel extensionModel, DslSyntaxResolver dslSyntaxResolver,
-                                            ExtensionParsingContext parsingContext) {
-    super(definition, dslSyntaxResolver, parsingContext);
+                                            ExtensionParsingContext parsingContext,
+                                            Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslSyntaxResolver, parsingContext, typeLoader);
     this.providerModel = providerModel;
     this.extensionModel = extensionModel;
     this.connectionDsl = dslSyntaxResolver.resolve(providerModel);

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/construct/ConstructDefinitionParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/construct/ConstructDefinitionParser.java
@@ -6,14 +6,17 @@
  */
 package org.mule.runtime.module.extension.internal.config.dsl.construct;
 
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.construct.ConstructModel;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition.Builder;
 import org.mule.runtime.extension.api.dsl.syntax.resolver.DslSyntaxResolver;
-import org.mule.runtime.module.extension.internal.parser.AbstractComponentDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingContext;
+import org.mule.runtime.module.extension.internal.parser.AbstractComponentDefinitionParser;
 import org.mule.runtime.module.extension.internal.runtime.operation.ConstructMessageProcessor;
+
+import java.util.Optional;
 
 /**
  * A {@link ExtensionDefinitionParser} for parsing {@link ConstructMessageProcessor} instances through a
@@ -26,8 +29,9 @@ public class ConstructDefinitionParser extends AbstractComponentDefinitionParser
   public ConstructDefinitionParser(Builder definition, ExtensionModel extensionModel,
                                    ConstructModel constructModel,
                                    DslSyntaxResolver dslSyntaxResolver,
-                                   ExtensionParsingContext parsingContext) {
-    super(definition, extensionModel, constructModel, dslSyntaxResolver, parsingContext);
+                                   ExtensionParsingContext parsingContext,
+                                   Optional<ClassTypeLoader> typeLoader) {
+    super(definition, extensionModel, constructModel, dslSyntaxResolver, parsingContext, typeLoader);
   }
 
   @Override

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/construct/RouteComponentParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/construct/RouteComponentParser.java
@@ -6,13 +6,17 @@
  */
 package org.mule.runtime.module.extension.internal.config.dsl.construct;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 import static org.mule.metadata.api.utils.MetadataTypeUtils.isObjectType;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromChildCollectionConfiguration;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromFixedValue;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromReferenceObject;
 import static org.mule.runtime.dsl.api.component.TypeDefinition.fromType;
+
+import static java.lang.String.format;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.ObjectType;
 import org.mule.runtime.api.meta.model.nested.NestedRouteModel;
@@ -25,6 +29,8 @@ import org.mule.runtime.extension.api.dsl.syntax.resolver.DslSyntaxResolver;
 import org.mule.runtime.module.extension.api.runtime.resolver.ValueResolver;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingContext;
+
+import java.util.Optional;
 
 /**
  * A parser which returns the definition parsers for a given {@link NestedRouteModel}
@@ -46,8 +52,9 @@ public class RouteComponentParser extends ExtensionDefinitionParser {
                               ClassLoader classLoader,
                               DslElementSyntax routeDsl,
                               DslSyntaxResolver dslResolver,
-                              ExtensionParsingContext context) {
-    super(definition, dslResolver, context);
+                              ExtensionParsingContext context,
+                              Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslResolver, context, typeLoader);
 
     checkArgument(isObjectType(metadataType),
                   format("Only an ObjectType can be parsed as a TypedParameterGroup, found [%s] instead",

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/operation/OperationDefinitionParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/operation/OperationDefinitionParser.java
@@ -8,6 +8,7 @@ package org.mule.runtime.module.extension.internal.config.dsl.operation;
 
 import static org.mule.runtime.extension.privileged.util.ComponentDeclarationUtils.isNoErrorMapping;
 
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.VoidType;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.operation.OperationModel;
@@ -17,6 +18,8 @@ import org.mule.runtime.module.extension.internal.config.dsl.ExtensionDefinition
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingContext;
 import org.mule.runtime.module.extension.internal.parser.AbstractComponentDefinitionParser;
 import org.mule.runtime.module.extension.internal.runtime.operation.OperationMessageProcessor;
+
+import java.util.Optional;
 
 /**
  * A {@link ExtensionDefinitionParser} for parsing {@link OperationMessageProcessor} instances through a
@@ -29,8 +32,9 @@ public class OperationDefinitionParser extends AbstractComponentDefinitionParser
   public OperationDefinitionParser(Builder definition, ExtensionModel extensionModel,
                                    OperationModel operationModel,
                                    DslSyntaxResolver dslSyntaxResolver,
-                                   ExtensionParsingContext parsingContext) {
-    super(definition, extensionModel, operationModel, dslSyntaxResolver, parsingContext);
+                                   ExtensionParsingContext parsingContext,
+                                   Optional<ClassTypeLoader> typeLoader) {
+    super(definition, extensionModel, operationModel, dslSyntaxResolver, parsingContext, typeLoader);
   }
 
   @Override

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/AnonymousInlineParameterGroupParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/AnonymousInlineParameterGroupParser.java
@@ -6,11 +6,13 @@
  */
 package org.mule.runtime.module.extension.internal.config.dsl.parameter;
 
-import static java.util.Collections.singletonList;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromFixedValue;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromReferenceObject;
 import static org.mule.runtime.dsl.api.component.TypeDefinition.fromType;
 
+import static java.util.Collections.singletonList;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.meta.model.parameter.ParameterGroupModel;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationException;
@@ -28,6 +30,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A {@link ParameterGroupParser} which returns the values of the parameters in the group as a {@link Map}
@@ -41,8 +44,9 @@ public class AnonymousInlineParameterGroupParser extends ParameterGroupParser {
                                              ClassLoader classLoader,
                                              DslElementSyntax groupDsl,
                                              DslSyntaxResolver dslResolver,
-                                             ExtensionParsingContext context) {
-    super(definition, group, classLoader, groupDsl, dslResolver, context);
+                                             ExtensionParsingContext context,
+                                             Optional<ClassTypeLoader> typeLoader) {
+    super(definition, group, classLoader, groupDsl, dslResolver, context, typeLoader);
   }
 
   @Override

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/ObjectTypeParameterParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/ObjectTypeParameterParser.java
@@ -6,21 +6,26 @@
  */
 package org.mule.runtime.module.extension.internal.config.dsl.parameter;
 
-import static java.lang.String.format;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromFixedValue;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromReferenceObject;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromSimpleParameter;
-import static org.mule.runtime.dsl.api.component.ComponentBuildingDefinition.Builder;
 import static org.mule.runtime.dsl.api.component.TypeDefinition.fromType;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.getId;
+
+import static java.lang.String.format;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.ObjectType;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.config.ConfigurationException;
+import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition.Builder;
 import org.mule.runtime.extension.api.dsl.syntax.DslElementSyntax;
 import org.mule.runtime.extension.api.dsl.syntax.resolver.DslSyntaxResolver;
 import org.mule.runtime.module.extension.api.runtime.resolver.ValueResolver;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingContext;
+
+import java.util.Optional;
 
 /**
  * A {@link ExtensionDefinitionParser} for parsing extension objects that can be defined as named top level elements and be placed
@@ -40,8 +45,9 @@ public class ObjectTypeParameterParser extends ExtensionDefinitionParser {
   private final String namespace;
 
   public ObjectTypeParameterParser(Builder definition, ObjectType type, ClassLoader classLoader,
-                                   DslSyntaxResolver dslResolver, ExtensionParsingContext context) {
-    super(definition, dslResolver, context);
+                                   DslSyntaxResolver dslResolver, ExtensionParsingContext context,
+                                   Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslResolver, context, typeLoader);
     this.type = type;
     this.classLoader = classLoader;
     this.typeDsl = dslResolver.resolve(type)
@@ -52,8 +58,9 @@ public class ObjectTypeParameterParser extends ExtensionDefinitionParser {
 
   public ObjectTypeParameterParser(Builder definition, String name, String namespace, ObjectType type,
                                    ClassLoader classLoader,
-                                   DslSyntaxResolver dslResolver, ExtensionParsingContext context) {
-    super(definition, dslResolver, context);
+                                   DslSyntaxResolver dslResolver, ExtensionParsingContext context,
+                                   Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslResolver, context, typeLoader);
     this.name = name;
     this.namespace = namespace;
     this.type = type;

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/ParameterGroupParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/ParameterGroupParser.java
@@ -7,13 +7,17 @@
 package org.mule.runtime.module.extension.internal.config.dsl.parameter;
 
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
-import static org.mule.runtime.dsl.api.component.ComponentBuildingDefinition.Builder;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.meta.model.parameter.ParameterGroupModel;
+import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition.Builder;
 import org.mule.runtime.extension.api.dsl.syntax.DslElementSyntax;
 import org.mule.runtime.extension.api.dsl.syntax.resolver.DslSyntaxResolver;
 import org.mule.runtime.module.extension.api.runtime.resolver.ValueResolver;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionDefinitionParser;
 import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingContext;
+
+import java.util.Optional;
 
 /**
  * A {@link ExtensionDefinitionParser} for parsing extension objects that are expressed as an inline {@link ParameterGroupModel}
@@ -32,8 +36,9 @@ public abstract class ParameterGroupParser extends ExtensionDefinitionParser {
   protected final String namespace;
 
   public ParameterGroupParser(Builder definition, ParameterGroupModel group, ClassLoader classLoader, DslElementSyntax groupDsl,
-                              DslSyntaxResolver dslResolver, ExtensionParsingContext context) {
-    super(definition, dslResolver, context);
+                              DslSyntaxResolver dslResolver, ExtensionParsingContext context,
+                              Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslResolver, context, typeLoader);
 
     checkArgument(group.isShowInDsl(), "Cannot parse an implicit group");
     this.group = group;

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/TypedInlineParameterGroupParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/TypedInlineParameterGroupParser.java
@@ -54,7 +54,8 @@ public class TypedInlineParameterGroupParser extends ParameterGroupParser {
                                          ExtensionParsingContext context,
                                          Optional<ClassTypeLoader> typeLoader) {
     super(definition, group, classLoader, groupDsl, dslResolver, context, typeLoader);
-    MetadataType type = getDefault().createTypeLoader(classLoader).load(groupDescriptor.getType().getDeclaringClass().get());
+    MetadataType type = typeLoader.orElseGet(() -> getDefault().createTypeLoader(classLoader))
+        .load(groupDescriptor.getType().getDeclaringClass().get());
 
     checkArgument(isObjectType(type), format("Only an ObjectType can be parsed as a TypedParameterGroup, found [%s] instead",
                                              type.getClass().getName()));

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/TypedInlineParameterGroupParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/parameter/TypedInlineParameterGroupParser.java
@@ -6,14 +6,17 @@
  */
 package org.mule.runtime.module.extension.internal.config.dsl.parameter;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 import static org.mule.metadata.api.utils.MetadataTypeUtils.isObjectType;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromFixedValue;
 import static org.mule.runtime.dsl.api.component.AttributeDefinition.Builder.fromReferenceObject;
 import static org.mule.runtime.dsl.api.component.TypeDefinition.fromType;
 import static org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory.getDefault;
 
+import static java.lang.String.format;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.ObjectType;
 import org.mule.runtime.api.meta.NamedObject;
@@ -30,6 +33,7 @@ import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingCon
 import org.mule.runtime.module.extension.internal.loader.ParameterGroupDescriptor;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -47,8 +51,9 @@ public class TypedInlineParameterGroupParser extends ParameterGroupParser {
                                          ParameterGroupDescriptor groupDescriptor,
                                          ClassLoader classLoader, DslElementSyntax groupDsl,
                                          DslSyntaxResolver dslResolver,
-                                         ExtensionParsingContext context) {
-    super(definition, group, classLoader, groupDsl, dslResolver, context);
+                                         ExtensionParsingContext context,
+                                         Optional<ClassTypeLoader> typeLoader) {
+    super(definition, group, classLoader, groupDsl, dslResolver, context, typeLoader);
     MetadataType type = getDefault().createTypeLoader(classLoader).load(groupDescriptor.getType().getDeclaringClass().get());
 
     checkArgument(isObjectType(type), format("Only an ObjectType can be parsed as a TypedParameterGroup, found [%s] instead",

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/source/SourceDefinitionParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/config/dsl/source/SourceDefinitionParser.java
@@ -15,6 +15,7 @@ import static org.mule.runtime.extension.api.ExtensionConstants.BACK_PRESSURE_ST
 import static org.mule.runtime.extension.api.ExtensionConstants.PRIMARY_NODE_ONLY_PARAMETER_NAME;
 import static org.mule.runtime.module.extension.internal.util.MuleExtensionUtils.toBackPressureStrategy;
 
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.parameter.ParameterGroupModel;
 import org.mule.runtime.api.meta.model.source.SourceModel;
@@ -31,6 +32,7 @@ import org.mule.runtime.module.extension.internal.config.dsl.ExtensionParsingCon
 import org.mule.runtime.module.extension.internal.runtime.source.ExtensionMessageSource;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * An {@link ExtensionMessageSource} used to parse instances of {@link ExtensionMessageSource} instances through a
@@ -46,8 +48,8 @@ public class SourceDefinitionParser extends ExtensionDefinitionParser {
 
   public SourceDefinitionParser(Builder definition, ExtensionModel extensionModel,
                                 SourceModel sourceModel, DslSyntaxResolver dslSyntaxResolver,
-                                ExtensionParsingContext parsingContext) {
-    super(definition, dslSyntaxResolver, parsingContext);
+                                ExtensionParsingContext parsingContext, Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslSyntaxResolver, parsingContext, typeLoader);
     this.extensionModel = extensionModel;
     this.sourceModel = sourceModel;
     this.sourceDsl = dslSyntaxResolver.resolve(sourceModel);

--- a/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/parser/AbstractComponentDefinitionParser.java
+++ b/modules/extensions-spring-support/src/main/java/org/mule/runtime/module/extension/internal/parser/AbstractComponentDefinitionParser.java
@@ -16,6 +16,7 @@ import static org.mule.runtime.extension.api.ExtensionConstants.ERROR_MAPPINGS_P
 import static org.mule.runtime.extension.api.ExtensionConstants.TARGET_PARAMETER_NAME;
 import static org.mule.runtime.extension.api.ExtensionConstants.TARGET_VALUE_PARAMETER_NAME;
 
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.artifact.Registry;
 import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.meta.model.ExtensionModel;
@@ -56,8 +57,9 @@ public abstract class AbstractComponentDefinitionParser<T extends ComponentModel
   public AbstractComponentDefinitionParser(Builder definition, ExtensionModel extensionModel,
                                            T componentModel,
                                            DslSyntaxResolver dslSyntaxResolver,
-                                           ExtensionParsingContext parsingContext) {
-    super(definition, dslSyntaxResolver, parsingContext);
+                                           ExtensionParsingContext parsingContext,
+                                           Optional<ClassTypeLoader> typeLoader) {
+    super(definition, dslSyntaxResolver, parsingContext, typeLoader);
     this.extensionModel = extensionModel;
     this.componentModel = componentModel;
     this.operationDsl = dslSyntaxResolver.resolve(componentModel);

--- a/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/config/dsl/config/ConfigurationDefinitionParserTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/runtime/module/extension/internal/config/dsl/config/ConfigurationDefinitionParserTestCase.java
@@ -12,6 +12,7 @@ import static org.mule.test.module.extension.internal.util.ExtensionDeclarationT
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static java.util.Optional.of;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -25,6 +26,7 @@ import org.mule.runtime.api.util.Pair;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition;
 import org.mule.runtime.dsl.api.component.ComponentBuildingDefinition.Builder;
 import org.mule.runtime.dsl.api.component.TypeConverter;
+import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.dsl.syntax.resolver.DslSyntaxResolver;
 import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
 import org.mule.runtime.extension.internal.loader.DefaultExtensionLoadingContext;
@@ -65,7 +67,8 @@ public class ConfigurationDefinitionParserTestCase extends AbstractMuleTestCase 
 
       ConfigurationDefinitionParser configurationDefinitionParser =
           new ConfigurationDefinitionParser(definitionBuilder, extensionModel, configurationModel, dslSyntaxResolver,
-                                            extensionParsingContext);
+                                            extensionParsingContext,
+                                            of(ExtensionsTypeLoaderFactory.getDefault().createTypeLoader()));
 
       componentBuildingDefinitions = configurationDefinitionParser.parse();
     } finally {

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataExtensionFunctionalTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataExtensionFunctionalTestCase.java
@@ -13,8 +13,8 @@ import static org.mule.runtime.api.metadata.MetadataService.METADATA_SERVICE_KEY
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 import static org.mule.tck.junit4.matcher.metadata.MetadataKeyResultFailureMatcher.isFailure;
 import static org.mule.tck.junit4.matcher.metadata.MetadataKeyResultSuccessMatcher.isSuccess;
-import static org.mule.test.allure.AllureConstants.SdkToolingSupport.MetadataTypeResolutionStory.METADATA_SERVICE;
 import static org.mule.test.allure.AllureConstants.SdkToolingSupport.SDK_TOOLING_SUPPORT;
+import static org.mule.test.allure.AllureConstants.SdkToolingSupport.MetadataTypeResolutionStory.METADATA_SERVICE;
 import static org.mule.test.metadata.extension.MetadataConnection.CAR;
 import static org.mule.test.metadata.extension.MetadataConnection.PERSON;
 import static org.mule.test.metadata.extension.resolver.TestMetadataResolverUtils.getCarMetadata;
@@ -27,10 +27,10 @@ import static org.mule.test.module.extension.metadata.MetadataExtensionFunctiona
 import static org.mule.test.module.extension.metadata.MetadataExtensionFunctionalTestCase.ResolutionType.EXPLICIT_RESOLUTION;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.builder.BaseTypeBuilder;
@@ -66,10 +66,11 @@ import java.util.function.BiConsumer;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import io.qameta.allure.Feature;
-import io.qameta.allure.Story;
 import org.junit.Before;
 import org.junit.runners.Parameterized;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
 
 //TODO MULE-12809: Make MetadataTestCase use LazyMetadataService
 @RunnerDelegateTo(Parameterized.class)

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataExtensionFunctionalTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataExtensionFunctionalTestCase.java
@@ -7,6 +7,7 @@
 package org.mule.test.module.extension.metadata;
 
 import static org.mule.metadata.api.model.MetadataFormat.JAVA;
+import static org.mule.metadata.api.utils.MetadataTypeUtils.getTypeId;
 import static org.mule.runtime.api.message.Message.of;
 import static org.mule.runtime.api.metadata.MetadataKeyBuilder.newKey;
 import static org.mule.runtime.api.metadata.MetadataService.METADATA_SERVICE_KEY;
@@ -26,6 +27,9 @@ import static org.mule.test.metadata.extension.resolver.TestMultiLevelKeyResolve
 import static org.mule.test.module.extension.metadata.MetadataExtensionFunctionalTestCase.ResolutionType.DSL_RESOLUTION;
 import static org.mule.test.module.extension.metadata.MetadataExtensionFunctionalTestCase.ResolutionType.EXPLICIT_RESOLUTION;
 
+import static java.util.function.UnaryOperator.identity;
+import static java.util.stream.Collectors.toMap;
+
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -35,6 +39,7 @@ import static org.hamcrest.core.Is.is;
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.builder.BaseTypeBuilder;
 import org.mule.metadata.api.model.MetadataType;
+import org.mule.metadata.api.model.ObjectType;
 import org.mule.runtime.api.component.location.Location;
 import org.mule.runtime.api.meta.Typed;
 import org.mule.runtime.api.meta.model.ComponentModel;
@@ -50,16 +55,16 @@ import org.mule.runtime.api.metadata.resolving.MetadataComponent;
 import org.mule.runtime.api.metadata.resolving.MetadataFailure;
 import org.mule.runtime.api.metadata.resolving.MetadataResult;
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.api.extension.ExtensionManager;
 import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.metadata.NullMetadataKey;
 import org.mule.runtime.module.extension.api.metadata.MultilevelMetadataKeyBuilder;
 import org.mule.test.module.extension.AbstractExtensionFunctionalTestCase;
-import org.mule.test.module.extension.internal.util.ExtensionsTestUtils;
 import org.mule.test.runner.RunnerDelegateTo;
 
-import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
@@ -155,10 +160,15 @@ public abstract class MetadataExtensionFunctionalTestCase<T extends ComponentMod
           .withChild(MultilevelMetadataKeyBuilder.newKey(SAN_FRANCISCO, CITY))).build();
 
   protected static final NullMetadataKey NULL_METADATA_KEY = new NullMetadataKey();
-  protected static final ClassTypeLoader TYPE_LOADER = ExtensionsTestUtils.TYPE_LOADER;
 
+  protected static final MetadataType ANY_TYPE = BaseTypeBuilder.create(JAVA).anyType().build();
   protected static final MetadataType VOID_TYPE = BaseTypeBuilder.create(JAVA).voidType().build();
   protected static final MetadataType STRING_TYPE = BaseTypeBuilder.create(JAVA).stringType().build();
+
+  protected Map<String, ObjectType> types;
+
+  @Inject
+  private ExtensionManager extensionManager;
 
   @Inject
   @Named(METADATA_SERVICE_KEY)
@@ -209,6 +219,14 @@ public abstract class MetadataExtensionFunctionalTestCase<T extends ComponentMod
     personType = getPersonMetadata();
     houseType = getHouseMetadata();
     carType = getCarMetadata();
+  }
+
+  @Before
+  public void loadTypes() {
+    types = extensionManager.getExtension("Metadata").get().getTypes()
+        .stream()
+        .filter(type -> getTypeId(type).isPresent())
+        .collect(toMap(type -> getTypeId(type).get(), identity()));
   }
 
   @Override
@@ -274,15 +292,6 @@ public abstract class MetadataExtensionFunctionalTestCase<T extends ComponentMod
     }
   }
 
-  void assertExpectedOutput(ConnectableComponentModel model, Type payloadType, Type attributesType) {
-    assertExpectedOutput(model.getOutput(), model.getOutputAttributes(), TYPE_LOADER.load(payloadType),
-                         TYPE_LOADER.load(attributesType));
-  }
-
-  void assertExpectedOutput(ConnectableComponentModel model, MetadataType payloadType, Type attributesType) {
-    assertExpectedOutput(model.getOutput(), model.getOutputAttributes(), payloadType, TYPE_LOADER.load(attributesType));
-  }
-
   void assertExpectedOutput(ConnectableComponentModel model, MetadataType payloadType, MetadataType attributesType) {
     assertExpectedOutput(model.getOutput(), model.getOutputAttributes(), payloadType, attributesType);
   }
@@ -296,7 +305,8 @@ public abstract class MetadataExtensionFunctionalTestCase<T extends ComponentMod
     assertThat(type, is(expectedType));
   }
 
-  protected void assertExpectedParameterMetadataDescriptor(ParameterMetadataDescriptor parameterMetadataDescriptor, Type type,
+  protected void assertExpectedParameterMetadataDescriptor(ParameterMetadataDescriptor parameterMetadataDescriptor,
+                                                           MetadataType type,
                                                            boolean dynamic) {
     assertThat(parameterMetadataDescriptor.isDynamic(), is(dynamic));
     assertExpectedType(parameterMetadataDescriptor.getType(), type);
@@ -308,12 +318,8 @@ public abstract class MetadataExtensionFunctionalTestCase<T extends ComponentMod
     assertExpectedType(parameterMetadataDescriptor.getType(), type);
   }
 
-  protected void assertExpectedType(Typed type, Type expectedType) {
-    assertThat(type.getType(), is(TYPE_LOADER.load(expectedType)));
-  }
-
-  protected void assertExpectedType(MetadataType metadataType, Type expectedType) {
-    assertExpectedType(metadataType, TYPE_LOADER.load(expectedType));
+  protected void assertExpectedType(Typed type, MetadataType expectedType) {
+    assertThat(type.getType(), is(expectedType));
   }
 
   protected void assertExpectedType(Typed typedModel, MetadataType expectedType, boolean isDynamic) {

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataOperationTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataOperationTestCase.java
@@ -39,8 +39,8 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
@@ -97,8 +97,9 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import io.qameta.allure.Issue;
 import org.junit.Test;
+
+import io.qameta.allure.Issue;
 
 public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase {
 
@@ -851,7 +852,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     assertThat(type, is(instanceOf(ObjectType.class)));
     ObjectType objectType = (ObjectType) type;
     assertThat(objectType.getFields(), hasSize(2));
-    objectType.getFields().forEach(f -> assertThat(f.getKey().getName().getLocalPart(), isOneOf(TIRES, BRAND)));
+    objectType.getFields().forEach(f -> assertThat(f.getKey().getName().getLocalPart(), oneOf(TIRES, BRAND)));
     Optional<MetadataKey> metadataKeyOptional = result.get().getMetadataAttributes().getKey();
     assertThat(metadataKeyOptional.isPresent(), is(true));
     assertThat(metadataKeyOptional.get().getId(), is(CAR));

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataOperationTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/MetadataOperationTestCase.java
@@ -85,7 +85,6 @@ import org.mule.test.metadata.extension.model.attribute.AbstractOutputAttributes
 import org.mule.test.metadata.extension.model.shapes.Rectangle;
 import org.mule.test.metadata.extension.model.shapes.Shape;
 import org.mule.test.metadata.extension.resolver.TestThreadContextClassLoaderResolver;
-import org.mule.test.module.extension.internal.util.ExtensionsTestUtils;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -258,7 +257,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
 
@@ -268,7 +267,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     assertExpectedType(getParameter(typedModel, "firstPerson"), personType, true);
     assertExpectedType(getParameter(typedModel, "otherPerson"), personType, true);
   }
@@ -279,7 +278,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     MetadataResult<InputMetadataDescriptor> inputMetadataResult = metadataService.getInputMetadata(location, PERSON_METADATA_KEY);
     assertThat(inputMetadataResult.isSuccess(), is(true));
     InputMetadataDescriptor inputMetadataDescriptor = inputMetadataResult.get();
-    assertExpectedParameterMetadataDescriptor(inputMetadataDescriptor.getParameterMetadata("type"), String.class, false);
+    assertExpectedParameterMetadataDescriptor(inputMetadataDescriptor.getParameterMetadata("type"),
+                                              STRING_TYPE, false);
     assertExpectedParameterMetadataDescriptor(inputMetadataDescriptor.getParameterMetadata("firstPerson"), personType);
     assertExpectedParameterMetadataDescriptor(inputMetadataDescriptor.getParameterMetadata("otherPerson"), personType);
   }
@@ -536,8 +536,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, personType, void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
 
   }
 
@@ -548,8 +548,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, void.class, void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, VOID_TYPE, VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
 
@@ -560,7 +560,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final OperationModel typedModel = metadataDescriptor.getModel();
     MetadataType objectMetadataType = (new ParameterTypeWrapper(Object.class, typeLoader)).asMetadataType();
 
-    assertExpectedOutput(typedModel, personType, void.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), objectMetadataType, false);
 
   }
@@ -571,7 +571,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
         Location.builder().globalName(CONTENT_AND_OUTPUT_METADATA_WITHOUT_KEY_ID).addProcessorsPart().addIndexPart(0).build();
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor = getSuccessComponentDynamicMetadata(NULL_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, personType, void.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
 
@@ -582,8 +582,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, void.class, void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, VOID_TYPE, VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
 
@@ -594,8 +594,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, personType, void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
 
   }
 
@@ -604,9 +604,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     location = Location.builder().globalName(MESSAGE_ATTRIBUTES_ANY_TYPE_METADATA).addProcessorsPart().addIndexPart(0).build();
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor = getSuccessComponentDynamicMetadata(NULL_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, ExtensionsTestUtils.TYPE_BUILDER.anyType().build(),
-                         ExtensionsTestUtils.TYPE_BUILDER.anyType().build());
-    assertExpectedType(getParameter(typedModel, TARGET_PARAMETER_NAME), String.class);
+    assertExpectedOutput(typedModel, ANY_TYPE, ANY_TYPE);
+    assertExpectedType(getParameter(typedModel, TARGET_PARAMETER_NAME), STRING_TYPE);
   }
 
   @Test
@@ -615,8 +614,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, personType, StringAttributes.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, personType, types.get(StringAttributes.class.getName()));
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
 
   }
 
@@ -655,8 +654,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
         .addIndexPart(0).build();
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor = getSuccessComponentDynamicMetadata(NULL_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, Shape.class, AbstractOutputAttributes.class);
-
+    assertExpectedOutput(typedModel,
+                         types.get(Shape.class.getName()), types.get(AbstractOutputAttributes.class.getName()));
   }
 
   @Test
@@ -665,8 +664,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, typeBuilder.anyType().build(), void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, typeBuilder.anyType().build(), VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
 
@@ -676,8 +675,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadata(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, typeBuilder.anyType().build(), void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, typeBuilder.anyType().build(), VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
 
@@ -689,8 +688,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final OperationModel typedModel = metadataDescriptor.getModel();
     MetadataType objectMetadataType = (new ParameterTypeWrapper(Object.class, typeLoader)).asMetadataType();
 
-    assertExpectedOutput(typedModel, personType, void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), objectMetadataType, false);
   }
 
@@ -699,7 +698,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     location = Location.builder().globalName(CONTENT_METADATA_WITHOUT_KEY_ID).addProcessorsPart().addIndexPart(0).build();
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor = getSuccessComponentDynamicMetadata(NULL_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, typeBuilder.anyType().build(), void.class);
+    assertExpectedOutput(typedModel, typeBuilder.anyType().build(), VOID_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
 
@@ -710,7 +709,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final OperationModel typedModel = metadataDescriptor.getModel();
     MetadataType objectMetadataType = (new ParameterTypeWrapper(Object.class, typeLoader)).asMetadataType();
 
-    assertExpectedOutput(typedModel, personType, void.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
     assertExpectedType(getParameter(typedModel, "content"), objectMetadataType, false);
   }
 
@@ -753,8 +752,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadata(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, personType, void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
     // TODO MULE-14190: Revamp MetadataScope annotation
     // assertExpectedType(getParameter(typedModel, "content"), personType, true);
   }
@@ -764,7 +763,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     location = Location.builder().globalName(PAGED_OPERATION_METADATA).addProcessorsPart().addIndexPart(0).build();
     ComponentMetadataDescriptor metadataDescriptor = getSuccessComponentDynamicMetadata(NULL_METADATA_KEY);
     final ComponentModel typedModel = metadataDescriptor.getModel();
-    assertExpectedType(getParameter(typedModel, "animal"), Animal.class);
+    assertExpectedType(getParameter(typedModel, "animal"), types.get(Animal.class.getName()));
   }
 
   @Test
@@ -774,7 +773,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     MetadataType param = metadataDescriptor.getModel().getOutput().getType();
     assertThat(param, is(instanceOf(ArrayType.class)));
     assertThat(getId(param).get(), is(Iterator.class.getName()));
-    assertMessageType(((ArrayType) param).getType(), personType, TYPE_LOADER.load(Animal.class));
+    assertMessageType(((ArrayType) param).getType(), personType, types.get(Animal.class.getName()));
   }
 
   @Test
@@ -793,9 +792,9 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     location = Location.builder().globalName(TYPE_WITH_DECLARED_SUBTYPES_METADATA).addProcessorsPart().addIndexPart(0).build();
     ComponentMetadataDescriptor metadataDescriptor = getSuccessComponentDynamicMetadata(NULL_METADATA_KEY);
     final ComponentModel typedModel = metadataDescriptor.getModel();
-    assertExpectedType(getParameter(typedModel, "plainShape"), Shape.class);
-    assertExpectedType(getParameter(typedModel, "animal"), Animal.class);
-    assertExpectedType(getParameter(typedModel, "rectangleSubtype"), Rectangle.class);
+    assertExpectedType(getParameter(typedModel, "plainShape"), types.get(Shape.class.getName()));
+    assertExpectedType(getParameter(typedModel, "animal"), types.get(Animal.class.getName()));
+    assertExpectedType(getParameter(typedModel, "rectangleSubtype"), types.get(Rectangle.class.getName()));
   }
 
   @Test
@@ -815,7 +814,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     MetadataResult<ComponentMetadataDescriptor<OperationModel>> result =
         metadataService.getOperationMetadata(location, newKey("true").build());
     assertSuccessResult(result);
-    assertExpectedType(getParameter(result.get().getModel(), "content"), TYPE_LOADER.load(SwordFish.class), true);
+    assertExpectedType(getParameter(result.get().getModel(), "content"), types.get(SwordFish.class.getName()), true);
   }
 
   @Test
@@ -840,7 +839,7 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     location = Location.builder().globalName(ENUM_METADATA_KEY).addProcessorsPart().addIndexPart(0).build();
     ComponentMetadataDescriptor metadataDescriptor = getSuccessComponentDynamicMetadata(newKey("MAMMAL").build());
     final ComponentModel typedModel = metadataDescriptor.getModel();
-    assertExpectedType(getParameter(typedModel, "content"), TYPE_LOADER.load(Bear.class), true);
+    assertExpectedType(getParameter(typedModel, "content"), types.get(Bear.class.getName()), true);
   }
 
   @Test
@@ -885,8 +884,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     ComponentMetadataDescriptor<OperationModel> descriptor = result.get();
     MetadataType param = descriptor.getModel().getOutput().getType();
     assertThat(param, is(instanceOf(ArrayType.class)));
-    assertMessageType(((ArrayType) param).getType(), TYPE_LOADER.load(String.class),
-                      TYPE_LOADER.load(StringAttributes.class));
+    assertMessageType(((ArrayType) param).getType(),
+                      STRING_TYPE, types.get(StringAttributes.class.getName()));
   }
 
   @Test
@@ -965,8 +964,8 @@ public class MetadataOperationTestCase extends AbstractMetadataOperationTestCase
     final ComponentMetadataDescriptor<OperationModel> metadataDescriptor =
         getSuccessComponentDynamicMetadataWithKey(PERSON_METADATA_KEY);
     final OperationModel typedModel = metadataDescriptor.getModel();
-    assertExpectedOutput(typedModel, personType, void.class);
-    assertExpectedType(getParameter(typedModel, "type"), String.class);
+    assertExpectedOutput(typedModel, personType, VOID_TYPE);
+    assertExpectedType(getParameter(typedModel, "type"), STRING_TYPE);
 
   }
 

--- a/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/SourceMetadataTestCase.java
+++ b/modules/extensions-spring-support/src/test/java/org/mule/test/module/extension/metadata/SourceMetadataTestCase.java
@@ -6,14 +6,6 @@
  */
 package org.mule.test.module.extension.metadata;
 
-import static java.lang.String.format;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 import static org.mule.runtime.api.component.location.Location.builder;
 import static org.mule.tck.junit4.matcher.MetadataKeyMatcher.metadataKeyWithId;
 import static org.mule.tck.junit4.matcher.metadata.MetadataKeyResultSuccessMatcher.isSuccess;
@@ -28,6 +20,16 @@ import static org.mule.test.metadata.extension.resolver.TestMultiLevelKeyResolve
 import static org.mule.test.metadata.extension.resolver.TestMultiLevelKeyResolver.EUROPE;
 import static org.mule.test.metadata.extension.resolver.TestMultiLevelKeyResolver.LA_PLATA;
 import static org.mule.test.module.extension.metadata.MetadataExtensionFunctionalTestCase.ResolutionType.EXPLICIT_RESOLUTION;
+
+import static java.lang.String.format;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.ObjectType;
@@ -160,7 +162,7 @@ public class SourceMetadataTestCase extends MetadataExtensionFunctionalTestCase<
         metadataService.getOutputMetadata(location, PERSON_METADATA_KEY);
     assertThat(outputMetadataResult.isSuccess(), is(true));
     OutputMetadataDescriptor outputMetadataDescriptor = outputMetadataResult.get();
-    assertExpectedType(outputMetadataDescriptor.getAttributesMetadata().getType(), StringAttributes.class);
+    assertExpectedType(outputMetadataDescriptor.getAttributesMetadata().getType(), types.get(StringAttributes.class.getName()));
   }
 
   @Test

--- a/modules/extensions-spring-support/src/test/resources/models/subtypes.json
+++ b/modules/extensions-spring-support/src/test/resources/models/subtypes.json
@@ -6837,7 +6837,11 @@
                 "allowedStereotypes": [
                   {
                     "type": "SQUARE",
-                    "namespace": "SUBTYPES"
+                    "namespace": "SUBTYPES",
+                    "parent": {
+                      "type": "PARENT_SHAPE",
+                      "namespace": "SUBTYPES"
+                    }
                   }
                 ]
               }
@@ -6973,7 +6977,11 @@
                 "allowedStereotypes": [
                   {
                     "type": "RICIN",
-                    "namespace": "HEISENBERG"
+                    "namespace": "HEISENBERG",
+                    "parent": {
+                      "type": "WEAPON",
+                      "namespace": "HEISENBERG"
+                    }
                   }
                 ]
               }

--- a/modules/extensions-spring-support/src/test/resources/models/vegan-without-artifact-coordinates.json
+++ b/modules/extensions-spring-support/src/test/resources/models/vegan-without-artifact-coordinates.json
@@ -19252,7 +19252,11 @@
                 "allowedStereotypes": [
                   {
                     "type": "HEALTHY_FOOD",
-                    "namespace": "VEGAN"
+                    "namespace": "VEGAN",
+                    "parent": {
+                      "type": "FARMED_FOOD",
+                      "namespace": "VEGAN"
+                    }
                   }
                 ]
               }
@@ -19447,7 +19451,11 @@
                 "allowedStereotypes": [
                   {
                     "type": "HEALTHY_FOOD",
-                    "namespace": "VEGAN"
+                    "namespace": "VEGAN",
+                    "parent": {
+                      "type": "FARMED_FOOD",
+                      "namespace": "VEGAN"
+                    }
                   }
                 ]
               }

--- a/modules/extensions-spring-support/src/test/resources/models/vegan.json
+++ b/modules/extensions-spring-support/src/test/resources/models/vegan.json
@@ -19257,7 +19257,11 @@
                 "allowedStereotypes": [
                   {
                     "type": "HEALTHY_FOOD",
-                    "namespace": "VEGAN"
+                    "namespace": "VEGAN",
+                    "parent": {
+                      "type": "FARMED_FOOD",
+                      "namespace": "VEGAN"
+                    }
                   }
                 ]
               }
@@ -19452,7 +19456,11 @@
                 "allowedStereotypes": [
                   {
                     "type": "HEALTHY_FOOD",
-                    "namespace": "VEGAN"
+                    "namespace": "VEGAN",
+                    "parent": {
+                      "type": "FARMED_FOOD",
+                      "namespace": "VEGAN"
+                    }
                   }
                 ]
               }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/delegate/DefaultExtensionModelLoaderDelegate.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/delegate/DefaultExtensionModelLoaderDelegate.java
@@ -34,6 +34,7 @@ import org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils;
 import org.mule.runtime.module.extension.internal.error.ErrorsModelFactory;
 import org.mule.runtime.module.extension.internal.loader.java.property.CompileTimeModelProperty;
 import org.mule.runtime.module.extension.internal.loader.java.property.DevelopmentFrameworkModelProperty;
+import org.mule.runtime.module.extension.internal.loader.java.property.TypeLoaderModelProperty;
 import org.mule.runtime.module.extension.internal.loader.parser.ExtensionModelParser;
 import org.mule.runtime.module.extension.internal.loader.parser.ExtensionModelParserFactory;
 import org.mule.runtime.module.extension.internal.loader.parser.java.JavaExtensionModelParserFactory;
@@ -106,6 +107,7 @@ public class DefaultExtensionModelLoaderDelegate implements ModelLoaderDelegate 
         .ifPresent(m -> declarer.withModelProperty(new CompileTimeModelProperty()));
 
     declarer.withModelProperty(new DevelopmentFrameworkModelProperty(parser.getDevelopmentFramework()));
+    declarer.withModelProperty(new TypeLoaderModelProperty(context.getTypeLoader()));
     parser.getArtifactLifecycleListenerModelProperty().ifPresent(declarer::withModelProperty);
 
     this.declarer = declarer;

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/contributor/InfrastructureTypeResolver.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/contributor/InfrastructureTypeResolver.java
@@ -11,6 +11,7 @@ import static org.mule.runtime.extension.api.loader.util.InfrastructureTypeUtils
 
 import static java.util.function.Function.identity;
 
+import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.extension.api.declaration.type.DefaultExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.loader.util.InfrastructureTypeUtils;
 import org.mule.runtime.extension.api.loader.util.InfrastructureTypeUtils.MetadataTypeBasedInfrastructureType;
@@ -27,12 +28,12 @@ import java.util.Optional;
  */
 public class InfrastructureTypeResolver {
 
+  private static final ClassTypeLoader TYPE_LOADER = new DefaultExtensionsTypeLoaderFactory()
+      .createTypeLoader(InfrastructureTypeUtils.class.getClassLoader());
+
   private static final Map<Type, MetadataTypeBasedInfrastructureType> TYPE_MAPPING = getActionableInfrastructureTypes()
       .stream()
-      .collect(toImmutableMap(infrastructureType -> new TypeWrapper(infrastructureType.getClazz(),
-                                                                    new DefaultExtensionsTypeLoaderFactory()
-                                                                        .createTypeLoader(InfrastructureTypeUtils.class
-                                                                            .getClassLoader())),
+      .collect(toImmutableMap(infrastructureType -> new TypeWrapper(infrastructureType.getClazz(), TYPE_LOADER),
                               identity()));
 
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/enricher/JavaMimeTypeParametersDeclarationEnricher.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/enricher/JavaMimeTypeParametersDeclarationEnricher.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.module.extension.internal.loader.java.enricher;
 
-import static java.util.Optional.of;
 import static org.mule.metadata.api.model.MetadataFormat.JAVA;
 import static org.mule.runtime.api.meta.ExpressionSupport.SUPPORTED;
 import static org.mule.runtime.api.meta.model.parameter.ParameterGroupModel.DEFAULT_GROUP_NAME;
@@ -16,6 +15,8 @@ import static org.mule.runtime.module.extension.internal.ExtensionProperties.ADV
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.ENCODING_PARAMETER_NAME;
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.MIME_TYPE_PARAMETER_NAME;
 import static org.mule.runtime.module.extension.internal.loader.utils.JavaModelLoaderUtils.isInputStream;
+
+import static java.util.Optional.of;
 
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.annotation.EnumAnnotation;
@@ -42,7 +43,6 @@ import org.mule.runtime.api.meta.model.declaration.fluent.ParameterGroupDeclarat
 import org.mule.runtime.api.meta.model.declaration.fluent.SourceDeclaration;
 import org.mule.runtime.api.meta.model.declaration.fluent.WithSourcesDeclaration;
 import org.mule.runtime.api.meta.model.display.LayoutModel;
-import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.loader.DeclarationEnricher;
 import org.mule.runtime.extension.api.loader.DeclarationEnricherPhase;
 import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
@@ -90,7 +90,7 @@ public final class JavaMimeTypeParametersDeclarationEnricher implements WalkingD
   public Optional<DeclarationEnricherWalkDelegate> getWalkDelegate(ExtensionLoadingContext extensionLoadingContext) {
     return of(new IdempotentDeclarationEnricherWalkDelegate() {
 
-      private final ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
+      private final ClassTypeLoader typeLoader = extensionLoadingContext.getTypeLoader();
 
       @Override
       protected void onOperation(OperationDeclaration declaration) {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/enricher/JavaOAuthDeclarationEnricher.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/enricher/JavaOAuthDeclarationEnricher.java
@@ -6,8 +6,7 @@
  */
 package org.mule.runtime.module.extension.internal.loader.java.enricher;
 
-import static java.util.Optional.of;
-import static java.util.stream.Collectors.toList;
+import static org.mule.metadata.api.model.MetadataFormat.JAVA;
 import static org.mule.runtime.api.meta.ExpressionSupport.SUPPORTED;
 import static org.mule.runtime.api.meta.model.operation.ExecutionType.BLOCKING;
 import static org.mule.runtime.api.meta.model.parameter.ParameterGroupModel.DEFAULT_GROUP_NAME;
@@ -16,8 +15,13 @@ import static org.mule.runtime.extension.api.connectivity.oauth.ExtensionOAuthCo
 import static org.mule.runtime.extension.api.connectivity.oauth.ExtensionOAuthConstants.UNAUTHORIZE_OPERATION_NAME;
 import static org.mule.runtime.extension.api.loader.DeclarationEnricherPhase.STRUCTURE;
 
-import org.mule.metadata.api.ClassTypeLoader;
+import static java.util.Optional.of;
+import static java.util.stream.Collectors.toList;
+
+import org.mule.metadata.api.builder.BaseTypeBuilder;
 import org.mule.metadata.api.model.MetadataType;
+import org.mule.metadata.api.model.VoidType;
+import org.mule.metadata.api.model.impl.DefaultStringType;
 import org.mule.runtime.api.meta.model.declaration.fluent.ConfigurationDeclaration;
 import org.mule.runtime.api.meta.model.declaration.fluent.ConnectedDeclaration;
 import org.mule.runtime.api.meta.model.declaration.fluent.ConnectionProviderDeclaration;
@@ -33,7 +37,6 @@ import org.mule.runtime.extension.api.connectivity.oauth.ClientCredentialsGrantT
 import org.mule.runtime.extension.api.connectivity.oauth.OAuthGrantTypeVisitor;
 import org.mule.runtime.extension.api.connectivity.oauth.OAuthModelProperty;
 import org.mule.runtime.extension.api.connectivity.oauth.PlatformManagedOAuthGrantType;
-import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.loader.DeclarationEnricherPhase;
 import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
 import org.mule.runtime.extension.api.loader.WalkingDeclarationEnricher;
@@ -53,6 +56,9 @@ import java.util.Set;
  */
 public class JavaOAuthDeclarationEnricher implements WalkingDeclarationEnricher {
 
+  private static final DefaultStringType stringType = BaseTypeBuilder.create(JAVA).stringType().build();
+  private static final VoidType voidType = BaseTypeBuilder.create(JAVA).voidType().build();
+
   @Override
   public DeclarationEnricherPhase getExecutionPhase() {
     return STRUCTURE;
@@ -62,8 +68,8 @@ public class JavaOAuthDeclarationEnricher implements WalkingDeclarationEnricher 
   public Optional<DeclarationEnricherWalkDelegate> getWalkDelegate(ExtensionLoadingContext extensionLoadingContext) {
     return of(new DeclarationEnricherWalkDelegate() {
 
-      private ExtensionDeclaration extensionDeclaration = extensionLoadingContext.getExtensionDeclarer().getDeclaration();
-      private Set<Reference<ConfigurationDeclaration>> oauthConfigs = new HashSet<>();
+      private final ExtensionDeclaration extensionDeclaration = extensionLoadingContext.getExtensionDeclarer().getDeclaration();
+      private final Set<Reference<ConfigurationDeclaration>> oauthConfigs = new HashSet<>();
       private boolean oauthGloballySupported = false;
       private boolean supportsAuthCode = false;
 
@@ -110,10 +116,6 @@ public class JavaOAuthDeclarationEnricher implements WalkingDeclarationEnricher 
       }
 
       private OperationDeclaration buildUnauthorizeOperation(boolean supportsAuthCode) {
-        final ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
-        final MetadataType stringType = typeLoader.load(String.class);
-        final MetadataType voidType = typeLoader.load(void.class);
-
         OperationDeclaration operation = new OperationDeclaration(UNAUTHORIZE_OPERATION_NAME);
         operation
             .setDescription("Deletes all the access token information of a given resource owner id so that it's impossible to "

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/enricher/PollingSourceDeclarationEnricher.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/enricher/PollingSourceDeclarationEnricher.java
@@ -6,22 +6,23 @@
  */
 package org.mule.runtime.module.extension.internal.loader.java.enricher;
 
-import static java.util.Optional.of;
 import static org.mule.metadata.api.model.MetadataFormat.JAVA;
 import static org.mule.metadata.api.utils.MetadataTypeUtils.getTypeId;
 import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
 import static org.mule.runtime.api.meta.model.parameter.ParameterGroupModel.DEFAULT_GROUP_NAME;
+import static org.mule.runtime.config.internal.dsl.utils.DslConstants.CORE_NAMESPACE;
+import static org.mule.runtime.config.internal.dsl.utils.DslConstants.CORE_PREFIX;
+import static org.mule.runtime.config.internal.dsl.utils.DslConstants.SCHEDULING_STRATEGY_ELEMENT_IDENTIFIER;
 import static org.mule.runtime.extension.api.ExtensionConstants.POLLING_SOURCE_LIMIT_PARAMETER_DESCRIPTION;
 import static org.mule.runtime.extension.api.ExtensionConstants.POLLING_SOURCE_LIMIT_PARAMETER_NAME;
 import static org.mule.runtime.extension.api.ExtensionConstants.SCHEDULING_STRATEGY_PARAMETER_DESCRIPTION;
 import static org.mule.runtime.extension.api.ExtensionConstants.SCHEDULING_STRATEGY_PARAMETER_NAME;
 import static org.mule.runtime.extension.api.annotation.param.display.Placement.ADVANCED_TAB;
 import static org.mule.runtime.extension.api.loader.DeclarationEnricherPhase.STRUCTURE;
-import static org.mule.runtime.config.internal.dsl.utils.DslConstants.CORE_NAMESPACE;
-import static org.mule.runtime.config.internal.dsl.utils.DslConstants.CORE_PREFIX;
-import static org.mule.runtime.config.internal.dsl.utils.DslConstants.SCHEDULING_STRATEGY_ELEMENT_IDENTIFIER;
 import static org.mule.runtime.module.extension.api.util.MuleExtensionUtils.isPollingSourceLimitEnabled;
 import static org.mule.runtime.module.extension.internal.loader.java.contributor.InfrastructureTypeResolver.getInfrastructureType;
+
+import static java.util.Optional.of;
 
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.builder.BaseTypeBuilder;
@@ -37,7 +38,6 @@ import org.mule.runtime.api.meta.model.declaration.fluent.SourceDeclaration;
 import org.mule.runtime.api.meta.model.display.LayoutModel;
 import org.mule.runtime.api.scheduler.SchedulingStrategy;
 import org.mule.runtime.extension.api.declaration.type.DefaultExtensionsTypeLoaderFactory;
-import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.loader.DeclarationEnricher;
 import org.mule.runtime.extension.api.loader.DeclarationEnricherPhase;
 import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
@@ -74,7 +74,7 @@ public class PollingSourceDeclarationEnricher implements WalkingDeclarationEnric
                                                 new DefaultExtensionsTypeLoaderFactory()
                                                     .createTypeLoader(extensionLoadingContext.getExtensionClassLoader())))
                                                         .map(MetadataTypeBasedInfrastructureType::getSequence).orElse(0);
-      ClassTypeLoader loader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
+      ClassTypeLoader loader = extensionLoadingContext.getTypeLoader();
       ExtensionDeclarer extensionDeclarer = extensionLoadingContext.getExtensionDeclarer();
       boolean thereArePollingSources = false;
 
@@ -131,8 +131,8 @@ public class PollingSourceDeclarationEnricher implements WalkingDeclarationEnric
       @Override
       public void onWalkFinished() {
         if (thereArePollingSources && !isSchedulerAlreadyImported(extensionDeclarer.getDeclaration())) {
-          ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
-          extensionDeclarer.withImportedType(new ImportedTypeModel((ObjectType) loadSchedulingStrategyType(typeLoader)));
+          extensionDeclarer.withImportedType(new ImportedTypeModel((ObjectType) loadSchedulingStrategyType(extensionLoadingContext
+              .getTypeLoader())));
         }
       }
     });

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/property/TypeLoaderModelProperty.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/property/TypeLoaderModelProperty.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.loader.java.property;
+
+import org.mule.metadata.api.ClassTypeLoader;
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.api.meta.model.ModelProperty;
+
+/**
+ * Provides access to the same {@link ClassTypeLoader} used when loading the extension when using the {@link ExtensionModel} at a
+ * later time.
+ * 
+ * @since 4.9
+ */
+public class TypeLoaderModelProperty implements ModelProperty {
+
+  private static final long serialVersionUID = 1L;
+
+  private final ClassTypeLoader typeLoader;
+
+  public TypeLoaderModelProperty(ClassTypeLoader typeLoader) {
+    this.typeLoader = typeLoader;
+  }
+
+  public ClassTypeLoader getTypeLoader() {
+    return typeLoader;
+  }
+
+  @Override
+  public String getName() {
+    return "typeLoader";
+  }
+
+  @Override
+  public boolean isPublic() {
+    return false;
+  }
+
+
+
+}

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/property/TypeLoaderModelProperty.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/property/TypeLoaderModelProperty.java
@@ -40,6 +40,4 @@ public class TypeLoaderModelProperty implements ModelProperty {
     return false;
   }
 
-
-
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/property/stackabletypes/StackableType.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/property/stackabletypes/StackableType.java
@@ -8,7 +8,8 @@ package org.mule.runtime.module.extension.internal.loader.java.property.stackabl
 
 import static java.util.Optional.ofNullable;
 
-import org.mule.metadata.java.api.JavaTypeLoader;
+import org.mule.metadata.api.ClassTypeLoader;
+import org.mule.metadata.api.model.MetadataType;
 import org.mule.runtime.module.extension.api.loader.java.type.Type;
 import org.mule.runtime.module.extension.api.runtime.resolver.ValueResolver;
 import org.mule.runtime.module.extension.internal.loader.java.type.runtime.TypeWrapper;
@@ -79,11 +80,12 @@ public class StackableType {
   /**
    * Creates a new instance of {@link Builder Wrapper Type Builder}
    *
-   * @param type The type that the {@link StackableType} will represent
+   * @param type       The type that the {@link StackableType} will represent
+   * @param typeLoader the typeLoader to use to get {@link MetadataType}s from Java classes.
    * @return The builder
    */
-  public static <T> Builder<T> builder(Class<T> type) {
-    return new Builder<>(new TypeWrapper(type, new JavaTypeLoader(Thread.currentThread().getContextClassLoader())));
+  public static <T> Builder<T> builder(Class<T> type, ClassTypeLoader typeLoader) {
+    return new Builder<>(new TypeWrapper(type, typeLoader));
   }
 
   public static class Builder<T> {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/ClassBasedAnnotationValueFetcher.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/type/runtime/ClassBasedAnnotationValueFetcher.java
@@ -11,7 +11,6 @@ import static java.util.stream.Collectors.toList;
 
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.runtime.api.util.LazyValue;
-import org.mule.runtime.extension.api.declaration.type.DefaultExtensionsTypeLoaderFactory;
 import org.mule.runtime.module.extension.api.loader.java.type.AnnotationValueFetcher;
 import org.mule.runtime.module.extension.api.loader.java.type.Type;
 
@@ -29,8 +28,8 @@ import java.util.stream.Stream;
  */
 public class ClassBasedAnnotationValueFetcher<T extends Annotation> implements AnnotationValueFetcher<T> {
 
-  private ClassTypeLoader typeLoader;
-  private LazyValue<T> annotation;
+  private final ClassTypeLoader typeLoader;
+  private final LazyValue<T> annotation;
 
   public ClassBasedAnnotationValueFetcher(Class<T> annotationClass, AnnotatedElement annotatedElement,
                                           ClassTypeLoader typeLoader) {
@@ -71,7 +70,7 @@ public class ClassBasedAnnotationValueFetcher<T extends Annotation> implements A
    */
   @Override
   public TypeWrapper getClassValue(Function<T, Class> function) {
-    return new TypeWrapper(function.apply(annotation.get()), new DefaultExtensionsTypeLoaderFactory().createTypeLoader());
+    return new TypeWrapper(function.apply(annotation.get()), typeLoader);
   }
 
   /**

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/validation/NullSafeModelValidator.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/java/validation/NullSafeModelValidator.java
@@ -6,9 +6,6 @@
  */
 package org.mule.runtime.module.extension.internal.loader.java.validation;
 
-import static java.lang.String.format;
-import static java.util.stream.Collectors.joining;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.mule.metadata.api.model.MetadataFormat.JAVA;
 import static org.mule.metadata.api.utils.MetadataTypeUtils.getLocalPart;
 import static org.mule.metadata.java.api.utils.JavaTypeUtils.getType;
@@ -17,6 +14,11 @@ import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.isF
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.isMap;
 import static org.mule.runtime.module.extension.internal.loader.java.validation.JavaModelValidationUtils.isCompiletime;
 import static org.mule.runtime.module.extension.internal.util.IntrospectionUtils.isInstantiable;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import org.mule.metadata.api.TypeLoader;
 import org.mule.metadata.api.annotation.TypeIdAnnotation;
@@ -38,6 +40,7 @@ import org.mule.runtime.extension.api.declaration.type.annotation.NullSafeTypeAn
 import org.mule.runtime.extension.api.loader.ExtensionModelValidator;
 import org.mule.runtime.extension.api.loader.Problem;
 import org.mule.runtime.extension.api.loader.ProblemsReporter;
+import org.mule.runtime.module.extension.internal.loader.java.property.TypeLoaderModelProperty;
 import org.mule.runtime.module.extension.internal.util.ReflectionCache;
 
 /**
@@ -55,7 +58,8 @@ public final class NullSafeModelValidator implements ExtensionModelValidator {
   @Override
   public void validate(ExtensionModel extensionModel, ProblemsReporter problemsReporter) {
     ReflectionCache reflectionCache = new ReflectionCache();
-    TypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
+    TypeLoader typeLoader = extensionModel.getModelProperty(TypeLoaderModelProperty.class)
+        .map(TypeLoaderModelProperty::getTypeLoader).orElseGet(ExtensionsTypeLoaderFactory.getDefault()::createTypeLoader);
     new ExtensionWalker() {
 
       @Override

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/JavaExtensionModelParserFactory.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/JavaExtensionModelParserFactory.java
@@ -59,8 +59,7 @@ public class JavaExtensionModelParserFactory implements ExtensionModelParserFact
               try {
                 ClassLoader extensionClassLoader = context.getExtensionClassLoader();
                 return new ExtensionTypeWrapper<>(loadClass(type, extensionClassLoader),
-                                                  new DefaultExtensionsTypeLoaderFactory()
-                                                      .createTypeLoader(extensionClassLoader));
+                                                  context.getTypeLoader());
               } catch (ClassNotFoundException e) {
                 throw new RuntimeException(format("Class '%s' cannot be loaded", type), e);
               }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/ParameterDeclarationContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/ParameterDeclarationContext.java
@@ -21,12 +21,11 @@ import java.util.List;
  */
 public final class ParameterDeclarationContext {
 
-  private static final StackableTypesModelPropertyResolver STACKABLE_TYPES_RESOLVER = newInstance();
-
   private final String componentName;
   private final String componentType;
 
   private final ExtensionLoadingContext loadingContext;
+  private final StackableTypesModelPropertyResolver stackableTypesResolver;
 
   private final boolean keyResolverAvailable;
 
@@ -74,6 +73,7 @@ public final class ParameterDeclarationContext {
     this.componentName = componentName;
     this.componentType = componentType;
     this.loadingContext = loadingContext;
+    this.stackableTypesResolver = newInstance(loadingContext);
     this.keyResolverAvailable = keyResolverAvailable;
   }
 
@@ -103,6 +103,6 @@ public final class ParameterDeclarationContext {
   }
 
   public List<ModelProperty> resolveStackableTypes(ExtensionParameter extensionParameter) {
-    return STACKABLE_TYPES_RESOLVER.resolveStackableProperties(extensionParameter, this);
+    return stackableTypesResolver.resolveStackableProperties(extensionParameter, this);
   }
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/StackableTypesModelPropertyResolver.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/parser/java/StackableTypesModelPropertyResolver.java
@@ -6,8 +6,9 @@
  */
 package org.mule.runtime.module.extension.internal.loader.parser.java;
 
-import static java.lang.String.format;
 import static org.mule.runtime.api.metadata.DataType.fromType;
+
+import static java.lang.String.format;
 
 import org.mule.runtime.api.meta.model.ModelProperty;
 import org.mule.runtime.api.meta.model.declaration.fluent.ParameterDeclarer;
@@ -15,6 +16,7 @@ import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.util.LazyValue;
 import org.mule.runtime.extension.api.exception.IllegalParameterModelDefinitionException;
+import org.mule.runtime.extension.api.loader.ExtensionLoadingContext;
 import org.mule.runtime.extension.api.runtime.parameter.Literal;
 import org.mule.runtime.extension.api.runtime.parameter.ParameterResolver;
 import org.mule.runtime.module.extension.api.loader.java.type.ExtensionParameter;
@@ -45,10 +47,10 @@ import java.util.Optional;
  */
 class StackableTypesModelPropertyResolver {
 
-  public static StackableTypesModelPropertyResolver newInstance() {
+  public static StackableTypesModelPropertyResolver newInstance(ExtensionLoadingContext loadingContext) {
     return StackableTypesModelPropertyResolver.builder()
         .addType(StackableType
-            .builder(ParameterResolver.class)
+            .builder(ParameterResolver.class, loadingContext.getTypeLoader())
             .setStaticResolverFactory(value -> new StaticValueResolver<>(new StaticParameterResolver<>(value)))
             .setDelegateResolverFactory(resolver -> new ParameterResolverValueResolverWrapper(resolver))
             .setExpressionBasedResolverFactory((value,
@@ -57,20 +59,20 @@ class StackableTypesModelPropertyResolver {
                                                                                                                    fromType(expectedType)))
             .build())
         .addType(StackableType
-            .builder(TypedValue.class)
+            .builder(TypedValue.class, loadingContext.getTypeLoader())
             .setStaticResolverFactory(value -> new StaticValueResolver<>(new TypedValue<>(value, DataType.fromObject(value))))
             .setDelegateResolverFactory(valueResolver -> new TypedValueValueResolverWrapper(valueResolver))
             .setExpressionBasedResolverFactory((expression, expectedType) -> new ExpressionTypedValueValueResolver(expression,
                                                                                                                    expectedType))
             .build())
         .addType(StackableType
-            .builder(Literal.class)
+            .builder(Literal.class, loadingContext.getTypeLoader())
             .setExpressionBasedResolverFactory((expression, expectedType) -> new StaticLiteralValueResolver(expression,
                                                                                                             expectedType))
             .setStaticResolverFactory((value) -> new StaticLiteralValueResolver(value.toString(), value.getClass()))
             .build())
         .addType(StackableType
-            .builder(org.mule.sdk.api.runtime.parameter.ParameterResolver.class)
+            .builder(org.mule.sdk.api.runtime.parameter.ParameterResolver.class, loadingContext.getTypeLoader())
             .setStaticResolverFactory(value -> new StaticValueResolver<>(new StaticParameterResolver<>(value)))
             .setDelegateResolverFactory(resolver -> new ParameterResolverValueResolverWrapper(resolver))
             .setExpressionBasedResolverFactory((value,
@@ -79,7 +81,7 @@ class StackableTypesModelPropertyResolver {
                                                                                                                    fromType(expectedType)))
             .build())
         .addType(StackableType
-            .builder(org.mule.sdk.api.runtime.parameter.Literal.class)
+            .builder(org.mule.sdk.api.runtime.parameter.Literal.class, loadingContext.getTypeLoader())
             .setExpressionBasedResolverFactory((expression, expectedType) -> new StaticLiteralValueResolver(expression,
                                                                                                             expectedType))
             .setStaticResolverFactory((value) -> new StaticLiteralValueResolver(value.toString(), value.getClass()))

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/ExtensionComponent.java
@@ -47,7 +47,6 @@ import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.meta.model.ComponentModel;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.parameter.ValueProviderModel;
-import org.mule.runtime.api.metadata.ScopeOutputMetadataContext;
 import org.mule.runtime.api.metadata.MetadataCache;
 import org.mule.runtime.api.metadata.MetadataContext;
 import org.mule.runtime.api.metadata.MetadataKey;
@@ -56,6 +55,7 @@ import org.mule.runtime.api.metadata.MetadataKeysContainer;
 import org.mule.runtime.api.metadata.MetadataProvider;
 import org.mule.runtime.api.metadata.MetadataResolvingException;
 import org.mule.runtime.api.metadata.RouterOutputMetadataContext;
+import org.mule.runtime.api.metadata.ScopeOutputMetadataContext;
 import org.mule.runtime.api.metadata.descriptor.ComponentMetadataDescriptor;
 import org.mule.runtime.api.metadata.descriptor.InputMetadataDescriptor;
 import org.mule.runtime.api.metadata.descriptor.OutputMetadataDescriptor;
@@ -94,6 +94,7 @@ import org.mule.runtime.module.extension.api.runtime.resolver.ValueResolvingCont
 import org.mule.runtime.module.extension.api.tooling.valueprovider.ValueProviderMediator;
 import org.mule.runtime.module.extension.internal.ExtensionResolvingContext;
 import org.mule.runtime.module.extension.internal.data.sample.DefaultSampleDataProviderMediator;
+import org.mule.runtime.module.extension.internal.loader.java.property.TypeLoaderModelProperty;
 import org.mule.runtime.module.extension.internal.metadata.DefaultMetadataContext;
 import org.mule.runtime.module.extension.internal.metadata.DefaultMetadataMediator;
 import org.mule.runtime.module.extension.internal.runtime.config.DynamicConfigurationProvider;
@@ -216,7 +217,9 @@ public abstract class ExtensionComponent<T extends ComponentModel> extends Abstr
     this.configurationProviderResolver.set(configurationProviderResolver);
     this.extensionManager = extensionManager;
     this.cursorProviderFactory = cursorProviderFactory;
-    this.typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader(classLoader);
+    this.typeLoader = extensionModel.getModelProperty(TypeLoaderModelProperty.class)
+        .map(TypeLoaderModelProperty::getTypeLoader)
+        .orElseGet(() -> ExtensionsTypeLoaderFactory.getDefault().createTypeLoader(classLoader));
   }
 
   /**

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/resolver/ParameterResolverValueResolverWrapper.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/resolver/ParameterResolverValueResolverWrapper.java
@@ -6,10 +6,11 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.resolver;
 
+import static org.mule.runtime.module.extension.internal.runtime.resolver.ResolverUtils.resolveRecursively;
+
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.initialiseIfNeeded;
-import static org.mule.runtime.module.extension.internal.runtime.resolver.ResolverUtils.resolveRecursively;
 
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
@@ -39,14 +40,14 @@ public class ParameterResolverValueResolverWrapper<T>
   private MuleContext muleContext;
   private final Reference<Function<ValueResolvingContext, ParameterResolver>> parameterResolverSupplier = new Reference<>();
 
-  public ParameterResolverValueResolverWrapper(ValueResolver resolver) {
+  public ParameterResolverValueResolverWrapper(ValueResolver<T> resolver) {
     this.resolver = resolver;
     Function<ValueResolvingContext, ParameterResolver> parameterResolverFactory = (context) -> new ParameterResolver<T>() {
 
       @Override
       public T resolve() {
         try {
-          return resolveRecursively((ValueResolver<T>) resolver, context);
+          return resolveRecursively(resolver, context);
         } catch (MuleException e) {
           throw new MuleRuntimeException(e);
         }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/util/FieldSetter.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/util/FieldSetter.java
@@ -62,7 +62,7 @@ public final class FieldSetter<Target, Value> {
     } else {
       try {
         field.set(target, value);
-      } catch (IllegalAccessException ex) {
+      } catch (IllegalAccessException | IllegalArgumentException ex) {
         throw new IllegalStateException("Unexpected reflection exception - " + ex.getClass().getName() + ": " + ex.getMessage());
       }
     }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/enricher/JavaMimeTypeParametersDeclarationEnricherTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/enricher/JavaMimeTypeParametersDeclarationEnricherTestCase.java
@@ -6,18 +6,6 @@
  */
 package org.mule.runtime.module.extension.internal.loader.enricher;
 
-import static java.util.Collections.singletonList;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mule.metadata.api.model.MetadataFormat.JAVA;
 import static org.mule.runtime.api.meta.ExpressionSupport.SUPPORTED;
 import static org.mule.runtime.api.meta.model.parameter.ParameterGroupModel.DEFAULT_GROUP_NAME;
@@ -25,6 +13,21 @@ import static org.mule.runtime.extension.api.annotation.param.MediaType.TEXT_PLA
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.ENCODING_PARAMETER_NAME;
 import static org.mule.runtime.module.extension.internal.ExtensionProperties.MIME_TYPE_PARAMETER_NAME;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.toMetadataType;
+
+import static java.util.Collections.singletonList;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 import org.mule.metadata.api.ClassTypeLoader;
 import org.mule.metadata.api.annotation.EnumAnnotation;
@@ -68,18 +71,22 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 @SmallTest
-@RunWith(MockitoJUnitRunner.class)
 public class JavaMimeTypeParametersDeclarationEnricherTestCase extends AbstractMuleTestCase {
 
   private static final BaseTypeBuilder builder = BaseTypeBuilder.create(JAVA);
 
   private static SinceMuleVersionModelProperty SINCE_MULE_VERSION_MODEL_PROPERTY = new SinceMuleVersionModelProperty("4.2.0");
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule().strictness(STRICT_STUBS);
 
   @Mock(answer = RETURNS_DEEP_STUBS)
   private ExtensionLoadingContext extensionLoadingContext;
@@ -96,13 +103,14 @@ public class JavaMimeTypeParametersDeclarationEnricherTestCase extends AbstractM
   @Mock(answer = RETURNS_DEEP_STUBS)
   private SourceDeclaration source;
 
-  private JavaMimeTypeParametersDeclarationEnricher enricher = new JavaMimeTypeParametersDeclarationEnricher();
+  private final JavaMimeTypeParametersDeclarationEnricher enricher = new JavaMimeTypeParametersDeclarationEnricher();
 
-  private ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
+  private final ClassTypeLoader typeLoader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
 
   @Before
   public void before() {
     when(extensionLoadingContext.getExtensionDeclarer()).thenReturn(extensionDeclarer);
+    when(extensionLoadingContext.getTypeLoader()).thenReturn(ExtensionsTypeLoaderFactory.getDefault().createTypeLoader());
     when(extensionDeclarer.getDeclaration()).thenReturn(extensionDeclaration);
     when(extensionDeclaration.getOperations()).thenReturn(singletonList(operation));
     when(extensionDeclaration.getMessageSources()).thenReturn(singletonList(source));

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/NullSafeModelValidatorTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/loader/validation/NullSafeModelValidatorTestCase.java
@@ -6,21 +6,28 @@
  */
 package org.mule.runtime.module.extension.internal.loader.validation;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptySet;
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.when;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.mockParameters;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.toMetadataType;
 import static org.mule.test.module.extension.internal.util.ExtensionsTestUtils.validate;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static java.util.Optional.of;
+
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.LENIENT;
+
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.meta.model.operation.OperationModel;
 import org.mule.runtime.api.meta.model.parameter.ParameterModel;
 import org.mule.runtime.extension.api.annotation.param.NullSafe;
 import org.mule.runtime.extension.api.annotation.param.Optional;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
+import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.runtime.extension.api.exception.IllegalModelDefinitionException;
 import org.mule.runtime.extension.api.loader.ExtensionModelValidator;
+import org.mule.runtime.module.extension.internal.loader.java.property.TypeLoaderModelProperty;
 import org.mule.runtime.module.extension.internal.loader.java.validation.NullSafeModelValidator;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.size.SmallTest;
@@ -30,31 +37,38 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 @SmallTest
-@RunWith(MockitoJUnitRunner.class)
 public class NullSafeModelValidatorTestCase extends AbstractMuleTestCase {
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule().strictness(LENIENT);
 
   @Mock(answer = RETURNS_DEEP_STUBS)
   private ExtensionModel extensionModel;
 
-  @Mock(lenient = true)
+  @Mock
   private OperationModel operationModel;
 
-  @Mock(lenient = true)
+  @Mock
   private ParameterModel parameterModel;
 
-  private ExtensionModelValidator validator = new NullSafeModelValidator();
+  private final ExtensionModelValidator validator = new NullSafeModelValidator();
 
   @Before
   public void before() {
     when(extensionModel.getOperationModels()).thenReturn(asList(operationModel));
     mockParameters(operationModel, parameterModel);
     when(extensionModel.getImportedTypes()).thenReturn(emptySet());
+    when(extensionModel.getModelProperty(TypeLoaderModelProperty.class))
+        .thenReturn(of(new TypeLoaderModelProperty(ExtensionsTypeLoaderFactory.getDefault().createTypeLoader())));
+
   }
 
   @Test(expected = IllegalModelDefinitionException.class)

--- a/modules/extensions-support/src/test/java/org/mule/test/module/extension/internal/util/ExtensionsTestUtils.java
+++ b/modules/extensions-support/src/test/java/org/mule/test/module/extension/internal/util/ExtensionsTestUtils.java
@@ -24,7 +24,7 @@ import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -101,7 +101,9 @@ import org.custommonkey.xmlunit.DetailedDiff;
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.Difference;
 import org.custommonkey.xmlunit.XMLUnit;
+
 import org.hamcrest.Matcher;
+
 import org.mockito.Mockito;
 
 public final class ExtensionsTestUtils {

--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelProvider.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelProvider.java
@@ -57,6 +57,7 @@ public final class MuleExtensionModelProvider {
   public static final BaseTypeBuilder BASE_TYPE_BUILDER = BaseTypeBuilder.create(JAVA);
   public static final MetadataType STRING_TYPE = loadPrimitive(STRING);
   public static final MetadataType INTEGER_TYPE = TYPE_LOADER.load(Integer.class);
+  public static final MetadataType LONG_TYPE = TYPE_LOADER.load(Long.class);
   public static final MetadataType NUMBER_TYPE = loadPrimitive(NUMBER);
   public static final MetadataType BOOLEAN_TYPE = loadPrimitive(BOOLEAN);
   public static final MetadataType NULL_TYPE = BASE_TYPE_BUILDER.nullType().build();

--- a/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/resolver/TestEnumMetadataResolver.java
+++ b/tests/test-extensions/metadata-extension/src/main/java/org/mule/test/metadata/extension/resolver/TestEnumMetadataResolver.java
@@ -7,20 +7,17 @@
 package org.mule.test.metadata.extension.resolver;
 
 import static org.mule.runtime.api.metadata.resolving.FailureCode.INVALID_METADATA_KEY;
-import org.mule.metadata.api.ClassTypeLoader;
+
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.runtime.api.connection.ConnectionException;
 import org.mule.runtime.api.metadata.MetadataContext;
 import org.mule.runtime.api.metadata.MetadataResolvingException;
 import org.mule.runtime.api.metadata.resolving.InputTypeResolver;
-import org.mule.runtime.extension.api.declaration.type.ExtensionsTypeLoaderFactory;
 import org.mule.test.metadata.extension.model.animals.AnimalClade;
 import org.mule.test.metadata.extension.model.animals.Bear;
 import org.mule.test.metadata.extension.model.animals.SwordFish;
 
 public class TestEnumMetadataResolver implements InputTypeResolver<AnimalClade> {
-
-  public static final ClassTypeLoader loader = ExtensionsTypeLoaderFactory.getDefault().createTypeLoader();
 
   @Override
   public String getCategoryName() {
@@ -32,9 +29,9 @@ public class TestEnumMetadataResolver implements InputTypeResolver<AnimalClade> 
       throws MetadataResolvingException, ConnectionException {
     switch (key) {
       case MAMMAL:
-        return loader.load(Bear.class);
+        return context.getTypeLoader().load(Bear.class);
       case FISH:
-        return loader.load(SwordFish.class);
+        return context.getTypeLoader().load(SwordFish.class);
       default:
         throw new MetadataResolvingException("Cannot identify animal", INVALID_METADATA_KEY);
     }


### PR DESCRIPTION
* Reuse the same caching type loader for all type loads done for an extension model
* Create constants for commonly used basic MetadataTypes
* Minor improvement for CNFE message creation (do not use String.format)