### PR TITLE
W-17750692: Add unit test coverage for package `org.mule.runtime.core.internal.transaction`

### DIFF
--- a/core-tests/src/test/java/org/mule/runtime/core/api/transaction/DelegateTransactionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/transaction/DelegateTransactionTestCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.api.transaction;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.mule.runtime.api.notification.NotificationDispatcher;
+import org.mule.runtime.api.tx.TransactionException;
+import org.mule.runtime.core.internal.transaction.DelegateTransaction;
+import org.junit.Test;
+
+public class DelegateTransactionTestCase {
+
+  @Test
+  public void nullTx() throws TransactionException {
+    DelegateTransaction delegateTransaction = new DelegateTransaction("app", mock(NotificationDispatcher.class), null);
+    assertThat(delegateTransaction.isBegun(), is(false));
+    assertThat(delegateTransaction.isRollbackOnly(), is(false));
+    assertThat(delegateTransaction.isRolledBack(), is(false));
+    delegateTransaction.resume();
+    assertThat(delegateTransaction.suspend(), is(nullValue()));
+    delegateTransaction.commit();
+    delegateTransaction.rollback();
+    delegateTransaction.begin();
+    delegateTransaction.setRollbackOnly();
+    assertThat(delegateTransaction.isBegun(), is(false));
+    assertThat(delegateTransaction.isRollbackOnly(), is(false));
+    assertThat(delegateTransaction.isRolledBack(), is(false));
+    delegateTransaction.setTimeout(20);
+    assertThat(delegateTransaction.getTimeout(), is(20));
+  }
+
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/api/transaction/SingleResourceTxTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/transaction/SingleResourceTxTestCase.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.api.transaction;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+import org.mule.runtime.api.notification.NotificationDispatcher;
+import org.mule.runtime.api.tx.TransactionException;
+import org.mule.runtime.core.internal.transaction.AbstractSingleResourceTransaction;
+import org.mule.runtime.core.internal.transaction.AbstractTransaction;
+import org.junit.Test;
+import org.mule.runtime.core.internal.transaction.xa.IllegalTransactionStateException;
+
+
+public class SingleResourceTxTestCase {
+
+
+  @Test
+  public void resourceWithWrongKey() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.bindResource(transaction, transaction);
+    assertThat(transaction.hasResource("wrongKey"), is(false));
+    assertThat(transaction.getResource("wrongKey"), is(nullValue()));
+  }
+
+  @Test
+  public void correctKey() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.bindResource(transaction, transaction);
+    assertThat(transaction.hasResource(transaction), is(true));
+    assertThat(transaction.getResource(transaction), is(transaction));
+  }
+
+  @Test
+  public void nullKey() {
+    AbstractTransaction transaction = new TestTransaction(null, null);
+    assertThat(transaction.hasResource(null), is(false));
+    assertThat(transaction.getResource(null), is(nullValue()));
+  }
+
+  @Test(expected = IllegalTransactionStateException.class)
+  public void bindNullKey() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.bindResource(null, transaction);
+  }
+
+  @Test(expected = IllegalTransactionStateException.class)
+  public void bindNullResource() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.bindResource(transaction, null);
+  }
+
+  @Test(expected = IllegalTransactionStateException.class)
+  public void bindAfterBinded() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.bindResource(transaction, transaction);
+    transaction.bindResource(transaction, transaction);
+  }
+
+  @Test
+  public void stringRepr() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.bindResource("hello", "world");
+    assertThat(transaction.toString(), containsString("[status=STATUS_NO_TRANSACTION, key=hello]"));
+    assertThat(transaction.toString(), containsString(TestTransaction.class.getName()));
+  }
+
+  @Test
+  public void supports() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.bindResource("hello", "world");
+    assertThat(transaction.supports("hello", "world"), is(true));
+    assertThat(transaction.supports("hello", "no"), is(false));
+    assertThat(transaction.supports("Jelou", "uorld"), is(false));
+    assertThat(transaction.supports(transaction, "world"), is(false));
+    assertThat(transaction.supports("hello", transaction), is(false));
+  }
+
+  @Test
+  public void hasBegun() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", mock(NotificationDispatcher.class));
+    assertThat(transaction.isBegun(), is(false));
+    transaction.bindResource("hello", "world");
+    assertThat(transaction.isBegun(), is(false));
+    try {
+      transaction.begin();
+      assertThat(transaction.isBegun(), is(true));
+    } finally {
+      // to stop having tx binded, which would affect following tests
+      transaction.rollback();
+    }
+  }
+
+  @Test
+  public void hasBeenRolledBack() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", mock(NotificationDispatcher.class));
+    assertThat(transaction.isRolledBack(), is(false));
+    transaction.bindResource("hello", "world");
+    assertThat(transaction.isRolledBack(), is(false));
+    transaction.rollback();
+    assertThat(transaction.isRolledBack(), is(true));
+  }
+
+  @Test
+  public void hasBeenCommitted() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", mock(NotificationDispatcher.class));
+    assertThat(transaction.isCommitted(), is(false));
+    transaction.bindResource("hello", "world");
+    assertThat(transaction.isCommitted(), is(false));
+    transaction.commit();
+    assertThat(transaction.isCommitted(), is(true));
+  }
+
+  @Test(expected = IllegalTransactionStateException.class)
+  public void suspendNotSupported() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.suspend();
+  }
+
+  @Test(expected = IllegalTransactionStateException.class)
+  public void resumeNotSupported() throws TransactionException {
+    AbstractTransaction transaction = new TestTransaction("test", null);
+    transaction.resume();
+  }
+
+  private static class TestTransaction extends AbstractSingleResourceTransaction {
+
+    protected TestTransaction(String applicationName, NotificationDispatcher notificationFirer) {
+      super(applicationName, notificationFirer);
+    }
+
+    @Override
+    protected void doBegin() throws TransactionException {
+
+    }
+
+    @Override
+    protected void doCommit() throws TransactionException {
+
+    }
+
+    @Override
+    protected void doRollback() throws TransactionException {
+
+    }
+
+    @Override
+    protected Class getResourceType() {
+      return String.class;
+    }
+
+    @Override
+    protected Class getKeyType() {
+      return String.class;
+    }
+  }
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/api/transaction/xa/AbstractTransactionContextTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/transaction/xa/AbstractTransactionContextTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.api.transaction.xa;
+
+import static javax.transaction.Status.STATUS_ACTIVE;
+import static javax.transaction.Status.STATUS_COMMITTED;
+import static javax.transaction.Status.STATUS_COMMITTING;
+import static javax.transaction.Status.STATUS_MARKED_ROLLBACK;
+import static javax.transaction.Status.STATUS_NO_TRANSACTION;
+import static javax.transaction.Status.STATUS_PREPARED;
+import static javax.transaction.Status.STATUS_PREPARING;
+import static javax.transaction.Status.STATUS_ROLLEDBACK;
+import static javax.transaction.Status.STATUS_ROLLING_BACK;
+import static javax.transaction.Status.STATUS_UNKNOWN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.mule.runtime.core.internal.transaction.xa.AbstractTransactionContext;
+import org.junit.Test;
+
+public class AbstractTransactionContextTestCase {
+
+  @Test
+  public void stringRepresentation() {
+    TxContext txContext = new TxContext();
+    txContext.setStatus(STATUS_ACTIVE);
+    assertThat(txContext.toString(), containsString("[active, readonly]"));
+    txContext.setStatus(STATUS_MARKED_ROLLBACK);
+    assertThat(txContext.toString(), containsString("[marked rollback, readonly]"));
+    txContext.setStatus(STATUS_PREPARED);
+    assertThat(txContext.toString(), containsString("[prepared, readonly]"));
+    txContext.setStatus(STATUS_COMMITTED);
+    assertThat(txContext.toString(), containsString("[committed, readonly]"));
+    txContext.setStatus(STATUS_ROLLEDBACK);
+    assertThat(txContext.toString(), containsString("[rolled back, readonly]"));
+    txContext.setStatus(STATUS_NO_TRANSACTION);
+    assertThat(txContext.toString(), containsString("[no transaction, readonly]"));
+    txContext.setStatus(STATUS_COMMITTING);
+    assertThat(txContext.toString(), containsString("[committing, readonly]"));
+    txContext.setStatus(STATUS_ROLLING_BACK);
+    assertThat(txContext.toString(), containsString("[rolling back, readonly]"));
+    txContext.setStatus(STATUS_UNKNOWN);
+    assertThat(txContext.toString(), containsString("[unknown, readonly]"));
+    txContext.setStatus(120);
+    assertThat(txContext.toString(), containsString("[undefined status, readonly]"));
+    txContext.setStatus(STATUS_PREPARING);
+    assertThat(txContext.toString(), containsString("[preparing, readonly]"));
+    txContext.notifyFinish();
+    assertThat(txContext.toString(), containsString("[preparing, readonly, finished]"));
+  }
+
+
+  private static final class TxContext extends AbstractTransactionContext {
+
+    @Override
+    public void doCommit() throws ResourceManagerException {
+
+    }
+
+    @Override
+    public void doRollback() throws ResourceManagerException {
+
+    }
+  }
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/api/transaction/xa/XAResourceManagerTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/transaction/xa/XAResourceManagerTestCase.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.api.transaction.xa;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+import org.mule.runtime.core.internal.transaction.xa.AbstractTransactionContext;
+import org.mule.runtime.core.internal.transaction.xa.AbstractXAResourceManager;
+import org.mule.runtime.core.internal.transaction.xa.AbstractXaTransactionContext;
+import org.junit.Test;
+
+import javax.transaction.xa.Xid;
+
+
+public class XAResourceManagerTestCase {
+
+  @Test(expected = ResourceManagerException.class)
+  public void prepareTxNotReady() throws ResourceManagerException {
+    TestXaResourceManager manager = new TestXaResourceManager();
+    manager.prepareTransaction(mock(AbstractXaTransactionContext.class));
+    assertThat(manager.isPrepared(), is(true));
+  }
+
+  @Test
+  public void prepareTx() throws ResourceManagerException {
+    TestXaResourceManager manager = new TestXaResourceManager();
+    manager.start();
+    manager.prepareTransaction(mock(AbstractXaTransactionContext.class));
+    assertThat(manager.isPrepared(), is(true));
+  }
+
+  @Test
+  public void activeTransactionResource() {
+    Xid xid = mock(Xid.class);
+    AbstractXaTransactionContext context = mock(AbstractXaTransactionContext.class);
+    TestXaResourceManager manager = new TestXaResourceManager();
+    manager.addActiveTransactionalResource(xid, context);
+    assertThat(manager.getTransactionalResource(xid), is(context));
+  }
+
+  @Test
+  public void suspendedTransactionResource() {
+    Xid xid = mock(Xid.class);
+    AbstractXaTransactionContext context = mock(AbstractXaTransactionContext.class);
+    TestXaResourceManager manager = new TestXaResourceManager();
+    manager.addSuspendedTransactionalResource(xid, context);
+    assertThat(manager.getTransactionalResource(xid), is(context));
+  }
+
+  @Test
+  public void removeTransactionResource() {
+    Xid xid = mock(Xid.class);
+    AbstractXaTransactionContext context = mock(AbstractXaTransactionContext.class);
+    AbstractXaTransactionContext context2 = mock(AbstractXaTransactionContext.class);
+    TestXaResourceManager manager = new TestXaResourceManager();
+    manager.addActiveTransactionalResource(xid, context);
+    manager.removeActiveTransactionalResource(xid);
+    manager.addSuspendedTransactionalResource(xid, context2);
+    assertThat(manager.getTransactionalResource(xid), is(context2));
+  }
+
+  @Test
+  public void removeSuspendedTransactionResource() {
+    Xid xid = mock(Xid.class);
+    AbstractXaTransactionContext context = mock(AbstractXaTransactionContext.class);
+    AbstractXaTransactionContext context2 = mock(AbstractXaTransactionContext.class);
+    TestXaResourceManager manager = new TestXaResourceManager();
+    manager.addActiveTransactionalResource(xid, context);
+    manager.removeActiveTransactionalResource(xid);
+    manager.addSuspendedTransactionalResource(xid, context2);
+    manager.removeSuspendedTransactionalResource(xid);
+    assertThat(manager.getTransactionalResource(xid), is(nullValue()));
+  }
+
+  private static final class TestXaResourceManager extends AbstractXAResourceManager<AbstractXaTransactionContext> {
+
+    private boolean isPrepared = false;
+
+    public boolean isPrepared() {
+      return isPrepared;
+    }
+
+    @Override
+    protected int doPrepare(AbstractXaTransactionContext context) throws ResourceManagerException {
+      isPrepared = true;
+      return 0;
+    }
+
+    @Override
+    protected void doBegin(AbstractTransactionContext context) {
+
+    }
+
+    @Override
+    protected void doCommit(AbstractTransactionContext context) throws ResourceManagerException {
+
+    }
+
+    @Override
+    protected void doRollback(AbstractTransactionContext context) throws ResourceManagerException {
+
+    }
+  }
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/api/transaction/xa/XaSessionTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/api/transaction/xa/XaSessionTestCase.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.core.api.transaction.xa;
+
+import static javax.transaction.xa.XAResource.TMFAIL;
+import static javax.transaction.xa.XAResource.TMNOFLAGS;
+import static javax.transaction.xa.XAResource.TMRESUME;
+import static javax.transaction.xa.XAResource.TMSUCCESS;
+import static javax.transaction.xa.XAResource.TMSUSPEND;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.mule.runtime.core.internal.transaction.xa.AbstractXAResourceManager;
+import org.mule.runtime.core.internal.transaction.xa.AbstractXaTransactionContext;
+import org.mule.runtime.core.internal.transaction.xa.DefaultXASession;
+
+import org.junit.Before;
+import org.junit.Test;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.Xid;
+
+
+public class XaSessionTestCase {
+
+  private AbstractXAResourceManager resourceManager = mock(AbstractXAResourceManager.class);
+  private DefaultXASession xaSession;
+  private static final AbstractXaTransactionContext TX_CONTEXT = mock(AbstractXaTransactionContext.class);
+
+  @Before
+  public void setUp() {
+    xaSession = new TestXaSession(resourceManager);
+  }
+
+  @Test
+  public void resource() {
+    assertThat(xaSession.getXAResource(), is(xaSession));
+    assertThat(xaSession.getResourceManager(), is(resourceManager));
+  }
+
+  @Test
+  public void sameRM() throws XAException {
+    assertThat(xaSession.isSameRM(xaSession), is(true));
+    assertThat(xaSession.isSameRM(new TestXaSession(resourceManager)), is(true));
+    assertThat(xaSession.isSameRM(new TestXaSession(mock(AbstractXAResourceManager.class))), is(false));
+  }
+
+  @Test
+  public void startTx() throws Exception {
+    Xid xid = mock(Xid.class);
+    xaSession.start(xid, TMNOFLAGS);
+    verify(resourceManager).beginTransaction(TX_CONTEXT);
+    verify(resourceManager).addActiveTransactionalResource(xid, TX_CONTEXT);
+  }
+
+  @Test(expected = XAException.class)
+  public void startTxAlreadyStarted() throws Exception {
+    Xid xid = mock(Xid.class);
+    xaSession.start(xid, TMNOFLAGS);
+    xaSession.start(xid, TMNOFLAGS);
+  }
+
+  @Test(expected = XAException.class)
+  public void startTxWithFailure() throws Exception {
+    Xid xid = mock(Xid.class);
+    doThrow(RuntimeException.class).when(resourceManager).beginTransaction(TX_CONTEXT);
+    xaSession.start(xid, TMNOFLAGS);
+  }
+
+  @Test
+  public void resumesTx() throws Exception {
+    Xid xid = mock(Xid.class);
+    when(resourceManager.getSuspendedTransactionalResource(xid)).thenReturn(TX_CONTEXT);
+    xaSession.start(xid, TMRESUME);
+    verify(resourceManager).removeSuspendedTransactionalResource(xid);
+    verify(resourceManager).addActiveTransactionalResource(xid, TX_CONTEXT);
+  }
+
+  @Test(expected = XAException.class)
+  public void endTxNotStarted() throws Exception {
+    xaSession.end(mock(Xid.class), TMSUCCESS);
+  }
+
+  @Test
+  public void endTx() throws Exception {
+    Xid xid = mock(Xid.class);
+    xaSession.start(xid, TMNOFLAGS);
+    xaSession.end(xid, TMSUCCESS);
+    verify(resourceManager, never()).addSuspendedTransactionalResource(xid, TX_CONTEXT);
+    verify(resourceManager, never()).removeActiveTransactionalResource(xid);
+    verify(resourceManager, never()).setTransactionRollbackOnly(TX_CONTEXT);
+    // we can start it again and there is no error
+    xaSession.start(xid, TMNOFLAGS);
+  }
+
+  @Test
+  public void suspend() throws Exception {
+    Xid xid = mock(Xid.class);
+    xaSession.start(xid, TMNOFLAGS);
+    xaSession.end(xid, TMSUSPEND);
+    verify(resourceManager).addSuspendedTransactionalResource(xid, TX_CONTEXT);
+    verify(resourceManager).removeActiveTransactionalResource(xid);
+    verify(resourceManager, never()).setTransactionRollbackOnly(TX_CONTEXT);
+    // we can start it again and there is no error
+    xaSession.start(xid, TMNOFLAGS);
+  }
+
+  @Test
+  public void rollbackOnly() throws Exception {
+    Xid xid = mock(Xid.class);
+    xaSession.start(xid, TMSUCCESS);
+    xaSession.end(xid, TMFAIL);
+    verify(resourceManager, never()).addSuspendedTransactionalResource(xid, TX_CONTEXT);
+    verify(resourceManager, never()).removeActiveTransactionalResource(xid);
+    verify(resourceManager).setTransactionRollbackOnly(TX_CONTEXT);
+    // we can start it again and there is no error
+    xaSession.start(xid, TMNOFLAGS);
+  }
+
+  @Test(expected = XAException.class)
+  public void commitNoXid() throws Exception {
+    xaSession.commit(null, false);
+  }
+
+  @Test
+  public void commit() throws Exception {
+    Xid xid = mock(Xid.class);
+    when(resourceManager.getActiveTransactionalResource(xid)).thenReturn(TX_CONTEXT);
+    xaSession.commit(xid, true);
+    verify(resourceManager).commitTransaction(TX_CONTEXT);
+  }
+
+  @Test(expected = XAException.class)
+  public void rollbackNoXid() throws Exception {
+    xaSession.rollback(null);
+  }
+
+  @Test
+  public void rollback() throws Exception {
+    Xid xid = mock(Xid.class);
+    when(resourceManager.getActiveTransactionalResource(xid)).thenReturn(TX_CONTEXT);
+    xaSession.rollback(xid);
+    verify(resourceManager).rollbackTransaction(TX_CONTEXT);
+  }
+
+  @Test
+  public void prepare() throws Exception {
+    Xid xid = mock(Xid.class);
+    when(resourceManager.getTransactionalResource(xid)).thenReturn(TX_CONTEXT);
+    xaSession.prepare(xid);
+    verify(resourceManager).prepareTransaction(TX_CONTEXT);
+  }
+
+  @Test(expected = XAException.class)
+  public void prepareNoContext() throws Exception {
+    Xid xid = mock(Xid.class);
+    xaSession.prepare(xid);
+  }
+
+  @Test(expected = XAException.class)
+  public void prepareNoXid() throws Exception {
+    xaSession.prepare(null);
+  }
+
+  @Test(expected = XAException.class)
+  public void forgetNoContext() throws XAException {
+    Xid xid = mock(Xid.class);
+    xaSession.forget(xid);
+  }
+
+  @Test
+  public void forget() throws XAException {
+    Xid xid = mock(Xid.class);
+    when(resourceManager.getTransactionalResource(xid)).thenReturn(TX_CONTEXT);
+    xaSession.forget(xid);
+    verify(resourceManager).removeSuspendedTransactionalResource(xid);
+    verify(resourceManager).removeActiveTransactionalResource(xid);
+  }
+
+  @Test
+  public void timeout() throws XAException {
+    when(resourceManager.getDefaultTransactionTimeout()).thenReturn(1000L);
+    assertThat(xaSession.getTransactionTimeout(), is(1));
+  }
+
+  private static final class TestXaSession extends DefaultXASession {
+
+    protected TestXaSession(AbstractXAResourceManager resourceManager) {
+      super(resourceManager);
+    }
+
+    @Override
+    protected void commitDanglingTransaction(Xid xid, boolean onePhase) throws XAException {
+
+    }
+
+    @Override
+    protected void rollbackDandlingTransaction(Xid xid) throws XAException {
+
+    }
+
+    @Override
+    protected AbstractXaTransactionContext createTransactionContext(Xid xid) {
+      return TX_CONTEXT;
+    }
+
+    @Override
+    public Xid[] recover(int flag) throws XAException {
+      return new Xid[0];
+    }
+  }
+
+}

--- a/core-tests/src/test/java/org/mule/runtime/core/internal/transaction/MuleTransactionConfigTestCase.java
+++ b/core-tests/src/test/java/org/mule/runtime/core/internal/transaction/MuleTransactionConfigTestCase.java
@@ -6,12 +6,27 @@
  */
 package org.mule.runtime.core.internal.transaction;
 
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_ALWAYS_BEGIN;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_ALWAYS_BEGIN_STRING;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_ALWAYS_JOIN;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_ALWAYS_JOIN_STRING;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_BEGIN_OR_JOIN;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_BEGIN_OR_JOIN_STRING;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_INDIFFERENT;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_INDIFFERENT_STRING;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_JOIN_IF_POSSIBLE;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_JOIN_IF_POSSIBLE_STRING;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_NONE;
+import static org.mule.runtime.core.internal.transaction.MuleTransactionConfig.ACTION_NONE_STRING;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+
+import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.tx.TransactionException;
-import org.mule.runtime.core.internal.transaction.MuleTransactionConfig;
-import org.mule.runtime.core.privileged.transaction.TransactionConfig;
+import org.mule.runtime.core.privileged.transaction.TransactionFactory;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.testmodels.mule.TestTransactionFactory;
 
@@ -24,35 +39,35 @@ public class MuleTransactionConfigTestCase extends AbstractMuleContextTestCase {
     MuleTransactionConfig c = new MuleTransactionConfig();
     c.setMuleContext(muleContext);
 
-    c.setAction(MuleTransactionConfig.ACTION_ALWAYS_BEGIN);
-    assertEquals(MuleTransactionConfig.ACTION_ALWAYS_BEGIN_STRING, c.getActionAsString());
+    c.setAction(ACTION_ALWAYS_BEGIN);
+    assertEquals(ACTION_ALWAYS_BEGIN_STRING, c.getActionAsString());
 
-    c.setAction(MuleTransactionConfig.ACTION_ALWAYS_JOIN);
-    assertEquals(MuleTransactionConfig.ACTION_ALWAYS_JOIN_STRING, c.getActionAsString());
+    c.setAction(ACTION_ALWAYS_JOIN);
+    assertEquals(ACTION_ALWAYS_JOIN_STRING, c.getActionAsString());
 
-    c.setAction(MuleTransactionConfig.ACTION_BEGIN_OR_JOIN);
-    assertEquals(MuleTransactionConfig.ACTION_BEGIN_OR_JOIN_STRING, c.getActionAsString());
+    c.setAction(ACTION_BEGIN_OR_JOIN);
+    assertEquals(ACTION_BEGIN_OR_JOIN_STRING, c.getActionAsString());
 
-    c.setAction(MuleTransactionConfig.ACTION_JOIN_IF_POSSIBLE);
-    assertEquals(MuleTransactionConfig.ACTION_JOIN_IF_POSSIBLE_STRING, c.getActionAsString());
+    c.setAction(ACTION_JOIN_IF_POSSIBLE);
+    assertEquals(ACTION_JOIN_IF_POSSIBLE_STRING, c.getActionAsString());
 
-    c.setAction(MuleTransactionConfig.ACTION_NONE);
-    assertEquals(MuleTransactionConfig.ACTION_NONE_STRING, c.getActionAsString());
+    c.setAction(ACTION_NONE);
+    assertEquals(ACTION_NONE_STRING, c.getActionAsString());
 
-    c.setAction(MuleTransactionConfig.ACTION_INDIFFERENT);
-    assertEquals(MuleTransactionConfig.ACTION_INDIFFERENT_STRING, c.getActionAsString());
+    c.setAction(ACTION_INDIFFERENT);
+    assertEquals(ACTION_INDIFFERENT_STRING, c.getActionAsString());
   }
 
   @Test
   public void testDefaults() throws Exception {
-    MuleTransactionConfig c = new MuleTransactionConfig(TransactionConfig.ACTION_ALWAYS_BEGIN);
+    MuleTransactionConfig c = new MuleTransactionConfig(ACTION_ALWAYS_BEGIN);
     c.setMuleContext(muleContext);
     assertEquals("Wrong default TX timeout", 30000, c.getTimeout());
   }
 
   @Test
   public void testTransactionJoinIfPossible() throws TransactionException {
-    MuleTransactionConfig txConfig = new MuleTransactionConfig(TransactionConfig.ACTION_JOIN_IF_POSSIBLE);
+    MuleTransactionConfig txConfig = new MuleTransactionConfig(ACTION_JOIN_IF_POSSIBLE);
     txConfig.setMuleContext(muleContext);
     txConfig.setFactory(new TestTransactionFactory());
     assertFalse(txConfig.isTransacted());
@@ -60,7 +75,7 @@ public class MuleTransactionConfigTestCase extends AbstractMuleContextTestCase {
 
   @Test
   public void testFailNoFactory() {
-    MuleTransactionConfig txConfig = new MuleTransactionConfig(TransactionConfig.ACTION_ALWAYS_BEGIN);
+    MuleTransactionConfig txConfig = new MuleTransactionConfig(ACTION_ALWAYS_BEGIN);
     txConfig.setMuleContext(muleContext);
     // note how we don't set a factory here so the default in MTC is null
 
@@ -72,4 +87,27 @@ public class MuleTransactionConfigTestCase extends AbstractMuleContextTestCase {
     }
   }
 
+  @Test
+  public void testEquals() {
+    MuleTransactionConfig config = new MuleTransactionConfig();
+    assertThat(config.equals(config), is(true));
+    assertThat(config.equals(null), is(false));
+    assertThat(config.equals("foo"), is(false));
+    MuleTransactionConfig config2 = new MuleTransactionConfig();
+
+    TransactionFactory factory = new TestTransactionFactory();
+    config.setFactory(factory);
+    config2.setFactory(factory);
+    config.setActionAsString(ACTION_ALWAYS_BEGIN_STRING);
+    config2.setActionAsString(ACTION_ALWAYS_BEGIN_STRING);
+
+    assertThat(config.equals(config2), is(true));
+  }
+
+  @Test(expected = MuleRuntimeException.class)
+  public void failingWithoutFactory() {
+    MuleTransactionConfig config = new MuleTransactionConfig();
+    config.setActionAsString(ACTION_ALWAYS_BEGIN_STRING);
+    config.isTransacted();
+  }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/AbstractSingleResourceTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/AbstractSingleResourceTransaction.java
@@ -64,7 +64,7 @@ public abstract class AbstractSingleResourceTransaction extends AbstractTransact
     txStatusMappings = unmodifiableMap(txStatusMappings);
   }
 
-  @Deprecated
+  @Deprecated(since = "4.4")
   protected AbstractSingleResourceTransaction(MuleContext muleContext) {
     super(muleContext);
   }

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/AbstractTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/AbstractTransaction.java
@@ -56,7 +56,7 @@ public abstract class AbstractTransaction implements TransactionAdapter {
   protected final NotificationDispatcher notificationFirer;
   protected boolean rollbackAfterTimeout;
 
-  @Deprecated
+  @Deprecated(since = "4.4.0")
   protected AbstractTransaction(MuleContext muleContext) {
     this.muleContext = muleContext;
     try {

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/DelegateTransaction.java
@@ -102,8 +102,7 @@ public class DelegateTransaction extends AbstractTransaction {
   @Override
   public void bindResource(Object key, Object resource) throws TransactionException {
     if (!(this.delegate instanceof NullTransaction)) {
-      throw new TransactionException(CoreMessages
-          .createStaticMessage("Single resource transaction has already a resource bound"));
+      throw new TransactionException(createStaticMessage("Single resource transaction has already a resource bound"));
     }
 
     this.unbindTransaction();

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/MuleTransactionConfig.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/MuleTransactionConfig.java
@@ -155,13 +155,10 @@ public final class MuleTransactionConfig implements TransactionConfig, MuleConte
     }
 
     switch (action) {
-      case ACTION_ALWAYS_BEGIN:
-      case ACTION_ALWAYS_JOIN:
-      case ACTION_BEGIN_OR_JOIN:
+      case ACTION_ALWAYS_BEGIN, ACTION_ALWAYS_JOIN, ACTION_BEGIN_OR_JOIN:
         return true;
 
-      case ACTION_JOIN_IF_POSSIBLE:
-      case ACTION_INDIFFERENT:
+      case ACTION_JOIN_IF_POSSIBLE, ACTION_INDIFFERENT:
         return TransactionCoordination.getInstance().getTransaction() != null;
 
       default:

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/XaTransaction.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/XaTransaction.java
@@ -49,6 +49,8 @@ import org.slf4j.Logger;
 public class XaTransaction extends AbstractTransaction {
 
   private static final Logger LOGGER = getLogger(XaTransaction.class);
+  private static final String TX_MANAGER_CLASS = "javax.transaction.TransactionManager";
+  private static final String TX_MANAGER_NAME = "Transaction Manager";
 
   /**
    * The inner JTA transaction
@@ -70,7 +72,7 @@ public class XaTransaction extends AbstractTransaction {
   /**
    * @deprecated since 4.3.0. Use {@link #XaTransaction(String, TransactionManager, NotificationDispatcher)} instead
    */
-  @Deprecated
+  @Deprecated(since = "4.3.0")
   public XaTransaction(MuleContext muleContext) {
     super(muleContext);
     this.txManager = muleContext.getTransactionManager();
@@ -79,8 +81,7 @@ public class XaTransaction extends AbstractTransaction {
   @Override
   protected void doBegin() throws TransactionException {
     if (txManager == null) {
-      throw new IllegalStateException(objectNotRegistered("javax.transaction.TransactionManager", "Transaction Manager")
-          .getMessage());
+      throw new IllegalStateException(objectNotRegistered(TX_MANAGER_CLASS, TX_MANAGER_NAME).getMessage());
     }
 
     try {
@@ -176,7 +177,6 @@ public class XaTransaction extends AbstractTransaction {
        * of execution from the current transaction. There's no JTA API-way to do that after the call, so the thread's transaction
        * is subject to manual recovery process. Instead TransactionManager or UserTransaction must be used.
        */
-      // delistResources();
       txManager.rollback();
     } catch (Exception e) {
       throw new TransactionRollbackException(e);
@@ -251,16 +251,15 @@ public class XaTransaction extends AbstractTransaction {
     resources.put(normalizedKey, resource);
 
     if (key == null) {
-      LOGGER.error("Key for bound resource " + resource + " is null");
+      LOGGER.error("Key for bound resource {} is null", resource);
     }
 
-    if (resource instanceof MuleXaObject) {
-      MuleXaObject xaObject = (MuleXaObject) resource;
+    if (resource instanceof MuleXaObject xaObject) {
       xaObject.enlist();
-    } else if (resource instanceof XAResource) {
-      enlistResource((XAResource) resource);
+    } else if (resource instanceof XAResource xaResource) {
+      enlistResource(xaResource);
     } else {
-      LOGGER.error("Bound resource " + resource + " is neither a MuleXaObject nor XAResource");
+      LOGGER.error("Bound resource {} is neither a MuleXaObject nor XAResource", resource);
     }
   }
 
@@ -313,8 +312,7 @@ public class XaTransaction extends AbstractTransaction {
   @Override
   public void resume() throws TransactionException {
     if (txManager == null) {
-      throw new IllegalStateException(objectNotRegistered("javax.transaction.TransactionManager", "Transaction Manager")
-          .getMessage());
+      throw new IllegalStateException(objectNotRegistered(TX_MANAGER_CLASS, TX_MANAGER_NAME).getMessage());
     }
     try {
       txManager.resume(transaction);
@@ -326,8 +324,7 @@ public class XaTransaction extends AbstractTransaction {
   @Override
   public Transaction suspend() throws TransactionException {
     if (txManager == null) {
-      throw new IllegalStateException(objectNotRegistered("javax.transaction.TransactionManager", "Transaction Manager")
-          .getMessage());
+      throw new IllegalStateException(objectNotRegistered(TX_MANAGER_CLASS, TX_MANAGER_NAME).getMessage());
     }
     try {
       transaction = txManager.suspend();
@@ -338,15 +335,14 @@ public class XaTransaction extends AbstractTransaction {
   }
 
   protected synchronized void delistResources() {
-    for (Object o : resources.entrySet()) {
-      Map.Entry entry = (Map.Entry) o;
-      final Object xaObject = entry.getValue();
-      if (xaObject instanceof MuleXaObject) {
+    for (Map.Entry<ResourceKey, Object> entry : resources.entrySet()) {
+      final Object value = entry.getValue();
+      if (value instanceof MuleXaObject xaObject) {
         // there is need for reuse object
         try {
-          ((MuleXaObject) xaObject).delist();
+          xaObject.delist();
         } catch (Exception e) {
-          LOGGER.error("Failed to delist resource " + xaObject, e);
+          LOGGER.error("Failed to delist resource {}", xaObject, e);
         }
       }
     }
@@ -354,15 +350,14 @@ public class XaTransaction extends AbstractTransaction {
 
   protected synchronized void closeResources() {
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("About to close {} resources for XA tx {}...", resources.size(), toString());
+      LOGGER.debug("About to close {} resources for XA tx {}...", resources.size(), this);
     }
 
-    Iterator i = resources.entrySet().iterator();
+    Iterator<Map.Entry<ResourceKey, Object>> i = resources.entrySet().iterator();
     while (i.hasNext()) {
-      Map.Entry entry = (Map.Entry) i.next();
+      Map.Entry<ResourceKey, Object> entry = i.next();
       final Object value = entry.getValue();
-      if (value instanceof MuleXaObject) {
-        MuleXaObject xaObject = (MuleXaObject) value;
+      if (value instanceof MuleXaObject xaObject) {
         if (!xaObject.isReuseObject()) {
           if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("About to close resource {}...", xaObject);
@@ -392,15 +387,15 @@ public class XaTransaction extends AbstractTransaction {
   }
 
   private ResourceKey getResourceEntry(Object resourceFactory) {
-    resourceFactory = (resourceFactory instanceof XaResourceFactoryHolder
-        ? ((XaResourceFactoryHolder) resourceFactory).getHoldObject()
+    resourceFactory = (resourceFactory instanceof XaResourceFactoryHolder xaResourceFactory
+        ? xaResourceFactory.getHoldObject()
         : resourceFactory);
     return new ResourceKey(resourceFactory, null);
   }
 
   private ResourceKey getResourceEntry(Object resourceFactory, Object resource) {
-    resourceFactory = (resourceFactory instanceof XaResourceFactoryHolder
-        ? ((XaResourceFactoryHolder) resourceFactory).getHoldObject()
+    resourceFactory = (resourceFactory instanceof XaResourceFactoryHolder xaResourceFactory
+        ? xaResourceFactory.getHoldObject()
         : resourceFactory);
     return new ResourceKey(resourceFactory, resource);
   }
@@ -429,10 +424,6 @@ public class XaTransaction extends AbstractTransaction {
       return resourceFactory;
     }
 
-    public Object getResource() {
-      return resource;
-    }
-
     @Override
     public int hashCode() {
       return Objects.hashCode(resourceFactory);
@@ -441,7 +432,7 @@ public class XaTransaction extends AbstractTransaction {
     @Override
     public boolean equals(Object obj) {
       // we use this class internally only so are sure obj is always a ResourceEntry
-      return resourceFactory.equals(((ResourceKey) obj).getResourceFactory());
+      return obj instanceof ResourceKey other && resourceFactory.equals(other.getResourceFactory());
     }
   }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/AbstractResourceManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/AbstractResourceManager.java
@@ -18,6 +18,8 @@ import javax.transaction.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.lang.Thread.currentThread;
+
 /**
  * This code is based on code coming from the <a href="http://jakarta.apache.org/commons/transaction/">commons-transaction</a>
  * project.
@@ -62,7 +64,6 @@ public abstract class AbstractResourceManager {
     operationMode = OPERATION_MODE_STARTING;
     doStart();
     recover();
-    // sync();
     operationMode = OPERATION_MODE_STARTED;
     if (dirty) {
       logger.warn("Started ResourceManager, but in dirty mode only (Recovery of pending transactions failed)");
@@ -87,7 +88,7 @@ public abstract class AbstractResourceManager {
     return stop(mode, getDefaultTransactionTimeout() * DEFAULT_COMMIT_TIMEOUT_FACTOR);
   }
 
-  public synchronized boolean stop(int mode, long timeOut) throws ResourceManagerSystemException {
+  public synchronized boolean stop(int mode, long timeOut) {
     logger.info("Stopping ResourceManager");
     operationMode = OPERATION_MODE_STOPPING;
     boolean success = shutdown(mode, timeOut);
@@ -107,7 +108,6 @@ public abstract class AbstractResourceManager {
         return waitForAllTxToStop(timeoutMSecs);
       case SHUTDOWN_MODE_ROLLBACK:
         throw new UnsupportedOperationException();
-      // return rollBackOrForward();
       case SHUTDOWN_MODE_KILL:
         return true;
       default:
@@ -137,12 +137,12 @@ public abstract class AbstractResourceManager {
 
     synchronized (context) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Beginning transaction " + context);
+        logger.debug("Beginning transaction {}", context);
       }
       doBegin(context);
       context.status = Status.STATUS_ACTIVE;
       if (logger.isDebugEnabled()) {
-        logger.debug("Began transaction " + context);
+        logger.debug("Began transaction {}", context);
       }
     }
     globalTransactions.add(context);
@@ -152,19 +152,13 @@ public abstract class AbstractResourceManager {
     assureReady();
     synchronized (context) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Rolling back transaction " + context);
+        logger.debug("Rolling back transaction {}", context);
       }
       try {
         context.status = Status.STATUS_ROLLING_BACK;
         doRollback(context);
         context.status = Status.STATUS_ROLLEDBACK;
-      } catch (Error e) {
-        setDirty(context, e);
-        throw e;
-      } catch (RuntimeException e) {
-        setDirty(context, e);
-        throw e;
-      } catch (ResourceManagerSystemException e) {
+      } catch (Exception e) {
         setDirty(context, e);
         throw e;
       } finally {
@@ -174,7 +168,7 @@ public abstract class AbstractResourceManager {
         context.notifyFinish();
       }
       if (logger.isDebugEnabled()) {
-        logger.debug("Rolled back transaction " + context);
+        logger.debug("Rolled back transaction {}", context);
       }
     }
   }
@@ -190,24 +184,18 @@ public abstract class AbstractResourceManager {
     }
     synchronized (context) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Committing transaction " + context);
+        logger.debug("Committing transaction {}", context);
       }
       try {
         context.status = Status.STATUS_COMMITTING;
         doCommit(context);
         context.status = Status.STATUS_COMMITTED;
-      } catch (Error e) {
-        setDirty(context, e);
-        throw e;
-      } catch (RuntimeException e) {
-        setDirty(context, e);
-        throw e;
-      } catch (ResourceManagerSystemException e) {
-        setDirty(context, e);
-        throw e;
       } catch (ResourceManagerException e) {
         logger.warn("Could not commit tx " + context + ", rolling back instead", e);
         doRollback(context);
+      } catch (Exception e) {
+        setDirty(context, e);
+        throw e;
       } finally {
         globalTransactions.remove(context);
         context.finalCleanUp();
@@ -250,25 +238,26 @@ public abstract class AbstractResourceManager {
 
       synchronized (context) {
         if (!context.finished) {
-          logger.info("Waiting for tx " + context + " to finish for " + remainingTimeout + " milli seconds");
+          logger.info("Waiting for tx {} to finish for {} milli seconds", context, remainingTimeout);
         }
         while (!context.finished && remainingTimeout > 0) {
           try {
             context.wait(remainingTimeout);
           } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
           }
           remainingTimeout = startTime - System.currentTimeMillis() + timeoutMSecs;
         }
         if (context.finished) {
-          logger.info("Tx " + context + " finished");
+          logger.info("Tx {} finished", context);
         } else {
-          logger.warn("Tx " + context + " failed to finish in given time");
+          logger.warn("Tx {} failed to finish in given time", context);
         }
       }
     }
 
-    return (globalTransactions.size() == 0);
+    return globalTransactions.isEmpty();
   }
 
   /**
@@ -278,8 +267,7 @@ public abstract class AbstractResourceManager {
    * @param t
    */
   private void setDirty(AbstractTransactionContext context, Throwable t) {
-    logger.error("Fatal error during critical commit/rollback of transaction " + context + ", setting resource manager to dirty.",
-                 t);
+    logger.error("Fatal error during critical commit/rollback of transaction {}, setting resource manager to dirty.", context, t);
     dirty = true;
   }
 

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/AbstractTransactionContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/AbstractTransactionContext.java
@@ -17,12 +17,10 @@ public abstract class AbstractTransactionContext {
   protected long timeout;
   protected int status;
   private boolean readOnly;
-  private boolean suspended;
   protected boolean finished;
 
-  public AbstractTransactionContext() {
+  protected AbstractTransactionContext() {
     status = Status.STATUS_NO_TRANSACTION;
-    suspended = false;
     finished = false;
     readOnly = true;
   }
@@ -31,9 +29,6 @@ public abstract class AbstractTransactionContext {
     StringBuilder sb = new StringBuilder();
     sb.append(id).append("[");
     sb.append(getStatusString());
-    if (suspended) {
-      sb.append(", suspended");
-    }
     if (readOnly) {
       sb.append(", readonly");
     }
@@ -83,4 +78,8 @@ public abstract class AbstractTransactionContext {
   public abstract void doCommit() throws ResourceManagerException;
 
   public abstract void doRollback() throws ResourceManagerException;
+
+  public void setStatus(int status) {
+    this.status = status;
+  }
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/AbstractXAResourceManager.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/transaction/xa/AbstractXAResourceManager.java
@@ -19,7 +19,7 @@ public abstract class AbstractXAResourceManager<T extends AbstractXaTransactionC
   private Map<Xid, T> suspendedContexts = new ConcurrentHashMap<>();
   private Map<Xid, T> activeContexts = new ConcurrentHashMap<>();
 
-  public AbstractXAResourceManager() {
+  protected AbstractXAResourceManager() {
     super();
   }
 
@@ -27,13 +27,13 @@ public abstract class AbstractXAResourceManager<T extends AbstractXaTransactionC
     assureReady();
     synchronized (context) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Preparing transaction " + context);
+        logger.debug("Preparing transaction {}", context);
       }
       context.status = Status.STATUS_PREPARING;
       int status = doPrepare(context);
       context.status = Status.STATUS_PREPARED;
       if (logger.isDebugEnabled()) {
-        logger.debug("Prepared transaction " + context);
+        logger.debug("Prepared transaction {}", context);
       }
       return status;
     }
@@ -41,7 +41,7 @@ public abstract class AbstractXAResourceManager<T extends AbstractXaTransactionC
 
   protected abstract int doPrepare(T context) throws ResourceManagerException;
 
-  T getTransactionalResource(Xid xid) {
+  public T getTransactionalResource(Xid xid) {
     T context = getActiveTransactionalResource(xid);
     if (context != null) {
       return context;
@@ -50,27 +50,27 @@ public abstract class AbstractXAResourceManager<T extends AbstractXaTransactionC
     }
   }
 
-  T getActiveTransactionalResource(Xid xid) {
+  public T getActiveTransactionalResource(Xid xid) {
     return activeContexts.get(xid);
   }
 
-  T getSuspendedTransactionalResource(Xid xid) {
+  public T getSuspendedTransactionalResource(Xid xid) {
     return suspendedContexts.get(xid);
   }
 
-  void addActiveTransactionalResource(Xid xid, T context) {
+  public void addActiveTransactionalResource(Xid xid, T context) {
     activeContexts.put(xid, context);
   }
 
-  void addSuspendedTransactionalResource(Xid xid, T context) {
+  public void addSuspendedTransactionalResource(Xid xid, T context) {
     suspendedContexts.put(xid, context);
   }
 
-  void removeActiveTransactionalResource(Xid xid) {
+  public void removeActiveTransactionalResource(Xid xid) {
     activeContexts.remove(xid);
   }
 
-  void removeSuspendedTransactionalResource(Xid xid) {
+  public void removeSuspendedTransactionalResource(Xid xid) {
     suspendedContexts.remove(xid);
   }
 }


### PR DESCRIPTION
Most of the modified productive code is changing loggers formatting, so it will imply in "lii civirigi if nii linis"