### PR TITLE
W-17916889: Include trace context in OTEL logs.

### DIFF
--- a/modules/tracing/mule-tracer-internal-impl/src/main/java/org/mule/runtime/tracer/impl/span/command/SpanMDCUtils.java
+++ b/modules/tracing/mule-tracer-internal-impl/src/main/java/org/mule/runtime/tracer/impl/span/command/SpanMDCUtils.java
@@ -8,7 +8,6 @@ package org.mule.runtime.tracer.impl.span.command;
 
 import org.mule.runtime.api.profiling.tracing.Span;
 import org.mule.runtime.api.profiling.tracing.SpanIdentifier;
-import org.mule.runtime.tracer.impl.span.InternalSpan;
 
 import org.slf4j.MDC;
 
@@ -19,8 +18,10 @@ import org.slf4j.MDC;
  */
 public class SpanMDCUtils {
 
-  public static final String SPAN_ID_MDC_KEY = "span-id";
-  public static final String TRACE_ID_MDC_KEY = "trace-id";
+  public static final String SPAN_ID_MDC_KEY = "span_id";
+  public static final String TRACE_ID_MDC_KEY = "trace_id";
+  public static final String TRACE_FLAGS_MDC_KEY = "trace_flags";
+  private static final String TRACE_FLAGS_DEFAULT_HEX_VALUE = "01";
 
   private SpanMDCUtils() {
 
@@ -36,6 +37,7 @@ public class SpanMDCUtils {
     if (spanIdentifier != null && spanIdentifier.isValid()) {
       MDC.put(SPAN_ID_MDC_KEY, spanIdentifier.getId());
       MDC.put(TRACE_ID_MDC_KEY, spanIdentifier.getTraceId());
+      MDC.put(TRACE_FLAGS_MDC_KEY, TRACE_FLAGS_DEFAULT_HEX_VALUE);
     }
   }
 


### PR DESCRIPTION
This PR renames the span_id and trace_id identifiers in order to follow the OTEL specification and adds the trace_flags identifier with a default value to the logging MDC. Further development will be needed in order to communicate the actual runtime sampling and inform a non-default trace_flags.