### PR TITLE
W-17846088: Handle all websocket close codes

### DIFF
--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/ws/WebSocketCloseCode.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/ws/WebSocketCloseCode.java
@@ -44,38 +44,56 @@ public enum WebSocketCloseCode {
   MESSAGE_TOO_LARGE(1004),
   /**
    * Indicates termination due to inconsistent data in a message (e.g., non-UTF-8).
+   * 
+   * @since 4.10.0
    */
   INVALID_PAYLOAD(1007),
   /**
    * Indicates termination due to a policy violation.
+   * 
+   * @since 4.10.0
    */
   POLICY_VIOLATION(1008),
   /**
    * Indicates termination because the message is too big to process.
+   * 
+   * @since 4.10.0
    */
   MESSAGE_TOO_BIG(1009),
   /**
    * Indicates client termination; expected extensions were not negotiated.
+   * 
+   * @since 4.10.0
    */
   MISSING_EXTENSIONS(1010),
   /**
    * Indicates server termination due to an unexpected condition.
+   * 
+   * @since 4.10.0
    */
   INTERNAL_SERVER_ERROR(1011),
   /**
    * Indicates that the service is restarted.
+   * 
+   * @since 4.10.0
    */
   SERVICE_RESTARTED(1012),
   /**
    * Indicates that the service is experiencing overload.
+   * 
+   * @since 4.10.0
    */
   TRY_AGAIN_LATER(1013),
   /**
    * Indicates the server, acting as a gateway, received an invalid response.
+   * 
+   * @since 4.10.0
    */
   BAD_GATEWAY(1014),
   /**
    * Indicates any close code not explicitly defined in this enum.
+   * 
+   * @since 4.10.0
    */
   UNKNOWN(-1);
 
@@ -105,7 +123,7 @@ public enum WebSocketCloseCode {
       } else if (isRegisteredCode(protocolCode)) { // 3000-3999
         LOGGER.debug("Received library/framework WebSocket close code: {}", protocolCode);
       } else if (isReservedCode(protocolCode)) { // 1000-2999
-        throw new IllegalArgumentException("Received undefined reserved WebSocket close code:" + protocolCode);
+        LOGGER.debug("Received undefined reserved WebSocket close code: {}", protocolCode);
       } else {
         throw new IllegalArgumentException("Received invalid WebSocket close code:" + protocolCode); // Should never happen
       }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/ws/WebSocketCloseCode.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/ws/WebSocketCloseCode.java
@@ -101,13 +101,13 @@ public enum WebSocketCloseCode {
     WebSocketCloseCode code = CODES.get(protocolCode);
     if (code == null) {
       if (isPrivateUseCode(protocolCode)) { // 4000-4999
-        LOGGER.info("Received private use WebSocket close code: {}", protocolCode);
+        LOGGER.debug("Received private use WebSocket close code: {}", protocolCode);
       } else if (isRegisteredCode(protocolCode)) { // 3000-3999
-        LOGGER.warn("Received library/framework WebSocket close code: {}", protocolCode);
+        LOGGER.debug("Received library/framework WebSocket close code: {}", protocolCode);
       } else if (isReservedCode(protocolCode)) { // 1000-2999
-        LOGGER.error("Received undefined reserved WebSocket close code: {}", protocolCode);
+        throw new IllegalArgumentException("Received undefined reserved WebSocket close code:" + protocolCode);
       } else {
-        LOGGER.error("Received invalid WebSocket close code: {}", protocolCode); // Should never happen
+        throw new IllegalArgumentException("Received invalid WebSocket close code:" + protocolCode); // Should never happen
       }
       return unknownWithCode(protocolCode);
     }
@@ -122,28 +122,62 @@ public enum WebSocketCloseCode {
     this.originalCode = protocolCode;
   }
 
+  /**
+   * Creates a WebSocketCloseCode instance for an unknown close code, preserving the original numeric code received.
+   *
+   * @param originalCode The original, numeric close code received.
+   * @return A WebSocketCloseCode instance representing the unknown code.
+   */
   public static WebSocketCloseCode unknownWithCode(int originalCode) {
     WebSocketCloseCode unknown = WebSocketCloseCode.UNKNOWN;
     unknown.originalCode = originalCode;
     return unknown;
   }
 
+  /**
+   * Gets the WebSocket protocol close code.
+   *
+   * @return The WebSocket protocol close code.
+   */
   public int getProtocolCode() {
     return protocolCode;
   }
 
+  /**
+   * Gets the original, numeric close code received.
+   *
+   * @return The original, numeric close code.
+   */
   public int getOriginalCode() {
     return originalCode;
   }
 
+  /**
+   * Checks if the given close code is a reserved code (1000-2999).
+   *
+   * @param code The close code to check.
+   * @return {@code true} if the code is reserved, {@code false} otherwise.
+   */
   public static boolean isReservedCode(int code) {
     return code >= 1000 && code <= 2999;
   }
 
+  /**
+   * Checks if the given close code is an IANA-registered code (3000-3999).
+   *
+   * @param code The close code to check.
+   * @return {@code true} if the code is registered, {@code false} otherwise.
+   */
   public static boolean isRegisteredCode(int code) {
     return code >= 3000 && code <= 3999;
   }
 
+  /**
+   * Checks if the given close code is a private use code (4000-4999).
+   *
+   * @param code The close code to check.
+   * @return {@code true} if the code is a private use code, {@code false} otherwise.
+   */
   public static boolean isPrivateUseCode(int code) {
     return code >= 4000 && code <= 4999;
   }

--- a/modules/http-api/src/main/java/org/mule/runtime/http/api/ws/WebSocketCloseCode.java
+++ b/modules/http-api/src/main/java/org/mule/runtime/http/api/ws/WebSocketCloseCode.java
@@ -6,8 +6,12 @@
  */
 package org.mule.runtime.http.api.ws;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.util.HashMap;
 import java.util.Map;
+
+import org.slf4j.Logger;
 
 /**
  * The codes of the close frame that will be sent (or has been received) when closing a {@link WebSocket}
@@ -34,15 +38,55 @@ public enum WebSocketCloseCode {
    */
   INVALID_DATA(1003),
   /**
-   * indicates that an endpoint is terminating the connection because it has received a message that is too large.
+   * Indicates that an endpoint is terminating the connection because it has received a message that is too large. Depreciated,
+   * 1009 is preferred.
    */
-  MESSAGE_TOO_LARGE(1004);
+  MESSAGE_TOO_LARGE(1004),
+  /**
+   * Indicates termination due to inconsistent data in a message (e.g., non-UTF-8).
+   */
+  INVALID_PAYLOAD(1007),
+  /**
+   * Indicates termination due to a policy violation.
+   */
+  POLICY_VIOLATION(1008),
+  /**
+   * Indicates termination because the message is too big to process.
+   */
+  MESSAGE_TOO_BIG(1009),
+  /**
+   * Indicates client termination; expected extensions were not negotiated.
+   */
+  MISSING_EXTENSIONS(1010),
+  /**
+   * Indicates server termination due to an unexpected condition.
+   */
+  INTERNAL_SERVER_ERROR(1011),
+  /**
+   * Indicates that the service is restarted.
+   */
+  SERVICE_RESTARTED(1012),
+  /**
+   * Indicates that the service is experiencing overload.
+   */
+  TRY_AGAIN_LATER(1013),
+  /**
+   * Indicates the server, acting as a gateway, received an invalid response.
+   */
+  BAD_GATEWAY(1014),
+  /**
+   * Indicates any close code not explicitly defined in this enum.
+   */
+  UNKNOWN(-1);
 
   private static final Map<Integer, WebSocketCloseCode> CODES = new HashMap<>(WebSocketCloseCode.values().length);
+  private static final Logger LOGGER = getLogger(WebSocketCloseCode.class);
 
   static {
     for (WebSocketCloseCode code : WebSocketCloseCode.values()) {
-      CODES.put(code.protocolCode, code);
+      if (code.protocolCode != -1) {
+        CODES.put(code.protocolCode, code);
+      }
     }
   }
 
@@ -56,20 +100,52 @@ public enum WebSocketCloseCode {
   public static WebSocketCloseCode fromProtocolCode(int protocolCode) {
     WebSocketCloseCode code = CODES.get(protocolCode);
     if (code == null) {
-      throw new IllegalArgumentException("Invalid protocol code " + protocolCode);
+      if (isPrivateUseCode(protocolCode)) { // 4000-4999
+        LOGGER.info("Received private use WebSocket close code: {}", protocolCode);
+      } else if (isRegisteredCode(protocolCode)) { // 3000-3999
+        LOGGER.warn("Received library/framework WebSocket close code: {}", protocolCode);
+      } else if (isReservedCode(protocolCode)) { // 1000-2999
+        LOGGER.error("Received undefined reserved WebSocket close code: {}", protocolCode);
+      } else {
+        LOGGER.error("Received invalid WebSocket close code: {}", protocolCode); // Should never happen
+      }
+      return unknownWithCode(protocolCode);
     }
-
     return code;
   }
 
   private final int protocolCode;
+  private int originalCode;
 
   WebSocketCloseCode(int protocolCode) {
     this.protocolCode = protocolCode;
+    this.originalCode = protocolCode;
+  }
+
+  public static WebSocketCloseCode unknownWithCode(int originalCode) {
+    WebSocketCloseCode unknown = WebSocketCloseCode.UNKNOWN;
+    unknown.originalCode = originalCode;
+    return unknown;
   }
 
   public int getProtocolCode() {
     return protocolCode;
+  }
+
+  public int getOriginalCode() {
+    return originalCode;
+  }
+
+  public static boolean isReservedCode(int code) {
+    return code >= 1000 && code <= 2999;
+  }
+
+  public static boolean isRegisteredCode(int code) {
+    return code >= 3000 && code <= 3999;
+  }
+
+  public static boolean isPrivateUseCode(int code) {
+    return code >= 4000 && code <= 4999;
   }
 
 }

--- a/modules/http-api/src/test/java/org/mule/runtime/http/api/ws/WebSocketCloseCodeTestCase.java
+++ b/modules/http-api/src/test/java/org/mule/runtime/http/api/ws/WebSocketCloseCodeTestCase.java
@@ -66,9 +66,11 @@ public class WebSocketCloseCodeTestCase {
     assertThat(code.getOriginalCode(), is(3500));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void fromProtocolCodeWithReservedCodeThrowsException() {
-    fromProtocolCode(2500);
+  @Test
+  public void fromProtocolCodeWithReservedCode() {
+    WebSocketCloseCode code = fromProtocolCode(2500);
+    assertThat(code, is(UNKNOWN));
+    assertThat(code.getOriginalCode(), is(2500));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/modules/http-api/src/test/java/org/mule/runtime/http/api/ws/WebSocketCloseCodeTestCase.java
+++ b/modules/http-api/src/test/java/org/mule/runtime/http/api/ws/WebSocketCloseCodeTestCase.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.http.api.ws;
+
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.BAD_GATEWAY;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.ENDPOINT_GOING_DOWN;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.INTERNAL_SERVER_ERROR;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.INVALID_DATA;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.INVALID_PAYLOAD;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.MESSAGE_TOO_BIG;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.MESSAGE_TOO_LARGE;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.MISSING_EXTENSIONS;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.NORMAL_CLOSURE;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.POLICY_VIOLATION;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.PROTOCOL_ERROR;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.SERVICE_RESTARTED;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.TRY_AGAIN_LATER;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.UNKNOWN;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.fromProtocolCode;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.isPrivateUseCode;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.isRegisteredCode;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.isReservedCode;
+import static org.mule.runtime.http.api.ws.WebSocketCloseCode.unknownWithCode;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.qameta.allure.Issue;
+import org.junit.Test;
+
+@Issue("W-17846088")
+public class WebSocketCloseCodeTestCase {
+
+  @Test
+  public void testFromProtocolCodeWithKnownCodes() {
+    assertThat(fromProtocolCode(1000), is(NORMAL_CLOSURE));
+    assertThat(fromProtocolCode(1001), is(ENDPOINT_GOING_DOWN));
+    assertThat(fromProtocolCode(1002), is(PROTOCOL_ERROR));
+    assertThat(fromProtocolCode(1003), is(INVALID_DATA));
+    assertThat(fromProtocolCode(1004), is(MESSAGE_TOO_LARGE));
+    assertThat(fromProtocolCode(1007), is(INVALID_PAYLOAD));
+    assertThat(fromProtocolCode(1008), is(POLICY_VIOLATION));
+    assertThat(fromProtocolCode(1009), is(MESSAGE_TOO_BIG));
+    assertThat(fromProtocolCode(1010), is(MISSING_EXTENSIONS));
+    assertThat(fromProtocolCode(1011), is(INTERNAL_SERVER_ERROR));
+    assertThat(fromProtocolCode(1012), is(SERVICE_RESTARTED));
+    assertThat(fromProtocolCode(1013), is(TRY_AGAIN_LATER));
+    assertThat(fromProtocolCode(1014), is(BAD_GATEWAY));
+  }
+
+  @Test
+  public void fromProtocolCodeWithPrivateUseCode() {
+    WebSocketCloseCode code = fromProtocolCode(4500);
+    assertThat(code, is(UNKNOWN));
+    assertThat(code.getOriginalCode(), is(4500));
+  }
+
+  @Test
+  public void fromProtocolCodeWithRegisteredCode() {
+    WebSocketCloseCode code = fromProtocolCode(3500);
+    assertThat(code, is(UNKNOWN));
+    assertThat(code.getOriginalCode(), is(3500));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void fromProtocolCodeWithReservedCodeThrowsException() {
+    fromProtocolCode(2500);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void fromProtocolCodeWithInvalidCodeThrowsException() {
+    fromProtocolCode(5000);
+  }
+
+  @Test
+  public void unknownWithCodeSetsOriginalCode() {
+    WebSocketCloseCode code = unknownWithCode(9999);
+    assertThat(code, is(UNKNOWN));
+    assertThat(code.getOriginalCode(), is(9999));
+  }
+
+  @Test
+  public void getProtocolCodeReturnsCorrectCode() {
+    assertThat(NORMAL_CLOSURE.getProtocolCode(), is(1000));
+    assertThat(UNKNOWN.getProtocolCode(), is(-1));
+  }
+
+  @Test
+  public void isReservedCodeReturnsCorrectBoolean() {
+    assertThat(isReservedCode(1000), is(true));
+    assertThat(isReservedCode(2999), is(true));
+    assertThat(isReservedCode(999), is(false));
+    assertThat(isReservedCode(3000), is(false));
+  }
+
+  @Test
+  public void isRegisteredCodeReturnsCorrectBoolean() {
+    assertThat(isRegisteredCode(3000), is(true));
+    assertThat(isRegisteredCode(3999), is(true));
+    assertThat(isRegisteredCode(2999), is(false));
+    assertThat(isRegisteredCode(4000), is(false));
+  }
+
+  @Test
+  public void isPrivateUseCodeReturnsCorrectBoolean() {
+    assertThat(isPrivateUseCode(4000), is(true));
+    assertThat(isPrivateUseCode(4999), is(true));
+    assertThat(isPrivateUseCode(3999), is(false));
+    assertThat(isPrivateUseCode(5000), is(false));
+  }
+
+}


### PR DESCRIPTION
The WebSocket client now robustly handles all close codes, including unknown and custom codes, without throwing exceptions. The original numeric code is preserved, and logging is improved to differentiate code ranges.