### PR TITLE
W-17607446: Handle missing fields in DefaultMessageBuilder

### DIFF
--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -596,7 +596,8 @@ module org.mule.runtime.core {
   opens org.mule.runtime.core.internal.management.stats to
       kryo.shaded;
   opens org.mule.runtime.core.internal.message to
-      kryo.shaded;
+          com.mulesoft.mule.runtime.kryo,
+          kryo.shaded;
   opens org.mule.runtime.core.internal.policy to
       org.mule.runtime.deployment,
       spring.core;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -596,8 +596,7 @@ module org.mule.runtime.core {
   opens org.mule.runtime.core.internal.management.stats to
       kryo.shaded;
   opens org.mule.runtime.core.internal.message to
-      com.mulesoft.mule.runtime.kryo,
-      kryo.shaded;
+      com.mulesoft.mule.runtime.kryo;
   opens org.mule.runtime.core.internal.policy to
       org.mule.runtime.deployment,
       spring.core;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -596,7 +596,8 @@ module org.mule.runtime.core {
   opens org.mule.runtime.core.internal.management.stats to
       kryo.shaded;
   opens org.mule.runtime.core.internal.message to
-      com.mulesoft.mule.runtime.kryo;
+      com.mulesoft.mule.runtime.kryo,
+      kryo.shaded;
   opens org.mule.runtime.core.internal.policy to
       org.mule.runtime.deployment,
       spring.core;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -596,8 +596,8 @@ module org.mule.runtime.core {
   opens org.mule.runtime.core.internal.management.stats to
       kryo.shaded;
   opens org.mule.runtime.core.internal.message to
-          com.mulesoft.mule.runtime.kryo,
-          kryo.shaded;
+      com.mulesoft.mule.runtime.kryo,
+      kryo.shaded;
   opens org.mule.runtime.core.internal.policy to
       org.mule.runtime.deployment,
       spring.core;


### PR DESCRIPTION

```
org.mule.runtime.api.serialization.SerializationException: Could not serialize object
Caused by: com.esotericsoftware.kryo.KryoException: java.lang.reflect.InaccessibleObjectException: Unable to make field private org.mule.runtime.api.metadata.TypedValue org.mule.runtime.core.internal.message.DefaultMessageBuilder.attributes accessible: module org.mule.runtime.core does not "opens org.mule.runtime.core.internal.message" to module com.mulesoft.mule.runtime.kryo
```