### PR TITLE
W-17225272: Fix metadata key id warning

### DIFF
--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
@@ -225,6 +225,7 @@ public class JavaMetadataKeyIdModelParserUtils {
         && outputResolverModelParser == null
         && attributesResolverModelParser == null
         && inputResolverModelParsers.isEmpty()) {
+      // TODO W-14195099 - change this once we have `ProblemsReporter` available
       LOGGER
           .warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver for element {} of extension {}",
                 elementName, extensionElement.getName());

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
@@ -222,8 +222,8 @@ public class JavaMetadataKeyIdModelParserUtils {
     }
 
     if (keyIdResolverModelParser.isPresent()
-        && outputResolverModelParser != null
-        && attributesResolverModelParser != null
+        && outputResolverModelParser == null
+        && attributesResolverModelParser == null
         && inputResolverModelParsers.isEmpty()) {
       LOGGER.warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver");
     }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
@@ -221,6 +221,13 @@ public class JavaMetadataKeyIdModelParserUtils {
       }
     }
 
+    if (keyIdResolverModelParser.isPresent()
+        && outputResolverModelParser != null
+        && attributesResolverModelParser != null
+        && inputResolverModelParsers.isEmpty()) {
+      LOGGER.warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver");
+    }
+
     return keyIdResolverModelParser;
   }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/loader/utils/JavaMetadataKeyIdModelParserUtils.java
@@ -225,7 +225,9 @@ public class JavaMetadataKeyIdModelParserUtils {
         && outputResolverModelParser == null
         && attributesResolverModelParser == null
         && inputResolverModelParsers.isEmpty()) {
-      LOGGER.warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver");
+      LOGGER
+          .warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver for element {} of extension {}",
+                elementName, extensionElement.getName());
     }
 
     return keyIdResolverModelParser;
@@ -246,9 +248,6 @@ public class JavaMetadataKeyIdModelParserUtils {
     for (InputResolverModelParser inputResolverModelParser : inputResolverModelParsers) {
       return inputResolverModelParser.getInputResolver().getCategoryName();
     }
-
-    // TODO W-14195099 - change this once we have `ProblemsReporter` available
-    LOGGER.warn("A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver");
 
     return null;
   }


### PR DESCRIPTION

Test result with mule app (basic-1.0.0-SNAPSHOT-mule-application.jar)
```
WARN  2024-12-04 09:09:09,027 [ForkJoinPool.commonPool-worker-2] [processor: ; event: ] org.mule.runtime.module.extension.internal.loader.utils.JavaMetadataKeyIdModelParserUtils: A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver for element deleteColumnsValue of extension CassandraDB
WARN  2024-12-04 09:09:22,321 [ForkJoinPool.commonPool-worker-2] [processor: ; event: ] org.mule.runtime.module.extension.internal.loader.utils.JavaMetadataKeyIdModelParserUtils: A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver for element deleteRows of extension CassandraDB
WARN  2024-12-04 09:09:32,250 [ForkJoinPool.commonPool-worker-2] [processor: ; event: ] org.mule.runtime.module.extension.internal.loader.utils.JavaMetadataKeyIdModelParserUtils: A Keys Resolver is being defined without defining an Output Resolver, Input Resolver nor Attributes Resolver for element select of extension CassandraDB
```