### PR TITLE
W-17340911: Resolve loader constraint violation in policy isolation

### DIFF
--- a/modules/artifact-activation/src/main/java/org/mule/runtime/module/artifact/activation/internal/classloader/DefaultArtifactClassLoaderResolver.java
+++ b/modules/artifact-activation/src/main/java/org/mule/runtime/module/artifact/activation/internal/classloader/DefaultArtifactClassLoaderResolver.java
@@ -486,6 +486,10 @@ public class DefaultArtifactClassLoaderResolver implements ArtifactClassLoaderRe
                                                                                  .put(exportedPackage, CHILD_FIRST));
     }
 
+    if (packagesLookupPolicies.isEmpty()) {
+      return baseLookupPolicy.extend(pluginsLookupPolicies);
+    }
+
     return baseLookupPolicy.extend(pluginsLookupPolicies).extend(packagesLookupPolicies, true);
   }
 


### PR DESCRIPTION
When policy isolation is enabled, classes from plugins used in the policy should be loaded with the policy's classloader, not the domain classloader. This change prevents loader constraint violation errors that can occur when using a custom domain and a policy that both have the same connector dependency.