### PR TITLE
W-16159618: Fixing dynamic output type of Scatter Gather

### DIFF
--- a/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelDeclarer.java
+++ b/runtime-extension-model/src/main/java/org/mule/runtime/core/api/extension/provider/MuleExtensionModelDeclarer.java
@@ -853,7 +853,7 @@ public class MuleExtensionModelDeclarer {
             .build())
         .describedAs("Strategy that determines that the results are aggregated in a list rather than on a map.");
 
-    scatterGather.withOutput().ofDynamicType(BaseTypeBuilder.create(MetadataFormat.JAVA).arrayType().of(ANY_TYPE).build());
+    scatterGather.withOutput().ofDynamicType(ANY_TYPE);
     scatterGather.withOutputAttributes().ofDynamicType(ANY_TYPE);
     configurerFactory.create()
         .addRoutePassThroughChainInputResolver("route")


### PR DESCRIPTION
The output type of the Scatter Gather router is not always of array type, in fact it is rarely of array type. That only happens if the `collect-list` parameter is used, which is not documented.

Having it declared as always being of array type makes it have the wrong type when the collect-list parameter is not present. It ends up having an array of objects with each route type as attributes. The expected type should be just the object with each route type as attributes (not wrapped into an array type).