### PR TITLE
W-16371427 Restore execution to dry-run profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -736,6 +736,27 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots-in-deps</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseDeps>
+                                            <message>No Snapshots Allowed in Deps!</message>
+                                            <excludes>
+                                                <exclude>org.mule.weave:*</exclude>
+                                                <exclude>org.mule.runtime:mule-dwb-api</exclude>
+                                                <exclude>org.mule.services:mule-service-weave:*</exclude>
+                                            </excludes>
+                                        </requireReleaseDeps>
+                                    </rules>
+                                    <skip>${skipNoSnapshotsEnforcerPluginRule}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
W-16371427  From https://maven.apache.org/guides/introduction/introduction-to-profiles.html#:~:text=xml)%20.-,Profile%20Inheritance,plugins%20defined%20in%20the%20profile: The profiles are not inherited as other POM elements by child POMs. 

The original idea was to add the change to `mule-plugin-mgmt-parent-pom/pom.xml` but even if the profile could be inherited that would affect all the projects that has as parent that module which is not desirable.

We have to restore the configuration and add a new exception for the new repo data-weave-mule-service. This will allow to use the DW snapshot version when building the dry run profile.