### PR TITLE
W-16678404: New SDK KeyResolver validation for JDK17 is not working as expected

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
@@ -172,6 +172,9 @@ public class JavaMetadataKeyIdModelParserUtils {
                                                                               ExtensionElement extensionElement,
                                                                               String elementName,
                                                                               String elementType) {
+    if (outputResolverModelParser == null && inputResolverModelParsers.isEmpty() && isJavaVersionAtLeast(JAVA_17)) {
+      return empty();
+    }
 
     String categoryName = getCategoryName(outputResolverModelParser, attributesResolverModelParser, inputResolverModelParsers);
 
@@ -242,7 +245,14 @@ public class JavaMetadataKeyIdModelParserUtils {
     }
 
     // TODO W-14195099 - change this once we have `ProblemsReporter` available
-    throw new IllegalModelDefinitionException("Unable to create Keys Resolver. A Keys Resolver is being defined " +
-        "without defining an Output Resolver, Input Resolver nor Attributes Resolver");
+    if (isJavaVersionAtLeast(JAVA_17)) {
+      throw new IllegalModelDefinitionException("Unable to create Keys Resolver. A Keys Resolver is being defined " +
+          "without defining an Output Resolver, Input Resolver nor Attributes Resolver");
+    }
+
+    // TODO W-14195099 - change this once we have `ProblemsReporter` available
+    LOGGER.warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver");
+
+    return null;
   }
 }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
@@ -172,9 +172,6 @@ public class JavaMetadataKeyIdModelParserUtils {
                                                                               ExtensionElement extensionElement,
                                                                               String elementName,
                                                                               String elementType) {
-    if (outputResolverModelParser == null && inputResolverModelParsers.isEmpty() && isJavaVersionAtLeast(JAVA_17)) {
-      return empty();
-    }
 
     String categoryName = getCategoryName(outputResolverModelParser, attributesResolverModelParser, inputResolverModelParsers);
 
@@ -245,14 +242,7 @@ public class JavaMetadataKeyIdModelParserUtils {
     }
 
     // TODO W-14195099 - change this once we have `ProblemsReporter` available
-    if (isJavaVersionAtLeast(JAVA_17)) {
-      throw new IllegalModelDefinitionException("Unable to create Keys Resolver. A Keys Resolver is being defined " +
-          "without defining an Output Resolver, Input Resolver nor Attributes Resolver");
-    }
-
-    // TODO W-14195099 - change this once we have `ProblemsReporter` available
-    LOGGER.warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver");
-
-    return null;
+    throw new IllegalModelDefinitionException("Unable to create Keys Resolver. A Keys Resolver is being defined " +
+        "without defining an Output Resolver, Input Resolver nor Attributes Resolver");
   }
 }


### PR DESCRIPTION
result when run on mule4-cassandradb-connector
<img width="2535" alt="Screenshot 2024-10-30 at 12 02 52 PM" src="https://github.com/user-attachments/assets/e574a0b2-4a19-4aab-9e65-62d684ecf0a8">
