### PR TITLE
W-17980769: Parallel For Each events randomly timeout after NPE exception while getting operation execution parameters for result in ComponentMessageProcessor.java

### DIFF
--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -80,6 +80,7 @@ public abstract class AbstractEventContext implements SpanContextAware, BaseEven
   // Kept for backwards compatibility of deserialization of objects serialized with previous versions
   private byte state = -1;
   private transient AtomicInteger stateCtx = new AtomicInteger(STATE_READY);
+  private transient volatile AtomicInteger childIdProvider = new AtomicInteger();
   private transient volatile boolean childrenComplete = false;
   private volatile Either<Throwable, CoreEvent> result;
 
@@ -444,6 +445,13 @@ public abstract class AbstractEventContext implements SpanContextAware, BaseEven
 
   protected int getState() {
     return stateCtx.get();
+  }
+
+  @Override
+  public String nextChildId() {
+    return getId() != null
+        ? new StringBuilder(getId()).append("_").append(childIdProvider.getAndIncrement()).toString()
+        : "" + childIdProvider.getAndIncrement();
   }
 
 }

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -88,7 +88,7 @@ public abstract class AbstractEventContext implements SpanContextAware, BaseEven
 
   protected FlowCallStack flowCallStack;
 
-  public AbstractEventContext() {
+  protected AbstractEventContext() {
     this(NULL_EXCEPTION_HANDLER, 0, Optional.empty());
   }
 
@@ -97,8 +97,8 @@ public abstract class AbstractEventContext implements SpanContextAware, BaseEven
    * @param externalCompletion optional future that allows an external entity (e.g. a source) to signal completion of response
    *                           processing and delay termination.
    */
-  public AbstractEventContext(FlowExceptionHandler exceptionHandler, int depthLevel,
-                              Optional<CompletableFuture<Void>> externalCompletion) {
+  protected AbstractEventContext(FlowExceptionHandler exceptionHandler, int depthLevel,
+                                 Optional<CompletableFuture<Void>> externalCompletion) {
     this.depthLevel = depthLevel;
     this.externalCompletion = externalCompletion.orElse(null);
     if (this.externalCompletion != null) {
@@ -231,8 +231,8 @@ public abstract class AbstractEventContext implements SpanContextAware, BaseEven
       Optional<BaseEventContext> parentContext = getParentContext();
       if (parentContext.isPresent()) {
         BaseEventContext context = parentContext.get();
-        if (context instanceof AbstractEventContext) {
-          ((AbstractEventContext) context).tryComplete();
+        if (context instanceof AbstractEventContext aec) {
+          aec.tryComplete();
         }
       }
 
@@ -372,8 +372,8 @@ public abstract class AbstractEventContext implements SpanContextAware, BaseEven
     try {
       childContexts.stream().filter(context -> !context.isTerminated()).forEach(context -> {
         childConsumer.accept(context);
-        if (context instanceof AbstractEventContext) {
-          ((AbstractEventContext) context).forEachChild(childConsumer);
+        if (context instanceof AbstractEventContext aec) {
+          aec.forEachChild(childConsumer);
         }
       });
     } finally {

--- a/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/AbstractEventContext.java
@@ -80,7 +80,7 @@ public abstract class AbstractEventContext implements SpanContextAware, BaseEven
   // Kept for backwards compatibility of deserialization of objects serialized with previous versions
   private byte state = -1;
   private transient AtomicInteger stateCtx = new AtomicInteger(STATE_READY);
-  private transient volatile AtomicInteger childIdProvider = new AtomicInteger();
+  private transient AtomicInteger childIdProvider = new AtomicInteger();
   private transient volatile boolean childrenComplete = false;
   private volatile Either<Throwable, CoreEvent> result;
 

--- a/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/event/DefaultEventContext.java
@@ -9,7 +9,6 @@ package org.mule.runtime.core.internal.event;
 import static org.mule.runtime.core.api.util.StringUtils.EMPTY;
 import static org.mule.runtime.core.privileged.event.DefaultFlowCallStack.newDefaultFlowCallStack;
 
-import static java.lang.System.identityHashCode;
 import static java.lang.System.lineSeparator;
 import static java.time.Instant.now;
 import static java.util.Objects.requireNonNull;
@@ -346,9 +345,7 @@ public final class DefaultEventContext extends AbstractEventContext implements S
       this.root = parent.getRootContext();
       this.parent = parent;
       this.componentLocation = componentLocation;
-      this.id = parent.getId() != null
-          ? parent.getId().concat("_").concat(Integer.toString(identityHashCode(this)))
-          : Integer.toString(identityHashCode(this));
+      this.id = parent.nextChildId();
       this.correlationId = correlationId != null ? correlationId : parent.getCorrelationId();
       this.rootId = root.getRootId();
       if (parent instanceof SpanContextAware) {

--- a/core/src/main/java/org/mule/runtime/core/internal/streaming/EventStreamingState.java
+++ b/core/src/main/java/org/mule/runtime/core/internal/streaming/EventStreamingState.java
@@ -6,18 +6,23 @@
  */
 package org.mule.runtime.core.internal.streaming;
 
-import static java.lang.System.identityHashCode;
-import static org.slf4j.LoggerFactory.getLogger;
 import static org.mule.runtime.core.internal.streaming.CursorManager.STREAMING_VERBOSE;
 import static org.mule.runtime.core.internal.streaming.CursorUtils.unwrap;
+
+import static java.lang.System.identityHashCode;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.streaming.Cursor;
+import org.mule.runtime.api.streaming.CursorProvider;
 
 import java.lang.ref.WeakReference;
 import java.util.Optional;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.mule.runtime.api.component.location.ComponentLocation;
-import org.mule.runtime.api.streaming.CursorProvider;
+
 import org.slf4j.Logger;
 
 /**
@@ -40,9 +45,10 @@ public class EventStreamingState {
    * @param ghostBuster the {@link StreamingGhostBuster} used to do early reclamation of the {@code provider}
    * @return the {@link ManagedCursorProvider} that must continue to be used
    */
-  public ManagedCursorProvider addProvider(ManagedCursorProvider provider, StreamingGhostBuster ghostBuster) {
+  public <T extends Cursor> ManagedCursorProvider<T> addProvider(ManagedCursorProvider<T> provider,
+                                                                 StreamingGhostBuster ghostBuster) {
     final int id = provider.getId();
-    ManagedCursorProvider managedProvider = getOrAddManagedProvider(id, provider, ghostBuster);
+    ManagedCursorProvider<T> managedProvider = getOrAddManagedProvider(id, provider, ghostBuster);
 
     // This can happen when a foreach component splits a text document using a stream.
     // Iteration N might try to manage the same root provider that was already managed in iteration N-1, but the
@@ -61,12 +67,12 @@ public class EventStreamingState {
     return managedProvider;
   }
 
-  private ManagedCursorProvider getOrAddManagedProvider(int id,
-                                                        ManagedCursorProvider provider,
-                                                        StreamingGhostBuster ghostBuster) {
+  private <T extends Cursor> ManagedCursorProvider<T> getOrAddManagedProvider(int id,
+                                                                              ManagedCursorProvider<T> provider,
+                                                                              StreamingGhostBuster ghostBuster) {
     return providers.get(id, k -> {
       if (STREAMING_VERBOSE) {
-        CursorProvider innerDelegate = unwrap(provider);
+        CursorProvider<T> innerDelegate = unwrap(provider);
         Optional<ComponentLocation> originatingLocation = provider.getOriginatingLocation();
         LOGGER.info("Added ManagedCursorProvider: {} for delegate: {} opened by: {}", k, identityHashCode(innerDelegate),
                     originatingLocation.map(ComponentLocation::getLocation).orElse("unknown"));
@@ -80,7 +86,7 @@ public class EventStreamingState {
    */
   public void dispose() {
     providers.asMap().forEach((hash, weakReference) -> {
-      ManagedCursorProvider provider = weakReference.get();
+      ManagedCursorProvider<?> provider = weakReference.get();
       if (provider != null) {
         weakReference.clear();
         provider.releaseResources();

--- a/core/src/main/java/org/mule/runtime/core/privileged/event/BaseEventContext.java
+++ b/core/src/main/java/org/mule/runtime/core/privileged/event/BaseEventContext.java
@@ -202,4 +202,11 @@ public interface BaseEventContext extends EventContext {
    */
   int getDepthLevel();
 
+  /**
+   * @return a unique id with the if of this context as prefix
+   * 
+   * @since 4.10, 4.9.4, 4.6.16, 4.4.0-202505
+   */
+  String nextChildId();
+
 }

--- a/modules/extensions-mule-support/src/main/java/org/mule/runtime/module/extension/mule/internal/execution/MuleOperationExecutor.java
+++ b/modules/extensions-mule-support/src/main/java/org/mule/runtime/module/extension/mule/internal/execution/MuleOperationExecutor.java
@@ -90,7 +90,7 @@ public class MuleOperationExecutor implements CompletableComponentExecutor<Compo
     Map<String, Object> parameters = new HashMap<>();
     from(inputEvent)
         .getOperationExecutionParams(ctx.getComponent().getLocation(), inputEvent.getContext().getId())
-        .getParameters()
+        .parameters()
         .forEach((key, value) -> parameters.put(key, mapParameterValue(value)));
     return parameters;
   }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -122,9 +122,8 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
         getLocationSpecificSdkInternalContext(location, eventId);
     final OperationExecutionParams<M> operationExecutionParams = locationSpecificSdkInternalContext.getOperationExecutionParams();
     if (operationExecutionParams == null) {
-      final var locationString = getLocationString(location);
       throw new NullPointerException("No Operation Parameters for Context at location - %s for event - %s"
-          .formatted(locationString, eventId));
+          .formatted(getLocationString(location), eventId));
     }
     return operationExecutionParams;
   }

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -6,7 +6,6 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.execution;
 
-import static java.util.Collections.synchronizedMap;
 import static java.util.Optional.empty;
 import static java.util.function.Function.identity;
 
@@ -14,7 +13,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.util.Pair;
-import org.mule.runtime.api.util.collection.SmallMap;
 import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.event.InternalEvent;
 import org.mule.runtime.core.internal.message.EventInternalContext;
@@ -26,6 +24,7 @@ import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContext
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -55,9 +54,8 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
    * SDK components may be nested within each other, so some of the context must be kept separately for the component it belongs
    * to.
    */
-  // TODO MULE-18296 determine what implementation of thread safe map is better here after that fix.
   private final Map<Pair<ComponentLocation, String>, LocationSpecificSdkInternalContext> locationSpecificContext =
-      synchronizedMap(new SmallMap<>());
+      new ConcurrentHashMap<>(5);
 
   private Function<Context, Context> innerChainSubscriberContextMapping = identity();
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -118,14 +118,8 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
 
   public <M extends ComponentModel> OperationExecutionParams<M> getOperationExecutionParams(ComponentLocation location,
                                                                                             String eventId) {
-    final LocationSpecificSdkInternalContext<M> locationSpecificSdkInternalContext =
-        getLocationSpecificSdkInternalContext(location, eventId);
-    final OperationExecutionParams<M> operationExecutionParams = locationSpecificSdkInternalContext.getOperationExecutionParams();
-    if (operationExecutionParams == null) {
-      throw new NullPointerException("No Operation Parameters for Context at location - %s for event - %s"
-          .formatted(getLocationString(location), eventId));
-    }
-    return operationExecutionParams;
+    return this.<M>getLocationSpecificSdkInternalContext(location, eventId)
+        .getOperationExecutionParams();
   }
 
   private <M extends ComponentModel> LocationSpecificSdkInternalContext<M> getLocationSpecificSdkInternalContext(ComponentLocation location,

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContext.java
@@ -61,12 +61,13 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
   private UnaryOperator<Context> innerChainSubscriberContextMapping = identity();
 
   public void removeContext(ComponentLocation location, String eventId) {
-    LOGGER.debug("Removing context at location - {} for event - {}", location != null ? location.getLocation() : "null", eventId);
+    LOGGER.debug("Removing context at location - {} for event - {}",
+                 getLocationString(location), eventId);
     locationSpecificContext.remove(new Pair<>(location, eventId));
   }
 
   public void putContext(ComponentLocation location, String eventId) {
-    final var locationString = location != null ? location.getLocation() : "null";
+    final var locationString = getLocationString(location);
     LOGGER.debug("Adding new context at location - {} for event - {}", locationString, eventId);
 
     final var previousValue =
@@ -85,8 +86,8 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
    */
   public void setConfiguration(ComponentLocation location, String eventId,
                                Optional<ConfigurationInstance> configuration) {
-    LOGGER.debug("Adding configuration at location - {} for event - {}", location != null ? location.getLocation() : "null",
-                 eventId);
+    LOGGER.debug("Adding configuration at location - {} for event - {}",
+                 getLocationString(location), eventId);
     locationSpecificContext.get(new Pair<>(location, eventId)).setConfiguration(configuration);
   }
 
@@ -99,7 +100,7 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
                                                                      Map<String, Object> parameters, CoreEvent operationEvent,
                                                                      ExecutorCallback callback,
                                                                      ExecutionContextAdapter<M> executionContextAdapter) {
-    final var locationString = location != null ? location.getLocation() : "null";
+    final var locationString = getLocationString(location);
     LOGGER.debug("Setting Operation Parameters at location - {} for event - {}",
                  locationString, eventId);
 
@@ -121,7 +122,7 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
         getLocationSpecificSdkInternalContext(location, eventId);
     final OperationExecutionParams<M> operationExecutionParams = locationSpecificSdkInternalContext.getOperationExecutionParams();
     if (operationExecutionParams == null) {
-      final var locationString = location != null ? location.getLocation() : "null";
+      final var locationString = getLocationString(location);
       throw new NullPointerException("No Operation Parameters for Context at location - %s for event - %s"
           .formatted(locationString, eventId));
     }
@@ -133,11 +134,15 @@ public class SdkInternalContext implements EventInternalContext<SdkInternalConte
     final LocationSpecificSdkInternalContext<M> locationSpecificSdkInternalContext =
         locationSpecificContext.get(new Pair<>(location, eventId));
     if (locationSpecificSdkInternalContext == null) {
-      final var locationString = location != null ? location.getLocation() : "null";
+      final var locationString = getLocationString(location);
       throw new NullPointerException("No Context at location - %s for event - %s"
           .formatted(locationString, eventId));
     }
     return locationSpecificSdkInternalContext;
+  }
+
+  private String getLocationString(ComponentLocation location) {
+    return location != null ? location.getLocation() : "null";
   }
 
   public Map<String, Object> getResolutionResult(ComponentLocation location, String eventId) {

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ComponentMessageProcessor.java
@@ -513,7 +513,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
               getOperationExecutionParams(event);
 
           if (operationExecutionParams != null) {
-            operationContext = operationExecutionParams.getExecutionContextAdapter();
+            operationContext = operationExecutionParams.executionContextAdapter();
             operationContext.changeEvent(event);
           } else {
             // There was an error propagated before <execute-next> and the operation execution parameters don't exist yet.
@@ -726,9 +726,9 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
           .configureInternalPublisher(from(p)
               .transform(processingStrategy.onProcessor(innerProcessor))
               .doOnNext(result -> getOperationExecutionParams(result)
-                  .getCallback().complete(result))
+                  .callback().complete(result))
               .onErrorContinue((t, result) -> getOperationExecutionParams(((EventProcessingException) t).getEvent())
-                  .getCallback().error(t.getCause()))));
+                  .callback().error(t.getCause()))));
     },
                                                 getRuntime().availableProcessors());
   }
@@ -819,7 +819,7 @@ public abstract class ComponentMessageProcessor<T extends ComponentModel> extend
   private void prepareAndExecuteOperation(CoreEvent event, Supplier<ExecutorCallback> callbackSupplier) {
     OperationExecutionParams oep = getOperationExecutionParams(event);
 
-    ExecutionContextAdapter<T> operationContext = oep.getExecutionContextAdapter();
+    ExecutionContextAdapter<T> operationContext = oep.executionContextAdapter();
 
     setCurrentEvent((PrivilegedEvent) event);
     boolean wasProcessorPathSet = setCurrentLocation();

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChildContextChainExecutor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChildContextChainExecutor.java
@@ -85,9 +85,9 @@ public class ImmutableProcessorChildContextChainExecutor implements ChildContext
     SdkInternalContext.OperationExecutionParams params =
         sdkInternalContext.getOperationExecutionParams(location, originalEvent.getContext().getId());
     if (params != null) {
-      sdkInternalContext.setOperationExecutionParams(location, eventId, params.getConfiguration(), params.getParameters(),
-                                                     eventWithCorrelationId, params.getCallback(),
-                                                     params.getExecutionContextAdapter());
+      sdkInternalContext.setOperationExecutionParams(location, eventId, params.configuration(), params.parameters(),
+                                                     eventWithCorrelationId, params.callback(),
+                                                     params.executionContextAdapter());
     }
   }
 

--- a/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChildContextChainExecutor.java
+++ b/modules/extensions-support/src/main/java/org/mule/runtime/module/extension/internal/runtime/operation/ImmutableProcessorChildContextChainExecutor.java
@@ -82,13 +82,6 @@ public class ImmutableProcessorChildContextChainExecutor implements ChildContext
     final String eventId = eventWithCorrelationId.getContext().getId();
     SdkInternalContext sdkInternalContext = SdkInternalContext.from(eventWithCorrelationId);
     sdkInternalContext.putContext(location, eventId);
-    SdkInternalContext.OperationExecutionParams params =
-        sdkInternalContext.getOperationExecutionParams(location, originalEvent.getContext().getId());
-    if (params != null) {
-      sdkInternalContext.setOperationExecutionParams(location, eventId, params.configuration(), params.parameters(),
-                                                     eventWithCorrelationId, params.callback(),
-                                                     params.executionContextAdapter());
-    }
   }
 
   private CoreEvent withPreviousCorrelationid(CoreEvent event) {

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextTestCase.java
@@ -50,8 +50,8 @@ public class SdkInternalContextTestCase extends AbstractMuleTestCase {
     pushContext(ctx, comp1, "event1", completedForComponents);
     pushContext(ctx, comp2, "event1", completedForComponents);
 
-    ctx.getOperationExecutionParams(comp1, "event1").getCallback().complete(comp1);
-    ctx.getOperationExecutionParams(comp2, "event1").getCallback().complete(comp2);
+    ctx.getOperationExecutionParams(comp1, "event1").callback().complete(comp1);
+    ctx.getOperationExecutionParams(comp2, "event1").callback().complete(comp2);
 
     assertThat(completedForComponents, contains(new Pair<>(comp1, "event1"), new Pair<>(comp2, "event1")));
   }
@@ -69,8 +69,8 @@ public class SdkInternalContextTestCase extends AbstractMuleTestCase {
     pushContext(ctx, comp1, "event1", completedForComponents);
     pushContext(ctx, comp1, "event2", completedForComponents);
 
-    ctx.getOperationExecutionParams(comp1, "event1").getCallback().complete(comp1);
-    ctx.getOperationExecutionParams(comp1, "event2").getCallback().complete(comp1);
+    ctx.getOperationExecutionParams(comp1, "event1").callback().complete(comp1);
+    ctx.getOperationExecutionParams(comp1, "event2").callback().complete(comp1);
 
     assertThat(completedForComponents, contains(new Pair<>(comp1, "event1"), new Pair<>(comp1, "event2")));
   }

--- a/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextTestCase.java
+++ b/modules/extensions-support/src/test/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextTestCase.java
@@ -10,14 +10,19 @@ import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation
 
 import static java.util.Collections.emptyMap;
 import static java.util.Optional.empty;
+import static java.util.Optional.of;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.util.Pair;
+import org.mule.runtime.extension.api.runtime.config.ConfigurationInstance;
 import org.mule.runtime.extension.api.runtime.operation.CompletableComponentExecutor.ExecutorCallback;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
@@ -68,6 +73,46 @@ public class SdkInternalContextTestCase extends AbstractMuleTestCase {
     ctx.getOperationExecutionParams(comp1, "event2").getCallback().complete(comp1);
 
     assertThat(completedForComponents, contains(new Pair<>(comp1, "event1"), new Pair<>(comp1, "event2")));
+  }
+
+  @Test
+  @Issue("W-17980769")
+  public void putCollidingKeys() {
+    final SdkInternalContext ctx = new SdkInternalContext();
+
+    final ComponentLocation comp1 = from("comp1");
+
+    ctx.putContext(comp1, "event1");
+    final var configInstance = mock(ConfigurationInstance.class);
+    ctx.setConfiguration(comp1, "event1", of(configInstance));
+    assertThrows(IllegalStateException.class, () -> ctx.putContext(comp1, "event1"));
+
+    assertThat("The failed call to `putContext` overwrote the original context",
+               ctx.getConfiguration(comp1, "event1").orElseThrow(), sameInstance(configInstance));
+  }
+
+  @Test
+  @Issue("W-17980769")
+  public void putOperationExecutionParamsTwice() throws MuleException {
+    final SdkInternalContext ctx = new SdkInternalContext();
+
+    final ComponentLocation comp1 = from("comp1");
+
+    ctx.putContext(comp1, "event1");
+    ctx.setOperationExecutionParams(comp1, "event1", empty(), emptyMap(), testEvent(), null, null);
+    assertThrows(IllegalStateException.class,
+                 () -> ctx.setOperationExecutionParams(comp1, "event1", empty(), emptyMap(), testEvent(), null, null));
+  }
+
+  @Test
+  @Issue("W-17980769")
+  public void putOperationExecutionWithoutContext() throws MuleException {
+    final SdkInternalContext ctx = new SdkInternalContext();
+
+    final ComponentLocation comp1 = from("comp1");
+
+    assertThrows(NullPointerException.class,
+                 () -> ctx.setOperationExecutionParams(comp1, TEST_CONNECTOR, empty(), emptyMap(), testEvent(), null, null));
   }
 
   private void pushContext(final SdkInternalContext ctx, ComponentLocation location, String eventId,

--- a/tests/performance/pom.xml
+++ b/tests/performance/pom.xml
@@ -119,12 +119,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.databene</groupId>
-            <artifactId>contiperf</artifactId>
-            <version>2.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
         </dependency>

--- a/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextBenchmark.java
@@ -6,11 +6,11 @@
  */
 package org.mule.runtime.module.extension.internal.runtime.execution;
 
+import static java.lang.Thread.currentThread;
 import static java.util.Optional.empty;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import org.mule.AbstractBenchmark;
-import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.dsl.api.component.config.DefaultComponentLocation;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(NANOSECONDS)
 public class SdkInternalContextBenchmark extends AbstractBenchmark {
 
-  final static ComponentLocation LOCATION = DefaultComponentLocation.from("comp/0");
 
   @State(Scope.Benchmark)
   public static class ContextContainer {
@@ -44,22 +43,24 @@ public class SdkInternalContextBenchmark extends AbstractBenchmark {
   @Benchmark
   @Threads(3)
   public void contextWith3Parallel(ContextContainer ctx) {
+    var location = DefaultComponentLocation.from("comp/" + currentThread().getId());
     for (int i = 0; i < 100; ++i) {
       final var id = "" + i;
-      ctx.ctx.putContext(LOCATION, id);
-      ctx.ctx.setConfiguration(LOCATION, id, empty());
-      ctx.ctx.removeContext(LOCATION, id);
+      ctx.ctx.putContext(location, id);
+      ctx.ctx.setConfiguration(location, id, empty());
+      ctx.ctx.removeContext(location, id);
     }
   }
 
   @Benchmark
   @Threads(300)
   public void contextWith300ParallelChildren(ContextContainer ctx) {
+    var location = DefaultComponentLocation.from("comp/" + currentThread().getId());
     for (int i = 0; i < 100; ++i) {
       final var id = "" + i;
-      ctx.ctx.putContext(LOCATION, id);
-      ctx.ctx.setConfiguration(LOCATION, id, empty());
-      ctx.ctx.removeContext(LOCATION, id);
+      ctx.ctx.putContext(location, id);
+      ctx.ctx.setConfiguration(location, id, empty());
+      ctx.ctx.removeContext(location, id);
     }
   }
 }

--- a/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextBenchmark.java
+++ b/tests/performance/src/main/java/org/mule/runtime/module/extension/internal/runtime/execution/SdkInternalContextBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.module.extension.internal.runtime.execution;
+
+import static java.util.Optional.empty;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import org.mule.AbstractBenchmark;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.dsl.api.component.config.DefaultComponentLocation;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 20)
+@Measurement(iterations = 100)
+@OutputTimeUnit(NANOSECONDS)
+public class SdkInternalContextBenchmark extends AbstractBenchmark {
+
+  final static ComponentLocation LOCATION = DefaultComponentLocation.from("comp/0");
+
+  @State(Scope.Benchmark)
+  public static class ContextContainer {
+
+    SdkInternalContext ctx;
+
+    @Setup(Level.Iteration)
+    public void setUp() {
+      ctx = new SdkInternalContext();
+    }
+  }
+
+  @Benchmark
+  @Threads(3)
+  public void contextWith3Parallel(ContextContainer ctx) {
+    for (int i = 0; i < 100; ++i) {
+      final var id = "" + i;
+      ctx.ctx.putContext(LOCATION, id);
+      ctx.ctx.setConfiguration(LOCATION, id, empty());
+      ctx.ctx.removeContext(LOCATION, id);
+    }
+  }
+
+  @Benchmark
+  @Threads(300)
+  public void contextWith300ParallelChildren(ContextContainer ctx) {
+    for (int i = 0; i < 100; ++i) {
+      final var id = "" + i;
+      ctx.ctx.putContext(LOCATION, id);
+      ctx.ctx.setConfiguration(LOCATION, id, empty());
+      ctx.ctx.removeContext(LOCATION, id);
+    }
+  }
+}

--- a/tests/performance/src/test/java/org/mule/test/performance/util/AbstractIsolatedFunctionalPerformanceTestCase.java
+++ b/tests/performance/src/test/java/org/mule/test/performance/util/AbstractIsolatedFunctionalPerformanceTestCase.java
@@ -8,12 +8,6 @@ package org.mule.test.performance.util;
 
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 
-import org.databene.contiperf.junit.ContiPerfRule;
-import org.junit.Rule;
-
 public abstract class AbstractIsolatedFunctionalPerformanceTestCase extends MuleArtifactFunctionalTestCase {
-
-  @Rule
-  public ContiPerfRule rule = new ContiPerfRule();
 
 }


### PR DESCRIPTION
Improvements in times:

```Benchmark                                                                    Mode  Cnt        Score       Error   Units
Baseline:
EventContextBenchmark.createEventContextWith1000ChildrenTerminateAllAtOnce   avgt   10    378451.152 ± 16140.772     ns/op
SdkInternalContextBenchmark.contextWith300ParallelChildren                   avgt   10  14594822.655 ± 1281822.849   ns/op
SdkInternalContextBenchmark.contextWith3Parallel                             avgt   10     90799.671 ±    3848.457   ns/op

After:
EventContextBenchmark.createEventContextWith1000ChildrenTerminateAllAtOnce   avgt   10    342399.367 ± 28087.914    
 ns/op (-9.5%)
SdkInternalContextBenchmark.contextWith300ParallelChildren                   avgt   10   1813778.934 ± 173664.899    ns/op (-87,5%)
SdkInternalContextBenchmark.contextWith3Parallel                             avgt   10     37869.280 ±   3338.925    ns/op (-58,3%)
```