### PR TITLE
W-18369243: Reintroduce JAR URLConnection cache disabling

### DIFF
--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoader.java
@@ -43,6 +43,11 @@ public class FineGrainedControlClassLoader extends URLClassLoader
 
   static {
     registerAsParallelCapable();
+
+    // Disables the default caching behavior of {@link JarURLConnection} for the "jar" protocol.
+    // By default, Java caches open JAR file handles when resolving resources via {@link JarURLConnection}. This can cause file
+    // locking issues, especially on Windows platforms, preventing the deletion or modification of JAR files during the
+    // un-deployment of applications or extensions.
     setDefaultUseCaches("jar", false);
   }
 

--- a/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoader.java
+++ b/modules/artifact/src/main/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoader.java
@@ -11,6 +11,7 @@ import static org.mule.runtime.api.util.MuleSystemProperties.MULE_LOG_VERBOSE_CL
 import static java.lang.Boolean.valueOf;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
+import static java.net.URLConnection.setDefaultUseCaches;
 import static java.util.Objects.requireNonNull;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -42,6 +43,7 @@ public class FineGrainedControlClassLoader extends URLClassLoader
 
   static {
     registerAsParallelCapable();
+    setDefaultUseCaches("jar", false);
   }
 
   private static final Logger LOGGER = getLogger(FineGrainedControlClassLoader.class);

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoaderTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/FineGrainedControlClassLoaderTestCase.java
@@ -20,7 +20,6 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.Mockito.mock;
@@ -75,7 +74,7 @@ public class FineGrainedControlClassLoaderTestCase extends AbstractMuleTestCase 
     FineGrainedControlClassLoader ext =
         new FineGrainedControlClassLoader(new URL[] {getChildFileResource()}, parent, lookupPolicy);
 
-    assertEquals(EXPECTED_PARENT_MESSAGE, invokeTestClassMethod(ext));
+    assertThat(invokeTestClassMethod(ext), is(EXPECTED_PARENT_MESSAGE));
   }
 
   @Test
@@ -108,7 +107,7 @@ public class FineGrainedControlClassLoaderTestCase extends AbstractMuleTestCase 
     FineGrainedControlClassLoader ext =
         new FineGrainedControlClassLoader(new URL[] {getChildFileResource()}, parent, lookupPolicy);
 
-    assertEquals(EXPECTED_PARENT_MESSAGE, invokeTestClassMethod(ext));
+    assertThat(invokeTestClassMethod(ext), is(EXPECTED_PARENT_MESSAGE));
   }
 
   @Test
@@ -123,7 +122,7 @@ public class FineGrainedControlClassLoaderTestCase extends AbstractMuleTestCase 
     FineGrainedControlClassLoader ext =
         new FineGrainedControlClassLoader(new URL[] {getChildFileResource()}, parent, lookupPolicy);
 
-    assertEquals(EXPECTED_CHILD_MESSAGE, invokeTestClassMethod(ext));
+    assertThat(invokeTestClassMethod(ext), is(EXPECTED_CHILD_MESSAGE));
   }
 
   @Test
@@ -157,7 +156,7 @@ public class FineGrainedControlClassLoaderTestCase extends AbstractMuleTestCase 
     FineGrainedControlClassLoader ext =
         new FineGrainedControlClassLoader(new URL[] {getChildFileResource()}, parent, lookupPolicy);
 
-    assertEquals(EXPECTED_CHILD_MESSAGE, invokeTestClassMethod(ext));
+    assertThat(invokeTestClassMethod(ext), is(EXPECTED_CHILD_MESSAGE));
   }
 
   @Test
@@ -169,11 +168,11 @@ public class FineGrainedControlClassLoaderTestCase extends AbstractMuleTestCase 
 
     FineGrainedControlClassLoader ext = new FineGrainedControlClassLoader(new URL[0], parent, lookupPolicy);
 
-    assertEquals(EXPECTED_PARENT_MESSAGE, invokeTestClassMethod(ext));
+    assertThat(invokeTestClassMethod(ext), is(EXPECTED_PARENT_MESSAGE));
   }
 
   @Test
-  public void usesChildFirstThenParentLookupAndFails() throws Exception {
+  public void usesChildFirstThenParentLookupAndFails() {
     ClassLoader parent = currentThread().getContextClassLoader();
 
     final ClassLoaderLookupPolicy lookupPolicy = mock(ClassLoaderLookupPolicy.class);
@@ -215,8 +214,8 @@ public class FineGrainedControlClassLoaderTestCase extends AbstractMuleTestCase 
   }
 
   private String invokeTestClassMethod(ClassLoader loader) throws Exception {
-    Class cls = loader.loadClass(TEST_CLASS_NAME);
+    Class<?> cls = loader.loadClass(TEST_CLASS_NAME);
     Method method = cls.getMethod("hi");
-    return (String) method.invoke(cls.newInstance());
+    return (String) method.invoke(cls.getDeclaredConstructor().newInstance());
   }
 }

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoaderTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/MuleArtifactClassLoaderTestCase.java
@@ -105,6 +105,7 @@ public class MuleArtifactClassLoaderTestCase extends AbstractMuleTestCase {
     URL resource = classLoader.findResource(request + ":" + resourceName);
     assertThat(resource, is(notNullValue()));
     assertThat(resource, is(equalTo(new URL("jar:" + expectedArtifactLocation.toString() + "!/" + resourceName))));
+    assertThat(resource.openConnection().getUseCaches(), is(false));
     assertThat(readLines(resource.openStream(), UTF_8).get(0), is(expectedLine));
   }
 

--- a/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoaderTestCase.java
+++ b/modules/artifact/src/test/java/org/mule/runtime/module/artifact/api/classloader/RegionClassLoaderTestCase.java
@@ -25,12 +25,6 @@ import static java.util.Collections.list;
 import static java.util.Collections.singleton;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -39,6 +33,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.mule.runtime.core.api.util.ClassUtils;
 import org.mule.runtime.module.artifact.api.classloader.test.TestArtifactClassLoader;
@@ -57,12 +55,10 @@ import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Test;
-
-import org.hamcrest.CoreMatchers;
-
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
 
 @Feature(CLASSLOADING_ISOLATION)
 @Story(ARTIFACT_CLASSLOADERS)
@@ -704,6 +700,11 @@ public class RegionClassLoaderTestCase extends AbstractMuleTestCase {
     URL result = regionClassLoader.findResource(resource);
 
     assertThat(result, is(expectedResult));
+
+    if (expectedResult != null) {
+      // useCaches should be false
+      assertThat(result.openConnection().getUseCaches(), is(false));
+    }
   }
 
   public static class TestApplicationClassLoader extends TestArtifactClassLoader {


### PR DESCRIPTION
This PR is actually reintroducing the behavior removed at #12330.

Particularly, there was a class `NonCachingURLStreamHandlerFactory` that was extending the behavior of the default `URLStreamHandler`, which was a `sun.net.www.protocol.jar.Handler`, by adding a `.setUseCaches(false)`. We can't re-introduce that implementation because the `Handler` class belongs to a private package of `java.base`.

Instead, we're setting `java.net.URLConnection.setDefaultUseCaches("jar", false)` in a static block of `FineGrainedControlClassLoader`, in order to make it effective for all the "deployable" artifacts (apps, plugins, its libraries, etc), but after the runtime loaded its own libraries that share its lifecycle (lib/mule, lib/opt...).

We're also re-introducing the test cases removed together with the `NonCachingURLStreamHandlerFactory`.

**Note**: Wherever WE control the input stream opening from jar files, we should use `ClassLoader#getResourceAsStream()`, but some library may use `URL#openStream()` with the same purposes. In that case, even if they close the stream, the jar file will be leaked because of [this code from the JDK](https://github.com/openjdk/jdk17u-dev/blob/c269609dad26a6b25b7a154a9ee3627b8b256500/src/java.base/share/classes/sun/net/www/protocol/jar/JarURLConnection.java#L93).